### PR TITLE
refactor(@cubejs-backend/schema-compiler): use snake_case for all date operators in `BaseFilter`

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/BaseFilter.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseFilter.js
@@ -7,7 +7,8 @@ const {
 
 const BaseDimension = require('./BaseDimension');
 
-const DATE_OPERATORS = ['in_date_range', 'not_in_date_range', 'on_the_date', 'before_date', 'after_date'];
+// Todo: `onTheDate` is missing in the documentation, possibly deprecated?
+const DATE_OPERATORS = ['inDateRange', 'notInDateRange', 'onTheDate', 'beforeDate', 'afterDate'];
 const dateTimeLocalMsRegex = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d$/;
 const dateRegex = /^\d\d\d\d-\d\d-\d\d$/;
 
@@ -79,8 +80,12 @@ class BaseFilter extends BaseDimension {
     return this.operator === 'contains' || this.operator === 'not_contains';
   }
 
+  isDateOperator() {
+    return contains(this.operator, DATE_OPERATORS);
+  }
+
   filterParams() {
-    if (contains(this.operator, DATE_OPERATORS)) {
+    if (this.isDateOperator()) {
       return [this.inDbTimeZoneDateFrom(this.values[0]), this.inDbTimeZoneDateTo(this.values[1])];
     }
     if (this.operator === 'set' || this.operator === 'not_set' || this.operator === 'expressionEquals') {

--- a/packages/cubejs-schema-compiler/adapter/BaseTimeDimension.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseTimeDimension.js
@@ -25,7 +25,7 @@ class BaseTimeDimension extends BaseFilter {
   constructor(query, timeDimension) {
     super(query, {
       dimension: timeDimension.dimension,
-      operator: 'in_date_range',
+      operator: 'inDateRange',
       values: timeDimension.dateRange
     });
     this.query = query;

--- a/packages/cubejs-schema-compiler/test/ClickHouseDataSchemaCompilerTest.js
+++ b/packages/cubejs-schema-compiler/test/ClickHouseDataSchemaCompilerTest.js
@@ -155,7 +155,7 @@ describe('ClickHouse DataSchemaCompiler', function test() {
         }],
         filters: [{
           dimension: 'visitors.updated_at',
-          operator: 'in_date_range',
+          operator: 'inDateRange',
           values: ['2017-01-01', '2017-01-30']
         }],
         order: [{
@@ -355,7 +355,7 @@ describe('ClickHouse DataSchemaCompiler', function test() {
         ],
         [{ "visitors__created_at": '2017-01-06T16:00:00.000' }]
       ];
-      ['in_date_range', 'not_in_date_range', 'on_the_date', 'before_date', 'after_date'].map((operator, index) => {
+      ['inDateRange', 'notInDateRange', 'onTheDate', 'beforeDate', 'afterDate'].map((operator, index) => {
         const filterValues = index < 2 ? ['2017-01-01', '2017-01-03'] : ['2017-01-06', '2017-01-06'];
         it(`filtered dates ${operator}`, async () => {
 

--- a/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
+++ b/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
@@ -149,7 +149,7 @@ describe('DataSchemaCompiler', function test() {
         }],
         filters: [{
           dimension: 'visitors.updated_at',
-          operator: 'in_date_range',
+          operator: 'inDateRange',
           values: ['2017-01-01', '2017-01-30']
         }],
         order: [{
@@ -275,7 +275,7 @@ describe('DataSchemaCompiler', function test() {
       [{ "visitors__created_at": '2017-01-07T00:00:00.000Z' }]
     ];
     const result = compiler.compile().then(() => {
-      const queries = ['in_date_range', 'not_in_date_range', 'on_the_date', 'before_date', 'after_date'].map((operator, index) => {
+      const queries = ['inDateRange', 'notInDateRange', 'onTheDate', 'beforeDate', 'afterDate'].map((operator, index) => {
         const filterValues = index < 2 ? ['2017-01-01', '2017-01-03'] : ['2017-01-06', '2017-01-06'];
         return new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
           measures: [],

--- a/packages/cubejs-schema-compiler/test/SQLGenerationTest.js
+++ b/packages/cubejs-schema-compiler/test/SQLGenerationTest.js
@@ -1665,4 +1665,36 @@ describe('SQL Generation', function test() {
       { "visitors__foo": '6' }
     ])
   );
+
+  const baseQuery = {
+    measures: [
+      'visitors.countDistinctApproxRolling'
+    ],
+    filters: [],
+    timeDimensions: [],
+    order: [{
+      id: 'visitors.created_at'
+    }],
+    timezone: 'America/Los_Angeles'
+  }
+
+  it('Should date with TZ, when pass filter with inDateRange operator', () => {
+    const result = compiler.compile().then(() => {
+      const query = new BigqueryQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...baseQuery,
+        filters: [{
+          dimension: 'visitors.created_at',
+          operator: 'inDateRange',
+          values: ['2017-01-01', '2017-01-10']
+        }]
+      });
+
+      const sqlBuild = query.buildSqlAndParams()
+
+      sqlBuild[1][0].should.be.equal('2017-01-01T08:00:00Z');
+      sqlBuild[1][1].should.be.equal('2017-01-11T07:59:59Z');
+    });
+
+    return result;
+  });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

https://github.com/cube-js/cube.js/pull/972#discussion_r471025382

What changes:

- All date operators replaced to camelCase style, including all the tests
- Add isDateOperator() method in BaseFilter

PS: 
I think good point for refactoring:
- Too bad the constants are not used and the problem of shared between modules base interfaces is not solved. Turn your attention to such DDD techniques as "ubiquitous language" and as an option for implement it is protobuf. 

- Test excluded from eslint checker, i recommend that you treat the tests same way you treat the work code