### PR TITLE
Converted likeIgnoreCase to contains search in Elasticsearch

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.js
@@ -16,7 +16,7 @@ const GRANULARITY_TO_INTERVAL = {
 
 class ElasticSearchQueryFilter extends BaseFilter {
   likeIgnoreCase(column, not, param) {
-    return `${not ? ' NOT' : ''} MATCH(${column}, ${this.allocateParam(param)}, 'fuzziness=AUTO:1,5')`;
+    return `${not ? " NOT" : ""}  ${column} RLIKE '.*${param}.*'`;
   }
 }
 


### PR DESCRIPTION
Converted likeIgnoreCase to contains search instead of fuzzy match

**Description of Changes Made (if issue reference is not provided)**
likeIgnoreCase function of ElasticSearchQuery was doing a fuzzy match. This leads to unexpected results in contains queries
I have changed to LIKE query as in the other Databases we support