### PR TITLE
refactor(@cubejs-backend/mysql-driver): return promise from `MySqlDriver` pool `destroy()` method

### DIFF
--- a/packages/cubejs-mysql-driver/src/MySqlDriver.ts
+++ b/packages/cubejs-mysql-driver/src/MySqlDriver.ts
@@ -112,7 +112,7 @@ export class MySqlDriver extends BaseDriver implements DriverInterface {
         }
         return true;
       },
-      destroy: (connection) => promisify(connection.end.bind(connection))(),
+      destroy: (connection) => promisify(connection.end.bind(connection)),
     }, {
       min: 0,
       max: process.env.CUBEJS_DB_MAX_POOL && parseInt(process.env.CUBEJS_DB_MAX_POOL, 10) || 8,


### PR DESCRIPTION
destroy method would return promise not to call it. 

