### PR TITLE
fix(redshift-driver): Use Redshift-specific schema query.

### DIFF
--- a/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
+++ b/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
@@ -22,6 +22,19 @@ export class RedshiftDriver extends PostgresDriver<RedshiftDriverConfiguration> 
     super(options);
   }
 
+  /**
+   * @param {string} schemaName
+   * @return {Promise<Array<unknown>>}
+   */
+   async createSchemaIfNotExists(schemaName: string) {
+    const schemaExistsQuery = `SELECT nspname FROM pg_namespace where nspname = ${this.param(0)}`;
+    const schemas = await this.query(schemaExistsQuery, [schemaName])
+    if (schemas.length === 0) {
+      return this.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+    }
+    return null;
+  }
+
   protected getInitialConfiguration(): Partial<RedshiftDriverConfiguration> {
     return {
       // @todo It's not possible to support UNLOAD in readOnly mode, because we need column types (CREATE TABLE?)


### PR DESCRIPTION
Fixes #3876.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #3876 

**Description of Changes Made (if issue reference is not provided)**

Override `BaseDriver.createSchemaIfNotExists()` in `RedshiftDriver` with a schema-discovery query that is compatible with Redshift information schema permission semantics. See details in #3876.
