### PR TITLE
With modern SQLite schema extraction.

### DIFF
--- a/packages/cubejs-sqlite-driver/CHANGELOG.md
+++ b/packages/cubejs-sqlite-driver/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.29.26](https://github.com/cube-js/cube.js/compare/v0.29.25...v0.29.26) (2022-02-07)
+
+### Bug Fixes
+
+* Uses modern (SQLite >= 3.16.0) PRAGMA for schema extraction rather than error-prone text-based SQL parsing.
+
+
+
 ## [0.29.25](https://github.com/cube-js/cube.js/compare/v0.29.24...v0.29.25) (2022-02-03)
 
 **Note:** Version bump only for package @cubejs-backend/sqlite-driver

--- a/packages/cubejs-sqlite-driver/package.json
+++ b/packages/cubejs-sqlite-driver/package.json
@@ -2,7 +2,7 @@
   "name": "@cubejs-backend/sqlite-driver",
   "description": "Cube.js Sqlite database driver",
   "author": "Cube Dev, Inc.",
-  "version": "0.29.25",
+  "version": "0.29.26",
   "repository": {
     "type": "git",
     "url": "https://github.com/cube-js/cube.js.git",


### PR DESCRIPTION
This fixes SQLite-related schema extraction issues by replacing the old error-prone text-based SQL parsing with proper SQLite PRAGMA usage. This is related to reemergence of #626.
