### PR TITLE
feat(cubestore): Query cache - limits by time_to_idle/max_capacity

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.15",
@@ -1028,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.8",
+ "crossbeam-epoch 0.9.14",
  "crossbeam-utils 0.8.15",
 ]
 
@@ -1049,15 +1049,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.15",
- "lazy_static",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -1216,6 +1215,7 @@ dependencies = [
  "cubezetasketch",
  "datafusion",
  "deadqueue",
+ "deepsize",
  "deflate",
  "enum_primitive",
  "flatbuffers 23.1.21",
@@ -1235,6 +1235,7 @@ dependencies = [
  "log",
  "lru",
  "mockall",
+ "moka 0.10.1",
  "msql-srv",
  "mysql_common 0.26.0",
  "nanoid",
@@ -1270,7 +1271,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
- "uuid",
+ "uuid 0.8.2",
  "warp",
 ]
 
@@ -1326,7 +1327,7 @@ dependencies = [
  "log",
  "lru",
  "md-5",
- "moka",
+ "moka 0.8.6",
  "num_cpus",
  "ordered-float 2.7.0",
  "parquet",
@@ -1354,6 +1355,26 @@ checksum = "16a2561fd313df162315935989dceb8c99db4ee1933358270a57a3cfb8c957f3"
 dependencies = [
  "crossbeam-queue 0.3.8",
  "tokio 1.18.1",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2246,7 +2267,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tempfile",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2543,6 +2564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,11 +2698,11 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9d038ced38770a867f2300ef21e1193b5e26d8e8e060fa5c034d1dddc57452"
+checksum = "975fa04238144061e7f8df9746b2e9cd93ef85881da5548d842a7c6a4b614415"
 dependencies = [
- "crossbeam-channel 0.5.4",
+ "crossbeam-channel 0.5.7",
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.8.15",
  "num_cpus",
@@ -2685,7 +2715,33 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid",
+ "uuid 1.3.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccedbe530334b20d6f57b2ca9f7c54c7bd1072a5a0b0035970aafd53982bd8d"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "crossbeam-channel 0.5.7",
+ "crossbeam-epoch 0.9.14",
+ "crossbeam-utils 0.8.15",
+ "futures-util",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.0",
+ "quanta",
+ "rustc_version 0.4.0",
+ "scheduled-thread-pool",
+ "skeptic",
+ "smallvec 1.8.0",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2774,7 +2830,7 @@ dependencies = [
  "sha2 0.8.2",
  "time 0.2.7",
  "twox-hash",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2803,7 +2859,7 @@ dependencies = [
  "sha2 0.9.5",
  "time 0.2.7",
  "twox-hash",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3204,17 +3260,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api 0.4.6",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
@@ -3235,20 +3280,6 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.14",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall 0.2.10",
- "smallvec 1.8.0",
  "winapi 0.3.9",
 ]
 
@@ -3580,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
 dependencies = [
  "crossbeam-utils 0.8.15",
  "libc",
@@ -3823,7 +3854,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.4",
+ "crossbeam-channel 0.5.7",
  "crossbeam-deque 0.8.1",
  "crossbeam-utils 0.8.15",
  "lazy_static",
@@ -4091,7 +4122,7 @@ dependencies = [
  "simpl",
  "tokio 0.2.25",
  "url",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -4216,11 +4247,11 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -5431,6 +5462,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]

--- a/rust/cubestore/cubestore-sql-tests/src/benches.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/benches.rs
@@ -86,7 +86,7 @@ impl Bench for ParquetMetadataCacheBench {
         let config = Config::test(name.as_str()).update_config(|mut c| {
             c.partition_split_threshold = 10_000_000;
             c.max_partition_split_threshold = 10_000_000;
-            c.max_cached_queries = 0;
+            c.query_cache_max_capacity_bytes = 0;
             c.metadata_cache_max_capacity_bytes =
                 env_parse("CUBESTORE_METADATA_CACHE_MAX_CAPACITY_BYTES", 0);
             c.metadata_cache_time_to_idle_secs = 1000;

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -79,6 +79,7 @@ http-auth-basic = "0.1.2"
 tracing = "0.1.25"
 tracing-futures = { version = "0.2.5", features = ["tokio", "tokio-executor"] }
 lru = "0.6.5"
+moka = { version = "0.10.1", features = ["future"]}
 ctor = "0.1.20"
 json = "0.12.4"
 futures-util = "0.3.17"
@@ -90,6 +91,7 @@ indoc = "1.0"
 rdkafka = { version = "0.29.0" }
 parse-size = "1.0.0"
 humansize = "2.1.3"
+deepsize = "0.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rdkafka = { version = "0.29.0", features = ["ssl", "gssapi", "cmake-build"] }

--- a/rust/cubestore/cubestore/src/app_metrics.rs
+++ b/rust/cubestore/cubestore/src/app_metrics.rs
@@ -10,7 +10,10 @@ pub static STARTUPS: Counter = metrics::counter("cs.startup");
 /// Incoming SQL queries that do data reads.
 pub static DATA_QUERIES: Counter = metrics::counter("cs.sql.query.data");
 pub static DATA_QUERIES_CACHE_HIT: Counter = metrics::counter("cs.sql.query.data.cache.hit");
+// Approximate number of entries in this cache.
 pub static DATA_QUERIES_CACHE_SIZE: Gauge = metrics::gauge("cs.sql.query.data.cache.size");
+// Approximate total weighted size of entries in this cache.
+pub static DATA_QUERIES_CACHE_WEIGHT: Gauge = metrics::gauge("cs.sql.query.data.cache.weight");
 pub static DATA_QUERY_TIME_MS: Histogram = metrics::histogram("cs.sql.query.data.ms");
 /// Incoming SQL queries that only read metadata or do trivial computations.
 pub static META_QUERIES: Counter = metrics::counter("cs.sql.query.meta");

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -846,6 +846,12 @@ where
 impl Config {
     pub fn default() -> Config {
         let query_timeout = env_parse("CUBESTORE_QUERY_TIMEOUT", 120);
+        let query_cache_time_to_idle_secs = env_parse(
+            "CUBESTORE_QUERY_CACHE_TIME_TO_IDLE",
+            // 1 hour
+            60 * 60,
+        );
+
         Config {
             injector: Injector::new(),
             config_obj: Arc::new(ConfigObjImpl {
@@ -977,11 +983,11 @@ impl Config {
                     Some(16384 << 20),
                     Some(0),
                 ) as u64,
-                query_cache_time_to_idle_secs: Some(env_parse(
-                    "CUBESTORE_QUERY_CACHE_TIME_TO_IDLE",
-                    // 1 hour
-                    60 * 60,
-                )),
+                query_cache_time_to_idle_secs: if query_cache_time_to_idle_secs == 0 {
+                    None
+                } else {
+                    Some(query_cache_time_to_idle_secs)
+                },
                 metadata_cache_max_capacity_bytes: env_parse(
                     "CUBESTORE_METADATA_CACHE_MAX_CAPACITY_BYTES",
                     0,

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -420,7 +420,9 @@ pub trait ConfigObj: DIService {
 
     fn malloc_trim_every_secs(&self) -> u64;
 
-    fn max_cached_queries(&self) -> usize;
+    fn query_cache_max_capacity_bytes(&self) -> u64;
+
+    fn query_cache_time_to_idle_secs(&self) -> Option<u64>;
 
     fn metadata_cache_max_capacity_bytes(&self) -> u64;
 
@@ -498,7 +500,8 @@ pub struct ConfigObjImpl {
     pub enable_topk: bool,
     pub enable_startup_warmup: bool,
     pub malloc_trim_every_secs: u64,
-    pub max_cached_queries: usize,
+    pub query_cache_max_capacity_bytes: u64,
+    pub query_cache_time_to_idle_secs: Option<u64>,
     pub metadata_cache_max_capacity_bytes: u64,
     pub metadata_cache_time_to_idle_secs: u64,
     pub stream_replay_check_interval_secs: u64,
@@ -685,8 +688,11 @@ impl ConfigObj for ConfigObjImpl {
     fn malloc_trim_every_secs(&self) -> u64 {
         self.malloc_trim_every_secs
     }
-    fn max_cached_queries(&self) -> usize {
-        self.max_cached_queries
+    fn query_cache_max_capacity_bytes(&self) -> u64 {
+        self.query_cache_max_capacity_bytes
+    }
+    fn query_cache_time_to_idle_secs(&self) -> Option<u64> {
+        self.query_cache_time_to_idle_secs
     }
     fn metadata_cache_max_capacity_bytes(&self) -> u64 {
         self.metadata_cache_max_capacity_bytes
@@ -965,7 +971,17 @@ impl Config {
                 enable_topk: env_bool("CUBESTORE_ENABLE_TOPK", true),
                 enable_startup_warmup: env_bool("CUBESTORE_STARTUP_WARMUP", true),
                 malloc_trim_every_secs: env_parse("CUBESTORE_MALLOC_TRIM_EVERY_SECS", 30),
-                max_cached_queries: env_parse("CUBESTORE_MAX_CACHED_QUERIES", 10_000),
+                query_cache_max_capacity_bytes: env_parse_size(
+                    "CUBESTORE_QUERY_CACHE_MAX_CAPACITY",
+                    512 << 20,
+                    Some(16384 << 20),
+                    Some(0),
+                ) as u64,
+                query_cache_time_to_idle_secs: Some(env_parse(
+                    "CUBESTORE_QUERY_CACHE_TIME_TO_IDLE",
+                    // 1 hour
+                    60 * 60,
+                )),
                 metadata_cache_max_capacity_bytes: env_parse(
                     "CUBESTORE_METADATA_CACHE_MAX_CAPACITY_BYTES",
                     0,
@@ -1075,7 +1091,8 @@ impl Config {
                 enable_topk: true,
                 enable_startup_warmup: true,
                 malloc_trim_every_secs: 0,
-                max_cached_queries: 10_000,
+                query_cache_max_capacity_bytes: 512 << 20,
+                query_cache_time_to_idle_secs: Some(600),
                 metadata_cache_max_capacity_bytes: 0,
                 metadata_cache_time_to_idle_secs: 1_000,
                 meta_store_log_upload_interval: 30,
@@ -1618,7 +1635,8 @@ impl Config {
                     c.wal_split_threshold() as usize,
                     Duration::from_secs(c.query_timeout()),
                     Duration::from_secs(c.import_job_timeout() * 2),
-                    c.max_cached_queries(),
+                    c.query_cache_max_capacity_bytes(),
+                    c.query_cache_time_to_idle_secs(),
                 )
             })
             .await;

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -81,6 +81,7 @@ use std::str::FromStr;
 
 use crate::cachestore::{CacheItem, QueueItem, QueueItemStatus, QueueResult, QueueResultAckEvent};
 use crate::remotefs::LocalDirRemoteFs;
+use deepsize::DeepSizeOf;
 use snapshot_info::SnapshotInfo;
 use std::time::{Duration, SystemTime};
 use table::Table;
@@ -318,7 +319,7 @@ impl DataFrameValue<String> for Option<Vec<AggregateFunction>> {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq, Hash, DeepSizeOf)]
 pub enum HllFlavour {
     Airlift,    // Compatible with Presto, Athena, etc.
     Snowflake,  // Same storage as Airlift, imports from Snowflake JSON.
@@ -342,7 +343,7 @@ pub fn is_valid_plain_binary_hll(data: &[u8], f: HllFlavour) -> Result<(), CubeE
     return Ok(());
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash, DeepSizeOf)]
 pub enum ColumnType {
     String,
     Int,
@@ -480,7 +481,7 @@ impl From<&Column> for parquet::schema::types::Type {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash, DeepSizeOf)]
 pub struct Column {
     name: String,
     column_type: ColumnType,

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1874,8 +1874,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                config.query_cache_max_capacity_bytes(),
-                config.query_cache_time_to_idle_secs(),
+                config.config_obj().query_cache_max_capacity_bytes(),
+                config.config_obj().query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA foo").await.unwrap();
             assert_eq!(
@@ -1947,8 +1947,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                config.query_cache_max_capacity_bytes(),
-                config.query_cache_time_to_idle_secs(),
+                config.config_obj().query_cache_max_capacity_bytes(),
+                config.config_obj().query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA Foo").await.unwrap();
             assert_eq!(
@@ -2049,8 +2049,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                config.query_cache_max_capacity_bytes(),
-                config.query_cache_time_to_idle_secs(),
+                config.config_obj().query_cache_max_capacity_bytes(),
+                config.config_obj().query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA Foo").await.unwrap();
             assert_eq!(

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -73,6 +73,7 @@ use crate::{
 use data::create_array_builder;
 use datafusion::cube_ext::catch_unwind::async_try_with_catch_unwind;
 use datafusion::physical_plan::parquet::NoopParquetMetadataCache;
+use deepsize::DeepSizeOf;
 use std::mem::take;
 
 pub mod cache;
@@ -118,7 +119,7 @@ pub struct QueryPlans {
     pub worker: Arc<dyn ExecutionPlan>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, DeepSizeOf)]
 pub struct InlineTable {
     pub id: u64,
     pub name: String,
@@ -194,11 +195,11 @@ impl SqlServiceImpl {
         rows_per_chunk: usize,
         query_timeout: Duration,
         create_table_timeout: Duration,
-        max_cached_queries: usize,
+        query_cache_max_capacity_bytes: u64,
+        query_cache_time_to_idle_secs: Option<u64>,
     ) -> Arc<SqlServiceImpl> {
         Arc::new(SqlServiceImpl {
             cachestore: CacheStoreSqlService::new(cachestore, query_planner.clone()),
-            cache: SqlResultCache::new(max_cached_queries),
             db,
             chunk_store,
             limits,
@@ -211,6 +212,10 @@ impl SqlServiceImpl {
             query_timeout,
             create_table_timeout,
             remote_fs,
+            cache: SqlResultCache::new(
+                query_cache_max_capacity_bytes,
+                query_cache_time_to_idle_secs,
+            ),
         })
     }
 
@@ -1813,6 +1818,7 @@ mod tests {
     use crate::remotefs::queue::QueueRemoteFs;
     use crate::scheduler::SchedulerImpl;
     use crate::table::data::{cmp_min_rows, cmp_row_key_heap};
+    use crate::table::TableValue;
     use regex::Regex;
 
     #[tokio::test]
@@ -1868,7 +1874,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                10_000, // max_cached_queries
+                config.query_cache_max_capacity_bytes(),
+                config.query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA foo").await.unwrap();
             assert_eq!(
@@ -1940,7 +1947,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                10_000, // max_cached_queries
+                config.query_cache_max_capacity_bytes(),
+                config.query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA Foo").await.unwrap();
             assert_eq!(
@@ -2041,7 +2049,8 @@ mod tests {
                 rows_per_chunk,
                 query_timeout,
                 query_timeout,
-                10_000, // max_cached_queries
+                config.query_cache_max_capacity_bytes(),
+                config.query_cache_time_to_idle_secs(),
             );
             let i = service.exec_query("CREATE SCHEMA Foo").await.unwrap();
             assert_eq!(
@@ -2298,8 +2307,8 @@ mod tests {
                                         union all \
                                         select * from foo.b \
                                         ) \
-                             union all 
-                             select * from 
+                             union all
+                             select * from
                                 ( \
                                         select * from foo.a1 \
                                         union all \
@@ -2336,8 +2345,8 @@ mod tests {
                          select * from ( \
                                         select * from foo.a\
                                         ) \
-                             union all 
-                             select * from 
+                             union all
+                             select * from
                                 ( \
                                         select * from foo.a1 \
                                         union all \
@@ -2372,8 +2381,8 @@ mod tests {
                          select * from ( \
                                         select * from foo.a where 1 = 0\
                                         ) \
-                             union all 
-                             select * from 
+                             union all
+                             select * from
                                 ( \
                                         select * from foo.a1 \
                                         union all \

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -42,6 +42,7 @@ use arrow::record_batch::RecordBatch;
 use compaction::{merge_chunks, merge_replay_handles};
 use datafusion::cube_ext;
 use datafusion::cube_ext::util::lexcmp_array_rows;
+use deepsize::DeepSizeOf;
 use futures::future::join_all;
 use itertools::Itertools;
 use log::trace;
@@ -53,7 +54,7 @@ use tokio::task::JoinHandle;
 
 pub const ROW_GROUP_SIZE: usize = 16384; // TODO config
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug, DeepSizeOf)]
 pub struct DataFrame {
     columns: Vec<Column>,
     data: Vec<Row>,

--- a/rust/cubestore/cubestore/src/table/mod.rs
+++ b/rust/cubestore/cubestore/src/table/mod.rs
@@ -9,6 +9,7 @@ use arrow::datatypes::{DataType, TimeUnit};
 
 use chrono::{SecondsFormat, TimeZone, Utc};
 use datafusion::cube_ext::ordfloat::OrdF64;
+use deepsize::{Context, DeepSizeOf};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -29,6 +30,25 @@ pub enum TableValue {
     Bytes(Vec<u8>),
     Timestamp(TimestampValue),
     Boolean(bool),
+}
+
+impl DeepSizeOf for TableValue {
+    fn deep_size_of(&self) -> usize {
+        32
+    }
+
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        match self {
+            TableValue::Null => 0,
+            TableValue::String(v) => v.deep_size_of_children(context),
+            TableValue::Int(_) => 0,
+            TableValue::Decimal(_) => 0,
+            TableValue::Float(_) => 0,
+            TableValue::Bytes(v) => v.deep_size_of_children(context),
+            TableValue::Timestamp(_) => 0,
+            TableValue::Boolean(_) => 0,
+        }
+    }
 }
 
 impl TableValue {
@@ -166,7 +186,7 @@ impl ToString for TimestampValue {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash, DeepSizeOf)]
 pub struct Row {
     values: Vec<TableValue>,
 }

--- a/rust/cubestore/cubestore/src/util/decimal.rs
+++ b/rust/cubestore/cubestore/src/util/decimal.rs
@@ -1,8 +1,9 @@
 use bigdecimal::BigDecimal;
+use deepsize::DeepSizeOf;
 use num::BigInt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, DeepSizeOf)]
 #[repr(transparent)]
 /// This it not a general-purpose decimal implementation. We use it inside [TableValue] to cement
 /// data format of decimals in CubeStore.


### PR DESCRIPTION
Hello!

The first implementation of Query Cache was based on a simple LRU, which doesn't provide flexibility for configuration. In this PR I've introduced a new Query Cache on top of `moka` crate, that allows making limits on capacity/time to idle.

Thanks