### PR TITLE
feat(schema-compiler): add `sql` expression option for `rollingWindow`

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.js
@@ -109,7 +109,7 @@ export class BaseMeasure {
     const { rollingWindow } = this.measureDefinition();
     if (rollingWindow) {
       return this.query.rollingWindowDateJoinCondition(
-        rollingWindow.trailing, rollingWindow.leading, rollingWindow.offset
+        rollingWindow.trailing, rollingWindow.leading, rollingWindow.offset, this.cube().name
       );
     }
     return null;
@@ -133,6 +133,9 @@ export class BaseMeasure {
   granularityFromInterval(interval) {
     if (!interval) {
       return undefined;
+    }
+    if (interval.sql) {
+      return interval.granularity;
     }
     if (interval.match(/day/)) {
       return 'day';

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -625,31 +625,72 @@ class BaseQuery {
       d => [
         d,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (dateFrom, dateTo, dateField, dimensionDateFrom, dimensionDateTo) => `${dateField} >= ${dimensionDateFrom} AND ${dateField} <= ${dateTo}`
+        (dateFrom, dateTo, dateField, dimensionDateFrom, dimensionDateTo) => `${dateField} >= ${dimensionDateFrom} AND ${dateField} <= ${dateTo}`,
+        []
       ]
     );
   }
 
-  rollingWindowDateJoinCondition(trailingInterval, leadingInterval, offset) {
+  rollingWindowDateJoinCondition(trailingInterval, leadingInterval, offset, cubeName) {
     offset = offset || 'end';
+
+    const references = R.pipe(
+      R.map(i => {
+        if (i && i.sql) {
+          const fieldReferencesUsed = [];
+          const { cubeEvaluator } = this;
+          cubeEvaluator.collectUsedCubeReferences(cubeName, i.sql, { fieldReferencesUsed });
+          return fieldReferencesUsed;
+        }
+
+        return null;
+      }),
+      R.uniq,
+      R.filter(R.identity),
+      R.flatten
+    )([trailingInterval, leadingInterval]);
+
     return this.timeDimensions.map(
       d => [d, (dateFrom, dateTo, dateField, dimensionDateFrom, dimensionDateTo, isFromStartToEnd) => {
         // dateFrom based window
         const conditions = [];
-        if (trailingInterval !== 'unbounded') {
+        if (trailingInterval && trailingInterval.sql) {
+          const fn = () => this.evaluateSql(cubeName, trailingInterval.sql);
+          const context = {
+            interval: {
+              startDate: dateFrom,
+              endDate: dateTo,
+              dateField
+            }
+          };
+          const evaluated = this.evaluateSymbolSqlWithContext(fn, context);
+          conditions.push(`${evaluated}`);
+        } else if (trailingInterval !== 'unbounded') {
           const startDate = isFromStartToEnd || offset === 'start' ? dateFrom : dateTo;
           const trailingStart = trailingInterval ? this.subtractInterval(startDate, trailingInterval) : startDate;
           const sign = offset === 'start' ? '>=' : '>';
           conditions.push(`${dateField} ${sign} ${trailingStart}`);
         }
-        if (leadingInterval !== 'unbounded') {
+
+        if (leadingInterval && leadingInterval.sql) {
+          const fn = () => this.evaluateSql(cubeName, leadingInterval.sql);
+          const context = {
+            interval: {
+              startDate: dateFrom,
+              endDate: dateTo,
+              dateField
+            }
+          };
+          const evaluated = this.evaluateSymbolSqlWithContext(fn, context);
+          conditions.push(`${evaluated}`);
+        } else if (leadingInterval !== 'unbounded') {
           const endDate = isFromStartToEnd || offset === 'end' ? dateTo : dateFrom;
           const leadingEnd = leadingInterval ? this.addInterval(endDate, leadingInterval) : endDate;
           const sign = offset === 'end' ? '<=' : '<';
           conditions.push(`${dateField} ${sign} ${leadingEnd}`);
         }
         return conditions.length ? conditions.join(' AND ') : '1 = 1';
-      }]
+      }, references]
     );
   }
 
@@ -964,6 +1005,17 @@ class BaseQuery {
 
   overTimeSeriesQuery(baseQueryFn, cumulativeMeasure, fromRollup) {
     const dateJoinCondition = cumulativeMeasure.dateJoinCondition();
+    
+    // TODO: Move this to compiler.
+    const referencedJoinDimensions = R.pipe(
+      R.map(i => i[2]),
+      R.uniq,
+      R.flatten,
+      R.map(this.newDimension.bind(this))
+    )(
+      dateJoinCondition
+    );
+    
     const cumulativeMeasures = [cumulativeMeasure];
     if (!this.timeDimensions.find(d => d.granularity)) {
       const filters = this.segments.concat(this.filters).concat(this.dateFromStartToEndConditionSql(dateJoinCondition, fromRollup, false));
@@ -971,23 +1023,35 @@ class BaseQuery {
     }
     const dateSeriesSql = this.timeDimensions.map(d => this.dateSeriesSql(d)).join(', ');
     const filters = this.segments.concat(this.filters).concat(this.dateFromStartToEndConditionSql(dateJoinCondition, fromRollup, true));
+
+    // TODO: This method deserves a better name.
     const baseQuery = this.groupedUngroupedSelect(
       () => baseQueryFn(cumulativeMeasures, filters),
       cumulativeMeasure.shouldUngroupForCumulative(),
       !cumulativeMeasure.shouldUngroupForCumulative() && this.minGranularity(
         cumulativeMeasure.windowGranularity(), this.timeDimensions.find(d => d.granularity).granularity
-      ) || undefined
+      ) || undefined,
+      referencedJoinDimensions
     );
+
     const baseQueryAlias = this.cubeAlias('base');
+
+    const dateJoinRenderedReferenceContext = {
+      renderedReference: R.pipe(
+        R.map(d => [d.dimension, `${baseQueryAlias}.${d.aliasName()}`]),
+        R.fromPairs,
+      )(referencedJoinDimensions),
+    };
+
     const dateJoinConditionSql =
       dateJoinCondition.map(
-        ([d, f]) => f(
+        ([d, f]) => this.evaluateSymbolSqlWithContext(() => f(
           `${d.dateSeriesAliasName()}.${this.escapeColumnName('date_from')}`,
           `${d.dateSeriesAliasName()}.${this.escapeColumnName('date_to')}`,
           `${baseQueryAlias}.${d.aliasName()}`,
           `'${d.dateFromFormatted()}'`,
           `'${d.dateToFormatted()}'`
-        )
+        ), dateJoinRenderedReferenceContext)
       ).join(' AND ');
 
     return this.overTimeSeriesSelect(
@@ -1367,10 +1431,10 @@ class BaseQuery {
       }));
   }
 
-  groupedUngroupedSelect(select, ungrouped, granularityOverride) {
+  groupedUngroupedSelect(select, ungrouped, granularityOverride, referencedDimensions = []) {
     return this.evaluateSymbolSqlWithContext(
       select,
-      { ungrouped, granularityOverride, overTimeSeriesAggregate: true }
+      { ungrouped, granularityOverride, referencedDimensions, overTimeSeriesAggregate: true }
     );
   }
 
@@ -1640,7 +1704,7 @@ class BaseQuery {
    * @returns {Array<BaseDimension>}
    */
   dimensionsForSelect() {
-    return this.dimensions.concat(this.timeDimensions);
+    return this.dimensions.concat(this.timeDimensions).concat(this.safeEvaluateSymbolContext().referencedDimensions || []);
   }
 
   dimensionSql(dimension) {
@@ -2737,13 +2801,25 @@ class BaseQuery {
         filterParams: this.filtersProxy(),
         sqlUtils: {
           convertTz: this.convertTz.bind(this)
-        }
+        },
+        interval: this.lazyEvaluateSymbolContextProxy('interval'),
       }, R.map(
         (symbols) => this.contextSymbolsProxy(symbols),
         this.contextSymbols
       ));
     }
     return this.parametrizedContextSymbolsValue;
+  }
+
+  lazyEvaluateSymbolContextProxy(symbol) {
+    return new Proxy(this, {
+      get: (target, name) => {
+        if (name === '_objectWithResolvedProperties') {
+          return true;
+        }
+        return target.safeEvaluateSymbolContext()[symbol][name];
+      }
+    });
   }
 
   static emptyParametrizedContextSymbols(cubeEvaluator, allocateParam) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -376,7 +376,7 @@ export class CubeEvaluator extends CubeSymbols {
     return path.split('.');
   }
 
-  collectUsedCubeReferences(cube, sqlFn) {
+  collectUsedCubeReferences(cube, sqlFn, context = {}) {
     const cubeEvaluator = this;
 
     const cubeReferencesUsed = [];
@@ -395,7 +395,11 @@ export class CubeEvaluator extends CubeSymbols {
       return cubeEvaluator.pathFromArray([referencedCube, name]);
     }, {
       // eslint-disable-next-line no-shadow
-      sqlResolveFn: (symbol, cube, n) => cubeEvaluator.pathFromArray([cube, n]),
+      sqlResolveFn: (symbol, cube, n) => {
+        const path = cubeEvaluator.pathFromArray([cube, n]);
+        if (Array.isArray(context.fieldReferencesUsed)) context.fieldReferencesUsed.push(path);
+        return path;
+      },
       contextSymbols: BaseQuery.emptyParametrizedContextSymbols(this, () => '$empty_param$'),
       cubeReferencesUsed,
     });

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -10,7 +10,8 @@ const CONTEXT_SYMBOLS = {
   USER_CONTEXT: 'securityContext',
   SECURITY_CONTEXT: 'securityContext',
   FILTER_PARAMS: 'filterParams',
-  SQL_UTILS: 'sqlUtils'
+  SQL_UTILS: 'sqlUtils',
+  INTERVAL: 'interval'
 };
 
 const CURRENT_CUBE_CONSTANTS = ['CUBE', 'TABLE'];

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -38,7 +38,11 @@ const regexTimeInterval = Joi.string().custom((value, helper) => {
 const timeInterval =
   Joi.alternatives([
     regexTimeInterval,
-    Joi.any().valid('unbounded')
+    Joi.any().valid('unbounded'),
+    Joi.object().keys({
+      sql: Joi.func().required(),
+      granularity: Joi.string().valid('minute', 'hour', 'day', 'week', 'month', 'year').required()
+    })
   ]);
 
 const everyInterval = Joi.string().custom((value, helper) => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

- https://github.com/cube-js/cube.js/issues/209
- https://github.com/cube-js/cube.js/pull/223

**Description of Changes Made (if issue reference is not provided)**

- Added option to use `sql` expression for `rollingWindow.leading` and `rollingWindow.trailing` options. Inspired by issue/PR above.
- Introduced new context symbol `interval` that is used in `rollingDateJoinCondition`, with three fields:
    - `INTERVAL.dateField` -- as more powerful SQL expression got introduced than in the PR above, I had to explicitly expose `dateField` to make more powerful comparisons.
    - `INTERVAL.startDate` -- timeDimension start date (dateFrom).
    - `INTERVAL.endDate` -- timeDimension end date (dateTo).
- Added extended option beyond #223 that resolves and makes use of references used in respective `sql` expressions to support variable windows (a specific requirement for our business usecase).

---

The schema compiler/adapters are pretty complex and it was hard for me without guidance to figure out everything, therefore I made this semi-hacky solution with the idea to be given hints as how to improve. 

Even with that, I tried to keep things as intended wherever I could see through it. And now that I look at it after having battled through it, I guess the only hacky thing is the reference resolution for use in subquery and join conditions.

We want this feature in ASAP, as this is heavily blocking our business. While we found workarounds with Cube, they are insanely worse in terms of performance (dimension as measure subquery). So, I'm ready to pull all the weight, just let me know what needs to be improved to get this in.

---

**Usecase**

We are a demand planning SaaS startup where we do ML demand forecasting and then provide purpose-built dashboards and planning views that make great use of Cube.

We need a measure called "sales over lead time" that is derived from SKUs lead time. And we need to compute it on weekly basis looking lead time ahead. Read it like, for every week, compute the sum of sales over lead time ahead.

If it would be static across all SKUs everything would be fine with already available `rollingWindow` functionality, but no, lead time can vary between SKU's.

Something akin to:

```js
dimensions: {
  leadTime: {
    sql: "lead_time",
    type: "number"
  }
},
measures: {
  salesOverLeadTime: {
    sql: `quantity`,
    type: "sum",
    rollingWindow: {
      leading: `${CUBE.leadTime} days`,
      offset: "start"
    }
}
},
```

But this was/is not available, and while this would be preferred syntax, it comes with more challenges and less functionality than the solution I came up with, where I can express the solution above using:

```js
dimensions: {
  leadTime: {
    sql: "lead_time",
    type: "number"
  }
},
measures: {
  salesOverLeadTime: {
    sql: `quantity`,
    type: "sum",
    rollingWindow: {
      leading: {
        sql: `${INTERVAL.dateField} < (${INTERVAL.startDate} + interval '1' day * ${CUBE.leadTime})`
        granularity: 'day' // THIS DOES FEEL LIKE A LOOSE WHEEL THOUGH (but was hinted by Pavel)
      }
      offset: "start"
    }
}
},
```

That generates this SQL (multiple hand made redactions, as I don't have a full Cube server running with my updates to schema compiler):
```sql
SELECT
  q_0."sales__date_week",
  "sales__sales_over_lead_time" "sales__sales_over_lead_time"
FROM
  (
    SELECT
      "HSF.date_series"."date_from" "sales__date_week",
      sum("sales__sales_over_lead_time") "sales__sales_over_lead_time"
    FROM
      (
        SELECT
          date_from :: timestamp as "date_from",
          date_to :: timestamp as "date_to"
        FROM
          (
            VALUES
              (
                '2022-01-31T00:00:00.000',
                '2022-02-06T23:59:59.999'
              ),
              (
                '2022-02-07T00:00:00.000',
                '2022-02-13T23:59:59.999'
              ),
              -- ...redacted...
              (
                '2024-01-22T00:00:00.000',
                '2024-01-28T23:59:59.999'
              ),
              (
                '2024-01-29T00:00:00.000',
                '2024-02-04T23:59:59.999'
              )
          ) AS dates (date_from, date_to)
      ) AS "HSF.date_series"
      LEFT JOIN (
        SELECT
          date_trunc(
            'day',
            (
              "sales_sales_over_lead_time_cumulative__sales".date :: timestamptz AT TIME ZONE 'UTC'
            )
          ) "sales__date_week",
          "sales_sales_over_lead_time_cumulative__sales".lead_time "sales__lead_time", -- change #1, expose in select
          sum(
            "sales_sales_over_lead_time_cumulative__sales".quantity
          ) "sales__sales_over_lead_time"
        FROM
          sales AS "sales_sales_over_lead_time_cumulative__sales"
        WHERE
          (
            "sales_sales_over_lead_time_cumulative__sales".sku = $ 1
          )
          AND (
            (
              "sales_sales_over_lead_time_cumulative__sales".date :: timestamptz AT TIME ZONE 'UTC'
            ) >= $ 2 :: timestamp
            AND (
              "sales_sales_over_lead_time_cumulative__sales".date :: timestamptz AT TIME ZONE 'UTC'
            ) < $ 3 :: timestamp + interval '1' day * "sales_sales_over_lead_time_cumulative__sales".lead_time -- change #2, use in where
          )
        GROUP BY
          1, 2 -- change #3, added to grouping
      ) AS "sales_sales_over_lead_time_cumulative__base" ON "sales_sales_over_lead_time_cumulative__base"."sales__date_week" >= "HSF.date_series"."date_from"
      AND "sales_sales_over_lead_time_cumulative__base"."sales__date_week" < "HSF.date_series"."date_from" + interval '1' day * "sales_sales_over_lead_time_cumulative__base"."sales__lead_time" -- change #4, use in join condition
    GROUP BY
      1
  ) as q_0
ORDER BY
  1 ASC
LIMIT
  10000
```

---

The implementation asked for in #209/#223 should be possible to be expressed like this:
```js
{
  offset: 'start',
  trailing: {
    sql: `${INTERVAL.dateField} >= date_trunc('month', ${INTERVAL.startDate})`
  }
}
```

But since that isn't my usecase, I don't have a test for it, as I cannot figure out a plausible case.