### PR TITLE
fix(server-core): Fix dbType for baseDrivers & generic driverFactory

### DIFF
--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -247,11 +247,10 @@ export class OptsHandler {
         if (!this.driverFactoryType) {
           val = await driverFactory(ctx);
         }
-        if (
-          this.driverFactoryType === 'BaseDriver' &&
-          process.env.CUBEJS_DB_TYPE
-        ) {
-          type = <DatabaseType>process.env.CUBEJS_DB_TYPE;
+        if (this.driverFactoryType === 'BaseDriver') {
+          type = <DatabaseType>(process.env.CUBEJS_DB_TYPE || (await driverFactory(ctx)).constructor.name
+            .replace('Driver', '')
+            .toLowerCase());
         } else if (this.driverFactoryType === 'DriverConfig') {
           type = (<DriverConfig>(val || await driverFactory(ctx))).type;
         }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

When we setup the custom driverFactory handler in `cube.js` file we can get many db connections. 
An example: 
```
 driverFactory: ({ securityContext, dataSource }) => {
    if (dataSource === "datasource2" && securityContext.tenant === "local") {
      return new PostgresDriver({
        database: "database2",
      });
    }

    if (
      dataSource === "datasource3" &&
      securityContext.tenant === "clickhouse"
    ) {
      return new ClickhouseDriver({
        host: "",
      });
    }

    throw new Error("Unknown tenant in Security Context");
  },
```

To determine dbType for this case we get dbType from driverClassName 
