### PR TITLE
chore: Use correct link to the repository

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,5 +1,5 @@
 "help wanted":
     comment: |
         If you are interested in working on this issue, please leave a comment below and we will be happy to assign the issue to you.
-        If this is the first time you are contributing a Pull Request to Cube.js, please check our [contribution guidelines](https://github.com/cube-js/cube.js/blob/master/CONTRIBUTING.md).
+        If this is the first time you are contributing a Pull Request to Cube.js, please check our [contribution guidelines](https://github.com/cube-js/cube/blob/master/CONTRIBUTING.md).
         You can also post any questions while contributing in the #contributors channel in the [Cube.js Slack](https://slack.cube.dev/).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -609,7 +609,7 @@ jobs:
             cross: true
             # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
             strip: false
-            # UPX is broken, issue https://github.com/cube-js/cube.js/issues/4474
+            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
             compress: false
       fail-fast: false
     steps:

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -207,7 +207,7 @@ jobs:
             cross: true
             # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
             strip: false
-            # UPX is broken, issue https://github.com/cube-js/cube.js/issues/4474
+            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
             compress: false
       fail-fast: false
     steps:

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -147,7 +147,7 @@ jobs:
             cross: true
             # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
             strip: false
-            # UPX is broken, issue https://github.com/cube-js/cube.js/issues/4474
+            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
             compress: false
       fail-fast: false
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,15 +18,15 @@ Please review the following sections before proposing code changes.
 
 ### Developer Certificate of Origin (DCO)
 
-By contributing to Cube Dev, Inc., You accept and agree to the terms and conditions in the [Developer Certificate of Origin](https://github.com/cube-js/cube.js/blob/master/DCO.md) for Your present and future Contributions submitted to Cube Dev, Inc. Your contribution includes any submissions to the [Cube.js repository](https://github.com/cube-js) when you click on such buttons as `Propose changes` or `Create pull request`. Except for the licenses granted herein, You reserve all right, title, and interest in and to Your Contributions.
+By contributing to Cube Dev, Inc., You accept and agree to the terms and conditions in the [Developer Certificate of Origin](https://github.com/cube-js/cube/blob/master/DCO.md) for Your present and future Contributions submitted to Cube Dev, Inc. Your contribution includes any submissions to the [Cube.js repository](https://github.com/cube-js) when you click on such buttons as `Propose changes` or `Create pull request`. Except for the licenses granted herein, You reserve all right, title, and interest in and to Your Contributions.
 
 ### Our quarterly roadmap
 
-We publish our open source roadmap every quarter and discuss them during our [monthly community calls](https://cube.dev/community-call/). You can find our roadmap under [projects in our Cube.js repository](https://github.com/cube-js/cube.js/projects?query=is%3Aopen+sort%3Aupdated-desc). 
+We publish our open source roadmap every quarter and discuss them during our [monthly community calls](https://cube.dev/community-call/). You can find our roadmap under [projects in our Cube.js repository](https://github.com/cube-js/cube/projects?query=is%3Aopen+sort%3Aupdated-desc). 
 
 ## Step-by-step guide to contributing
 
-1. Find [issues](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) where we need help. Search for issues with either [`good first issue`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+) and/or [`help wanted`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22) labels.
+1. Find [issues](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) where we need help. Search for issues with either [`good first issue`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+) and/or [`help wanted`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22) labels.
 2. Follow the directions in the [Getting Started guide](https://cube.dev/docs/getting-started) to get Cube.js up and running (incl. the [Developer Playground](https://cube.dev/docs/dev-tools/dev-playground)). 
 3. Clone the [Cube.js repo](https://github.com/cube-js/cube.js).
 4. Submit your Pull Request. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,12 @@ We publish our open source roadmap every quarter and discuss them during our [mo
 
 ## Step-by-step guide to contributing
 
-1. Find [issues](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) where we need help. Search for issues with either [`good first issue`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+) and/or [`help wanted`](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22) labels.
+1. Find [issues](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) where we need help. Search for issues with either [`good first issue`](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22+) and/or [`help wanted`](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22) labels.
 2. Follow the directions in the [Getting Started guide](https://cube.dev/docs/getting-started) to get Cube.js up and running (incl. the [Developer Playground](https://cube.dev/docs/dev-tools/dev-playground)). 
-3. Clone the [Cube.js repo](https://github.com/cube-js/cube.js).
+3. Clone the [Cube.js repo](https://github.com/cube-js/cube).
 4. Submit your Pull Request. 
-5. Testing: Please include test(s) for your code contribution. See some of the test examples for [drivers](https://github.com/cube-js/cube.js/pull/1333/commits/56dadccd62ac4eaceafe650d2853406f5d3d9d43) and [backend](https://github.com/cube-js/cube.js/tree/master/packages/cubejs-backend-shared/test). 
-6. Documentation: When new features are added or there are changes to existing features that require updates to documentation, we encourage you to add/update any missing documentation in the [`/docs` folder](https://github.com/cube-js/cube.js/tree/master/docs). To update an existing documentation page, you can simply click on the `Edit this page` button on the top right corner of the documentation page. 
+5. Testing: Please include test(s) for your code contribution. See some of the test examples for [drivers](https://github.com/cube-js/cube/pull/1333/commits/56dadccd62ac4eaceafe650d2853406f5d3d9d43) and [backend](https://github.com/cube-js/cube/tree/master/packages/cubejs-backend-shared/test). 
+6. Documentation: When new features are added or there are changes to existing features that require updates to documentation, we encourage you to add/update any missing documentation in the [`/docs` folder](https://github.com/cube-js/cube/tree/master/docs). To update an existing documentation page, you can simply click on the `Edit this page` button on the top right corner of the documentation page. 
 7. Relevant team(s) will be pinged automatically for a review based on information in the `CODEOWNERS` file. 
 
 ## Development Workflow
@@ -82,7 +82,7 @@ $ cd packages/cubejs-client-core && yarn && yarn link && cd ../.. && cd packages
 If you are going to develop a JDBC driver, you need to [install Java with JDK][link-java-guide].
 
 [link-java-guide]:
-https://github.com/cube-js/cube.js/blob/master/packages/cubejs-jdbc-driver/README.md#java-installation
+https://github.com/cube-js/cube/blob/master/packages/cubejs-jdbc-driver/README.md#java-installation
 
 #### Development
 
@@ -91,7 +91,7 @@ Cube.js is written in a mixture of plain JavaScript and TypeScript. TypeScript i
 > Attention: Cube.js uses TypeScript configured in incremental mode, which uses cache to speed up compilation,  
 > but in some cases, you can run into a problem with a not recompiled file. To fix it, we recommend running `$ yarn clean` and `$ yarn tsc`.
 
-1. Clone the Cube.js repository, `git clone https://github.com/cube-js/cube.js`. 
+1. Clone the Cube.js repository, `git clone https://github.com/cube-js/cube`. 
 2. Run `yarn install` in the root directory.
 3. Run `yarn build` in the root directory to build the frontend dependent packages. 
 4. Run `yarn build` in `packages/cubejs-playground` to build the frontend.
@@ -119,7 +119,7 @@ To enhance the adoption of community-contributed drivers, we decided to split th
 2. This NPM package should be contributed to the list of [Third-party community drivers](https://cube.dev/docs/config/databases#third-party-community-drivers).
 3. Please make sure each npm package has a README with instructions on how to install it to the official docker image and how to connect it to the database.
 4. Posting a backlink to an open-source repository would be a good idea here so people can provide feedback on it by posting issues.
-5. Before creating PR for the main repository, please make sure it's tested with the standard Cube E2E testing suite. An example of an E2E testing suite can be found here: https://github.com/cube-js/cube.js/blob/master/packages/cubejs-testing/test/driver-postgres.test.ts
+5. Before creating PR for the main repository, please make sure it's tested with the standard Cube E2E testing suite. An example of an E2E testing suite can be found here: https://github.com/cube-js/cube/blob/master/packages/cubejs-testing/test/driver-postgres.test.ts
 6. If you're creating PR for the main repo, please be prepared to become a maintainer for this driver and dedicate some time to it. There're no specific time requirements. As a rule of thumb, you should expect to spend time on a weekly basis.
 7. Due to limited resources Core team will review and merge driver PRs based on popularity and development activity.
 
@@ -136,7 +136,7 @@ The rest will be done by `BaseDriver` class.
 6. If db requires connection pooling prefer use `generic-pool` implementation with settings similar to other db packages.
 7. Make sure your driver has `release()` method in case DB expects graceful shutdowns for connections.
 8. Please use yarn to add any dependencies and run `$ yarn` within the package before committing to ensure right `yarn.lock` is in place.
-9. Add this driver dependency to [cubejs-server-core/core/DriverDependencies.js](https://github.com/cube-js/cube.js/blob/master/packages/cubejs-server-core/core/DriverDependencies.js#L1).
+9. Add this driver dependency to [cubejs-server-core/core/DriverDependencies.js](https://github.com/cube-js/cube/blob/master/packages/cubejs-server-core/core/DriverDependencies.js#L1).
 
 ### Implementing a JDBC Driver
 

--- a/DCO.md
+++ b/DCO.md
@@ -10,7 +10,7 @@ contribute and that they understand that the contribution is under the terms of
 the [Cube.js project licenses][link-licenses].
 
 [link-licenses]:
-  https://github.com/cube-js/cube.js/blob/master/README.md#license
+  https://github.com/cube-js/cube/blob/master/README.md#license
 
 # Developer's Certificate of Origin
 
@@ -23,7 +23,7 @@ the licenses granted herein, You reserve all right, title, and interest in and
 to Your Contributions.
 
 [link-dco]: https://developercertificate.org/
-[link-cubejs-repo]: https://github.com/cube-js/cube.js
+[link-cubejs-repo]: https://github.com/cube-js/cube
 
 ```
 Developer Certificate of Origin

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Website](https://cube.dev?ref=github-readme) • [Getting Started](https://cube.dev/docs/getting-started?ref=github-readme) • [Docs](https://cube.dev/docs?ref=github-readme) • [Examples](https://cube.dev/docs/examples?ref=github-readme) • [Blog](https://cube.dev/blog?ref=github-readme) • [Slack](https://slack.cube.dev?ref=github-readme) • [Twitter](https://twitter.com/thecubejs)
 
 [![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
-[![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
+[![GitHub Actions](https://github.com/cube-js/cube/workflows/Build/badge.svg)](https://github.com/cube-js/cube/actions?query=workflow%3ABuild+branch%3Amaster)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcube-js%2Fcube.js.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcube-js%2Fcube.js?ref=badge_shield)
 
 __Cube is the semantic layer for building data applications.__ It helps data engineers and application developers access data from modern data stores, organize it into consistent definitions, and deliver it to every application.
@@ -82,7 +82,7 @@ You are also welcome to join our **monthly community calls** where we discuss co
 
 ### Our quarterly roadmap
 
-We publish our open source roadmap every quarter and discuss them during our [monthly community calls](https://cube.dev/community-call/). You can find our roadmap under [projects in our Cube.js repository](https://github.com/cube-js/cube.js/projects?query=is%3Aopen+sort%3Aupdated-desc). 
+We publish our open source roadmap every quarter and discuss them during our [monthly community calls](https://cube.dev/community-call/). You can find our roadmap under [projects in our Cube.js repository](https://github.com/cube-js/cube/projects?query=is%3Aopen+sort%3Aupdated-desc). 
 
 ### Contributing
 
@@ -93,9 +93,9 @@ There are many ways you can contribute to Cube! Here are a few possibilities:
 * Upvote issues with 👍 reaction so we know what's the demand for particular issue to prioritize it within road map.
 * Create issues every time you feel something is missing or goes wrong.
 * Ask questions on [Stack Overflow with cube.js tag](https://stackoverflow.com/questions/tagged/cube.js) if others can have these questions as well.
-* Provide pull requests for all open issues and especially for those with [help wanted](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") and [good first issue](https://github.com/cube-js/cube.js/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") labels.
+* Provide pull requests for all open issues and especially for those with [help wanted](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted") and [good first issue](https://github.com/cube-js/cube/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue") labels.
 
-All sort of contributions are **welcome and extremely helpful** 🙌 Please refer to [the contribution guide](https://github.com/cube-js/cube.js/blob/master/CONTRIBUTING.md) for more information.
+All sort of contributions are **welcome and extremely helpful** 🙌 Please refer to [the contribution guide](https://github.com/cube-js/cube/blob/master/CONTRIBUTING.md) for more information.
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.26.53](https://github.com/cube-js/cube.js/compare/v0.26.52...v0.26.53) (2021-03-11)
+## [0.26.53](https://github.com/cube-js/cube/compare/v0.26.52...v0.26.53) (2021-03-11)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -11,26 +11,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.49](https://github.com/cube-js/cube.js/compare/v0.26.48...v0.26.49) (2021-03-05)
+## [0.26.49](https://github.com/cube-js/cube/compare/v0.26.48...v0.26.49) (2021-03-05)
 
 
 ### Features
 
-* **elasticsearch-driver:** Support for elastic.co & improve docs ([#2240](https://github.com/cube-js/cube.js/issues/2240)) ([d8557f6](https://github.com/cube-js/cube.js/commit/d8557f6487ea98c19c055cc94b94b284dd273835))
+* **elasticsearch-driver:** Support for elastic.co & improve docs ([#2240](https://github.com/cube-js/cube/issues/2240)) ([d8557f6](https://github.com/cube-js/cube/commit/d8557f6487ea98c19c055cc94b94b284dd273835))
 
 
 
 
 
-## [0.26.46](https://github.com/cube-js/cube.js/compare/v0.26.45...v0.26.46) (2021-03-04)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.26.45](https://github.com/cube-js/cube.js/compare/v0.26.44...v0.26.45) (2021-03-04)
+## [0.26.46](https://github.com/cube-js/cube/compare/v0.26.45...v0.26.46) (2021-03-04)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -38,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.44](https://github.com/cube-js/cube.js/compare/v0.26.43...v0.26.44) (2021-03-02)
+## [0.26.45](https://github.com/cube-js/cube/compare/v0.26.44...v0.26.45) (2021-03-04)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -46,7 +38,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.40](https://github.com/cube-js/cube.js/compare/v0.26.39...v0.26.40) (2021-03-01)
+## [0.26.44](https://github.com/cube-js/cube/compare/v0.26.43...v0.26.44) (2021-03-02)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -54,7 +46,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.38](https://github.com/cube-js/cube.js/compare/v0.26.37...v0.26.38) (2021-02-26)
+## [0.26.40](https://github.com/cube-js/cube/compare/v0.26.39...v0.26.40) (2021-03-01)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -62,7 +54,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.36](https://github.com/cube-js/cube.js/compare/v0.26.35...v0.26.36) (2021-02-25)
+## [0.26.38](https://github.com/cube-js/cube/compare/v0.26.37...v0.26.38) (2021-02-26)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -70,7 +62,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.34](https://github.com/cube-js/cube.js/compare/v0.26.33...v0.26.34) (2021-02-25)
+## [0.26.36](https://github.com/cube-js/cube/compare/v0.26.35...v0.26.36) (2021-02-25)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -78,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.31](https://github.com/cube-js/cube.js/compare/v0.26.30...v0.26.31) (2021-02-23)
+## [0.26.34](https://github.com/cube-js/cube/compare/v0.26.33...v0.26.34) (2021-02-25)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -86,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.30](https://github.com/cube-js/cube.js/compare/v0.26.29...v0.26.30) (2021-02-22)
+## [0.26.31](https://github.com/cube-js/cube/compare/v0.26.30...v0.26.31) (2021-02-23)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -94,7 +86,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.29](https://github.com/cube-js/cube.js/compare/v0.26.28...v0.26.29) (2021-02-22)
+## [0.26.30](https://github.com/cube-js/cube/compare/v0.26.29...v0.26.30) (2021-02-22)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -102,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.20](https://github.com/cube-js/cube.js/compare/v0.26.19...v0.26.20) (2021-02-19)
+## [0.26.29](https://github.com/cube-js/cube/compare/v0.26.28...v0.26.29) (2021-02-22)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -110,73 +102,37 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.16](https://github.com/cube-js/cube.js/compare/v0.26.15...v0.26.16) (2021-02-18)
+## [0.26.20](https://github.com/cube-js/cube/compare/v0.26.19...v0.26.20) (2021-02-19)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.26.16](https://github.com/cube-js/cube/compare/v0.26.15...v0.26.16) (2021-02-18)
 
 
 ### Features
 
-* **druid-driver:** Support CUBEJS_DB_SSL ([d8124d0](https://github.com/cube-js/cube.js/commit/d8124d0a91c926ce0e1ffd21d6d057c164b01e79))
+* **druid-driver:** Support CUBEJS_DB_SSL ([d8124d0](https://github.com/cube-js/cube/commit/d8124d0a91c926ce0e1ffd21d6d057c164b01e79))
 
 
 
 
 
-## [0.26.15](https://github.com/cube-js/cube.js/compare/v0.26.14...v0.26.15) (2021-02-16)
-
-
-### Features
-
-* **clickhouse-driver:** HTTPS and readOnly support ([3d60ead](https://github.com/cube-js/cube.js/commit/3d60ead920635eb85c76b51a5c301e2f1fb08cb6))
-
-
-
-
-
-## [0.26.14](https://github.com/cube-js/cube.js/compare/v0.26.13...v0.26.14) (2021-02-15)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.26.13](https://github.com/cube-js/cube.js/compare/v0.26.12...v0.26.13) (2021-02-12)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.26.10](https://github.com/cube-js/cube.js/compare/v0.26.9...v0.26.10) (2021-02-09)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.26.7](https://github.com/cube-js/cube.js/compare/v0.26.6...v0.26.7) (2021-02-09)
+## [0.26.15](https://github.com/cube-js/cube/compare/v0.26.14...v0.26.15) (2021-02-16)
 
 
 ### Features
 
-* Support for Redis Sentinel + IORedis driver. fix [#1769](https://github.com/cube-js/cube.js/issues/1769) ([a5e7972](https://github.com/cube-js/cube.js/commit/a5e7972485fa97faaf9965b9794b0cf48256f484))
-* Use REDIS_URL for IORedis options (with santinels) ([988bfe5](https://github.com/cube-js/cube.js/commit/988bfe5526be3506fe7b773d247ad89b3287fad4))
+* **clickhouse-driver:** HTTPS and readOnly support ([3d60ead](https://github.com/cube-js/cube/commit/3d60ead920635eb85c76b51a5c301e2f1fb08cb6))
 
 
 
 
 
-## [0.26.6](https://github.com/cube-js/cube.js/compare/v0.26.5...v0.26.6) (2021-02-08)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.26.4](https://github.com/cube-js/cube.js/compare/v0.26.3...v0.26.4) (2021-02-02)
+## [0.26.14](https://github.com/cube-js/cube/compare/v0.26.13...v0.26.14) (2021-02-15)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -184,7 +140,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.26.2](https://github.com/cube-js/cube.js/compare/v0.26.1...v0.26.2) (2021-02-01)
+## [0.26.13](https://github.com/cube-js/cube/compare/v0.26.12...v0.26.13) (2021-02-12)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -192,26 +148,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.26.0](https://github.com/cube-js/cube.js/compare/v0.25.33...v0.26.0) (2021-02-01)
+## [0.26.10](https://github.com/cube-js/cube/compare/v0.26.9...v0.26.10) (2021-02-09)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.26.7](https://github.com/cube-js/cube/compare/v0.26.6...v0.26.7) (2021-02-09)
 
 
 ### Features
 
-* Storing userContext inside payload.u is deprecated, moved to root ([559bd87](https://github.com/cube-js/cube.js/commit/559bd8757d9754ab486eed88d1fdb0c280b82dc9))
+* Support for Redis Sentinel + IORedis driver. fix [#1769](https://github.com/cube-js/cube/issues/1769) ([a5e7972](https://github.com/cube-js/cube/commit/a5e7972485fa97faaf9965b9794b0cf48256f484))
+* Use REDIS_URL for IORedis options (with santinels) ([988bfe5](https://github.com/cube-js/cube/commit/988bfe5526be3506fe7b773d247ad89b3287fad4))
 
 
 
 
 
-## [0.25.32](https://github.com/cube-js/cube.js/compare/v0.25.31...v0.25.32) (2021-01-29)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.31](https://github.com/cube-js/cube.js/compare/v0.25.30...v0.25.31) (2021-01-28)
+## [0.26.6](https://github.com/cube-js/cube/compare/v0.26.5...v0.26.6) (2021-02-08)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -219,7 +176,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.25.28](https://github.com/cube-js/cube.js/compare/v0.25.27...v0.25.28) (2021-01-25)
+## [0.26.4](https://github.com/cube-js/cube/compare/v0.26.3...v0.26.4) (2021-02-02)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -227,7 +184,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.25.25](https://github.com/cube-js/cube.js/compare/v0.25.24...v0.25.25) (2021-01-24)
+## [0.26.2](https://github.com/cube-js/cube/compare/v0.26.1...v0.26.2) (2021-02-01)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -235,89 +192,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.25.23](https://github.com/cube-js/cube.js/compare/v0.25.22...v0.25.23) (2021-01-22)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.22](https://github.com/cube-js/cube.js/compare/v0.25.21...v0.25.22) (2021-01-21)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.21](https://github.com/cube-js/cube.js/compare/v0.25.20...v0.25.21) (2021-01-19)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.18](https://github.com/cube-js/cube.js/compare/v0.25.17...v0.25.18) (2021-01-14)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.14](https://github.com/cube-js/cube.js/compare/v0.25.13...v0.25.14) (2021-01-11)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.11](https://github.com/cube-js/cube.js/compare/v0.25.10...v0.25.11) (2021-01-04)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.25.4](https://github.com/cube-js/cube.js/compare/v0.25.3...v0.25.4) (2020-12-30)
+# [0.26.0](https://github.com/cube-js/cube/compare/v0.25.33...v0.26.0) (2021-02-01)
 
 
 ### Features
 
-* **server-core:** Compatibility shim, for legacy imports ([2116799](https://github.com/cube-js/cube.js/commit/21167995045d7a5c0d1056dc034b14ec18205277))
-* **server-core:** Introduce CUBEJS_PRE_AGGREGATIONS_SCHEMA, use dev_preaggregations/prod_preaggregations by default ([e5bdf3d](https://github.com/cube-js/cube.js/commit/e5bdf3dfbd28d5e1c1e775c554c275304a0941f3))
+* Storing userContext inside payload.u is deprecated, moved to root ([559bd87](https://github.com/cube-js/cube/commit/559bd8757d9754ab486eed88d1fdb0c280b82dc9))
 
 
 
 
 
-## [0.25.2](https://github.com/cube-js/cube.js/compare/v0.25.1...v0.25.2) (2020-12-27)
-
-
-### Features
-
-* Ability to set timeouts for polling in BigQuery/Athena ([#1675](https://github.com/cube-js/cube.js/issues/1675)) ([dc944b1](https://github.com/cube-js/cube.js/commit/dc944b1aaacc69dd74a9d9d31ceaf43e16d37ccd)), closes [#1672](https://github.com/cube-js/cube.js/issues/1672)
-
-
-
-
-
-## [0.25.1](https://github.com/cube-js/cube.js/compare/v0.25.0...v0.25.1) (2020-12-24)
-
-
-### Features
-
-* **elasticsearch-driver:** Support CUBEJS_DB_ELASTIC_QUERY_FORMAT, Thanks [@dylman79](https://github.com/dylman79) ([a7460f5](https://github.com/cube-js/cube.js/commit/a7460f5d45dc7e9d96b65f6cc36df810a5b9312e))
-
-
-
-
-
-# [0.25.0](https://github.com/cube-js/cube.js/compare/v0.24.15...v0.25.0) (2020-12-21)
+## [0.25.32](https://github.com/cube-js/cube/compare/v0.25.31...v0.25.32) (2021-01-29)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -325,12 +211,126 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.24.14](https://github.com/cube-js/cube.js/compare/v0.24.13...v0.24.14) (2020-12-19)
+## [0.25.31](https://github.com/cube-js/cube/compare/v0.25.30...v0.25.31) (2021-01-28)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.28](https://github.com/cube-js/cube/compare/v0.25.27...v0.25.28) (2021-01-25)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.25](https://github.com/cube-js/cube/compare/v0.25.24...v0.25.25) (2021-01-24)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.23](https://github.com/cube-js/cube/compare/v0.25.22...v0.25.23) (2021-01-22)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.22](https://github.com/cube-js/cube/compare/v0.25.21...v0.25.22) (2021-01-21)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.21](https://github.com/cube-js/cube/compare/v0.25.20...v0.25.21) (2021-01-19)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.18](https://github.com/cube-js/cube/compare/v0.25.17...v0.25.18) (2021-01-14)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.14](https://github.com/cube-js/cube/compare/v0.25.13...v0.25.14) (2021-01-11)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.11](https://github.com/cube-js/cube/compare/v0.25.10...v0.25.11) (2021-01-04)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.25.4](https://github.com/cube-js/cube/compare/v0.25.3...v0.25.4) (2020-12-30)
 
 
 ### Features
 
-* Add HTTP Post to cubejs client core ([#1608](https://github.com/cube-js/cube.js/issues/1608)). Thanks to [@mnifakram](https://github.com/mnifakram)! ([1ebd6a0](https://github.com/cube-js/cube.js/commit/1ebd6a04ac97b31c6a51ef63bb1d4c040e524190))
+* **server-core:** Compatibility shim, for legacy imports ([2116799](https://github.com/cube-js/cube/commit/21167995045d7a5c0d1056dc034b14ec18205277))
+* **server-core:** Introduce CUBEJS_PRE_AGGREGATIONS_SCHEMA, use dev_preaggregations/prod_preaggregations by default ([e5bdf3d](https://github.com/cube-js/cube/commit/e5bdf3dfbd28d5e1c1e775c554c275304a0941f3))
+
+
+
+
+
+## [0.25.2](https://github.com/cube-js/cube/compare/v0.25.1...v0.25.2) (2020-12-27)
+
+
+### Features
+
+* Ability to set timeouts for polling in BigQuery/Athena ([#1675](https://github.com/cube-js/cube/issues/1675)) ([dc944b1](https://github.com/cube-js/cube/commit/dc944b1aaacc69dd74a9d9d31ceaf43e16d37ccd)), closes [#1672](https://github.com/cube-js/cube/issues/1672)
+
+
+
+
+
+## [0.25.1](https://github.com/cube-js/cube/compare/v0.25.0...v0.25.1) (2020-12-24)
+
+
+### Features
+
+* **elasticsearch-driver:** Support CUBEJS_DB_ELASTIC_QUERY_FORMAT, Thanks [@dylman79](https://github.com/dylman79) ([a7460f5](https://github.com/cube-js/cube/commit/a7460f5d45dc7e9d96b65f6cc36df810a5b9312e))
+
+
+
+
+
+# [0.25.0](https://github.com/cube-js/cube/compare/v0.24.15...v0.25.0) (2020-12-21)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.24.14](https://github.com/cube-js/cube/compare/v0.24.13...v0.24.14) (2020-12-19)
+
+
+### Features
+
+* Add HTTP Post to cubejs client core ([#1608](https://github.com/cube-js/cube/issues/1608)). Thanks to [@mnifakram](https://github.com/mnifakram)! ([1ebd6a0](https://github.com/cube-js/cube.js/commit/1ebd6a04ac97b31c6a51ef63bb1d4c040e524190))
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -330,21 +330,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* Add HTTP Post to cubejs client core ([#1608](https://github.com/cube-js/cube/issues/1608)). Thanks to [@mnifakram](https://github.com/mnifakram)! ([1ebd6a0](https://github.com/cube-js/cube.js/commit/1ebd6a04ac97b31c6a51ef63bb1d4c040e524190))
+* Add HTTP Post to cubejs client core ([#1608](https://github.com/cube-js/cube/issues/1608)). Thanks to [@mnifakram](https://github.com/mnifakram)! ([1ebd6a0](https://github.com/cube-js/cube/commit/1ebd6a04ac97b31c6a51ef63bb1d4c040e524190))
 
 
 
 
 
-## [0.24.13](https://github.com/cube-js/cube.js/compare/v0.24.12...v0.24.13) (2020-12-18)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-
-
-
-
-## [0.24.11](https://github.com/cube-js/cube.js/compare/v0.24.10...v0.24.11) (2020-12-17)
+## [0.24.13](https://github.com/cube-js/cube/compare/v0.24.12...v0.24.13) (2020-12-18)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -352,7 +344,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.24.9](https://github.com/cube-js/cube.js/compare/v0.24.8...v0.24.9) (2020-12-16)
+## [0.24.11](https://github.com/cube-js/cube/compare/v0.24.10...v0.24.11) (2020-12-17)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+
+
+
+
+## [0.24.9](https://github.com/cube-js/cube/compare/v0.24.8...v0.24.9) (2020-12-16)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
@@ -365,23 +365,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.24.8](https://github.com/cube-js/cube.js/compare/v0.24.7...v0.24.8) (2020-12-15)
+## [0.24.8](https://github.com/cube-js/cube/compare/v0.24.7...v0.24.8) (2020-12-15)
 
 ### Features
 
 - **@cubejs-client/core:** Added pivotConfig option to alias series with a
-  prefix ([#1594](https://github.com/cube-js/cube.js/issues/1594)). Thanks to
+  prefix ([#1594](https://github.com/cube-js/cube/issues/1594)). Thanks to
   @MattGson!
-  ([a3342f7](https://github.com/cube-js/cube.js/commit/a3342f7fd0389ce3ad0bc62686c0e787de25f411))
+  ([a3342f7](https://github.com/cube-js/cube/commit/a3342f7fd0389ce3ad0bc62686c0e787de25f411))
 
-## [0.24.6](https://github.com/cube-js/cube.js/compare/v0.24.5...v0.24.6) (2020-12-13)
-
-**Note:** Version bump only for package @cubejs-docs/site
-
-## [0.24.5](https://github.com/cube-js/cube.js/compare/v0.24.4...v0.24.5) (2020-12-09)
+## [0.24.6](https://github.com/cube-js/cube/compare/v0.24.5...v0.24.6) (2020-12-13)
 
 **Note:** Version bump only for package @cubejs-docs/site
 
-## [0.24.4](https://github.com/cube-js/cube.js/compare/v0.24.3...v0.24.4) (2020-12-07)
+## [0.24.5](https://github.com/cube-js/cube/compare/v0.24.4...v0.24.5) (2020-12-09)
+
+**Note:** Version bump only for package @cubejs-docs/site
+
+## [0.24.4](https://github.com/cube-js/cube/compare/v0.24.3...v0.24.4) (2020-12-07)
 
 **Note:** Version bump only for package @cubejs-docs/site

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ scan the `docs/content/` folder and generate a static HTML site.
 
 [link-gatsby]: https://www.gatsbyjs.com/
 [link-docs-live]: https://cube.dev/docs
-[link-docs-content]: https://github.com/cube-js/cube.js/tree/master/docs/content
+[link-docs-content]: https://github.com/cube-js/cube/tree/master/docs/content
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git"
+    "url": "https://github.com/cube-js/cube.git"
   },
   "resolutions": {
     "@types/node": "^14",

--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-api-gateway"
   },
   "engines": {

--- a/packages/cubejs-athena-driver/package.json
+++ b/packages/cubejs-athena-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-athena-driver"
   },
   "engines": {

--- a/packages/cubejs-backend-maven/package.json
+++ b/packages/cubejs-backend-maven/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-druid-driver"
   },
   "engines": {

--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -7,7 +7,7 @@
   "typings": "dist/js/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cube-js/cube.js.git"
+    "url": "git+https://github.com/cube-js/cube.git"
   },
   "scripts": {
     "tsc": "tsc",

--- a/packages/cubejs-base-driver/package.json
+++ b/packages/cubejs-base-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-base-driver"
   },
   "engines": {

--- a/packages/cubejs-bigquery-driver/package.json
+++ b/packages/cubejs-bigquery-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-bigquery-driver"
   },
   "engines": {

--- a/packages/cubejs-cli/README.md
+++ b/packages/cubejs-cli/README.md
@@ -3,7 +3,7 @@
 [Website](https://cube.dev) • [Docs](https://cube.dev/docs) • [Blog](https://cube.dev/blog) • [Slack](https://slack.cube.dev) • [Twitter](https://twitter.com/thecubejs)
 
 [![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
-[![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
+[![GitHub Actions](https://github.com/cube-js/cube/workflows/Build/badge.svg)](https://github.com/cube-js/cube/actions?query=workflow%3ABuild+branch%3Amaster)
 
 # Cube.js CLI
 
@@ -19,7 +19,7 @@ Use:
 cubejs create hello-world -d postgres
 ```
 
-[Learn more](https://github.com/cube-js/cube.js#getting-started)
+[Learn more](https://github.com/cube-js/cube#getting-started)
 
 ## Tests
 

--- a/packages/cubejs-cli/package.json
+++ b/packages/cubejs-cli/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-cli"
   },
   "engines": {

--- a/packages/cubejs-clickhouse-driver/package.json
+++ b/packages/cubejs-clickhouse-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-clickhouse-driver"
   },
   "engines": {

--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -4,7 +4,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-client-core"
   },
   "description": "cube.js client",

--- a/packages/cubejs-client-dx/package.json
+++ b/packages/cubejs-client-dx/package.json
@@ -4,7 +4,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-client-dx"
   },
   "description": "Cube.js Client Developer eXperience",

--- a/packages/cubejs-client-ngx/package.json
+++ b/packages/cubejs-client-ngx/package.json
@@ -5,7 +5,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-client-ngx"
   },
   "description": "Cube.js client for Angular",

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -6,7 +6,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-client-react"
   },
   "description": "React components for cube.js",

--- a/packages/cubejs-client-ws-transport/package.json
+++ b/packages/cubejs-client-ws-transport/package.json
@@ -4,7 +4,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-client-ws-transport"
   },
   "description": "Cube.js WebSocket transport",

--- a/packages/cubejs-crate-driver/package.json
+++ b/packages/cubejs-crate-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-crate-driver"
   },
   "engines": {

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.8",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-cubestore-driver"
   },
   "engines": {

--- a/packages/cubejs-databricks-jdbc-driver/package.json
+++ b/packages/cubejs-databricks-jdbc-driver/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-databricks-driver"
   },
   "engines": {

--- a/packages/cubejs-dbt-schema-extension/package.json
+++ b/packages/cubejs-dbt-schema-extension/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-dbt-schema-extension"
   },
   "engines": {

--- a/packages/cubejs-dremio-driver/package.json
+++ b/packages/cubejs-dremio-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-dremio-driver"
   },
   "engines": {

--- a/packages/cubejs-druid-driver/package.json
+++ b/packages/cubejs-druid-driver/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-druid-driver"
   },
   "engines": {

--- a/packages/cubejs-elasticsearch-driver/package.json
+++ b/packages/cubejs-elasticsearch-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-elasticsearch-driver"
   },
   "engines": {

--- a/packages/cubejs-firebolt-driver/package.json
+++ b/packages/cubejs-firebolt-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-firebolt-driver"
   },
   "engines": {

--- a/packages/cubejs-hive-driver/package.json
+++ b/packages/cubejs-hive-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.5",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-hive-driver"
   },
   "engines": {

--- a/packages/cubejs-jdbc-driver/package.json
+++ b/packages/cubejs-jdbc-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-jdbc-driver"
   },
   "engines": {

--- a/packages/cubejs-ksql-driver/package.json
+++ b/packages/cubejs-ksql-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-ksql-driver"
   },
   "engines": {

--- a/packages/cubejs-linter/package.json
+++ b/packages/cubejs-linter/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-mssql-driver"
   },
   "engines": {

--- a/packages/cubejs-materialize-driver/package.json
+++ b/packages/cubejs-materialize-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-materialize-driver"
   },
   "engines": {

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-mongobi-driver"
   },
   "engines": {

--- a/packages/cubejs-mssql-driver/package.json
+++ b/packages/cubejs-mssql-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-mssql-driver"
   },
   "engines": {

--- a/packages/cubejs-mysql-aurora-serverless-driver/package.json
+++ b/packages/cubejs-mysql-aurora-serverless-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-mysql-aurora-serverless-driver"
   },
   "engines": {

--- a/packages/cubejs-mysql-driver/package.json
+++ b/packages/cubejs-mysql-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-mysql-driver"
   },
   "engines": {

--- a/packages/cubejs-oracle-driver/package.json
+++ b/packages/cubejs-oracle-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-oracle-driver"
   },
   "engines": {

--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -5,7 +5,7 @@
   "engines": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-playground"
   },
   "module": "lib/playground/index.js",

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-postgres-driver"
   },
   "engines": {

--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-prestodb-driver"
   },
   "engines": {

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-query-orchestrator"
   },
   "engines": {

--- a/packages/cubejs-questdb-driver/package.json
+++ b/packages/cubejs-questdb-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-questdb-driver"
   },
   "engines": {

--- a/packages/cubejs-redshift-driver/package.json
+++ b/packages/cubejs-redshift-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-postgres-driver"
   },
   "engines": {

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-schema-compiler"
   },
   "engines": {

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-server-core"
   },
   "engines": {

--- a/packages/cubejs-server/package.json
+++ b/packages/cubejs-server/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-server"
   },
   "engines": {

--- a/packages/cubejs-serverless-aws/package.json
+++ b/packages/cubejs-serverless-aws/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-serverless-aws"
   },
   "engines": {

--- a/packages/cubejs-serverless-google/package.json
+++ b/packages/cubejs-serverless-google/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-serverless-google"
   },
   "engines": {

--- a/packages/cubejs-serverless/package.json
+++ b/packages/cubejs-serverless/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.11",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-serverless"
   },
   "engines": {

--- a/packages/cubejs-snowflake-driver/package.json
+++ b/packages/cubejs-snowflake-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-snowflake-driver"
   },
   "engines": {

--- a/packages/cubejs-sqlite-driver/package.json
+++ b/packages/cubejs-sqlite-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-sqlite-driver"
   },
   "engines": {

--- a/packages/cubejs-testing/README.md
+++ b/packages/cubejs-testing/README.md
@@ -3,13 +3,13 @@
 [Website](https://cube.dev) • [Docs](https://cube.dev/docs) • [Blog](https://cube.dev/blog) • [Slack](https://slack.cube.dev) • [Twitter](https://twitter.com/thecubejs)
 
 [![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
-[![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
+[![GitHub Actions](https://github.com/cube-js/cube/workflows/Build/badge.svg)](https://github.com/cube-js/cube/actions?query=workflow%3ABuild+branch%3Amaster)
 
 # Cube.js Testing
 
 Internal package for testing.
 
-[Learn more](https://github.com/cube-js/cube.js#getting-started)
+[Learn more](https://github.com/cube-js/cube#getting-started)
 
 ### License
 

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -5,7 +5,7 @@
   "version": "0.32.10",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cube-js/cube.js.git",
+    "url": "https://github.com/cube-js/cube.git",
     "directory": "packages/cubejs-trino-driver"
   },
   "engines": {


### PR DESCRIPTION
Hello!

Issue: Lerna crashed on the release because we renamed our repository name...

Thanks