### PR TITLE
fix(cubestore): RocksStore - controll WAL ttls to protect logs uploading

### DIFF
--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -79,6 +79,7 @@ impl RocksStoreDetails for RocksCacheStoreDetails {
         opts.set_compaction_filter_factory(compaction::MetaStoreCacheCompactionFactory::new(
             compaction_state,
         ));
+        opts.set_wal_ttl_seconds(config.meta_store_log_upload_interval() * 2);
         // Disable automatic compaction before migration, will be enabled later in after_migration
         opts.set_disable_auto_compactions(true);
 

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -1152,6 +1152,7 @@ impl RocksStoreDetails for RocksMetaStoreDetails {
         opts.create_if_missing(true);
         opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(13));
         opts.set_merge_operator_associative("meta_store merge", meta_store_merge);
+        opts.set_wal_ttl_seconds(config.meta_store_log_upload_interval() * 2);
 
         let block_opts = {
             let mut block_opts = BlockBasedOptions::default();


### PR DESCRIPTION
Hello!

RocksStore snapshotting depends on WAL from RocksDB, but RocksDB uses 0 as default for WAL's TTL, which can lead to to a situation when RocksDB::get_updates_since can't return write batches. The previous versions of rust-rocks didn't return errors while iterating over the batches when the WAL was compacted.

Thanks