### PR TITLE
docs: fix - disable overscroll behaviour and make sidebar sticky on desktop

### DIFF
--- a/docs/src/components/Layout/MainMenu.tsx
+++ b/docs/src/components/Layout/MainMenu.tsx
@@ -94,6 +94,7 @@ const MainMenu: React.FC<Props> = (props = defaultProps) => {
     <Col
       {...layout.leftSidebar.width}
       xs={props.mobileMode === 'menu' ? 24 : 0}
+      className={cx(styles.menuWrapperCol)}
     >
       <div className={cx(styles.menuWrapper, styles.menuWrapperHack)}>
         <Menu {...menuProps} className={styles.antMenu}>

--- a/docs/static/styles/_layout.scss
+++ b/docs/static/styles/_layout.scss
@@ -1,6 +1,10 @@
 @import 'variables';
 @import 'mixins';
 
+body {
+  overscroll-behavior: none;
+}
+
 .algolia-autocomplete {
   line-height: 40px;
   width: 100%;
@@ -401,27 +405,34 @@ span.group-header {
 }
 
 .menuWrapperHack {
-  padding-top: 56px !important;
-  margin-top: -40px;
   @media screen and (max-width: 767px) {
+    height: 100% !important;
+    position: fixed;
+    top: 0;
     padding-top: 70px !important;
     margin-top: 0;
   }
 }
 
+.menuWrapperCol {
+  position: sticky;
+  top: 64px;
+}
+
 .menuWrapper {
-  height: 100%;
-  width: inherit;
+  // height: 100%;
+  height: calc(100vh - 64px);
+  width: 100%;
   background: $sidebar-bg;
-  padding: 16px 24px;
+  padding: 16px 24px 24px;
   overflow-y: auto;
   overflow-x: hidden;
-  position: fixed;
+  // position: fixed;
   //padding-left: calc(9999px + 24px);
   //padding-right: 24px;
   //margin-left: -9999px;
   //min-width: 245px;
-  max-height: calc(100% - 66px);
+  // max-height: calc(100% - 66px);
   //background: $light;
 
   @media screen and (max-width: 767px) {


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/827338/227882713-f9743dc0-0642-4897-85f6-15751edc4769.mp4

After:


- With Banner

https://user-images.githubusercontent.com/827338/227882959-2a03d36e-d3bd-4443-9c60-3450b5dbf2d6.mp4

- Without Banner

https://user-images.githubusercontent.com/827338/227882997-8fbf47ba-c4a3-4aff-a1d9-e3496b146788.mp4

- In Safari (witch overscrolling)

https://user-images.githubusercontent.com/827338/227883045-5275d19c-50cf-42b7-a2f9-7141e97b6881.mp4

