### PR TITLE
feat(schema): Introduce support for sqlTable

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1418,11 +1418,18 @@ class BaseQuery {
       }
       return this.preAggregations.originalSqlPreAggregationTable(foundPreAggregation);
     }
-    const evaluatedSql = this.evaluateSql(cube, this.cubeEvaluator.cubeFromPath(cube).sql);
+
+    const fromPath = this.cubeEvaluator.cubeFromPath(cube);
+    if (fromPath.sqlTable) {
+      return this.evaluateSql(cube, fromPath.sqlTable);
+    }
+
+    const evaluatedSql = this.evaluateSql(cube, fromPath.sql);
     const selectAsterisk = evaluatedSql.match(/^\s*select\s+\*\s+from\s+([a-zA-Z0-9_\-`".*]+)\s*$/i);
     if (selectAsterisk) {
       return selectAsterisk[1];
     }
+
     return `(${evaluatedSql})`;
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/index.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/index.ts
@@ -15,6 +15,7 @@ export * from './CubeStoreQuery';
 // Base queries that can be re-used across different drivers
 export * from './MysqlQuery';
 export * from './PostgresQuery';
+export * from './MssqlQuery';
 
 // Candidates to move from this package to drivers packages
 // export * from './PrestodbQuery';

--- a/packages/cubejs-schema-compiler/src/compiler/CompilerCache.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CompilerCache.ts
@@ -2,8 +2,11 @@ import LRUCache from 'lru-cache';
 import { QueryCache } from '../adapter/QueryCache';
 
 export class CompilerCache extends QueryCache {
-  constructor({ maxQueryCacheSize, maxQueryCacheAge }) {
+  protected readonly queryCache: LRUCache<string, QueryCache>;
+
+  public constructor({ maxQueryCacheSize, maxQueryCacheAge }) {
     super();
+
     this.queryCache = new LRUCache({
       max: maxQueryCacheSize || 10000,
       maxAge: (maxQueryCacheAge * 1000) || 1000 * 60 * 10,
@@ -11,11 +14,17 @@ export class CompilerCache extends QueryCache {
     });
   }
 
-  getQueryCache(key) {
+  public getQueryCache(key: unknown): QueryCache {
     const keyString = JSON.stringify(key);
-    if (!this.queryCache.get(keyString)) {
-      this.queryCache.set(keyString, new QueryCache());
+
+    const exist = this.queryCache.get(keyString);
+    if (exist) {
+      return exist;
     }
-    return this.queryCache.get(keyString);
+
+    const result = new QueryCache();
+    this.queryCache.set(keyString, result);
+
+    return result;
   }
 }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -37,12 +37,6 @@ export class CubeEvaluator extends CubeSymbols {
    * @protected
    */
   prepareCube(cube, errorReporter) {
-    if (cube.sqlTable) {
-      cube.sql = function sql(...args) {
-        return `SELECT * FROM ${cube.sqlTable(...args)}`;
-      };
-    }
-
     if (cube.preAggregations) {
       // eslint-disable-next-line no-restricted-syntax
       for (const preAggregation of Object.values(cube.preAggregations)) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -38,10 +38,8 @@ export class CubeEvaluator extends CubeSymbols {
    */
   prepareCube(cube, errorReporter) {
     if (cube.sqlTable) {
-      const sqlTable = cube.sqlTable(...args);
-
       cube.sql = function sql(...args) {
-        return `SELECT * FROM ${sqlTable(...args)}`;
+        return `SELECT * FROM ${cube.sqlTable(...args)}`;
       };
     }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -37,6 +37,14 @@ export class CubeEvaluator extends CubeSymbols {
    * @protected
    */
   prepareCube(cube, errorReporter) {
+    if (cube.sqlTable) {
+      const sqlTable = cube.sqlTable(...args);
+
+      cube.sql = function sql(...args) {
+        return `SELECT * FROM ${sqlTable(...args)}`;
+      };
+    }
+
     if (cube.preAggregations) {
       // eslint-disable-next-line no-restricted-syntax
       for (const preAggregation of Object.values(cube.preAggregations)) {
@@ -97,8 +105,9 @@ export class CubeEvaluator extends CubeSymbols {
   transformMembers(members, cube, errorReporter) {
     members = members || {};
     for (const memberName of Object.keys(members)) {
-      const member = members[memberName];
       let ownedByCube = true;
+
+      const member = members[memberName];
       if (member.sql && !member.subQuery) {
         const funcArgs = this.funcArguments(member.sql);
         const cubeReferences = this.collectUsedCubeReferences(cube.name, member.sql);
@@ -112,9 +121,11 @@ export class CubeEvaluator extends CubeSymbols {
           errorReporter.error(`Member '${cube.name}.${memberName}' references foreign cubes: ${foreignCubes.join(', ')}. Please split and move this definition to corresponding cubes.`);
         }
       }
+
       if (ownedByCube && cube.isView) {
         errorReporter.error(`View '${cube.name}' defines own member '${cube.name}.${memberName}'. Please move this member definition to one of the cubes.`);
       }
+
       members[memberName] = { ...members[memberName], ownedByCube };
     }
   }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -517,7 +517,7 @@ const cubeSchema = inherit(baseSchema, {
   sql: Joi.func(),
   sqlTable: Joi.func(),
 }).xor('sql', 'sqlTable').messages({
-  'object.xor': 'You must use only sql or sqlTable to define cube'
+  'object.xor': 'You must use either sql or sqlTable within a model, but not both'
 });
 
 const viewSchema = inherit(baseSchema, {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -450,17 +450,8 @@ const MeasuresSchema = Joi.object().pattern(identifierRegex, Joi.alternatives().
  * and update CubePropContextTranspiler.transpiledFieldsPatterns
  **************************** */
 
-const cubeSchema = Joi.object().keys({
+const baseSchema = {
   name: identifier,
-  sql: Joi.alternatives().conditional(
-    Joi.ref('..isView'), [
-      {
-        is: true,
-        then: Joi.forbidden(),
-        otherwise: Joi.func().required()
-      }
-    ]
-  ),
   refreshKey: CubeRefreshKeySchema,
   fileName: Joi.string().required(),
   extends: Joi.func(),
@@ -470,7 +461,6 @@ const cubeSchema = Joi.object().keys({
   dataSource: Joi.string(),
   description: Joi.string(),
   rewriteQueries: Joi.boolean().strict(),
-  isView: Joi.boolean().strict(),
   shown: Joi.boolean().strict(),
   joins: Joi.object().pattern(identifierRegex, Joi.object().keys({
     sql: Joi.func().required(),
@@ -521,6 +511,17 @@ const cubeSchema = Joi.object().keys({
   preAggregations: PreAggregationsAlternatives,
   includes: Joi.func(),
   excludes: Joi.func(),
+};
+
+const cubeSchema = inherit(baseSchema, {
+  sql: Joi.func(),
+  sqlTable: Joi.func(),
+}).xor('sql', 'sqlTable').messages({
+  'object.xor': 'You must use only sql or sqlTable to define cube'
+});
+
+const viewSchema = inherit(baseSchema, {
+  isView: Joi.boolean().strict(),
 });
 
 function formatErrorMessageFromDetails(explain, d) {
@@ -578,7 +579,7 @@ function collectFunctionFieldsPatterns(patterns, path, o) {
 
 export function functionFieldsPatterns() {
   const functionPatterns = new Set();
-  collectFunctionFieldsPatterns(functionPatterns, '', cubeSchema);
+  collectFunctionFieldsPatterns(functionPatterns, '', Object.assign({}, cubeSchema, viewSchema));
   return Array.from(functionPatterns);
 }
 
@@ -595,7 +596,7 @@ export class CubeValidator {
   }
 
   validate(cube, errorReporter) {
-    const result = cubeSchema.validate(cube);
+    const result = cube.isView ? viewSchema.validate(cube) : cubeSchema.validate(cube);
 
     if (result.error != null) {
       errorReporter.error(formatErrorMessage(result.error), result.error);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -579,7 +579,7 @@ function collectFunctionFieldsPatterns(patterns, path, o) {
 
 export function functionFieldsPatterns() {
   const functionPatterns = new Set();
-  collectFunctionFieldsPatterns(functionPatterns, '', Object.assign({}, cubeSchema, viewSchema));
+  collectFunctionFieldsPatterns(functionPatterns, '', { ...cubeSchema, ...viewSchema });
   return Array.from(functionPatterns);
 }
 

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.js
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.js
@@ -181,6 +181,7 @@ export class DataSchemaCompiler {
     if (err) {
       errorsReport.error(err.toString());
     }
+
     try {
       vm.runInNewContext(file.content, {
         view: (name, cube) => (

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -94,7 +94,7 @@ export class YamlCompiler {
       for (const p of transpiledFieldsPatterns) {
         const fullPath = propertyPath.join('.');
         if (fullPath.match(p)) {
-          if (typeof obj === 'string' && propertyPath[propertyPath.length - 1] === 'sql') {
+          if (typeof obj === 'string' && ['sql', 'sqlTable'].includes(propertyPath[propertyPath.length - 1])) {
             return this.parsePythonIntoArrowFunction(`f"${this.escapeDoubleQuotes(obj)}"`, cubeName, obj, errorsReport);
           } else if (typeof obj === 'string') {
             return this.parsePythonIntoArrowFunction(obj, cubeName, obj, errorsReport);

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
@@ -10,6 +10,7 @@ import type { CubeDictionary } from '../CubeDictionary';
 export const transpiledFieldsPatterns: Array<RegExp> = [
   /\.sql$/,
   /sql$/,
+  /sqlTable$/,
   /^measures\.[_a-zA-Z][_a-zA-Z0-9]*\.(drillMemberReferences|drillMembers)$/,
   /^preAggregations\.[_a-zA-Z][_a-zA-Z0-9]*\.indexes\.[_a-zA-Z][_a-zA-Z0-9]*\.columns$/,
   /^preAggregations\.[_a-zA-Z][_a-zA-Z0-9]*\.(timeDimensionReference|timeDimension|segments|dimensions|measures|rollups|segmentReferences|dimensionReferences|measureReferences|rollupReferences)$/,

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1,10 +1,30 @@
 import moment from 'moment-timezone';
 import { BaseQuery, PostgresQuery, MssqlQuery, UserError } from '../../src';
-import { prepareCompiler } from './PrepareCompiler';
-import { createCubeSchema, createJoinedCubesSchema } from './utils';
+import { prepareCompiler, prepareYamlCompiler } from './PrepareCompiler';
+import { createCubeSchema, createCubeSchemaYaml, createJoinedCubesSchema } from './utils';
 
 describe('SQL Generation', () => {
-  describe('Common - sqlTable', () => {
+  describe('Common - Yaml - syntax sugar', () => {
+    const compilers = /** @type Compilers */ prepareYamlCompiler(
+      createCubeSchemaYaml({ name: 'cards', sqlTable: 'card_tbl' })
+    );
+
+    it('Simple query', async () => {
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: [
+          'cards.count'
+        ],
+        timeDimensions: [],
+        filters: [],
+      });
+      const queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('card_tbl');
+    });
+  });
+
+  describe('Common - JS - syntax sugar', () => {
     const compilers = /** @type Compilers */ prepareCompiler(
       createCubeSchema({
         name: 'cards',
@@ -27,7 +47,7 @@ describe('SQL Generation', () => {
     });
   });
 
-  describe('Common', () => {
+  describe('Common - JS', () => {
     const compilers = /** @type Compilers */ prepareCompiler(
       createCubeSchema({
         name: 'cards',

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1,12 +1,32 @@
 import moment from 'moment-timezone';
-import { UserError } from '../../src/compiler/UserError';
-import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { BaseQuery, PostgresQuery, MssqlQuery, UserError } from '../../src';
 import { prepareCompiler } from './PrepareCompiler';
-import { MssqlQuery } from '../../src/adapter/MssqlQuery';
-import { BaseQuery } from '../../src';
 import { createCubeSchema, createJoinedCubesSchema } from './utils';
 
 describe('SQL Generation', () => {
+  describe('Common - sqlTable', () => {
+    const compilers = /** @type Compilers */ prepareCompiler(
+      createCubeSchema({
+        name: 'cards',
+        sqlTable: 'card_tbl'
+      })
+    );
+
+    it('Simple query', async () => {
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: [
+          'cards.count'
+        ],
+        timeDimensions: [],
+        filters: [],
+      });
+      const queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('card_tbl');
+    });
+  });
+
   describe('Common', () => {
     const compilers = /** @type Compilers */ prepareCompiler(
       createCubeSchema({

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -32,11 +32,11 @@ describe('Cube Validation', () => {
     expect(validationResult.error).toBeFalsy();
   });
 
-  it('cube defined with sql_table - correct', async () => {
+  it('cube defined with sqlTable - correct', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {
       name: 'name',
-      sql: () => 'public.Users',
+      sqlTable: () => 'public.Users',
       fileName: 'fileName',
     };
 
@@ -49,19 +49,19 @@ describe('Cube Validation', () => {
     expect(validationResult.error).toBeFalsy();
   });
 
-  it('cube defined with sql and sql_table - fail', async () => {
+  it('cube defined with sql and sqlTable - fail', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {
       name: 'name',
       sql: () => 'SELECT * FROM public.Users',
-      sql_table: () => 'public.Users',
+      sqlTable: () => 'public.Users',
       fileName: 'fileName',
     };
 
     const validationResult = cubeValidator.validate(cube, {
       error: (message, e) => {
         console.log(message);
-        expect(message).toContain('You must use only sql or sql_table to define cube');
+        expect(message).toContain('You must use only sql or sqlTable to define cube');
       }
     });
 

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -15,6 +15,77 @@ describe('Cube Validation', () => {
     console.log('CubePropContextTranspiler.transpiledFieldsPatterns =', transpiledFieldsPatterns);
   });
 
+  it('cube defined with sql - correct', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      sql: () => 'SELECT * FROM public.Users',
+      fileName: 'fileName',
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message, e) => {
+        console.log(message);
+      }
+    });
+
+    expect(validationResult.error).toBeFalsy();
+  });
+
+  it('cube defined with sql_table - correct', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      sql: () => 'public.Users',
+      fileName: 'fileName',
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message, e) => {
+        console.log(message);
+      }
+    });
+
+    expect(validationResult.error).toBeFalsy();
+  });
+
+  it('cube defined with sql and sql_table - fail', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      sql: () => 'SELECT * FROM public.Users',
+      sql_table: () => 'public.Users',
+      fileName: 'fileName',
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message, e) => {
+        console.log(message);
+        expect(message).toContain('You must use only sql or sql_table to define cube');
+      }
+    });
+
+    expect(validationResult.error).toBeTruthy();
+  });
+
+  it('view defined by includes - correct', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      // it's a hidden field which we use internally
+      isView: true,
+      fileName: 'fileName',
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message, e) => {
+        console.log(message);
+      }
+    });
+
+    expect(validationResult.error).toBeFalsy();
+  });
+
   it('refreshKey alternatives', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -61,7 +61,7 @@ describe('Cube Validation', () => {
     const validationResult = cubeValidator.validate(cube, {
       error: (message, e) => {
         console.log(message);
-        expect(message).toContain('You must use only sql or sqlTable to define cube');
+        expect(message).toContain('You must use either sql or sqlTable within a model, but not both');
       }
     });
 

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1,11 +1,9 @@
-import { CubeValidator } from '../../src/compiler/CubeValidator';
-import { CubeSymbols } from '../../src/compiler/CubeSymbols';
 import { prepareCompiler } from './PrepareCompiler';
 
 describe('pre-aggregations', () => {
   it('rollupJoin scheduledRefresh', async () => {
     process.env.CUBEJS_SCHEDULED_REFRESH_DEFAULT = 'true';
-    const { compiler, joinGraph, cubeEvaluator } = prepareCompiler(
+    const { compiler, cubeEvaluator } = prepareCompiler(
       `
         cube(\`Users\`, {
           sql: \`SELECT * FROM public.users\`,

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -8,7 +8,7 @@ interface CreateCubeSchemaOptions {
 export function createCubeSchema({ name, refreshKey = '', preAggregations = '', sqlTable }: CreateCubeSchemaOptions): string {
   return ` 
     cube('${name}', {
-        ${sqlTable ? `sqlTable: \`${sqlTable}\`` : `sql: \`select * from cards\``},
+        ${sqlTable ? `sqlTable: \`${sqlTable}\`` : 'sql: `select * from cards`'},
 
         ${refreshKey}
    
@@ -46,6 +46,35 @@ export function createCubeSchema({ name, refreshKey = '', preAggregations = '', 
             ${preAggregations}
         }
       }) 
+  `;
+}
+
+export function createCubeSchemaYaml({ name, sqlTable }: CreateCubeSchemaOptions): string {
+  return ` 
+    cubes:
+      - name: ${name}
+        sql_table: ${sqlTable}
+    
+        measures:
+          - name: count
+            type: count
+          - name: sum
+            type: sum
+            sql: amount
+          - name: min
+            sql: amount
+            type: min
+          - name: max
+            sql: amount
+            type: max
+        dimensions:
+          - name: id
+            sql: id
+            type: number
+            primary_key: true
+          - name: createdAt
+            sql: created_at
+            type: time
   `;
 }
 

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -1,21 +1,15 @@
 interface CreateCubeSchemaOptions {
   name: string,
+  sqlTable?: string,
   refreshKey?: string,
   preAggregations?: string,
 }
 
-/**
- * Returns test cube schema based on incoming parameters.
- * @param {CreateCubeSchemaOptions} param
- * @returns {string}
- */
-export function createCubeSchema({ name, refreshKey = '', preAggregations = '' }: CreateCubeSchemaOptions) {
+export function createCubeSchema({ name, refreshKey = '', preAggregations = '', sqlTable }: CreateCubeSchemaOptions): string {
   return ` 
     cube('${name}', {
-        sql: \`
-        select * from cards
-        \`,
-        
+        ${sqlTable ? `sqlTable: \`${sqlTable}\`` : `sql: \`select * from cards\``},
+
         ${refreshKey}
    
         measures: {
@@ -59,7 +53,6 @@ export function createCubeSchema({ name, refreshKey = '', preAggregations = '' }
  * Returns joined test cubes schema. Schema looks like: A -< B -< C >- D >- E.
  * The original data set can be found under the link.
  * {@link https://docs.google.com/spreadsheets/d/1BNDpA7x4JLhlvvPdrQIC0c0PH4xZhdRrEFfXdRW1j4U/edit?usp=sharing|Dataset}
- * @returns {string}
  */
 export function createJoinedCubesSchema(): string {
   return `


### PR DESCRIPTION
Hello!

This PR introduces syntax sugar. Instead of writing `sql: 'SELECT * FROM my_table'`, you can do `sqlTable: 'my_table'`.

Thanks