### PR TITLE
feat(cubesql): Support `date_trunc = literal date` filter

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -1,5 +1,6 @@
 use std::cmp::{max, min};
 
+use chrono::{Datelike, NaiveDateTime, Timelike};
 use datafusion::{physical_plan::aggregates::AggregateFunction, scalar::ScalarValue};
 
 pub fn parse_granularity_string(granularity: &str, to_normalize: bool) -> Option<String> {
@@ -148,6 +149,36 @@ pub fn reaggragate_fun(cube_fun: &str) -> Option<AggregateFunction> {
         "count" | "sum" => AggregateFunction::Sum,
         "min" => AggregateFunction::Min,
         "max" => AggregateFunction::Max,
+        _ => return None,
+    })
+}
+
+pub fn is_literal_date_trunced(ns: i64, granularity: &str) -> Option<bool> {
+    let granularity = parse_granularity_string(granularity, false)?;
+    let ns_in_seconds = 1_000_000_000;
+    if ns % ns_in_seconds > 0 {
+        return Some(false);
+    }
+    let seconds = ns / ns_in_seconds;
+    let dt = NaiveDateTime::from_timestamp_opt(seconds, 0)?;
+
+    let is_minute_trunced = |dt: NaiveDateTime| dt.second() == 0;
+    let is_hour_trunced = |dt| is_minute_trunced(dt) && dt.minute() == 0;
+    let is_day_trunced = |dt| is_hour_trunced(dt) && dt.hour() == 0;
+    let is_week_trunced = |dt| is_day_trunced(dt) && dt.weekday().num_days_from_monday() == 0;
+    let is_month_trunced = |dt| is_day_trunced(dt) && dt.day() == 1;
+    let is_quarter_trunced = |dt| is_month_trunced(dt) && dt.month0() % 3 == 0;
+    let is_year_trunced = |dt| is_month_trunced(dt) && dt.month() == 1;
+
+    Some(match granularity.as_str() {
+        "second" => true,
+        "minute" => is_minute_trunced(dt),
+        "hour" => is_hour_trunced(dt),
+        "day" => is_day_trunced(dt),
+        "week" => is_week_trunced(dt),
+        "month" => is_month_trunced(dt),
+        "quarter" => is_quarter_trunced(dt),
+        "year" => is_year_trunced(dt),
         _ => return None,
     })
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `date_trunc(granularity, time_dimension) = literal_date` filter expressions, such as `WHERE DATE_TRUNC('week', "pickupDate") = str_to_date('2022-11-14 00:00:00.000000', 'YYYY-MM-DD HH24:MI:[SS.US]')`.
A related test is included.
