### PR TITLE
docs: Move CORS configuration to the REST API page

### DIFF
--- a/docs/content/Configuration/Overview.mdx
+++ b/docs/content/Configuration/Overview.mdx
@@ -47,25 +47,6 @@ mode does the following:
 - Logs incorrect/invalid configuration for `externalRefresh` /`waitForRenew`
   instead of throwing errors
 
-## Configuring CORS
-
-The Cube REST API supports Cross-Origin Resource Sharing (CORS) for all API
-requests. By default, the middleware allows requests from any origin (`*`). To
-change the allowed domain, you can do the following:
-
-```javascript
-module.exports = {
-  http: {
-    cors: {
-      origin: 'https://myapp.com',
-    },
-  },
-};
-```
-
-Please consult the Configuration Reference [for more
-options][link-config-cors-opts].
-
 ## Concurrency and pooling
 
 <InfoBox>
@@ -85,7 +66,6 @@ default, you must ensure that the new value is greater than the number of
 concurrent connections used by Cube's query queues and refresh scheduler.
 
 [link-config]: /config
-[link-config-cors-opts]: /config#http
 [link-dev-playground]: /dev-tools/dev-playground
 [link-env-vars]: /reference/environment-variables
 [link-scheduled-refresh]: /schema/reference/pre-aggregations#scheduled-refresh

--- a/docs/content/REST-API/REST-API.mdx
+++ b/docs/content/REST-API/REST-API.mdx
@@ -42,8 +42,8 @@ curl -H "Authorization: EXAMPLE-API-TOKEN" https://example.com/cubejs-api/v1/sql
 
 REST API supports [Cross-Origin Resource Sharing (CORS)][cors].
 
-By default, requests from any origin (`*`) are allowed.
-To allow requests from a specific domain only, use the following configuration in the `cube.js` file:
+By default, requests from any origin (`*`) are allowed. To allow requests from a
+specific domain only, use the following configuration in the `cube.js` file:
 
 ```javascript
 module.exports = {

--- a/docs/content/REST-API/REST-API.mdx
+++ b/docs/content/REST-API/REST-API.mdx
@@ -38,6 +38,28 @@ you can still use it to pass a security context.
 curl -H "Authorization: EXAMPLE-API-TOKEN" https://example.com/cubejs-api/v1/sql
 ```
 
+### Configuring CORS
+
+REST API supports [Cross-Origin Resource Sharing (CORS)][cors].
+
+By default, requests from any origin (`*`) are allowed.
+To allow requests from a specific domain only, use the following configuration in the `cube.js` file:
+
+```javascript
+module.exports = {
+  http: {
+    cors: {
+      origin: 'https://example.com',
+    },
+  },
+};
+```
+
+Please see [configuration options][ref-config-cors] for details.
+
+[cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[ref-config-cors]: /config#http
+
 ### <--{"id" : "Prerequisites"}--> Continue wait
 
 If the request takes too long to be processed, Cube Backend responds with

--- a/docs/content/REST-API/REST-API.mdx
+++ b/docs/content/REST-API/REST-API.mdx
@@ -38,7 +38,7 @@ you can still use it to pass a security context.
 curl -H "Authorization: EXAMPLE-API-TOKEN" https://example.com/cubejs-api/v1/sql
 ```
 
-### Configuring CORS
+### <--{"id" : "Prerequisites"}--> Configuring CORS
 
 REST API supports [Cross-Origin Resource Sharing (CORS)][cors].
 


### PR DESCRIPTION
CORS configuration is irrelevant to the high-level configuration overview and should be placed under the REST API section.