### PR TITLE
docs: Add missing redirect

### DIFF
--- a/docs/content/Getting-Started/Core/01-Overview.mdx
+++ b/docs/content/Getting-Started/Core/01-Overview.mdx
@@ -6,6 +6,7 @@ subCategory: Cube Core
 menuOrder: 2
 redirect_from:
   - /getting-started-docker
+  - /getting-started/docker
 ---
 
 First, we'll create a new project, connect it to a database and generate a data


### PR DESCRIPTION
https://cube.dev/docs/getting-started/docker has moved to https://cube.dev/docs/getting-started/core/overview.