### PR TITLE
docs: Reference the pagination recipe from the mentions of the 50,000 row limit

### DIFF
--- a/docs/content/Examples-Tutorials-Recipes/Recipes/pagination.mdx
+++ b/docs/content/Examples-Tutorials-Recipes/Recipes/pagination.mdx
@@ -44,29 +44,43 @@ cube(`Orders`, {
 ## Query
 
 To select orders that belong to a particular page, we can use the `limit` and
-`offset` query properties. First, we get the number of all orders that we have.
-Then we should set the `limit` and `offset` properties for the queries that will
-get the orders from the Cube API.
+`offset` query properties. First, let's get the number of all orders that we have.
 
-```bash{outputLines: 1,3-4}
-# Get count of the orders
-curl cube:4000/cubejs-api/v1/load \
-  -H "Authorization: eeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoib3BlcmF0b3IiLCJpYXQiOjE2Mjg3NDUwNDUsImV4cCI6MTgwMTU0NTA0NX0.VErb2t7Bc43ryRwaOiEgXuU5KiolCT-69eI_i2pRq4o" \
-  "query={"measures": ["Orders.count"]}"
+```json
+{
+  "measures": [
+    "Orders.count"
+  ]
+}
 ```
 
-```bash{outputLines: 1,3-4}
-# Get first five orders
-curl cube:4000/cubejs-api/v1/load \
-  -H "Authorization: eeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoib3BlcmF0b3IiLCJpYXQiOjE2Mjg3NDUwNDUsImV4cCI6MTgwMTU0NTA0NX0.VErb2t7Bc43ryRwaOiEgXuU5KiolCT-69eI_i2pRq4o" \
-  "query={"order": [["Orders.number", "asc"]], "dimensions": ["Orders.number"], "limit": 5}"
+Then, let's retrieve first batch (page) of five orders:
+
+```json
+{
+  "dimensions": [
+    "Orders.number"
+  ],
+  "order": {
+    "Orders.number": "asc"
+  },
+  "limit": 5
+}
 ```
 
-```bash{outputLines: 1,3-4}
-# Get next five orders
-curl cube:4000/cubejs-api/v1/load \
-  -H "Authorization: eeyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoib3BlcmF0b3IiLCJpYXQiOjE2Mjg3NDUwNDUsImV4cCI6MTgwMTU0NTA0NX0.VErb2t7Bc43ryRwaOiEgXuU5KiolCT-69eI_i2pRq4o" \
-  "query={"order": [["Orders.number", "asc"]], "dimensions": ["Orders.number"], "limit": 5, "offset": 5}"
+Now, let's retrieve the second batch (page) of five orders:
+
+```json
+{
+  "dimensions": [
+    "Orders.number"
+  ],
+  "order": {
+    "Orders.number": "asc"
+  },
+  "limit": 5,
+  "offset": 5
+}
 ```
 
 ## Result

--- a/docs/content/REST-API/Query-Format.mdx
+++ b/docs/content/REST-API/Query-Format.mdx
@@ -35,7 +35,8 @@ A Query has the following properties:
 - `segments`: An array of segments. A segment is a named filter, created in the
   Data Schema.
 - `limit`: A row limit for your query. The default value is `10000`. The maximum
-  allowed limit is `50000`.
+  allowed limit is `50000`. If you'd like to request more rows than the maximum
+  allowed limit, consider using [pagination][ref-recipe-pagination].
 - `offset`: The number of initial rows to be skipped for your query. The default
   value is `0`.
 - `order`: An object, where the keys are measures or dimensions to order by and
@@ -590,6 +591,7 @@ date. If you need the current date also you can use `from N days ago to now` or
 }
 ```
 
+[ref-recipe-pagination]: /recipes/pagination
 [ref-client-core-resultset-drilldown]:
   /@cubejs-client-core#result-set-drill-down
 [ref-schema-ref-preaggs-refreshkey]:

--- a/docs/content/Reference/GraphQL-API/GraphQL-API.mdx
+++ b/docs/content/Reference/GraphQL-API/GraphQL-API.mdx
@@ -25,13 +25,15 @@ query {
 
 ## `CubeQueryArgs`
 
-| Key          | Schema                                | Description                                                                                                                                      |
-| ------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `where`      | [`RootWhereInput`](#root-where-input) | Represents a SQL `WHERE` clause                                                                                                                  |
-| `limit`      | `Int`                                 | A row limit for your query. The default value is `10000`. The maximum allowed limit is `50000`                                                   |
-| `offset`     | `Int`                                 | The number of initial rows to be skipped for your query. The default value is `0`                                                                |
-| `timezone`   | `String`                              | The timezone to use for the query. The default value is `UTC`                                                                                    |
-| `renewQuery` | `Boolean`                             | If `renewQuery` is set to `true`, Cube will renew all `refreshKey` for queries and query results in the foreground. The default value is `false` |
+| Key          | Schema                                | Description                                                                                                                                                                                                            |
+| ------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `where`      | [`RootWhereInput`](#root-where-input) | Represents a SQL `WHERE` clause                                                                                                                                                                                        |
+| `limit`      | `Int`                                 | A row limit for your query. The default value is `10000`. The maximum allowed limit is `50000`. If you'd like to request more rows than the maximum allowed limit, consider using [pagination][ref-recipe-pagination]. |
+| `offset`     | `Int`                                 | The number of initial rows to be skipped for your query. The default value is `0`                                                                                                                                      |
+| `timezone`   | `String`                              | The timezone to use for the query. The default value is `UTC`                                                                                                                                                          |
+| `renewQuery` | `Boolean`                             | If `renewQuery` is set to `true`, Cube will renew all `refreshKey` for queries and query results in the foreground. The default value is `false`                                                                       |
+
+[ref-recipe-pagination]: /recipes/pagination
 
 ## `RootWhereInput`
 

--- a/docs/content/SQL-API/Overview.mdx
+++ b/docs/content/SQL-API/Overview.mdx
@@ -193,7 +193,7 @@ time dimension date ranges whenever it's possible.
 Cube tries to push down all `ORDER BY` statements into Cube Query.
 
 If it can't be done ordering part would be done in a post-processing phase. In
-case there are more than 50k rows in the result set, incorrect results can be
+case there are more than 50,000 rows in the result set, incorrect results can be
 received in this case. Please use `EXPLAIN` in order to check if it's the case.
 
 Consider the following query.
@@ -223,14 +223,14 @@ see below, the sorting operation is done after Cube query and projection.
 +--- CubeScanExecutionPlan
 ```
 
-Because of the default limit in Cube queries (50k rows), there is a possibility
-of a wrong result if there are more than 50k rows. Given that queries to Cube
-are usually aggregated, it is rare that they may return more than 50k rows, but
+Because of the default limit in Cube queries (50,000 rows), there is a possibility
+of a wrong result if there are more than 50,000 rows. Given that queries to Cube
+are usually aggregated, it is rare that they may return more than 50,000 rows, but
 keep that limitation in mind when designing your queries.
 
 ### <--{"id" : "Querying cube tables"}--> Limit
 
-Limit push down is supported by Cube however, a limit over 50k can't be
+Limit push down is supported by Cube however, a limit over 50,000 can't be
 overridden. In future versions, paging and streaming would be used to avoid this
 limitation.
 


### PR DESCRIPTION
The pagination recipe provides a workaround for the 50,000 row limit.