### PR TITLE
Fix cubestore postinstall script inside yarn workspaces and npm >= 7

### DIFF
--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -48,7 +48,8 @@
     "node-fetch": "^2.6.1",
     "shelljs": "^0.8.5",
     "throttle-debounce": "^3.0.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "npm-conf": "^1.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-backend-shared/src/proxy.ts
+++ b/packages/cubejs-backend-shared/src/proxy.ts
@@ -1,27 +1,10 @@
-import { exec } from 'child_process';
 import HttpsProxyAgent from 'http-proxy-agent';
-
-function getCommandOutput(command: string) {
-  return new Promise<string>((resolve, reject) => {
-    exec(command, (error, stdout) => {
-      if (error) {
-        reject(error.message);
-        return;
-      }
-
-      resolve(stdout);
-    });
-  });
-}
+// @ts-ignore
+import npmConf from 'npm-conf';
 
 export async function getProxySettings() {
-  const [proxy] = (
-    await Promise.all([getCommandOutput('npm config -g get https-proxy'), getCommandOutput('npm config -g get proxy')])
-  )
-    .map((s) => s.trim())
-    .filter((s) => !['null', 'undefined', ''].includes(s));
-
-  return proxy;
+  const conf = npmConf();
+  return conf.get('https-proxy') ?? conf.get('proxy');
 }
 
 export async function getHttpAgentForProxySettings() {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**



**Description of Changes Made (if issue reference is not provided)**

This pull request resolves an issue that arises in a yarn monorepo with npm version 7 or higher, where the error `Command failed: npm config get proxy TypeError: workspaces config expects an Array` occurs.


