### PR TITLE
feature (firebolt-driver) timestamptz support

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -15,11 +15,22 @@ export class FireboltQuery extends BaseQuery {
   public paramAllocator!: ParamAllocator;
 
   public convertTz(field: string) {
-    return field;
+    return `${field} AT TIME ZONE '${this.timezone}'`;
   }
 
   public timeStampCast(value: string) {
-    return `${value}::timestamp`;
+    return `${value}::timestamptz`;
+  }
+
+  public dateTimeCast(value: string) {
+    return `${value}::timestampntz`;
+  }
+
+  seriesSql(timeDimension: any) {
+    const values = timeDimension.timeSeries().map(
+      ([from, to]: [string, string]) => `select '${from}' f, '${to}' t`
+    ).join(' UNION ALL ');
+    return `SELECT ${this.dateTimeCast('dates.f')} date_from, ${this.dateTimeCast('dates.t')} date_to FROM (${values}) AS dates`;
   }
 
   public timeGroupedColumn(granularity: string, dimension: string) {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**
Firebolt recently started to support new time data types: `timestamptz` and `timestampntz` and will deprecate `timestamp` data type. This pr adds proper timestamp casting, timezone conversion syntax to firebolt driver