### PR TITLE
fix (firebolt-driver) cast boolean params

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -1,4 +1,4 @@
-import { BaseQuery, ParamAllocator } from '@cubejs-backend/schema-compiler';
+import { BaseFilter, BaseQuery, ParamAllocator } from '@cubejs-backend/schema-compiler';
 
 const GRANULARITY_TO_INTERVAL: Record<string, string> = {
   day: 'DAY',
@@ -10,6 +10,16 @@ const GRANULARITY_TO_INTERVAL: Record<string, string> = {
   quarter: 'QUARTER',
   year: 'YEAR'
 };
+
+class FireboltFilter extends BaseFilter {
+  public castParameter() {
+    if (this.definition().type === 'boolean') {
+      return 'CAST(? AS BOOLEAN)';
+    }
+
+    return '?';
+  }
+}
 
 export class FireboltQuery extends BaseQuery {
   public paramAllocator!: ParamAllocator;
@@ -24,5 +34,9 @@ export class FireboltQuery extends BaseQuery {
 
   public timeGroupedColumn(granularity: string, dimension: string) {
     return `DATE_TRUNC('${GRANULARITY_TO_INTERVAL[granularity]}', ${dimension})`;
+  }
+
+  public newFilter(filter: any) {
+    return new FireboltFilter(this, filter);
   }
 }

--- a/packages/cubejs-firebolt-driver/test/FireboltQuery.test.ts
+++ b/packages/cubejs-firebolt-driver/test/FireboltQuery.test.ts
@@ -25,7 +25,11 @@ cube(\`sales\`, {
     salesDatetime: {
       type: 'time',
       sql: 'sales_datetime'
-    }
+    },
+    isShiped: {
+      type: 'boolean',
+      sql: 'is_shiped',
+    },
   }
 });
 `,
@@ -58,4 +62,28 @@ cube(\`sales\`, {
       'DATE_TRUNC(\'DAY\', "sales".sales_datetime)'
     );
   }));
-});
+
+  it('should cast BOOLEAN', () => compiler.compile().then(() => {
+    const query = new FireboltQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      {
+        measures: ['sales.count'],
+        filters: [
+          {
+            member: "sales.isShiped",
+            operator: "equals",
+            values: ["true"]
+          }
+        ]
+      }
+    )
+
+    const queryAndParams = query.buildSqlAndParams();
+
+    expect(queryAndParams[0]).toContain(
+      '("sales".is_shiped = CAST(? AS BOOL))'
+    );
+
+    expect(queryAndParams[1]).toEqual(["true"]);
+  }))
+})


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

Cube.js by default generate sql that is not supported by firebolt yet. (compare boolean column with "true", "false" string values)
This pr will fix issue with queries such as `select * from a_table where a_boolean = "true"`  by casting boolean parameters using `cast` syntax