### PR TITLE
feat(cubestore): Queue - allow to do merge_extra, heartbeat by processingId

### DIFF
--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -248,6 +248,10 @@ impl CacheStore for LazyRocksCacheStore {
         self.init().await?.queue_cancel_by_path(path).await
     }
 
+    async fn queue_heartbeat_by_id(&self, id: u64) -> Result<(), CubeError> {
+        self.init().await?.queue_heartbeat_by_id(id).await
+    }
+
     async fn queue_heartbeat_by_path(&self, path: String) -> Result<(), CubeError> {
         self.init().await?.queue_heartbeat_by_path(path).await
     }
@@ -286,6 +290,13 @@ impl CacheStore for LazyRocksCacheStore {
         self.init()
             .await?
             .queue_result_blocking_by_path(path, timeout)
+            .await
+    }
+
+    async fn queue_merge_extra_by_id(&self, id: u64, payload: String) -> Result<(), CubeError> {
+        self.init()
+            .await?
+            .queue_merge_extra_by_id(id, payload)
             .await
     }
 

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -788,6 +788,10 @@ impl CacheStore for CacheStoreMock {
         panic!("CacheStore mock!")
     }
 
+    async fn queue_heartbeat_by_id(&self, _id: u64) -> Result<(), CubeError> {
+        panic!("CacheStore mock!")
+    }
+
     async fn queue_heartbeat_by_path(&self, _path: String) -> Result<(), CubeError> {
         panic!("CacheStore mock!")
     }
@@ -820,6 +824,10 @@ impl CacheStore for CacheStoreMock {
         _path: String,
         _timeout: u64,
     ) -> Result<Option<QueueResultResponse>, CubeError> {
+        panic!("CacheStore mock!")
+    }
+
+    async fn queue_merge_extra_by_id(&self, _id: u64, _payload: String) -> Result<(), CubeError> {
         panic!("CacheStore mock!")
     }
 

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -235,10 +235,10 @@ impl<'a> CubeStoreParser<'a> {
 
                 Ok(QueueKey::ByPath(w.to_ident().value))
             }
-            Token::SingleQuotedString(s) => {
+            Token::SingleQuotedString(v) => {
                 self.parser.next_token();
 
-                Ok(QueueKey::ByPath(Ident::with_quote('\'', s).value))
+                Ok(QueueKey::ByPath(v))
             }
             _ => Ok(QueueKey::ById(self.parse_integer("id", false)?)),
         }

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -91,6 +91,12 @@ pub enum CacheCommand {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum QueueKey {
+    ById(u64),
+    ByPath(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum QueueCommand {
     Add {
         priority: i64,
@@ -116,14 +122,14 @@ pub enum QueueCommand {
         key: Ident,
     },
     Heartbeat {
-        key: Ident,
+        key: QueueKey,
     },
     Ack {
         key: Ident,
         result: Option<String>,
     },
     MergeExtra {
-        key: Ident,
+        key: QueueKey,
         payload: String,
     },
     Retrieve {
@@ -219,6 +225,22 @@ impl<'a> CubeStoreParser<'a> {
                 _ => Ok(Statement::Statement(self.parser.parse_statement()?)),
             },
             _ => Ok(Statement::Statement(self.parser.parse_statement()?)),
+        }
+    }
+
+    fn parse_queue_key(&mut self) -> Result<QueueKey, ParserError> {
+        match self.parser.peek_token() {
+            Token::Word(w) => {
+                self.parser.next_token();
+
+                Ok(QueueKey::ByPath(w.to_ident().value))
+            }
+            Token::SingleQuotedString(s) => {
+                self.parser.next_token();
+
+                Ok(QueueKey::ByPath(Ident::with_quote('\'', s).value))
+            }
+            _ => Ok(QueueKey::ById(self.parse_integer("id", false)?)),
         }
     }
 
@@ -416,7 +438,7 @@ impl<'a> CubeStoreParser<'a> {
                 key: self.parser.parse_identifier()?,
             },
             "heartbeat" => QueueCommand::Heartbeat {
-                key: self.parser.parse_identifier()?,
+                key: self.parse_queue_key()?,
             },
             "ack" => {
                 let key = self.parser.parse_identifier()?;
@@ -429,7 +451,7 @@ impl<'a> CubeStoreParser<'a> {
                 QueueCommand::Ack { key, result }
             }
             "merge_extra" => QueueCommand::MergeExtra {
-                key: self.parser.parse_identifier()?,
+                key: self.parse_queue_key()?,
                 payload: self.parser.parse_literal_string()?,
             },
             "get" => QueueCommand::Get {


### PR DESCRIPTION
Hello!

This PR introduces support for doing `HEARTBEAT` and `MERGE_EXRA` with `id` to protect race conditions.

Thanks