### PR TITLE
force ordering by column name

### DIFF
--- a/packages/cubejs-base-driver/src/BaseDriver.ts
+++ b/packages/cubejs-base-driver/src/BaseDriver.ts
@@ -370,7 +370,9 @@ export abstract class BaseDriver implements DriverInterface {
              columns.table_schema as ${this.quoteIdentifier('table_schema')},
              columns.data_type  as ${this.quoteIdentifier('data_type')}
       FROM information_schema.columns
-      WHERE table_name = ${this.param(0)} AND table_schema = ${this.param(1)}`,
+      WHERE table_name = ${this.param(0)} AND table_schema = ${this.param(1)}
+      ORDER BY columns.column_name
+      `,
       [name, schema]
     );
 


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[6023] - When querying `information_schema.columns` Redshift can sometimes return columns not in their ordinal position. When unloading a partitioned pre-aggregate to the export bucket, column orders may differ between partitions, causing any queries that use mismatched partitions to fail. 

**Description of Changes Made (if issue reference is not provided)**

Added an `order by` statement to `tableColumnTypes` query forcing columns to alway be returned in alphabetical order. 