### PR TITLE
Fix incorrect index in movePivotItem

### DIFF
--- a/packages/cubejs-client-core/src/utils.js
+++ b/packages/cubejs-client-core/src/utils.js
@@ -288,6 +288,7 @@ export function movePivotItem(
   if (id === 'measures') {
     destinationIndex = lastIndex + 1;
   } else if (
+    sourceAxis === destinationAxis &&
     destinationIndex >= lastIndex &&
     nextPivotConfig[destinationAxis][lastIndex] === 'measures'
   ) {

--- a/packages/cubejs-client-core/src/utils.js
+++ b/packages/cubejs-client-core/src/utils.js
@@ -298,7 +298,7 @@ export function movePivotItem(
     destinationIndex > lastIndex &&
     nextPivotConfig[destinationAxis][lastIndex] === 'measures'
   ) {
-    destinationIndex -= 1;
+    destinationIndex = lastIndex;
   }
 
   nextPivotConfig[sourceAxis].splice(sourceIndex, 1);

--- a/packages/cubejs-client-core/src/utils.js
+++ b/packages/cubejs-client-core/src/utils.js
@@ -293,6 +293,12 @@ export function movePivotItem(
     nextPivotConfig[destinationAxis][lastIndex] === 'measures'
   ) {
     destinationIndex = lastIndex - 1;
+  } else if (
+    sourceAxis !== destinationAxis &&
+    destinationIndex > lastIndex &&
+    nextPivotConfig[destinationAxis][lastIndex] === 'measures'
+  ) {
+    destinationIndex -= 1;
   }
 
   nextPivotConfig[sourceAxis].splice(sourceIndex, 1);


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**
Incorrect index in movePivotItem.
When moving a dimension from x to y at the second last index, dimension is inserted at third last index.
For example,
|  x | y | 
| ------------ | -------------| 
|dimension2 | dimension1 |
|| measures |

After dragging dimension2 to y index 1 (below dimension1 and above measure),
|  x | y | 
| ------------ | -------------| 
|| dimension2|
|| dimension1|
|| measures |

The expected behavior should be
|  x | y | 
| ------------ | -------------| 
|| dimension1|
|| dimension2|
|| measures |