### PR TITLE
fix: LogicalOrFilter in cubejs-client-ngx

### DIFF
--- a/packages/cubejs-client-ngx/src/query-builder/query-members.ts
+++ b/packages/cubejs-client-ngx/src/query-builder/query-members.ts
@@ -289,6 +289,9 @@ export class FilterMember {
 
   asArray(): any[] {
     return this.filters.map((filter) => {
+      if (filter.or) {
+        return { or: asArray(filter.or) };
+      }
       return {
         ...this.query.meta.resolveMember(filter.member || filter.dimension, [
           'dimensions',


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

Cannot use LogicalOrFilter when using query builder for Angular. asArray() method only expect BinaryFilter.
