### PR TITLE
fixes security vulnerability in docker base image bullseye-slim

### DIFF
--- a/rust/cubestore/Dockerfile
+++ b/rust/cubestore/Dockerfile
@@ -41,13 +41,13 @@ COPY cubestore cubestore
 RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
 	cargo build --release -p cubestore
 
-FROM debian:bullseye-slim
+FROM debian:12-slim
 
 WORKDIR /cube
 
 RUN set -ex; \
 	apt-get update; \
-	apt-get install -y libssl1.1 curl
+	apt-get install -y libssl3 curl
 
 COPY --from=builder /build/cubestore/target/release/cubestored .
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

This PR fixes the security vulnerabilities in the base image `bullseye-slim` which were of high severity

- **Critical severity vulnerability found in curl/libcurl4 [CVE-2023-23914](https://www.cve.org/CVERecord?id=CVE-2023-23914)**
- **High severity vulnerability found in curl/libcurl4 [CVE-2022-42916](https://www.cve.org/CVERecord?id=CVE-2022-42916) [CVE 2022-43551](https://www.cve.org/CVERecord?id=CVE-2022-43551)**
-  **Medium severity vulnerability found in curl/libcurl4 ([CVE-2023-23915](https://www.cve.org/CVERecord?id=CVE-2023-23915))**
