### PR TITLE
DuckDB dates interpreted as strings instead of timestamp

### DIFF
--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -2,6 +2,7 @@ import { BaseFilter, BaseQuery } from '@cubejs-backend/schema-compiler';
 
 type Granularity = 'day' | 'week' | 'hour' | 'minute' | 'second' | 'month' | 'quarter' | 'year';
 
+// duckdb timestamptz is interperted as string by cubejs
 const dateTrunc = (granularity: Granularity, date: string) => `DATE_TRUNC('${granularity}', ${date})::timestamp`;
 
 const GRANULARITY_TO_INTERVAL: Record<Granularity, (date: string) => string> = {

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -1,33 +1,41 @@
 import { BaseFilter, BaseQuery } from '@cubejs-backend/schema-compiler';
 
-const GRANULARITY_TO_INTERVAL: Record<string, (date: string) => string> = {
-  day: date => `DATE_TRUNC('day', ${date})`,
-  week: date => `DATE_TRUNC('week', ${date})`,
-  hour: date => `DATE_TRUNC('hour', ${date})`,
-  minute: date => `DATE_TRUNC('minute', ${date})`,
-  second: date => `DATE_TRUNC('second', ${date})`,
-  month: date => `DATE_TRUNC('month', ${date})`,
-  quarter: date => `DATE_TRUNC('quarter', ${date})`,
-  year: date => `DATE_TRUNC('year', ${date})`
+type Granularity = 'day' | 'week' | 'hour' | 'minute' | 'second' | 'month' | 'quarter' | 'year';
+
+const dateTrunc = (granularity: Granularity, date: string) => `DATE_TRUNC('${granularity}', ${date})::timestamp`;
+
+const GRANULARITY_TO_INTERVAL: Record<Granularity, (date: string) => string> = {
+  day: date => dateTrunc('day', date),
+  week: date => dateTrunc('week', date),
+  hour: date => dateTrunc('hour', date),
+  minute: date => dateTrunc('minute', date),
+  second: date => dateTrunc('second', date),
+  month: date => dateTrunc('month', date),
+  quarter: date => dateTrunc('quarter', date),
+  year: date => dateTrunc('year', date),
 };
 
 class DuckDBFilter extends BaseFilter {
 }
 
 export class DuckDBQuery extends BaseQuery {
-  public newFilter(filter: any) {
+  public newFilter(filter: any): DuckDBFilter {
     return new DuckDBFilter(this, filter);
   }
 
-  public convertTz(field: string) {
+  public convertTz(field: string): string {
     return `timezone('${this.timezone}', ${field}::timestamptz)`;
   }
 
-  public timeGroupedColumn(granularity: string, dimension: string) {
+  public timeGroupedColumn(granularity: Granularity, dimension: string): string {
+    if (!GRANULARITY_TO_INTERVAL[granularity]) {
+      throw new Error(`Unrecognized granularity: ${granularity}`);
+    }
+
     return GRANULARITY_TO_INTERVAL[granularity](dimension);
   }
 
-  public countDistinctApprox(sql: string) {
+  public countDistinctApprox(sql: string): string {
     return `approx_count_distinct(${sql})`;
   }
 }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

CubeJS was treating DuckDB TIMESTAMPTZ data type as a string rather than a timestamp. This created problems with pre-aggregation processes, especially when trying to group data by units of time like months, weeks, etc.