### PR TITLE
feat: GraphQL GROUP BY Resolver

### DIFF
--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -580,7 +580,7 @@ export function makeSchema(metaConfig: any): GraphQLSchema {
               if (memberType === MemberType.MEASURES) {
                 measures.push(key);
               } else if (memberType === MemberType.DIMENSIONS) {
-                if (groupBy.includes(memberName)) {  // only add the dimension if it's in the groupBy arg
+                if (groupBy.length > 0 && groupBy.includes(memberName)) {  // only add the dimension if it's in the groupBy arg
                   const granularityNodes = getFieldNodeChildren(memberNode, infos);
                   if (granularityNodes.length > 0) {
                     granularityNodes.forEach(granularityNode => {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Related: #3433

**Description of Changes Made (if issue reference is not provided)**

I noticed the GraphQL API supports `orderBy`, but there isn't a built-in resolver for `groupBy` currently. Here is an initial attempt at providing at providing the equivalent to the `GROUP BY` in SQL. 

The idea here would be to be able to .groupBy option just as the .orderBy option is already available in the built-in resolver. Then, if a user wanted to group by the timestamp column for example, the data would be returned as follows instead of as a flat array:

{ 2023-07-16:00:00:00: [{ field1: value1, field2: value2}, {field1: value3, field2: value4}], 2023-07-16:01:00:00: [{ field1: value1, field2: value2}, {field1: value3, field2: value4}], ...}

This avoids the need to perform to series or chart pivot operations on the front-end and lets the easier-to-scale back-end deliver data in a format that charting libraries such as @recharts expect.

Tagging @lvauvillier as they did amazing work on the initial implementation (https://github.com/cube-js/cube/issues/3433 / https://github.com/cube-js/cube/pull/3555) if they have time to offer their thoughts on the matter.