### PR TITLE
fix(redshift-driver): resolves issue where redshift column order can …

### DIFF
--- a/docs/content/Reference/Configuration/Environment-Variables-Reference.mdx
+++ b/docs/content/Reference/Configuration/Environment-Variables-Reference.mdx
@@ -447,6 +447,23 @@ The timeout value for any queries made to the database by Cube.
 | ---------------------------------------- | ---------------------- | --------------------- |
 | A number in seconds or a duration string | `10m`                  | `10m`                 |
 
+## `CUBEJS_DB_FETCH_COLUMNS_BY_ORDINAL_POSITION`
+
+Force fetching of columns by ordinal positions.  Certain data-providers (Redshift) do not guarantee columns in the
+same order on each request. (e.g. `SELECT * FROM foo`).  This flag ensures columns will be fetched in proper order
+for pre-aggregation generation.
+
+<InfoBox>
+
+    This flag currently defaults to `false`, as changing the value to `true` can cause breaking changes for existing
+    pre-aggregations.  This will eventually default to `true`.  For new deployments, consider setting this to `true`.
+
+</InfoBox>
+
+| Possible Values                                    | Default in Development | Default in Production |
+| -------------------------------------------------- | ---------------------- | --------------------- |
+| Whether to force fetch columns in ordinal position | `false`                | `false`               |
+
 ## `CUBEJS_DB_SNOWFLAKE_ACCOUNT`
 
 The Snowflake account identifier to use when connecting to the database.

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -588,6 +588,16 @@ const variables: Record<string, (...args: any) => any> = {
     .default('true')
     .asBoolStrict(),
 
+  /**
+   * Fetch Columns by Ordinal Position
+   *
+   * Currently defaults to 'false' as changing this in a live deployment could break existing pre-aggregations.
+   * This will eventually default to true.
+   */
+  fetchColumnsByOrdinalPosition: (): boolean => get('CUBEJS_DB_FETCH_COLUMNS_BY_ORDINAL_POSITION')
+    .default('false')
+    .asBoolStrict(),
+
   /** ****************************************************************
    * JDBC options                                                    *
    ***************************************************************** */

--- a/packages/cubejs-base-driver/src/BaseDriver.ts
+++ b/packages/cubejs-base-driver/src/BaseDriver.ts
@@ -370,7 +370,8 @@ export abstract class BaseDriver implements DriverInterface {
              columns.table_schema as ${this.quoteIdentifier('table_schema')},
              columns.data_type  as ${this.quoteIdentifier('data_type')}
       FROM information_schema.columns
-      WHERE table_name = ${this.param(0)} AND table_schema = ${this.param(1)}`,
+      WHERE table_name = ${this.param(0)} AND table_schema = ${this.param(1)}
+      ORDER BY columns.ordinal_position`,
       [name, schema]
     );
 

--- a/packages/cubejs-base-driver/src/BaseDriver.ts
+++ b/packages/cubejs-base-driver/src/BaseDriver.ts
@@ -371,7 +371,7 @@ export abstract class BaseDriver implements DriverInterface {
              columns.data_type  as ${this.quoteIdentifier('data_type')}
       FROM information_schema.columns
       WHERE table_name = ${this.param(0)} AND table_schema = ${this.param(1)}
-      ORDER BY columns.ordinal_position`,
+      ${getEnv('fetchColumnsByOrdinalPosition') ? 'ORDER BY columns.ordinal_position' : ''}`,
       [name, schema]
     );
 


### PR DESCRIPTION
…come back in a different order, causing preaggregations across partitions to encounter a union all error

**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[#6023] - When querying information_schema.columns Redshift can sometimes return columns not in their ordinal position. When unloading a partitioned pre-aggregate to the export bucket, column orders may differ between partitions, causing any queries that use mismatched partitions to fail.

**Description of Changes Made (if issue reference is not provided)**

Updated table column types query in BaseDriver.ts to order by the ordinal_position ensuring that columns always come back in the expected order.
