### PR TITLE
Add Meta to export

### DIFF
--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -348,5 +348,5 @@ class CubejsApi {
 
 export default (apiToken, options) => new CubejsApi(apiToken, options);
 
-export { CubejsApi, HttpTransport, ResultSet, RequestError };
+export { CubejsApi, HttpTransport, ResultSet, RequestError, Meta };
 export * from './utils';


### PR DESCRIPTION
Added Meta to export inside `index.js` in `@cubejs-client/core`