### PR TITLE
feat(cubesql): Support multiple values in `SET`

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "arrow",
  "chrono",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "ahash",
  "arrow",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "ahash",
  "arrow",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=104887f467aaa7172bcfc8b96200231e115bc177#104887f467aaa7172bcfc8b96200231e115bc177"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
 dependencies = [
  "ahash",
  "arrow",
@@ -4015,7 +4015,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=b3b40586d4c32a218ffdfcb0462e7e216cf3d6eb#b3b40586d4c32a218ffdfcb0462e7e216cf3d6eb"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=ac5fc7cbf4368cd4c9e6c2af0e0e35d2eff7cc16#ac5fc7cbf4368cd4c9e6c2af0e0e35d2eff7cc16"
 dependencies = [
  "log",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,12 +9,12 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "104887f467aaa7172bcfc8b96200231e115bc177", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "90f0168023bce6b7fa44d3473dd052afd444ca54", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }
 pg-srv = { path = "../pg-srv" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "b3b40586d4c32a218ffdfcb0462e7e216cf3d6eb" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ac5fc7cbf4368cd4c9e6c2af0e0e35d2eff7cc16" }
 lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.0", features = ["full", "rt", "tracing"] }

--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -1070,6 +1070,19 @@ impl AsyncTestSuite for PostgresIntegrationTestSuite {
         })
         .await?;
 
+        self.test_simple_query(
+            r#"SET search_path = public, other_schema"#.to_string(),
+            |messages| {
+                assert_eq!(messages.len(), 1);
+
+                // SET
+                if let SimpleQueryMessage::Row(_) = messages[0] {
+                    panic!("Must be CommandComplete command, (SET is used)")
+                }
+            },
+        )
+        .await?;
+
         // Tableau Desktop
         self.test_simple_query(
             r#"SET DateStyle = 'ISO';SET extra_float_digits = 2;show transaction_isolation"#


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/sqlparser-rs@b098e2d, adding support for setting several values in `SET`, comma-separated, e.g. `SET a = b, c`.
One case where this is problematic is `SET search_path = public, other_schema` with PostgreSQL. Such a query is issued, for instance, by DBeaver.
Related test is included.