### PR TITLE
feat(cubesql): Support `Date32` to `Timestamp` coercion

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "arrow",
  "chrono",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "ahash",
  "arrow",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "ahash",
  "arrow",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=90f0168023bce6b7fa44d3473dd052afd444ca54#90f0168023bce6b7fa44d3473dd052afd444ca54"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=915a600ea4d3b66161cd77ff94747960f840816e#915a600ea4d3b66161cd77ff94747960f840816e"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "90f0168023bce6b7fa44d3473dd052afd444ca54", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "915a600ea4d3b66161cd77ff94747960f840816e", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12913,6 +12913,33 @@ ORDER BY \"COUNT(count)\" DESC"
     }
 
     #[tokio::test]
+    async fn test_holistics_date_trunc_date32() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "holistics_date_trunc_date32",
+            execute_query(
+                "
+                with \"h__dates\" AS (
+                    SELECT
+                        CAST ('2023-02-01' AS date) as \"start_range\",
+                        CAST ( '2023-02-28' AS date ) as \"end_range\",
+                        28 as \"length\"
+                )
+                SELECT
+                    DATE_TRUNC( 'month', \"start_range\") AS \"dm_ddt_d_6e2110\",
+                    MAX(\"length\") AS \"h_dates_length\"
+                FROM \"h__dates\"
+                GROUP BY 1
+                "
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_holistics_group_by_date() {
         init_logger();
 

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__holistics_date_trunc_date32.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__holistics_date_trunc_date32.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                with \\\"h__dates\\\" AS (\n                    SELECT\n                        CAST ('2023-02-01' AS date) as \\\"start_range\\\",\n                        CAST ( '2023-02-28' AS date ) as \\\"end_range\\\",\n                        28 as \\\"length\\\"\n                )\n                SELECT\n                    DATE_TRUNC( 'month', \\\"start_range\\\") AS \\\"dm_ddt_d_6e2110\\\",\n                    MAX(\\\"length\\\") AS \\\"h_dates_length\\\"\n                FROM \\\"h__dates\\\"\n                GROUP BY 1\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------------------------+----------------+
+| dm_ddt_d_6e2110         | h_dates_length |
++-------------------------+----------------+
+| 2023-02-01T00:00:00.000 | 28             |
++-------------------------+----------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@915a600, adding support for `Date32` to `TimestampNanosecond` coercion. This is in line with PostgreSQL.
This improves compatibility with Holistics, which issues this query where `DATE` is passed directly to `DATE_TRUNC`:
```sql
with "h__dates" AS (
    SELECT
        CAST ('2023-02-01' AS date) as "start_range",
        CAST ( '2023-02-28' AS date ) as "end_range",
        28 as "length"
)
SELECT
    DATE_TRUNC( 'month', "start_range") AS "dm_ddt_d_6e2110",
    MAX("length") AS "h_dates_length"
FROM "h__dates"
GROUP BY 1
;
```
Related test is included.