### PR TITLE
feat(cubesql): Support `inet_server_addr` stub

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -3393,6 +3393,24 @@ pub fn create_udtf_stub(
     )
 }
 
+pub fn create_inet_server_addr_udf() -> ScalarUDF {
+    let fun = make_scalar_function(move |_: &[ArrayRef]| {
+        let mut builder = StringBuilder::new(1);
+        builder.append_value("127.0.0.1/32").unwrap();
+
+        Ok(Arc::new(builder.finish()) as ArrayRef)
+    });
+
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Utf8)));
+
+    ScalarUDF::new(
+        "inet_server_addr",
+        &Signature::exact(vec![], Volatility::Immutable),
+        &return_type,
+        &fun,
+    )
+}
+
 pub fn register_fun_stubs(mut ctx: SessionContext) -> SessionContext {
     macro_rules! register_fun_stub {
         ($FTYP:ident, $NAME:expr, argc=$ARGC:expr $(, rettyp=$RETTYP:ident)? $(, vol=$VOL:ident)?) => {
@@ -3795,13 +3813,6 @@ pub fn register_fun_stubs(mut ctx: SessionContext) -> SessionContext {
         "inet_client_port",
         argc = 0,
         rettyp = Int32,
-        vol = Stable
-    );
-    register_fun_stub!(
-        udf,
-        "inet_server_addr",
-        argc = 0,
-        rettyp = Utf8,
         vol = Stable
     );
     register_fun_stub!(

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -51,14 +51,14 @@ use self::{
             create_date_udf, create_dateadd_udf, create_datediff_udf, create_dayofmonth_udf,
             create_dayofweek_udf, create_dayofyear_udf, create_db_udf, create_ends_with_udf,
             create_format_type_udf, create_generate_series_udtf, create_generate_subscripts_udtf,
-            create_has_schema_privilege_udf, create_hour_udf, create_if_udf, create_instr_udf,
-            create_interval_mul_udf, create_isnull_udf, create_json_build_object_udf,
-            create_least_udf, create_locate_udf, create_makedate_udf, create_measure_udaf,
-            create_minute_udf, create_pg_backend_pid_udf, create_pg_datetime_precision_udf,
-            create_pg_encoding_to_char_udf, create_pg_expandarray_udtf,
-            create_pg_get_constraintdef_udf, create_pg_get_expr_udf, create_pg_get_indexdef_udf,
-            create_pg_get_serial_sequence_udf, create_pg_get_userbyid_udf,
-            create_pg_is_other_temp_schema, create_pg_my_temp_schema,
+            create_has_schema_privilege_udf, create_hour_udf, create_if_udf,
+            create_inet_server_addr_udf, create_instr_udf, create_interval_mul_udf,
+            create_isnull_udf, create_json_build_object_udf, create_least_udf, create_locate_udf,
+            create_makedate_udf, create_measure_udaf, create_minute_udf, create_pg_backend_pid_udf,
+            create_pg_datetime_precision_udf, create_pg_encoding_to_char_udf,
+            create_pg_expandarray_udtf, create_pg_get_constraintdef_udf, create_pg_get_expr_udf,
+            create_pg_get_indexdef_udf, create_pg_get_serial_sequence_udf,
+            create_pg_get_userbyid_udf, create_pg_is_other_temp_schema, create_pg_my_temp_schema,
             create_pg_numeric_precision_udf, create_pg_numeric_scale_udf,
             create_pg_table_is_visible_udf, create_pg_total_relation_size_udf,
             create_pg_truetypid_udf, create_pg_truetypmod_udf, create_pg_type_is_visible_udf,
@@ -1192,6 +1192,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_charindex_udf());
         ctx.register_udf(create_to_regtype_udf());
         ctx.register_udf(create_pg_get_indexdef_udf());
+        ctx.register_udf(create_inet_server_addr_udf());
 
         // udaf
         ctx.register_udaf(create_measure_udaf());
@@ -18863,6 +18864,26 @@ ORDER BY \"COUNT(count)\" DESC"
                     pg_catalog.pg_index.indrelid,
                     cls_idx.relname
                 ;".to_string(),
+                DatabaseProtocol::PostgreSQL,
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_zoho_inet_server_addr() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "zoho_inet_server_addr",
+            execute_query(
+                "
+                select
+                    pg_backend_pid(),
+                    coalesce(cast(inet_server_addr() as text ),'addr'),
+                    current_database()
+                ;"
+                .to_string(),
                 DatabaseProtocol::PostgreSQL,
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__zoho_inet_server_addr.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__zoho_inet_server_addr.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                select\n                    pg_backend_pid(),\n                    coalesce(cast(inet_server_addr() as text ),'addr'),\n                    current_database()\n                ;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++------------------+---------------------------------------------------------+--------------------+
+| pg_backend_pid() | coalesce(CAST(inet_server_addr() AS Utf8),Utf8("addr")) | current_database() |
++------------------+---------------------------------------------------------+--------------------+
+| 1                | 127.0.0.1/32                                            | cubedb             |
++------------------+---------------------------------------------------------+--------------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `inet_server_addr` function stub, returning `127.0.0.1/32` as a valid value.
This function is used by Zoho Analytics. Related test is included.
Note that the function returns `Utf8` type. In accordance with PostgreSQL, it should return `inet` type but we do not support that; this is mitigated by the fact that the function call is directly cast to the `text` type within the query.
