### PR TITLE
feat(@cubejs-backend/schema-compiler): Add WITH FILL to Clickhouse query adapter

### DIFF
--- a/docs/content/Configuration/Databases/ClickHouse.mdx
+++ b/docs/content/Configuration/Databases/ClickHouse.mdx
@@ -33,6 +33,7 @@ CUBEJS_DB_PASS=**********
 | `CUBEJS_DB_USER`                | The username used to connect to the database                                        | A valid database username |    ✅    |                                    ✅                                    |
 | `CUBEJS_DB_PASS`                | The password used to connect to the database                                        | A valid database password |    ✅    |                                    ✅                                    |
 | `CUBEJS_DB_CLICKHOUSE_READONLY` | Whether the ClickHouse user has read-only access or not                             | `true`, `false`           |    ❌    |                                    ✅                                    |
+| `CUBEJS_DB_CLICKHOUSE_WITHFILL` | Whether to use Clickhouse's `WITH FILL` modifier for date ranged queries            | `true`, `false`           |    ❌    |                                    ✅                                    |
 | `CUBEJS_CONCURRENCY`            | The number of concurrent connections each queue has to the database. Default is `5` | A valid number            |    ❌    |                                    ❌                                    |
 | `CUBEJS_DB_MAX_POOL`            | The maximum number of concurrent database connections to pool. Default is `20`      | A valid number            |    ❌    |                                    ✅                                    |
 
@@ -82,11 +83,21 @@ You can connect to a ClickHouse database when your user's permissions are
 [restricted][clickhouse-readonly] to read-only, by setting
 `CUBEJS_DB_CLICKHOUSE_READONLY` to `true`.
 
+You can use Clickhouse's [`WITH FILL` MODIFIER][clickhouse-with-fill] to fill
+any dates within the defined date range with `0` values. This will make sure
+that the date range is fully filled with data. This is useful for showing a
+true axis on a chart or exporting data for all dates given.
+
+Be aware that using `WITH FILL` may increase query times or resources used and you may need to increase the `limit`
+provided to your Cube queries.
+
 [clickhouse]: https://clickhouse.tech/
 [clickhouse-docs-users]:
   https://clickhouse.tech/docs/en/operations/settings/settings-users/
 [clickhouse-readonly]:
   https://clickhouse.tech/docs/en/operations/settings/permissions-for-queries/#settings_readonly
+[clickhouse-with-fill]:
+  https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
 [ref-caching-using-preaggs-build-strats]:
   /caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-config-multiple-ds-decorating-env]:

--- a/docs/content/Reference/Configuration/Environment-Variables-Reference.mdx
+++ b/docs/content/Reference/Configuration/Environment-Variables-Reference.mdx
@@ -177,6 +177,14 @@ Whether the ClickHouse user has read-only access or not.
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | N/A                    | N/A                   |
 
+## `CUBEJS_DB_CLICKHOUSE_WITHFILL`
+
+Whether to use Clickhouse's `WITH FILL` modifier for date ranged queries.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | N/A                    | N/A                   |
+
 ## `CUBEJS_DB_DATABRICKS_ACCEPT_POLICY`
 
 To accept the license terms for the Databricks JDBC driver, this must be set to

--- a/docs/docs-new/pages/product/configuration/data-sources/clickhouse.mdx
+++ b/docs/docs-new/pages/product/configuration/data-sources/clickhouse.mdx
@@ -35,6 +35,7 @@ CUBEJS_DB_PASS=**********
 | `CUBEJS_DB_USER`                | The username used to connect to the database                                        | A valid database username |    ✅    |                                    ✅                                    |
 | `CUBEJS_DB_PASS`                | The password used to connect to the database                                        | A valid database password |    ✅    |                                    ✅                                    |
 | `CUBEJS_DB_CLICKHOUSE_READONLY` | Whether the ClickHouse user has read-only access or not                             | `true`, `false`           |    ❌    |                                    ✅                                    |
+| `CUBEJS_DB_CLICKHOUSE_WITHFILL` | Whether to use Clickhouse's `WITH FILL` modifier for date ranged queries.           | `true`, `false`           |    ❌    |                                    ✅                                    |
 | `CUBEJS_CONCURRENCY`            | The number of concurrent connections each queue has to the database. Default is `5` | A valid number            |    ❌    |                                    ❌                                    |
 | `CUBEJS_DB_MAX_POOL`            | The maximum number of concurrent database connections to pool. Default is `20`      | A valid number            |    ❌    |                                    ✅                                    |
 
@@ -84,11 +85,21 @@ You can connect to a ClickHouse database when your user's permissions are
 [restricted][clickhouse-readonly] to read-only, by setting
 `CUBEJS_DB_CLICKHOUSE_READONLY` to `true`.
 
+You can use Clickhouse's [`WITH FILL` MODIFIER][clickhouse-with-fill] to fill
+any dates within the defined date range with `0` values. This will make sure
+that the date range is fully filled with data. This is useful for showing a
+true axis on a chart or exporting data for all dates given.
+
+Be aware that using `WITH FILL` may increase query times or resources used and you may need to increase the `limit`
+provided to your Cube queries.
+
 [clickhouse]: https://clickhouse.tech/
 [clickhouse-docs-users]:
   https://clickhouse.tech/docs/en/operations/settings/settings-users/
 [clickhouse-readonly]:
   https://clickhouse.tech/docs/en/operations/settings/permissions-for-queries/#settings_readonly
+[clickhouse-with-fill]:
+  https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
 [ref-caching-using-preaggs-build-strats]:
   /product/caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-config-multiple-ds-decorating-env]:

--- a/docs/docs-new/pages/reference/configuration/environment-variables.mdx
+++ b/docs/docs-new/pages/reference/configuration/environment-variables.mdx
@@ -176,6 +176,14 @@ Whether the ClickHouse user has read-only access or not.
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | N/A                    | N/A                   |
 
+## `CUBEJS_DB_CLICKHOUSE_WITHFILL`
+
+Whether to use Clickhouse's `WITH FILL` modifier for date ranged queries.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | N/A                    | N/A                   |
+
 ## `CUBEJS_DB_DATABRICKS_ACCEPT_POLICY`
 
 To accept the license terms for the Databricks JDBC driver, this must be set to

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -990,6 +990,19 @@ const variables: Record<string, (...args: any) => any> = {
     ]
   ),
 
+  /**
+   * Clickhouse WITH FILL flag.
+   */
+  clickhouseWithFill: ({
+    dataSource
+  }: {
+    dataSource: string,
+  }) => (
+    process.env[
+      keyByDataSource('CUBEJS_DB_CLICKHOUSE_WITHFILL', dataSource)
+    ]
+  ),
+
   /** ****************************************************************
    * ElasticSearch Driver                                            *
    ***************************************************************** */

--- a/packages/cubejs-backend-shared/test/db_env_multi.test.ts
+++ b/packages/cubejs-backend-shared/test/db_env_multi.test.ts
@@ -1452,6 +1452,35 @@ describe('Multiple datasources', () => {
     );
   });
 
+  test('getEnv("clickhouseWithFill")', () => {
+    process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = 'default1';
+    process.env.CUBEJS_DS_POSTGRES_DB_CLICKHOUSE_WITHFILL = 'postgres1';
+    process.env.CUBEJS_DS_WRONG_DB_CLICKHOUSE_WITHFILL = 'wrong1';
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toEqual('default1');
+    expect(getEnv('clickhouseWithFill', { dataSource: 'postgres' })).toEqual('postgres1');
+    expect(() => getEnv('clickhouseWithFill', { dataSource: 'wrong' })).toThrow(
+        'The wrong data source is missing in the declared CUBEJS_DATASOURCES.'
+    );
+
+    process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = 'default2';
+    process.env.CUBEJS_DS_POSTGRES_DB_CLICKHOUSE_WITHFILL = 'postgres2';
+    process.env.CUBEJS_DS_WRONG_DB_CLICKHOUSE_WITHFILL = 'wrong2';
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toEqual('default2');
+    expect(getEnv('clickhouseWithFill', { dataSource: 'postgres' })).toEqual('postgres2');
+    expect(() => getEnv('clickhouseWithFill', { dataSource: 'wrong' })).toThrow(
+        'The wrong data source is missing in the declared CUBEJS_DATASOURCES.'
+    );
+
+    delete process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL;
+    delete process.env.CUBEJS_DS_POSTGRES_DB_CLICKHOUSE_WITHFILL;
+    delete process.env.CUBEJS_DS_WRONG_DB_CLICKHOUSE_WITHFILL;
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toBeUndefined();
+    expect(getEnv('clickhouseWithFill', { dataSource: 'postgres' })).toBeUndefined();
+    expect(() => getEnv('clickhouseWithFill', { dataSource: 'wrong' })).toThrow(
+        'The wrong data source is missing in the declared CUBEJS_DATASOURCES.'
+    );
+  });
+
   test('getEnv("elasticApiId")', () => {
     process.env.CUBEJS_DB_ELASTIC_APIKEY_ID = 'default1';
     process.env.CUBEJS_DS_POSTGRES_DB_ELASTIC_APIKEY_ID = 'postgres1';

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -94,4 +94,14 @@ describe('getEnv', () => {
     process.env.CUBEJS_LIVE_PREVIEW = 'false';
     expect(getEnv('livePreview')).toBe(false);
   });
+
+  test('clickhouseWithFill', () => {
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toBeUndefined();
+
+    process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = 'true';
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toBe('true');
+
+    process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = 'false';
+    expect(getEnv('clickhouseWithFill', { dataSource: 'default' })).toBe('false');
+  });
 });

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.js
@@ -3,8 +3,8 @@ import moment from 'moment-timezone';
 import { BaseQuery } from './BaseQuery';
 import { BaseFilter } from './BaseFilter';
 import { UserError } from '../compiler';
-import { BaseMeasure } from './BaseMeasure';
-import { BaseDimension } from './BaseDimension';
+import { BaseMeasure } from "./BaseMeasure";
+import { BaseDimension } from "./BaseDimension";
 
 const GRANULARITY_TO_INTERVAL = {
   second: 'Second',

--- a/packages/cubejs-schema-compiler/test/unit/clickhouse-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/clickhouse-query.test.ts
@@ -1,0 +1,266 @@
+import moment from 'moment-timezone';
+import { ClickHouseQuery } from '../../src/adapter/ClickHouseQuery';
+import { prepareCompiler } from './PrepareCompiler';
+import { BaseDimension, BaseMeasure } from '../../src';
+
+interface HashOptions {
+  id: string,
+}
+
+describe('ClickHouseQuery', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareCompiler(`
+    cube(\`visitors\`, {
+      sql: \`
+      select * from visitors
+      \`,
+
+      measures: {
+        count: {
+          type: 'count'
+        }
+      },
+
+      dimensions: {
+        createdAt: {
+          type: 'time',
+          sql: 'created_at'
+        }
+      }
+    });
+    `);
+
+  const getQuery = async (overrides = {}) => {
+    await compiler.compile();
+
+    return new ClickHouseQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'visitors.count'
+      ],
+      dimensions: [
+        'visitors.createdAt',
+      ],
+      timeDimensions: [{
+        dimension: 'visitors.createdAt',
+        granularity: 'day',
+        dateRange: ['2017-01-01', '2017-01-30'],
+      }],
+      timezone: 'America/Los_Angeles',
+      order: [{
+        id: 'visitors.createdAt',
+      }, {
+        id: 'visitors.count',
+      }],
+      ...overrides,
+    });
+  };
+
+  const getDimensionHash = (query: ClickHouseQuery): HashOptions => query.order[0];
+  const getMeasureHash = (query: ClickHouseQuery): HashOptions => query.order[1];
+
+  describe('field methods', () => {
+    it('gets the correct field alias for dimensions and measures', async () => {
+      const query = await getQuery();
+
+      expect(query.getFieldAlias(getDimensionHash(query).id)).toBe('`visitors__created_at`');
+      expect(query.getFieldAlias(getMeasureHash(query).id)).toBe('`visitors__count`');
+    });
+
+    it('gets the correct field for dimensions and measures', async () => {
+      const query = await getQuery();
+
+      const dimensionField: BaseDimension = query.getField(getDimensionHash(query).id);
+      const measureField: BaseMeasure = query.getField(getMeasureHash(query).id);
+
+      expect(dimensionField.dimension).toBe(query.dimensions[0].dimension);
+      expect(measureField.measure).toBe(query.measures[0].measure);
+    });
+
+    it('gets the correct field type for dimensions and measures', async () => {
+      const query = await getQuery();
+
+      const dimensionField: BaseDimension = query.getField(getDimensionHash(query).id);
+      const measureField: BaseMeasure = query.getField(getMeasureHash(query).id);
+
+      expect(query.getFieldType(dimensionField)).toBe('time');
+      expect(query.getFieldType(measureField)).toBe('count');
+    });
+  });
+
+  describe('environment', () => {
+    afterEach(() => {
+      delete process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL;
+    });
+
+    it.each([true, false])('withFill returns the correct value given CUBEJS_DB_CLICKHOUSE_WITHFILL is %s', async (enabled) => {
+      process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = `${enabled}`;
+
+      const query = await getQuery();
+
+      expect(query.withFill).toBe(enabled);
+    });
+  });
+
+  describe('WITH FILL methods', () => {
+    describe('maximumDateRange', () => {
+      it.each`
+        description | queryOverrides | expectedDateRange
+        ${'no date range if the date range filters do not exist'} | ${
+  {
+    timeDimensions: [{
+      dimension: 'visitors.createdAt',
+      granularity: 'day',
+    }],
+  }
+} | ${{ start: null, end: null }}
+        ${'no date range if the date range filters do not have the dates set'} | ${
+  {
+    timeDimensions: [{
+      dimension: 'visitors.createdAt',
+      granularity: 'day',
+    }],
+    filters: [{
+      member: 'visitors.createdAt',
+      operator: 'inDateRange',
+      values: [],
+    }],
+  }
+} | ${{ start: null, end: null }}
+        ${'returns the correct date range if the filter is applied'} | ${
+  {
+    timeDimensions: [{
+      dimension: 'visitors.createdAt',
+      granularity: 'day',
+    }],
+    filters: [{
+      member: 'visitors.createdAt',
+      operator: 'inDateRange',
+      values: ['2017-01-01', '2017-01-30'],
+    }],
+  }
+} | ${{ start: '2017-01-01T00:00:00.000', end: '2017-01-30T00:00:00.000' }}
+        ${'returns the correct date range if the time dimension filter is applied'} | ${
+  {}
+} | ${{ start: '2017-01-01T00:00:00.000', end: '2017-01-30T00:00:00.000' }}
+        ${'returns the maximum date range if the time dimension filter and filter property is applied'} | ${
+  {
+    timeDimensions: [{
+      dimension: 'visitors.createdAt',
+      granularity: 'day',
+      dateRange: ['2016-12-01', '2017-01-30'],
+    }],
+    filters: [{
+      member: 'visitors.createdAt',
+      operator: 'inDateRange',
+      values: ['2017-01-01', '2017-05-01'],
+    }],
+  }
+} | ${{ start: '2016-12-01T00:00:00.000', end: '2017-05-01T00:00:00.000' }}
+      `('$description', async ({ queryOverrides, expectedDateRange }) => {
+        const query = await getQuery(queryOverrides);
+
+        const dateRange = query.maximumDateRange();
+
+        expect({
+          start: dateRange.start ? dateRange.start.format(moment.HTML5_FMT.DATETIME_LOCAL_MS) : null,
+          end: dateRange.end ? dateRange.end.format(moment.HTML5_FMT.DATETIME_LOCAL_MS) : null
+        }).toStrictEqual(expectedDateRange);
+      });
+    });
+
+    describe('withFillInterval', () => {
+      it.each`
+        granularity | result
+        ${null} | ${''}
+        ${'unknown'} | ${''}
+        ${'quarter'} | ${' STEP INTERVAL 1 QUARTER'}
+      `('returns $result if the granularity $granularity is given', async ({ granularity, result }) => {
+        const query = await getQuery();
+
+        expect(query.withFillInterval(granularity)).toBe(result);
+      });
+    });
+
+    describe('withFillRange', () => {
+      it.each`
+        description | queryOverrides | expectedFillRange
+        ${'returns a blank string if no date range filter is applied'} | ${
+  {
+    timeDimensions: [{
+      dimension: 'visitors.createdAt',
+      granularity: 'day',
+    }],
+  }
+} | ${''}
+                    ${'returns the correct fill range when in ASC order'} | ${
+  {
+    order: [{
+      id: 'visitors.createdAt',
+      desc: false,
+    }, {
+      id: 'visitors.count',
+    }],
+  }
+} | ${' FROM parseDateTimeBestEffort(\'2017-01-01T00:00:00.000\') TO parseDateTimeBestEffort(\'2017-01-30T00:00:00.000\')'}
+        ${'returns the correct fill range when in DESC order'} | ${
+  {
+    order: [{
+      id: 'visitors.createdAt',
+      desc: true,
+    }, {
+      id: 'visitors.count',
+    }],
+  }
+} | ${' FROM parseDateTimeBestEffort(\'2017-01-30T00:00:00.000\') TO parseDateTimeBestEffort(\'2017-01-01T00:00:00.000\')'}
+      `('$description', async ({ queryOverrides, expectedFillRange }) => {
+        const query = await getQuery(queryOverrides);
+
+        expect(query.withFillRange(getDimensionHash(query))).toBe(expectedFillRange);
+      });
+    });
+  });
+
+  describe('orderHashToString', () => {
+    afterEach(() => {
+      delete process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL;
+    });
+
+    it.each`
+        description | order | envEnabled | hash | expectedOrderString
+        ${'returns null if no hash is given'} | ${
+  {}
+} | ${'true'} | ${(query) => null} | ${null}
+        ${'returns null if the field cannot be found'} | ${
+  {}
+} | ${'true'} | ${(query) => ({ id: 'unknown' })} | ${null}
+        ${'returns the normal order by string when withFill is disabled'} | ${
+  {}
+} | ${'false'} | ${(query) => getDimensionHash(query)} | ${'`visitors__created_at` ASC'}
+        ${'returns the normal order by string when the field is not of type time'} | ${
+  {
+    order: [{
+      id: 'visitors.createdAt',
+    }, {
+      id: 'visitors.count',
+      desc: true,
+    }],
+  }
+} | ${'true'} | ${(query) => getMeasureHash(query)} | ${'`visitors__count` DESC'}
+        ${'returns the with fill order by string when withFill is enabled and the field is of type time'} | ${
+  {
+    order: [{
+      id: 'visitors.createdAt',
+      desc: true,
+    }, {
+      id: 'visitors.count',
+    }],
+  }
+} | ${'true'} | ${(query) => getDimensionHash(query)} | ${'`visitors__created_at` DESC WITH FILL FROM parseDateTimeBestEffort(\'2017-01-30T00:00:00.000\') TO parseDateTimeBestEffort(\'2017-01-01T00:00:00.000\')'}
+        `('$description', async ({ order, envEnabled, hash, expectedOrderString }) => {
+      process.env.CUBEJS_DB_CLICKHOUSE_WITHFILL = envEnabled;
+
+      const query = await getQuery(order);
+
+      expect(query.orderHashToString(hash(query))).toBe(expectedOrderString);
+    });
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#6893

**Description of Changes Made**

In this PR, a new env var named `CUBEJS_DB_CLICKHOUSE_WITHFILL` was added. This env var toggles the ability to use the [`WITH FILL` modifier](https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier) for Clickhouse queries.

The `WITH FILL` modifier will fill any dates within the defined date range, which don't have any data, with `0` values. Doing this means that when you receive the data, you receive the full date range provided, not just the data stored in the DB. The benefit for this is that you can show a true x or y-axis spanning the full date range provided which makes charts far less likely to misrepresent the data.

Setting the env var to `false` or not setting it at all will mean that there are no changes to the current Clickhouse behaviours. This is an opt-in feature.

Also, if a date range isn't provided, the `WITH FILL` modifier will be skipped as it requires a `FROM` and `TO` to function.

**Known possible issues**

Using the `WITH FILL` modifier will result in Clickhouse returning more rows than the normal query. This may result in two potential problems (hence the opt-in):

1. An increase in query times or performance degradation depending upon the Clickhouse server setup and Cube resources.
2. If a `limit` is set, the user needs to be aware that using `WITH FILL` may require that `limit` to be increased depending upon the date range/granularity being queried. One approach we're looking at internally is to dynamically adjust the `limit`  we send to Cube by the number of days/granularity based upon the date range used. We opted to not include it in this PR as it's an implementation detail.