### PR TITLE
fix(@cubejs-client/core): Check if timeDimension has dateRange before destructuring

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -169,7 +169,7 @@ class ResultSet {
             range.end
           ];
           
-          if (originalTimeDimension) {
+          if (originalTimeDimension?.dateRange) {
             const [originalStart, originalEnd] = originalTimeDimension.dateRange;
             
             dateRange = [

--- a/packages/cubejs-client-core/src/tests/drill-down.test.js
+++ b/packages/cubejs-client-core/src/tests/drill-down.test.js
@@ -241,6 +241,16 @@ describe('drill down query', () => {
       timeDimensions: [],
     })
   );
+  const resultSet5 = new ResultSet(
+    loadResponse({
+      timeDimensions: [
+        {
+          dimension: 'Orders.ts',
+          granularity: 'week',
+        }
+      ]
+    })
+  );
 
   it('handles a query with a time dimension', () => {
     expect(
@@ -364,6 +374,29 @@ describe('drill down query', () => {
         },
       ],
       timezone: 'UTC'
+    });
+  });
+
+  it('snap date range to granularity if the date range is not defined in the time dimension', () => {
+    expect(
+      resultSet5.drillDown({ xValues: ['2020-08-01T00:00:00.000'] })
+    ).toEqual({
+      measures: [],
+      segments: [],
+      dimensions: ['Orders.id', 'Orders.title'],
+      filters: [
+        {
+          member: 'Orders.count',
+          operator: 'measureFilter',
+        },
+      ],
+      timeDimensions: [
+        {
+          dimension: 'Orders.ts',
+          dateRange: ['2020-07-27T00:00:00.000', '2020-08-02T23:59:59.999'],
+        },
+      ],
+      timezone: 'UTC',
     });
   });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[#6913] Question related to drillDown method: undefined is not iterable error
- Fixes this error I've made an issue on. Where if you try to use ResultSet.drillDown method but you don't have a defined dateRange in the query it throws `undefined is not iterable error`.

**Description of Changes Made (if issue reference is not provided)**

The only thing I've changed is the condition where we now check if originalTimeDimension even has the dateRange array before we try to destructure it into variables.
- No tests were affected by this so I've added one that uses ResultSet with undefined dateRange - testing if drillDown snaps the dateRange according to granularity.

***PS***
This is my first time contributing to any project so I'm sorry if I've missed anything.. tried to go by your contribution guide so don't hesitate to point out anything I've missed. 🙂