### PR TITLE
chore: link for package badge

### DIFF
--- a/packages/cubejs-client-core/README.md
+++ b/packages/cubejs-client-core/README.md
@@ -2,7 +2,7 @@
 
 [Website](https://cube.dev) • [Docs](https://cube.dev/docs) • [Blog](https://cube.dev/blog) • [Slack](https://slack.cube.dev) • [Twitter](https://twitter.com/the_cube_dev)
 
-[![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
+[![npm version](https://badge.fury.io/js/%40cubejs-client%2Fcore.svg)](https://badge.fury.io/js/%40cubejs-client%2Fcore)
 [![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
 
 # Cube.js Client Core


### PR DESCRIPTION
**Description of Changes Made (if issue reference is not provided)**

The NPM badge for the core client package was linked to the backend server package. I've noticed that a number of badges in the root READMEs of packages link to the wrong NPM package but I've only fixed this one.