### PR TITLE
fix(databricks-jdbc-driver): ensure default UID property is set

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
@@ -202,6 +202,7 @@ export class DatabricksDriver extends JDBCDriver {
       drivername: 'com.databricks.client.jdbc.Driver',
       customClassPath: undefined,
       properties: {
+        UID: 'token',
         // PWD-parameter passed to the connection string has higher priority,
         // so we can set this one to an empty string to avoid a Java error.
         PWD:

--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
@@ -8,8 +8,6 @@ import {
   getEnv,
   assertDataSource,
 } from '@cubejs-backend/shared';
-import fs from 'fs';
-import path from 'path';
 import { S3, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
@@ -25,7 +23,7 @@ import {
   JDBCDriverConfiguration,
 } from '@cubejs-backend/jdbc-driver';
 import { DatabricksQuery } from './DatabricksQuery';
-import { downloadJDBCDriver } from './installer';
+import { resolveJDBCDriver, extractUidFromJdbcUrl } from './helpers';
 
 export type DatabricksDriverConfiguration = JDBCDriverConfiguration &
   {
@@ -91,16 +89,6 @@ export type DatabricksDriverConfiguration = JDBCDriverConfiguration &
     token?: string,
   };
 
-async function fileExistsOr(
-  fsPath: string,
-  fn: () => Promise<string>,
-): Promise<string> {
-  if (fs.existsSync(fsPath)) {
-    return fsPath;
-  }
-  return fn();
-}
-
 type ShowTableRow = {
   database: string,
   tableName: string,
@@ -114,25 +102,6 @@ type ShowDatabasesRow = {
 const DatabricksToGenericType: Record<string, string> = {
   'decimal(10,0)': 'bigint',
 };
-
-async function resolveJDBCDriver(): Promise<string> {
-  return fileExistsOr(
-    path.join(process.cwd(), 'DatabricksJDBC42.jar'),
-    async () => fileExistsOr(
-      path.join(__dirname, '..', 'download', 'DatabricksJDBC42.jar'),
-      async () => {
-        const pathOrNull = await downloadJDBCDriver();
-        if (pathOrNull) {
-          return pathOrNull;
-        }
-        throw new Error(
-          'Please download and place DatabricksJDBC42.jar inside your ' +
-          'project directory'
-        );
-      }
-    )
-  );
-}
 
 /**
  * Databricks driver class.
@@ -202,7 +171,7 @@ export class DatabricksDriver extends JDBCDriver {
       drivername: 'com.databricks.client.jdbc.Driver',
       customClassPath: undefined,
       properties: {
-        UID: 'token',
+        UID: extractUidFromJdbcUrl(url),
         // PWD-parameter passed to the connection string has higher priority,
         // so we can set this one to an empty string to avoid a Java error.
         PWD:

--- a/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
@@ -32,28 +32,10 @@ export async function resolveJDBCDriver(): Promise<string> {
   );
 }
 
-export function extractUidFromJdbcUrl(url: string): string {
-  const regex = /^jdbc:([^:]+):\/\/([^/]+)(\/[^;]*)?(?:;(.*))?$/;
-  const match = url.match(regex);
-
-  if (!match) {
-    throw new Error(`Invalid JDBC URL: ${url}`);
-  }
-
-  const paramsString = match[4];
-  if (!paramsString) {
-    return 'token';
-  }
-  
-  const params: Record<string, string> = {};
-  const paramsArray = paramsString.split(';');
-
-  paramsArray.forEach(param => {
-    const [key, value] = param.split('=');
-    if (key && value) {
-      params[key] = decodeURIComponent(value);
-    }
-  });
-
-  return params.UID || 'token'; // Return null if UID is not found
+export function extractUidFromJdbcUrl(jdbcUrl: string): string {
+  const [baseUrl, ...params] = jdbcUrl.split(';');
+  const queryString = params.join('&');
+  const standardUrl = `${baseUrl}?${queryString}`;
+  const url = new URL(standardUrl);
+  return url.searchParams.get('UID') || 'token';
 }

--- a/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+
+import { downloadJDBCDriver } from './installer';
+
+async function fileExistsOr(
+  fsPath: string,
+  fn: () => Promise<string>,
+): Promise<string> {
+  if (fs.existsSync(fsPath)) {
+    return fsPath;
+  }
+  return fn();
+}
+
+export async function resolveJDBCDriver(): Promise<string> {
+  return fileExistsOr(
+    path.join(process.cwd(), 'DatabricksJDBC42.jar'),
+    async () => fileExistsOr(
+      path.join(__dirname, '..', 'download', 'DatabricksJDBC42.jar'),
+      async () => {
+        const pathOrNull = await downloadJDBCDriver();
+        if (pathOrNull) {
+          return pathOrNull;
+        }
+        throw new Error(
+          'Please download and place DatabricksJDBC42.jar inside your ' +
+          'project directory'
+        );
+      }
+    )
+  );
+}
+
+export function extractUidFromJdbcUrl(url: string): string {
+  const regex = /^jdbc:([^:]+):\/\/([^/]+)(\/[^;]+);(.+)$/;
+  const match = url.match(regex);
+  
+  if (!match) {
+    throw new Error(`Invalid JDBC URL: ${url}`);
+  }
+
+  const paramsString = match[4];
+  const paramsArray = paramsString.split(';');
+  const params: any = {};
+
+  paramsArray.forEach(param => {
+    const [key, value] = param.split('=');
+    if (key && value) {
+      params[key] = value;
+    }
+  });
+
+  // Return the value of UID if present, otherwise return 'token'
+  return params.UID || 'token';
+}

--- a/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
@@ -33,23 +33,27 @@ export async function resolveJDBCDriver(): Promise<string> {
 }
 
 export function extractUidFromJdbcUrl(url: string): string {
-  const regex = /^jdbc:([^:]+):\/\/([^/]+)(\/[^;]+);(.+)$/;
+  const regex = /^jdbc:([^:]+):\/\/([^/]+)(\/[^;]*)?(?:;(.*))?$/;
   const match = url.match(regex);
-  
+
   if (!match) {
     throw new Error(`Invalid JDBC URL: ${url}`);
   }
 
   const paramsString = match[4];
+  if (!paramsString) {
+    return 'token';
+  }
+  
+  const params: Record<string, string> = {};
   const paramsArray = paramsString.split(';');
-  const params: any = {};
 
   paramsArray.forEach(param => {
     const [key, value] = param.split('=');
     if (key && value) {
-      params[key] = value;
+      params[key] = decodeURIComponent(value);
     }
   });
 
-  return params.UID || 'token';
+  return params.UID || 'token'; // Return null if UID is not found
 }

--- a/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
@@ -33,9 +33,8 @@ export async function resolveJDBCDriver(): Promise<string> {
 }
 
 export function extractUidFromJdbcUrl(jdbcUrl: string): string {
-  const [baseUrl, ...params] = jdbcUrl.split(';');
-  const queryString = params.join('&');
-  const standardUrl = `${baseUrl}?${queryString}`;
-  const url = new URL(standardUrl);
-  return url.searchParams.get('UID') || 'token';
+  const { pathname } = new URL(jdbcUrl);
+  const [_, ...params] = pathname.split(';');
+  const searchParams = new URLSearchParams(params.join('&'));
+  return searchParams.get('UID') || 'token';
 }

--- a/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/helpers.ts
@@ -51,6 +51,5 @@ export function extractUidFromJdbcUrl(url: string): string {
     }
   });
 
-  // Return the value of UID if present, otherwise return 'token'
   return params.UID || 'token';
 }

--- a/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
@@ -66,6 +66,8 @@ export function testIncrementalSchemaLoading(type: string): void {
           await driver.dropTable(t);
         }
         console.log(`Dropping ${tables.length} fixture tables completed`);
+      } catch (e: any) {
+        console.log('Error dropping fixtures', e.stack, e);
       } finally {
         await driver.release();
         await env.stop();

--- a/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
@@ -66,8 +66,6 @@ export function testIncrementalSchemaLoading(type: string): void {
           await driver.dropTable(t);
         }
         console.log(`Dropping ${tables.length} fixture tables completed`);
-      } catch (e: any) {
-        console.log('Error dropping fixtures', e.stack, e);
       } finally {
         await driver.release();
         await env.stop();

--- a/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testIncrementalSchemaLoading.ts
@@ -22,7 +22,6 @@ export function testIncrementalSchemaLoading(type: string): void {
         options: { highWaterMark: number },
       ) => Promise<any>
     };
-    let query: string[];
     let env: Environment;
     let inputSchemas: QuerySchemasResult[];
     let inputTables: QueryTablesResult[];
@@ -47,22 +46,34 @@ export function testIncrementalSchemaLoading(type: string): void {
         process.env.CUBEJS_DB_PORT = `${env.data.port}`;
       }
       driver = (await getDriver(type)).source;
+      const queries = getCreateQueries(type, suffix);
+      console.log(`Creating ${queries.length} fixture tables`);
+      try {
+        for (const q of queries) {
+          await driver.query(q);
+        }
+        console.log(`Creating ${queries.length} fixture tables completed`);
+      } catch (e: any) {
+        console.log('Error creating fixtures', e.stack);
+        throw e;
+      }
     });
   
     afterAll(async () => {
-      await driver.release();
-      await env.stop();
+      try {
+        console.log(`Dropping ${tables.length} fixture tables`);
+        for (const t of tables) {
+          await driver.dropTable(t);
+        }
+        console.log(`Dropping ${tables.length} fixture tables completed`);
+      } finally {
+        await driver.release();
+        await env.stop();
+      }
     });
   
     execute('should establish a connection', async () => {
       await driver.testConnection();
-    });
-  
-    execute('should create the data source', async () => {
-      query = getCreateQueries(type, suffix);
-      await Promise.all(query.map(async (q) => {
-        await driver.query(q);
-      }));
     });
 
     execute('should load and check driver capabilities', async () => {
@@ -103,14 +114,6 @@ export function testIncrementalSchemaLoading(type: string): void {
         column_name: expect.any(String),
         data_type: expect.any(String),
       });
-    });
-
-    execute('should delete the data source', async () => {
-      await Promise.all(
-        tables.map(async (t) => {
-          await driver.dropTable(t);
-        })
-      );
     });
   });
 }


### PR DESCRIPTION
We can not connect to Databricks by using the JDBC URL they provide.
To fix this, users [have to add](https://github.com/cube-js/cube/issues/6197#issuecomment-1690843865) `UID=token`.
This happens because the driver is trying to use a user/password mechanism to authenticate instead of a token in the URL because we're explicitly passing the params to `getConnection()` (PWD).
https://github.com/cube-js/cube/blob/master/packages/cubejs-jdbc-driver/src/JDBCDriver.ts#L140

