### PR TITLE
fix(cubestore): Escape regex symbols in all versions of like operator

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#c296882197dea4d1c38732c1db63c0e505e55436"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#12474778e8a77f7c53b6dac404b469489d38f642"
 dependencies = [
  "bitflags",
  "chrono",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#c296882197dea4d1c38732c1db63c0e505e55436"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#12474778e8a77f7c53b6dac404b469489d38f642"
 dependencies = [
  "arrow",
  "base64 0.13.0",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#c296882197dea4d1c38732c1db63c0e505e55436"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#12474778e8a77f7c53b6dac404b469489d38f642"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -1621,6 +1621,14 @@ async fn ilike(service: Box<dyn SqlClient>) {
         .unwrap();
     assert_eq!(to_rows(&r), rows(&["some_underscore"]));
 
+    let r = service
+        .exec_query(
+            "SELECT t FROM s.strings WHERE t ILIKE CONCAT('%', '(', '%') ORDER BY t",
+        )
+        .await
+        .unwrap();
+    assert_eq!(to_rows(&r), rows(&["some_underscore"]));
+
     // Compare constant string with a bunch of patterns.
     // Inputs are: ('aba', '%ABA'), ('ABa', '%aba%'), ('CABA', 'aba%'), ('ZABA', '%a%b%a%'),
     //             ('ZZZ', 'zzz'), ('TTT', 'TTT').


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
