### PR TITLE
fix(duckdb-driver): allow setting default schema

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1429,6 +1429,16 @@ const variables: Record<string, (...args: any) => any> = {
     ]
   ),
 
+  duckdbSchema: ({
+    dataSource
+  }: {
+    dataSource: string,
+  }) => (
+    process.env[
+      keyByDataSource('CUBEJS_DB_DUCKDB_SCHEMA', dataSource)
+    ]
+  ),
+
   /**
    * Presto catalog.
    */

--- a/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
@@ -85,6 +85,10 @@ export class DuckDBDriver extends BaseDriver implements DriverInterface {
         key: 'memory_limit',
         value: getEnv('duckdbMemoryLimit', this.config),
       },
+      {
+        key: 'schema',
+        value: getEnv('duckdbSchema', this.config),
+      },
     ];
     
     for (const { key, value } of configuration) {


### PR DESCRIPTION
**Expected Behaviour:**

when connecting to Motherduck and going through the data model wizard, the “Select Tables” page should show the database > schema > table hierarchy.  It should then create the cubes with sql_table: database.schema.table

**Actual Behaviour:**

the database level is missing from the data model wizard, so schemas from all databases are grouped together.  The database is also missing from the generated cube definitions, displaying as sql_table: schema.table