### PR TITLE
Order can be an array of objects (firestore storing support)

### DIFF
--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -103,7 +103,10 @@ const querySchema = Joi.object().keys({
   }).oxor('dateRange', 'compareDateRange')),
   order: Joi.alternatives(
     Joi.object().pattern(id, Joi.valid('asc', 'desc')),
-    Joi.array().items(Joi.array().min(2).ordered(id, Joi.valid('asc', 'desc')))
+    Joi.array().items(
+      Joi.array().min(2).ordered(id, Joi.valid('asc', 'desc')),
+      Joi.object().pattern(id, Joi.valid('asc', 'desc'))
+    )
   ),
   segments: Joi.array().items(id),
   timezone: Joi.string(),
@@ -119,9 +122,15 @@ const normalizeQueryOrder = order => {
   let result = [];
   const normalizeOrderItem = (k, direction) => ([k, direction]);
   if (order) {
-    result = Array.isArray(order) ?
-      order.map(([k, direction]) => normalizeOrderItem(k, direction)) :
-      Object.keys(order).map(k => normalizeOrderItem(k, order[k]));
+    if (Array.isArray(order)) {
+      result = order.map(order => {
+        return Array.isArray(order) ?
+          normalizeOrderItem(order[0], order[1]) :
+          (k = Object.keys(order)[0], normalizeOrderItem(k, order[k]))
+      });
+    } else {
+      result = Object.keys(order).map(k => normalizeOrderItem(k, order[k]));
+    }
   }
   return result;
 };


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

https://cube-js.slack.com/archives/C04NYBJP7RQ/p1695722856481539

**Description of Changes Made (if issue reference is not provided)**

Add support for storing order as array of objects as firestore doesnt allow storing array of arrays.