### PR TITLE
fix: Correct GraphQL endpoint displayed on front-end

### DIFF
--- a/packages/cubejs-playground/src/pages/FrontendIntegrations/FrontendIntegrationsPage.tsx
+++ b/packages/cubejs-playground/src/pages/FrontendIntegrations/FrontendIntegrationsPage.tsx
@@ -10,7 +10,7 @@ export function FrontendIntegrationsPage() {
   const apiUrl = 'http://localhost:4000/cubejs-api';
   const restUrl = `${apiUrl}/v1/load`;
   const wsUrl = "ws://localhost:4000/";
-  const graphqlUrl = `${apiUrl}/v1/graphql`;
+  const graphqlUrl = `${apiUrl}/graphql`;
 
   const dataSource = [
     {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

GraphQL endpoint has been incorrect here for a while.

**Description of Changes Made (if issue reference is not provided)**

Removed the `/v1` in front of `/graphql` so we render the correct endpoint.