### PR TITLE
fix(jdbc-driver): node-java-maven package.json path issue

### DIFF
--- a/packages/cubejs-cli/src/command/create.ts
+++ b/packages/cubejs-cli/src/command/create.ts
@@ -91,7 +91,7 @@ const create = async (projectName, options) => {
     logStage('Installing JDBC dependencies');
 
     // eslint-disable-next-line import/no-dynamic-require,global-require,@typescript-eslint/no-var-requires
-    const JDBCDriver = require(path.join(process.cwd(), 'node_modules', '@cubejs-backend', 'jdbc-driver', 'driver', 'JDBCDriver'));
+    const JDBCDriver = require(path.join(process.cwd(), 'node_modules', '@cubejs-backend', 'jdbc-driver'));
 
     const { jdbcDriver } = await inquirer.prompt([{
       type: 'list',

--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -15,6 +15,7 @@ import { BaseDriver } from '@cubejs-backend/base-driver';
 import * as SqlString from 'sqlstring';
 import { promisify } from 'util';
 import genericPool, { Factory, Pool } from 'generic-pool';
+import path from 'path';
 
 import { DriverOptionsInterface, SupportedDrivers } from './supported-drivers';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -37,7 +38,10 @@ type JdbcStatement = {
 const initMvn = (customClassPath: any) => {
   if (!mvnPromise) {
     mvnPromise = new Promise((resolve, reject) => {
-      mvn((err: any, mvnResults: any) => {
+      const options = {
+        packageJsonPath: `${path.join(__dirname, '../..')}/package.json`,
+      };
+      mvn(options, (err: any, mvnResults: any) => {
         if (err && !err.message.includes('Could not find java property')) {
           reject(err);
         } else {


### PR DESCRIPTION
Addressed an issue where the JDBC driver, utilizing the `node-java-maven` library, attempted to read a `package.json` file in the YAML deployment template directory. As this file was absent, queries failed to execute. The fix involves specifying the path to a valid `package.json` file using the `packageJsonPath` option in `node-java-maven`.