### PR TITLE
fix(duckdb-driver): use schema param in information_schema queries

### DIFF
--- a/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
@@ -26,10 +26,14 @@ type InitPromise = {
 export class DuckDBDriver extends BaseDriver implements DriverInterface {
   protected initPromise: Promise<InitPromise> | null = null;
 
+  private schema: string;
+
   public constructor(
     protected readonly config: DuckDBDriverConfiguration = {},
   ) {
     super();
+
+    this.schema = getEnv('duckdbSchema', this.config);
   }
 
   protected async init(): Promise<InitPromise> {
@@ -121,6 +125,26 @@ export class DuckDBDriver extends BaseDriver implements DriverInterface {
       connection,
       db
     };
+  }
+
+  public override informationSchemaQuery(): string {
+    if (this.schema) {
+      return `${super.informationSchemaQuery()} AND table_catalog = '${this.schema}'`;
+    }
+
+    return super.informationSchemaQuery();
+  }
+
+  public override getSchemasQuery(): string {
+    if (this.schema) {
+      return `
+        SELECT table_schema as ${super.quoteIdentifier('schema_name')}
+        FROM information_schema.tables
+        WHERE table_catalog = '${this.schema}'
+        GROUP BY table_schema
+      `;
+    }
+    return super.getSchemasQuery();
   }
 
   protected async getConnection(): Promise<Connection> {

--- a/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
@@ -16,6 +16,7 @@ import { HydrationStream, transformRow } from './HydrationStream';
 export type DuckDBDriverConfiguration = {
   dataSource?: string,
   initSql?: string,
+  schema?: string,
 };
 
 type InitPromise = {
@@ -33,7 +34,7 @@ export class DuckDBDriver extends BaseDriver implements DriverInterface {
   ) {
     super();
 
-    this.schema = getEnv('duckdbSchema', this.config);
+    this.schema = this.config.schema || getEnv('duckdbSchema', this.config);
   }
 
   protected async init(): Promise<InitPromise> {


### PR DESCRIPTION
There is a change on DuckDB's side, so previously `SET schema=<value>` worked for `information_schema` queries.
Now, we need the combination of `SET` and `WHERE` clause.
- `WHERE` clause will narrow the list of returned schemas
- `SET` will allow using these tables without referencing the catalog to resolve ambiguity.

> There is confusion with the param naming on DuckDB's side. While the param is called `schema` in [docs](https://duckdb.org/docs/archive/0.9.1/sql/configuration), when you issue `SET schema=<value>` it sets the **catalog**. 