### PR TITLE
feat(cubesql): Enable `COVAR` aggr functions push down

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2433,6 +2433,8 @@ class BaseQuery {
         STDDEV_SAMP: 'STDDEV_SAMP({{ args_concat }})',
         VAR_POP: 'VAR_POP({{ args_concat }})',
         VAR_SAMP: 'VAR_SAMP({{ args_concat }})',
+        COVAR_POP: 'COVAR_POP({{ args_concat }})',
+        COVAR_SAMP: 'COVAR_SAMP({{ args_concat }})',
 
         COALESCE: 'COALESCE({{ args_concat }})',
         CONCAT: 'CONCAT({{ args_concat }})',

--- a/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.js
@@ -11,4 +11,12 @@ export class RedshiftQuery extends PostgresQuery {
   nowTimestampSql() {
     return 'GETDATE()';
   }
+
+  sqlTemplates() {
+    return {
+      ...super.sqlTemplates(),
+      COVAR_POP: undefined,
+      COVAR_SAMP: undefined,
+    };
+  }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds SQL push down support for `COVAR_POP` and `COVAR_SAMP` aggregation functions, with the exception of Redshift which lacks support for these.
