### PR TITLE
fix(native): Jinja - catch panic from render workers

### DIFF
--- a/packages/cubejs-backend-native/src/template/workers.rs
+++ b/packages/cubejs-backend-native/src/template/workers.rs
@@ -1,10 +1,11 @@
 use crate::template::neon_mj::*;
 use cubesql::CubeError;
 
-use log::trace;
+use log::{error, trace};
 use minijinja as mj;
 use neon::prelude::*;
 use neon::types::Deferred;
+use std::panic;
 
 pub struct JinjaEngineWorkerJob {
     pub(crate) template_name: String,
@@ -17,38 +18,67 @@ struct JinjaEngineWorker {
 }
 
 impl JinjaEngineWorker {
+    /// Renders a template, converting an unwinding panic into an error.
+    ///
+    /// Rendering executes user provided code (Python filters/functions via pyo3, custom
+    /// value implementations), which can panic. Without catching it, the worker thread
+    /// dies: the promise is rejected with a useless `Deferred` was dropped without being
+    /// settled error and the pool silently shrinks. Once the last worker is gone, the job
+    /// channel is closed and every next render fails with "sending into a closed channel".
+    fn render_catch_panic(
+        env: &mj::Environment,
+        template_name: &str,
+        ctx: mj::value::Value,
+    ) -> Result<Result<String, mj::Error>, CubeError> {
+        let render_block = panic::AssertUnwindSafe(|| {
+            let template = env.get_template(template_name)?;
+
+            template.render(ctx)
+        });
+
+        panic::catch_unwind(render_block).map_err(|panic_payload| {
+            CubeError::panic_with_message(
+                panic_payload,
+                "Unexpected panic while rendering jinja template",
+            )
+        })
+    }
+
+    fn process_render(job: JinjaEngineWorkerJob, js_channel: &Channel, env: &mj::Environment) {
+        let JinjaEngineWorkerJob {
+            template_name,
+            ctx,
+            deferred,
+        } = job;
+
+        match Self::render_catch_panic(env, &template_name, ctx) {
+            Ok(result) => {
+                deferred.settle_with(js_channel, move |mut cx| -> NeonResult<Handle<JsString>> {
+                    match result {
+                        Ok(r) => Ok(cx.string(r)),
+                        Err(err) => cx.throw_from_mj_error(err),
+                    }
+                });
+            }
+            Err(err) => {
+                error!("{} (template: {})", err, template_name);
+
+                deferred.settle_with(js_channel, move |mut cx| -> NeonResult<Handle<JsString>> {
+                    cx.throw_error(err.to_string())
+                });
+            }
+        }
+    }
+
     fn new(
         id: usize,
         env: mj::Environment<'static>,
-        js_channel: neon::event::Channel,
+        js_channel: Channel,
         receiver: async_channel::Receiver<JinjaEngineWorkerJob>,
     ) -> Self {
         let thread = std::thread::spawn(move || loop {
             if let Ok(job) = receiver.recv_blocking() {
-                let template = match env.get_template(&job.template_name) {
-                    Ok(t) => t,
-                    Err(err) => {
-                        job.deferred.settle_with(
-                            &js_channel,
-                            move |mut cx| -> NeonResult<Handle<JsString>> {
-                                cx.throw_from_mj_error(err)
-                            },
-                        );
-
-                        continue;
-                    }
-                };
-
-                let result = template.render(job.ctx);
-                job.deferred.settle_with(
-                    &js_channel,
-                    move |mut cx| -> NeonResult<Handle<JsString>> {
-                        match result {
-                            Ok(r) => Ok(cx.string(r)),
-                            Err(err) => cx.throw_from_mj_error(err),
-                        }
-                    },
-                );
+                Self::process_render(job, &js_channel, &env);
             } else {
                 trace!(
                     "Closing jinja thread, id: {}, threadId: {:?}",
@@ -99,5 +129,79 @@ impl JinjaEngineWorkerPool {
         self.workers_rx
             .send_blocking(job)
             .map_err(|err| CubeError::internal(format!("Unable to schedule rendering: {}", err)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_environment() -> mj::Environment<'static> {
+        let mut env = mj::Environment::new();
+
+        env.add_function("panic_fn", || -> Result<mj::value::Value, mj::Error> {
+            panic!("Boom from a function")
+        });
+
+        env.add_template("render.jinja", "Hello {{ name }}")
+            .unwrap();
+        env.add_template("panic.jinja", "{{ panic_fn() }}").unwrap();
+
+        env
+    }
+
+    #[test]
+    fn test_render() {
+        let env = test_environment();
+
+        let actual = JinjaEngineWorker::render_catch_panic(
+            &env,
+            "render.jinja",
+            mj::context! { name => "world" },
+        )
+        .expect("Render must not panic")
+        .expect("Render must not fail");
+
+        assert_eq!(actual, "Hello world");
+    }
+
+    #[test]
+    fn test_render_unknown_template() {
+        let env = test_environment();
+
+        let err = JinjaEngineWorker::render_catch_panic(
+            &env,
+            "unknown.jinja",
+            mj::value::Value::UNDEFINED,
+        )
+        .expect("Unknown template must not panic")
+        .expect_err("Unknown template must fail");
+
+        assert_eq!(err.kind(), mj::ErrorKind::TemplateNotFound);
+    }
+
+    #[test]
+    fn test_render_panic() {
+        let env = test_environment();
+
+        let err =
+            JinjaEngineWorker::render_catch_panic(&env, "panic.jinja", mj::value::Value::UNDEFINED)
+                .expect_err("Panic must be caught");
+
+        assert_eq!(
+            err.message,
+            "Unexpected panic while rendering jinja template. Reason: Boom from a function"
+        );
+
+        // Environment must stay usable after a panic, because the worker is reused
+        let actual = JinjaEngineWorker::render_catch_panic(
+            &env,
+            "render.jinja",
+            mj::context! { name => "world" },
+        )
+        .expect("Render must not panic")
+        .expect("Render must not fail");
+
+        assert_eq!(actual, "Hello world");
     }
 }

--- a/packages/cubejs-backend-native/test/jinja.test.ts
+++ b/packages/cubejs-backend-native/test/jinja.test.ts
@@ -157,6 +157,7 @@ suite('Jinja (new api)', () => {
     loadTemplateFile(jinjaEngine, 'variables.yml.jinja');
     loadTemplateFile(jinjaEngine, 'filters.yml.jinja');
     loadTemplateFile(jinjaEngine, 'template_error_python.jinja');
+    loadTemplateFile(jinjaEngine, 'template_panic.jinja');
 
     for (let i = 1; i < 9; i++) {
       loadTemplateFile(jinjaEngine, `0${i}.yml.jinja`);
@@ -192,4 +193,21 @@ suite('Jinja (new api)', () => {
   for (let i = 1; i < 9; i++) {
     testTemplateBySnapshot(initJinjaEngine, `0${i}.yml.jinja`, {});
   }
+
+  // A panic inside a worker thread used to kill it, which left the promise
+  // pending forever and reduced the pool by one worker
+  test('render template_panic.jinja', async () => {
+    const { jinjaEngine } = await initJinjaEngine();
+
+    await expect(
+      jinjaEngine.renderTemplate('template_panic.jinja', { js_fn: () => 'unsupported' }, null)
+    ).rejects.toThrow(
+      'Unexpected panic while rendering jinja template. Reason: Converting from JsFunction to minijinja::Value is not supported'
+    );
+
+    // The worker must survive a panic and continue to process the next jobs
+    await expect(
+      jinjaEngine.renderTemplate('01.yml.jinja', {}, null)
+    ).resolves.toBeDefined();
+  });
 });

--- a/packages/cubejs-backend-native/test/jinja.test.ts
+++ b/packages/cubejs-backend-native/test/jinja.test.ts
@@ -202,7 +202,7 @@ suite('Jinja (new api)', () => {
     await expect(
       jinjaEngine.renderTemplate('template_panic.jinja', { js_fn: () => 'unsupported' }, null)
     ).rejects.toThrow(
-      'Unexpected panic while rendering jinja template. Reason: Converting from JsFunction to minijinja::Value is not supported'
+    ).rejects.toThrow(/Unexpected panic while rendering jinja template/);
     );
 
     // The worker must survive a panic and continue to process the next jobs

--- a/packages/cubejs-backend-native/test/jinja.test.ts
+++ b/packages/cubejs-backend-native/test/jinja.test.ts
@@ -201,9 +201,7 @@ suite('Jinja (new api)', () => {
 
     await expect(
       jinjaEngine.renderTemplate('template_panic.jinja', { js_fn: () => 'unsupported' }, null)
-    ).rejects.toThrow(
     ).rejects.toThrow(/Unexpected panic while rendering jinja template/);
-    );
 
     // The worker must survive a panic and continue to process the next jobs
     await expect(

--- a/packages/cubejs-backend-native/test/templates/template_panic.jinja
+++ b/packages/cubejs-backend-native/test/templates/template_panic.jinja
@@ -1,0 +1,3 @@
+{# Conversion of a JsFunction to a minijinja value is not supported and panics,
+   it's used to test that a panic inside a worker doesn't kill it #}
+{{ COMPILE_CONTEXT.js_fn }}


### PR DESCRIPTION
A panic inside a jinja render worker killed the worker thread, and that was worse than just losing one render:

- the pending `Deferred` was dropped unsettled, so `renderTemplate()` rejected with ``​`neon::types::Deferred` was dropped without being settled`` instead of the real reason;
- the worker was gone for good and the pool silently shrank. Once the last worker died, the job channel got closed and **every next render** failed with `Unable to schedule rendering: sending into a closed channel` — a single panic could brick the whole jinja engine (immediately when `workers: 1`).

Reproduced on `master` with a template referencing a JS function from the compile context (`to_minijinja_value` panics for `CLRepr::JsFunction`, and that conversion happens lazily on the worker thread while rendering):

```
[FAIL] panic.jinja rejected with an unexpected error: `neon::types::Deferred` was dropped without being settled
[FAIL] worker died after the panic: Unable to schedule rendering: sending into a closed channel
```

After the fix:

```
[OK] panic.jinja rejected with: Internal Error: Unexpected panic while rendering jinja template. Reason: Converting from JsFunction to minijinja::Value is not supported
[OK] worker is alive after the panic
```

## What's in the change

- rendering is extracted into `render_catch_panic()` and wrapped in `panic::catch_unwind`; the payload is turned into a `CubeError` via `CubeError::panic_with_message` (same pattern as the Python runtime in `src/python/runtime.rs`)
- the `Deferred` is now moved out of the job **before** rendering, so it is always available to settle the promise — including on the panic path
- the panic is logged with `error!` together with the template name
- Rust unit tests for `render_catch_panic` (success / template-not-found / panic + the environment stays usable afterwards)
- a jest regression test (`test/templates/template_panic.jinja`) asserting the promise is rejected with the panic reason and that the worker still serves the next render

## Verification

| check | result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | pass |
| `cargo clippy ... --features python -- -D warnings` | pass |
| `cargo test` (`template::workers`) | 3 passed |
| `jest dist/test/jinja.test.js` (build with Python 3.13) | 18 passed, 16 snapshots |

Note: the original version of this PR never compiled — `catch_unwind` rejected the closure on `UnwindSafe` grounds (7 × E0277) and `job` was used after being moved into it. That's fixed here.