### PR TITLE
feat(cubesql): Support SQL push down for several functions

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -118,6 +118,11 @@ export class DatabricksQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    templates.functions.BTRIM = 'TRIM({% if args[1] is defined %}{{ args[1] }} FROM {% endif %}{{ args[0] }})';
+    templates.functions.LTRIM = 'LTRIM({{ args|reverse|join(", ") }})';
+    templates.functions.RTRIM = 'RTRIM({{ args|reverse|join(", ") }})';
+    // Databricks has a DATEDIFF function but produces values different from Redshift
+    delete templates.functions.DATEDIFF;
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2470,6 +2470,24 @@ class BaseQuery {
 
         STDDEV: 'STDDEV_SAMP({{ args_concat }})',
         SUBSTR: 'SUBSTRING({{ args_concat }})',
+        CHARACTERLENGTH: 'CHAR_LENGTH({{ args[0] }})',
+
+        // Non-ANSI functions
+        BTRIM: 'BTRIM({{ args_concat }})',
+        LTRIM: 'LTRIM({{ args_concat }})',
+        RTRIM: 'RTRIM({{ args_concat }})',
+        ATAN2: 'ATAN2({{ args_concat }})',
+        COT: 'COT({{ args_concat }})',
+        DEGREES: 'DEGREES({{ args_concat }})',
+        RADIANS: 'RADIANS({{ args_concat }})',
+        SIGN: 'SIGN({{ args_concat }})',
+        ASCII: 'ASCII({{ args_concat }})',
+        STRPOS: 'POSITION({{ args[1] }} IN {{ args[0] }})',
+        REPLACE: 'REPLACE({{ args_concat }})',
+        DATEDIFF: 'DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})',
+        TO_CHAR: 'TO_CHAR({{ args_concat }})',
+        // DATEADD is being rewritten to DATE_ADD
+        // DATEADD: 'DATEADD({{ date_part }}, {{ interval }}, {{ args[2] }})',
       },
       statements: {
         select: 'SELECT {{ select_concat | map(attribute=\'aliased\') | join(\', \') }} \n' +

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -151,6 +151,12 @@ export class BigqueryQuery extends BaseQuery {
     templates.quotes.escape = '\\`';
     templates.functions.DATETRUNC = 'DATETIME_TRUNC(CAST({{ args[1] }} AS DATETIME), {{ date_part }})';
     templates.functions.LOG = 'LOG({{ args_concat }}{% if args[1] is undefined %}, 10{% endif %})';
+    templates.functions.BTRIM = 'TRIM({{ args_concat }})';
+    templates.functions.STRPOS = 'STRPOS({{ args_concat }})';
+    templates.functions.DATEDIFF = 'DATETIME_DIFF(CAST({{ args[2] }} AS DATETIME), CAST({{ args[1] }} AS DATETIME), {{ date_part }})';
+    // DATEADD is being rewritten to DATE_ADD
+    // templates.functions.DATEADD = 'DATETIME_ADD(CAST({{ args[2] }} AS DATETTIME), INTERVAL {{ interval }} {{ date_part }})';
+    delete templates.functions.TO_CHAR;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
     templates.expressions.interval = 'INTERVAL {{ interval }}';
     templates.expressions.extract = 'EXTRACT({% if date_part == \'DOW\' %}DAYOFWEEK{% elif date_part == \'DOY\' %}DAYOFYEAR{% else %}{{ date_part }}{% endif %} FROM {{ expr }})';

--- a/packages/cubejs-schema-compiler/src/adapter/PostgresQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PostgresQuery.ts
@@ -51,6 +51,9 @@ export class PostgresQuery extends BaseQuery {
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
     templates.functions.CONCAT = 'CONCAT({% for arg in args %}CAST({{arg}} AS TEXT){% if not loop.last %},{% endif %}{% endfor %})';
     templates.functions.DATEPART = 'DATE_PART({{ args_concat }})';
+    // DATEADD is being rewritten to DATE_ADD
+    // templates.functions.DATEADD = '({{ args[2] }} + \'{{ interval }} {{ date_part }}\'::interval)';
+    delete templates.functions.DATEDIFF;
     templates.expressions.interval = 'INTERVAL \'{{ interval }}\'';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
 

--- a/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
@@ -13,11 +13,10 @@ export class RedshiftQuery extends PostgresQuery {
   }
 
   public sqlTemplates() {
-    return {
-      ...super.sqlTemplates(),
-      COVAR_POP: undefined,
-      COVAR_SAMP: undefined,
-      DLOG10: 'LOG(10, {{ args_concat }})',
-    };
+    const templates = super.sqlTemplates();
+    templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
+    delete templates.functions.COVAR_POP;
+    delete templates.functions.COVAR_SAMP;
+    return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -56,6 +56,8 @@ export class SnowflakeQuery extends BaseQuery {
     templates.functions.DATEPART = 'DATE_PART({{ args_concat }})';
     templates.functions.LOG = 'LOG({% if args[1] is undefined %}10, {% endif %}{{ args_concat }})';
     templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
+    templates.functions.CHARACTERLENGTH = 'LENGTH({{ args[0] }})';
+    templates.functions.BTRIM = 'TRIM({{ args_concat }})';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.expressions.interval = 'INTERVAL \'{{ interval }}\'';
     return templates;

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -217,6 +217,9 @@ pub fn get_test_tenant_ctx_customized(custom_templates: Vec<(String, String)>) -
                     ("functions/FLOOR".to_string(), "FLOOR({{ args_concat }})".to_string()),
                     ("functions/TRUNC".to_string(), "TRUNC({{ args_concat }})".to_string()),
                     ("functions/LEAST".to_string(), "LEAST({{ args_concat }})".to_string()),
+                    ("functions/DATEDIFF".to_string(), "DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})".to_string()),
+                    // DATEADD is being rewritten to DATE_ADD
+                    // ("functions/DATEADD".to_string(), "DATEADD({{ date_part }}, {{ interval }}, {{ args[2] }})".to_string()),
                     ("expressions/extract".to_string(), "EXTRACT({{ date_part }} FROM {{ expr }})".to_string()),
                     (
                         "statements/select".to_string(),

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -410,12 +410,18 @@ impl SqlTemplates {
         scalar_function: String,
         args: Vec<String>,
         date_part: Option<String>,
+        interval: Option<String>,
     ) -> Result<String, CubeError> {
         let function = scalar_function.to_string().to_uppercase();
         let args_concat = args.join(", ");
         self.render_template(
             &format!("functions/{}", function),
-            context! { args_concat => args_concat, args => args, date_part => date_part },
+            context! {
+                args_concat => args_concat,
+                args => args,
+                date_part => date_part,
+                interval => interval,
+            },
         )
     }
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds SQL push down support for these functions:
- `ASCII`
- `ATAN2`
- `BTRIM`
- `CHAR_LENGTH`
- `COT`
- `DATEDIFF`
- `DEGREES`
- `LTRIM`
- `RADIANS`
- `REPLACE`
- `RTRIM`
- `SIGN`
- `STRPOS`
- `TO_CHAR`

It also fixes an issue with pushing down `DLOG10` in Redshift.