### PR TITLE
Cubestore - Minio s3 remotefs, undefined subpath consistency error.

### DIFF
--- a/rust/cubestore/cubestore/src/remotefs/minio.rs
+++ b/rust/cubestore/cubestore/src/remotefs/minio.rs
@@ -322,9 +322,9 @@ impl RemoteFs for MINIORemoteFs {
 //TODO
 impl MINIORemoteFs {
     fn s3_path(&self, remote_path: &str) -> String {
-        match &self.sub_path {
-            Some(sub_path) => format!("{}/{}", sub_path, remote_path),
-            None => remote_path.to_string(),
-        }
+        self.sub_path
+            .as_ref()
+            .map(|p| format!("{}/{}", p, remote_path))
+            .unwrap_or_else(|| format!("{}", remote_path))
     }
 }

--- a/rust/cubestore/cubestore/src/remotefs/minio.rs
+++ b/rust/cubestore/cubestore/src/remotefs/minio.rs
@@ -322,13 +322,9 @@ impl RemoteFs for MINIORemoteFs {
 //TODO
 impl MINIORemoteFs {
     fn s3_path(&self, remote_path: &str) -> String {
-        format!(
-            "{}/{}",
-            self.sub_path
-                .as_ref()
-                .map(|p| p.to_string())
-                .unwrap_or_else(|| "".to_string()),
-            remote_path
-        )
+        match &self.sub_path {
+            Some(sub_path) => format!("{}/{}", sub_path, remote_path),
+            None => remote_path.to_string(),
+        }
     }
 }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

During each file upload, a consistency error occurred. This could have been due to the fact that if there is no defined 'subpath,' a '/' is still appended to the beginning of the path. In the case of a defined subpath, this does not happen, as the subpath becomes the first value received, rather than the '/' symbol.


Error:

```
2023-11-23 09:33:46,454 ERROR [cubestore::util] <pid:1> Error during Metastore upload: CubeError { message: "File metastore-1700732026259/CURRENT can't be listed after upload. Either there's Cube Store cluster misconfiguration, or storage can't provide the required consistency.", backtrace: "", cause: Internal }
```

```
Error: Error during upload of asdasdasd_rollup_gg1crwol_pitg0ves_1ils6st-0.csv.gz create table: CREATE TABLE asdasdasd_rollup_gg1crwol_pitg0ves_1ils6st (`asd_asd__guid` varchar(64), `asd__record_main_type` varchar(255), `asd__record_sub_type` varchar(255), `asd__record_title` varchar(255), `asd__created_at_day` timestamp, `asd__count` bigint): Internal: File temp-uploads/asdasdasd_rollup_gg1crwol_pitg0ves_1ils6st-0.csv.gz can't be listed after upload. Either there's Cube Store cluster misconfiguration, or storage can't provide the required consistency.
    at /cube/node_modules/@cubejs-backend/cubestore-driver/src/CubeStoreDriver.ts:326:25
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```


