### PR TITLE
feat(cubesql): Support `Utf8 * Interval` expression

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "arrow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "async-trait",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "arrow",
  "chrono",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3fb79c32defa4ec39ccf658b6185704d1980f228#3fb79c32defa4ec39ccf658b6185704d1980f228"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5833202f5a9b69fded3cd45ffc9041ca5c404d33#5833202f5a9b69fded3cd45ffc9041ca5c404d33"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "3fb79c32defa4ec39ccf658b6185704d1980f228", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "5833202f5a9b69fded3cd45ffc9041ca5c404d33", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -20035,4 +20035,20 @@ ORDER BY \"COUNT(count)\" DESC"
             .sql;
         assert!(sql.contains("+ '7 day'::interval"));
     }
+
+    #[tokio::test]
+    async fn test_string_multiply_interval() -> Result<(), CubeError> {
+        init_logger();
+
+        insta::assert_snapshot!(
+            "test_string_multiply_interval",
+            execute_query(
+                "SELECT NULL * INTERVAL '1 day' n, '5' * INTERVAL '1 day' d5".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_string_multiply_interval.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_string_multiply_interval.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT NULL * INTERVAL '1 day' n, '5' * INTERVAL '1 day' d5\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++------+------------------------------------------------+
+| n    | d5                                             |
++------+------------------------------------------------+
+| NULL | 0 years 0 mons 5 days 0 hours 0 mins 0.00 secs |
++------+------------------------------------------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `Utf8 * Interval` (and vice versa) expressions, mainly to support `NULL * INTERVAL '…'` expressions. It also fixes with `date_add`/`date_sub` functions where adding a `NULL` interval would not yield `NULL`. Related tests are included.
