### PR TITLE
fix(cubejs-dremio-driver): Change TIMESTAMP to TO_TIMESTAMP

### DIFF
--- a/packages/cubejs-dremio-driver/driver/DremioQuery.js
+++ b/packages/cubejs-dremio-driver/driver/DremioQuery.js
@@ -73,7 +73,7 @@ class DremioQuery extends BaseQuery {
     const values = timeDimension.timeSeries().map(
       ([from, to]) => `select '${from}' f, '${to}' t`
     ).join(' UNION ALL ');
-    return `SELECT TIMESTAMP(dates.f) date_from, TIMESTAMP(dates.t) date_to FROM (${values}) AS dates`;
+    return `SELECT TO_TIMESTAMP(dates.f, 'YYYY-MM-DDTHH:MI:SS.FFF') date_from, TO_TIMESTAMP(dates.t, 'YYYY-MM-DDTHH:MI:SS.FFF') date_to FROM (${values}) AS dates`;
   }
 
   concatStringsSql(strings) {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Conversation in Slack: https://cube-js.slack.com/archives/C04KDTE2EF7/p1701944283139919

Dremio docs:
* https://docs.dremio.com/cloud/reference/sql/sql-functions/functions/TO_TIMESTAMP/
* https://docs.dremio.com/cloud/reference/sql/sql-functions/DATE_TIME/#datetime-formatting