### PR TITLE
fix(cubejs-server-core): sign jwt dev token with api secret

### DIFF
--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -578,7 +578,7 @@ export class DevServer {
       const { payload = {} } = req.body;
       const jwtOptions = typeof payload.exp != null ? {} : { expiresIn: '1d' };
 
-      const token = jwt.sign(payload, options.apiSecret, jwtOptions);
+      const token = jwt.sign(payload, process.env.CUBEJS_API_SECRET || options.apiSecret, jwtOptions);
 
       res.json({ token });
     }));


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#7562

**Description of Changes Made (if issue reference is not provided)**

Modified the token-signing logic to use process.env.CUBEJS_API_SECRET if available; otherwise, it falls back to using options.apiSecret. This change ensures that the signing process considers the environment variable CUBEJS_API_SECRET for enhanced flexibility and security.
