### PR TITLE
fix(@cubejs-client/ngx): set module to fesm2015

### DIFF
--- a/packages/cubejs-client-ngx/package.json
+++ b/packages/cubejs-client-ngx/package.json
@@ -44,7 +44,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "module": "dist/fesm5/cubejs-client-ngx.js",
+  "module": "dist/fesm2015/cubejs-client-ngx.js",
   "es2015_ivy_ngcc": "__ivy_ngcc__/dist/fesm2015/cubejs-client-ngx.js",
   "es2015": "dist/fesm2015/cubejs-client-ngx.js",
   "esm5": "dist/esm5/cubejs-client-ngx.js",


### PR DESCRIPTION
fesm5 is no longer supported by angular package format

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Closes #7570