### PR TITLE
feat(cubestore): Upgrade rust to 1.77.0-nightly (635124704 2024-01-27)

### DIFF
--- a/.github/workflows/birdbox.yml
+++ b/.github/workflows/birdbox.yml
@@ -33,12 +33,6 @@ jobs:
         run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -100,12 +94,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:
@@ -169,12 +157,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -66,12 +66,6 @@ jobs:
         run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - name: Install Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/drivers-tests.yml
+++ b/.github/workflows/drivers-tests.yml
@@ -211,13 +211,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
-
       - name: Install Node.js 18.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -661,7 +661,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-22
+          toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
           override: true
           components: rustfmt
@@ -738,7 +738,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-22
+          toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
           override: true
           components: rustfmt

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -225,12 +225,6 @@ jobs:
           df -h
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust/cubestore -> target

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -231,11 +231,10 @@ jobs:
           # Separate path for release key to protect cache bloating
           shared-key: cubestore-release
           key: ubuntu-20.04
-      - name: Build cubestore
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path rust/cubestore/Cargo.toml -j 4 --release
+      - name: Build Cube Store
+        run: |
+          cd rust/cubestore
+          cargo build --release -j 4
       - name: 'Upload cubestored-x86_64-unknown-linux-gnu-release artifact'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -56,12 +56,6 @@ jobs:
         with:
           # pulls all commits (needed for codecov)
           fetch-depth: 2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2022-06-22
-          override: true
-          components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust/cubesql -> target

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly-2022-06-22]
+        rust: [nightly-2024-01-29]
     env:
       RUST: ${{ matrix.rust }}
     steps:
@@ -185,7 +185,7 @@ jobs:
           repository: cubejs/cubestore
           readme-filepath: ./rust/cubestore/README.md
 
-  cross:
+  cubestore:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
@@ -194,39 +194,21 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
+          - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
-          - aarch64-unknown-linux-gnu
         include:
-          - os: ubuntu-20.04
-            target: x86_64-unknown-linux-gnu
-            executable_name: cubestored
-            cross: true
+          - os: windows-2019
+            target: x86_64-pc-windows-msvc
+            executable_name: cubestored.exe
             strip: true
-            compress: false
-          - os: ubuntu-20.04
-            target: x86_64-unknown-linux-musl
-            executable_name: cubestored
-            cross: true
-            strip: true
-            # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
+            # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
           - os: macos-11
             target: x86_64-apple-darwin
             executable_name: cubestored
-            cross: false
             strip: true
             compress: true
-          - os: ubuntu-20.04
-            target: aarch64-unknown-linux-gnu
-            executable_name: cubestored
-            cross: true
-            # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
-            strip: false
-            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
-            compress: false
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -234,6 +216,94 @@ jobs:
         run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./rust/cubestore -> target
+          prefix-key: v0-rust-cubestore-cross
+          key: target-${{ matrix.target }}
+      - run: source .github/actions/${{ matrix.before_script }}.sh
+        if: ${{ matrix.before_script }}
+        shell: bash
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startsWith(matrix.os, 'windows') }}
+      - name: Install OpenSSL for Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: vcpkg integrate install; vcpkg install openssl:x64-windows
+      - name: Instal LLVM for Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: choco install -y --force llvm --version 18.1.2
+      - name: Set Env Variables for Windows
+        uses: allenevans/set-env@v3.0.0
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        with:
+          OPENSSL_DIR: 'C:/vcpkg/packages/openssl_x64-windows'
+          # This paths are required to work with static linking
+          OPENSSL_LIB_DIR: 'C:/vcpkg/packages/openssl_x64-windows/lib'
+          OPENSSL_INCLUDE_DIR: 'C:/vcpkg/packages/openssl_x64-windows/include'
+          LIBCLANG_PATH: 'C:\Program Files\LLVM\bin'
+      - name: Build with Cargo
+        run: |
+          cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
+      - name: Compress binaries
+        uses: svenstaro/upx-action@v2
+        if: ${{ matrix.compress }}
+        with:
+          file: rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }}
+          args: --lzma
+          strip: ${{ matrix.strip }}
+      - name: Create folder for archive
+        run: |
+          mkdir cubestore-archive
+          mkdir cubestore-archive/bin
+      - name: Copy/paste OpenSSL to Archive (hotfix for Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: cp C:/vcpkg/packages/openssl_x64-windows/bin/*.dll cubestore-archive/bin
+      - name: Create archive for release
+        run: |
+          mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
+          cd cubestore-archive
+          tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
+      - uses: actions/upload-artifact@v2
+        with:
+          path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
+          name: cubestored-${{ matrix.target }}.tar.gz
+          retention-days: 1
+
+  cubestore_linux:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    env:
+      OPENSSL_STATIC: 1
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+        include:
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            executable_name: cubestored
+            strip: true
+            compress: false
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            executable_name: cubestored
+            strip: true
+            # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
+            compress: false
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            executable_name: cubestored
+            # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
+            strip: false
+            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
+            compress: false
+      fail-fast: false
+    container:
+      image: cubejs/rust-cross:${{ matrix.target }}-02042024
+    steps:
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -246,28 +316,7 @@ jobs:
           workspaces: ./rust/cubestore -> target
           prefix-key: v0-rust-cubestore-cross
           key: target-${{ matrix.target }}
-      - run: source .github/actions/${{ matrix.before_script }}.sh
-        if: ${{ matrix.before_script }}
-        shell: bash
-      #- name: Install dependencies Windows
-      #  run: vcpkg integrate install; vcpkg install openssl:x64-windows
-      #  if: matrix.os == 'windows-2019'
-      #  env:
-      #    VCPKG_ROOT: 'C:\vcpkg'
-      - name: Set Env Variables for Darwin
-        uses: allenevans/set-env@v3.0.0
-        if: ${{ matrix.target == 'x86_64-apple-darwin' }}
-        with:
-          OPENSSL_STATIC: "true"
-      - name: Build with Cross
-        if: ${{ matrix.cross }}
-        run: |
-          wget -c https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
-          chmod +x cross && sudo mv cross /usr/local/bin/cross
-          cd rust/cubestore
-          cross build --release --target=${{ matrix.target }}
       - name: Build with Cargo
-        if: ${{ !matrix.cross }}
         run: |
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
       - name: Compress binaries
@@ -277,10 +326,17 @@ jobs:
           file: rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }}
           args: --lzma
           strip: ${{ matrix.strip }}
-      - name: Create archive for release
+      - name: Create folder for archive
         run: |
           mkdir cubestore-archive
           mkdir cubestore-archive/bin
+      - name: Create archive for release
+        run: |
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
-          tar cv * | gzip --best  > cubestored-${{ matrix.target }}.tar.gz
+          tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
+      - uses: actions/upload-artifact@v2
+        with:
+          path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
+          name: cubestored-${{ matrix.target }}.tar.gz
+          retention-days: 1

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-22
+          toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
           override: true
           components: rustfmt

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Build with Cross
         if: ${{ matrix.cross }}
         run: |
-          wget -c https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
+          wget -c https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
           chmod +x cross && sudo mv cross /usr/local/bin/cross
           cd rust/cubestore
           cross build --release --target=${{ matrix.target }}

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-22
+          toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
           override: true
           components: rustfmt

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly-2022-06-22]
+        rust: [nightly-2024-01-29]
     env:
       RUST: ${{ matrix.rust }}
     steps:
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-22
+          toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
           override: true
           components: rustfmt

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -149,13 +149,6 @@ jobs:
         run: rustup set auto-self-update disable
         if: contains(runner.os, 'windows')
         shell: bash
-      - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2024-01-29
-          target: ${{ matrix.target }}
-          override: true
-          components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./rust/cubestore -> target

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -2305,7 +2305,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "libc",
- "mio 0.8.2",
+ "mio 0.8.11",
  "rand 0.8.4",
  "serde",
  "tempfile",
@@ -2676,7 +2676,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.2",
+ "miow",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2684,16 +2684,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2717,15 +2715,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2956,15 +2945,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "num"
@@ -4960,7 +4940,7 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio 0.8.11",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -5823,6 +5803,15 @@ dependencies = [
  "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#af17361949391edff25b2195f07996e2e66e5d66"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#4b05fac3c16adccd0396c482871de2b2b3ff0abc"
 dependencies = [
  "bitflags",
  "chrono",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#af17361949391edff25b2195f07996e2e66e5d66"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#4b05fac3c16adccd0396c482871de2b2b3ff0abc"
 dependencies = [
  "arrow",
  "base64 0.13.0",
@@ -489,7 +489,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc403c26e6b03005522e6e8053384c4e881dfe5b2bf041c0c2c49be33d64a539"
 dependencies = [
- "num-bigint 0.3.2",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits 0.2.14",
  "serde",
@@ -1256,6 +1256,7 @@ dependencies = [
  "libc",
  "log",
  "lru",
+ "memchr",
  "mockall",
  "moka 0.10.1",
  "msql-srv",
@@ -2951,7 +2952,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
- "num-bigint 0.3.2",
+ "num-bigint 0.3.3",
  "num-complex 0.3.1",
  "num-integer",
  "num-iter",
@@ -2965,7 +2966,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.0",
+ "num-bigint 0.4.3",
  "num-complex 0.4.0",
  "num-integer",
  "num-iter",
@@ -2986,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2997,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -3052,7 +3053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.3.2",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -3064,7 +3065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.4.0",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -3308,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#af17361949391edff25b2195f07996e2e66e5d66"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#4b05fac3c16adccd0396c482871de2b2b3ff0abc"
 dependencies = [
  "arrow",
  "base64 0.13.0",
@@ -3317,7 +3318,7 @@ dependencies = [
  "chrono",
  "flate2",
  "lz4",
- "num-bigint 0.4.0",
+ "num-bigint 0.4.3",
  "parquet-format",
  "rand 0.8.4",
  "snap",
@@ -5401,7 +5402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.4",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -2959,9 +2959,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -735,11 +735,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -829,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -1013,16 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 dependencies = [
  "crossbeam-utils 0.6.6",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -1255,7 +1246,7 @@ dependencies = [
  "http-auth-basic",
  "humansize",
  "indoc",
- "ipc-channel 0.18.0",
+ "ipc-channel",
  "itertools 0.11.0",
  "json",
  "lazy_static",
@@ -1317,7 +1308,7 @@ dependencies = [
  "futures 0.3.26",
  "futures-timer 3.0.2",
  "indoc",
- "ipc-channel 0.14.1",
+ "ipc-channel",
  "itertools 0.9.0",
  "lazy_static",
  "log",
@@ -2305,24 +2296,6 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3698b8affd5656032a074a7d40b3c2a29b71971f3e1ff6042b9d40724e20d97c"
-dependencies = [
- "bincode",
- "crossbeam-channel 0.4.4",
- "fnv",
- "lazy_static",
- "libc",
- "mio 0.6.23",
- "rand 0.7.3",
- "serde",
- "tempfile",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "ipc-channel"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
@@ -2485,12 +2458,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5450,7 +5423,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.6.5",
  "static_assertions",
 ]

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -133,7 +133,7 @@ name = "arrow"
 version = "5.0.0"
 source = "git+https://github.com/cube-js/arrow-rs?branch=cube#4b05fac3c16adccd0396c482871de2b2b3ff0abc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "csv",
  "flatbuffers 2.0.0",
@@ -199,7 +199,7 @@ checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
 dependencies = [
  "async-task 4.0.3",
  "concurrent-queue",
- "fastrand",
+ "fastrand 1.5.0",
  "futures-lite",
  "once_cell",
  "slab",
@@ -510,7 +510,7 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -529,6 +529,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake2b_simd"
@@ -589,7 +595,7 @@ dependencies = [
  "async-channel",
  "async-task 4.0.3",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.5.0",
  "futures-lite",
  "once_cell",
 ]
@@ -838,7 +844,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "textwrap",
@@ -881,7 +887,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1249,7 +1255,7 @@ dependencies = [
  "http-auth-basic",
  "humansize",
  "indoc",
- "ipc-channel",
+ "ipc-channel 0.18.0",
  "itertools 0.11.0",
  "json",
  "lazy_static",
@@ -1311,7 +1317,7 @@ dependencies = [
  "futures 0.3.26",
  "futures-timer 3.0.2",
  "indoc",
- "ipc-channel",
+ "ipc-channel 0.14.1",
  "itertools 0.9.0",
  "lazy_static",
  "log",
@@ -1561,6 +1567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
 name = "filetime"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,7 +1658,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4c5738bcd7fad10315029c50026f83c9da5e4a21f8ed66826f43e0e2bde5f6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "smallvec 1.11.0",
  "thiserror",
 ]
@@ -1647,7 +1669,7 @@ version = "23.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rustc_version 0.4.0",
 ]
 
@@ -1670,7 +1692,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3556c7e0d5b671814709229de0b91aa1e6dff7844df6102cd6b7ec6c3a46a187"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "num_enum",
  "serde",
@@ -1735,7 +1757,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fuchsia-zircon-sys",
 ]
 
@@ -1811,7 +1833,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
- "fastrand",
+ "fastrand 1.5.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -2014,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64 0.13.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes 1.0.1",
  "headers-core",
  "http",
@@ -2300,6 +2322,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-channel"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
+dependencies = [
+ "bincode",
+ "crossbeam-channel 0.5.7",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "mio 0.8.2",
+ "rand 0.8.4",
+ "serde",
+ "tempfile",
+ "uuid 1.3.0",
+ "windows",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,7 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
@@ -2438,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -2483,6 +2524,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -2850,7 +2897,7 @@ checksum = "c529a525c62e4788cff3a4557b652e2efd04eb3171da4ae2792031499f96442f"
 dependencies = [
  "base64 0.12.3",
  "bigdecimal 0.1.2",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "bytes 0.5.6",
  "chrono",
@@ -3159,7 +3206,7 @@ version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3661,7 +3708,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -3884,7 +3931,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738bc47119e3eeccc7e94c4a506901aea5e7b4944ecd0829cbebf4af04ceda12"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3966,7 +4013,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4012,15 +4059,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "reqwest"
@@ -4218,6 +4256,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4327,7 +4378,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4746,16 +4797,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
- "rand 0.8.4",
- "redox_syscall 0.2.10",
- "remove_dir_all",
- "winapi 0.3.9",
+ "fastrand 2.0.2",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5767,6 +5816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5785,13 +5843,52 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -5799,6 +5896,18 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5813,6 +5922,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5823,6 +5944,18 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5837,6 +5970,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5849,10 +5994,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5865,6 +6034,18 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winreg"

--- a/rust/cubestore/Dockerfile
+++ b/rust/cubestore/Dockerfile
@@ -1,8 +1,8 @@
 FROM rust:1-bullseye as builder
 
 RUN rustup update && \
-    rustup default nightly-2022-06-22 && \
-    rustup component add --toolchain nightly-2022-06-22 rustfmt;
+    rustup default nightly-2024-01-10 && \
+    rustup component add --toolchain nightly-2024-01-10 rustfmt;
 
 RUN apt update \
 	&& apt upgrade -y \

--- a/rust/cubestore/cubehll/src/instance.rs
+++ b/rust/cubestore/cubehll/src/instance.rs
@@ -1196,7 +1196,7 @@ fn alpha(index_bit_len: u8) -> f64 {
         4 => 0.673,
         5 => 0.697,
         6 => 0.709,
-        _ => (0.7213 / (1. + 1.079 / number_of_buckets(index_bit_len) as f64)),
+        _ => 0.7213 / (1. + 1.079 / number_of_buckets(index_bit_len) as f64),
     };
 }
 

--- a/rust/cubestore/cubestore-sql-tests/Cargo.toml
+++ b/rust/cubestore/cubestore-sql-tests/Cargo.toml
@@ -28,7 +28,7 @@ path = "tests/cluster.rs"
 harness = false
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-ipc-channel = { version = "0.14.1" }
+ipc-channel = { version = "0.18.0" }
 
 [dependencies]
 base64 = "0.13.0"

--- a/rust/cubestore/cubestore-sql-tests/src/lib.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/lib.rs
@@ -49,11 +49,19 @@ pub fn run_sql_tests(
                     ignore: false,
                     should_panic: ShouldPanic::No,
                     ignore_message: None,
+                    source_file: "",
+                    start_line: 0,
+                    start_col: 0,
+                    end_line: 0,
                     compile_fail: false,
                     no_run: false,
                     test_type: TestType::IntegrationTest,
+                    end_col: 0,
                 },
-                testfn: DynTestFn(Box::new(move || runner(name, test_fn))),
+                testfn: DynTestFn(Box::new(move || {
+                    runner(name, test_fn);
+                    Ok(())
+                })),
             }
         })
         .collect();

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -6785,7 +6785,7 @@ async fn assert_limit_pushdown(
 async fn cache_incr(service: Box<dyn SqlClient>) {
     let query = r#"CACHE INCR "prefix:key""#;
 
-    let r = service.exec_query(query.clone()).await.unwrap();
+    let r = service.exec_query(query).await.unwrap();
 
     assert_eq!(
         r.get_rows(),

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -16,7 +16,7 @@ libc = { version = "0.2.97", optional = true }
 [dependencies]
 base64 = "0.13.0"
 bumpalo = "3.6.1"
-tokio = { version = "1.0", features = ["full", "rt"] }
+tokio = { version = "1", features = ["full", "rt"] }
 warp = { version = "0.3.6" }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "4388f6712dae5073c2d71d74f64cae2edd418066" }
 serde_derive = "1.0.115"
@@ -74,6 +74,7 @@ tempfile = "3.2.0"
 tarpc = { version = "0.24", features = ["tokio1"] }
 pin-project-lite = "0.2.4"
 paste = "1.0.4"
+memchr = "2"
 flatbuffers = "23.1.21"
 http-auth-basic = "0.1.2"
 tracing = "0.1.25"

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 repository = "https://github.com/cube-js/cube.js"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-ipc-channel = { version = "0.14.1" }
+ipc-channel = { version = "0.18.0" }
 libc = { version = "0.2.97", optional = true }
 
 [dependencies]

--- a/rust/cubestore/cubestore/src/cachestore/cache_eviction_manager.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_eviction_manager.rs
@@ -234,7 +234,7 @@ impl CacheEvictionManager {
                     raw_size,
                 }) => {
                     let mut ttl_buffer = ttl_buffer_to_move.blocking_write();
-                    if let Some(mut cache_data) = ttl_buffer.get_mut(&row_id) {
+                    if let Some(cache_data) = ttl_buffer.get_mut(&row_id) {
                         let expired_lfu = if let Some(previous_lru) =
                             cache_data.lru.decode_value_as_opt_datetime().unwrap()
                         {

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -1108,7 +1108,7 @@ impl ClusterImpl {
         on_socket_bound: oneshot::Sender<()>,
         process_fn: impl Fn(Arc<ClusterImpl>, TcpStream) -> F + Send + Sync + Clone + 'static,
     ) -> Result<(), CubeError> {
-        let listener = TcpListener::bind(address.clone()).await?;
+        let listener = TcpListener::bind(address).await?;
         let _ = on_socket_bound.send(());
 
         info!("{} port open on {}", name, address);

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1155,8 +1155,8 @@ where
 impl Config {
     fn calculate_cache_compaction_trigger_size(cache_max_size: usize) -> usize {
         let trigger_size = match cache_max_size >> 20 {
-            d if d < 32 => (640 << 20),
-            d if d < 64 => (1280 << 20),
+            d if d < 32 => 640 << 20,
+            d if d < 64 => 1280 << 20,
             d if d < 512 => cache_max_size * 5,
             d if d < 1024 => cache_max_size * 4,
             d if d < 4096 => cache_max_size * 3,

--- a/rust/cubestore/cubestore/src/import/mod.rs
+++ b/rust/cubestore/cubestore/src/import/mod.rs
@@ -1,5 +1,5 @@
 use core::mem;
-use core::slice::memchr;
+use memchr;
 use std::convert::TryFrom;
 use std::path::Path;
 use std::pin::Pin;
@@ -567,7 +567,7 @@ impl ImportServiceImpl {
             Ok((temp_file, None))
         } else {
             Ok((
-                File::open(location.clone()).await.map_err(|e| {
+                File::open(location).await.map_err(|e| {
                     CubeError::internal(format!("Open location {}: {}", location, e))
                 })?,
                 None,
@@ -681,7 +681,7 @@ impl ImportServiceImpl {
             })?;
 
         let (file, tmp_path) = self
-            .resolve_location(location.clone(), table.get_id(), &temp_dir)
+            .resolve_location(location, table.get_id(), &temp_dir)
             .await?;
         let mut row_stream = format
             .row_stream(

--- a/rust/cubestore/cubestore/src/lib.rs
+++ b/rust/cubestore/cubestore/src/lib.rs
@@ -1,14 +1,11 @@
 #![feature(test)]
-#![feature(backtrace)]
 #![feature(async_closure)]
-#![feature(drain_filter)]
 #![feature(box_patterns)]
-#![feature(slice_internals)]
 #![feature(vec_into_raw_parts)]
 #![feature(hash_set_entry)]
-#![feature(map_first_last)]
 #![feature(is_sorted)]
 #![feature(result_flattening)]
+#![feature(extract_if)]
 // #![feature(trace_macros)]
 
 // trace_macros!(true);

--- a/rust/cubestore/cubestore/src/metastore/listener.rs
+++ b/rust/cubestore/cubestore/src/metastore/listener.rs
@@ -93,11 +93,13 @@ impl MetastoreListenerImpl {
     async fn process_event(&self, event: MetaStoreEvent) -> Result<(), CubeError> {
         let mut wait_fns = self.wait_fns.lock().await;
         let to_notify = wait_fns
-            .drain_filter(|(_, wait_fn)| wait_fn(event.clone()))
+            .extract_if(|(_, wait_fn)| wait_fn(event.clone()))
             .collect::<Vec<_>>();
+
         for (notify, _) in to_notify {
             notify.notify_waiters();
         }
+
         Ok(())
     }
 }

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -1629,7 +1629,7 @@ impl RocksMetaStore {
                 }
 
                 taken[i] = true;
-                index_columns.push(c.clone().replace_index(index_columns.len()));
+                index_columns.push(c.replace_index(index_columns.len()));
             }
 
             let seq_column = table_id.get_row().seq_column().ok_or_else(|| {

--- a/rust/cubestore/cubestore/src/queryplanner/physical_plan_flags.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/physical_plan_flags.rs
@@ -116,7 +116,7 @@ fn check_predicate_order(
             .iter()
             .filter_map(|(col, op)| {
                 if matches!(op, Operator::Eq) {
-                    Some(col.name().clone().to_string())
+                    Some(col.name().to_string())
                 } else {
                     None
                 }

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1690,7 +1690,7 @@ mod tests {
         let store_path = path.to_string() + &"_store".to_string();
         let remote_store_path = path.to_string() + &"remote_store".to_string();
 
-        let _ = fs::remove_dir_all(path.clone());
+        let _ = fs::remove_dir_all(path);
         let _ = fs::remove_dir_all(store_path.clone());
         let _ = fs::remove_dir_all(remote_store_path.clone());
 
@@ -1766,7 +1766,7 @@ mod tests {
         let store_path = path.to_string() + &"_store".to_string();
         let remote_store_path = path.to_string() + &"remote_store".to_string();
 
-        let _ = fs::remove_dir_all(path.clone());
+        let _ = fs::remove_dir_all(path);
         let _ = fs::remove_dir_all(store_path.clone());
         let _ = fs::remove_dir_all(remote_store_path.clone());
 
@@ -1872,7 +1872,7 @@ mod tests {
         let store_path = path.to_string() + &"_store".to_string();
         let remote_store_path = path.to_string() + &"remote_store".to_string();
 
-        let _ = fs::remove_dir_all(path.clone());
+        let _ = fs::remove_dir_all(path);
         let _ = fs::remove_dir_all(store_path.clone());
         let _ = fs::remove_dir_all(remote_store_path.clone());
 

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -1776,7 +1776,7 @@ mod tests {
         assert_eq!(9, chunks_row_count);
 
         let rows = (0..9)
-            .map(|i| Row::new(TableValue::from_columns(&batch.columns().clone(), i)))
+            .map(|i| Row::new(TableValue::from_columns(&batch.columns(), i)))
             .collect::<Vec<_>>();
 
         let expected = vec![

--- a/rust/cubestore/rust-toolchain.toml
+++ b/rust/cubestore/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-22"
+channel = "nightly-2024-01-29"
 components = ["rustfmt", "rustc-dev", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Hello!

```
rustc 1.77.0-nightly (635124704 2024-01-27)
binary: rustc
commit-hash: 635124704849eeead4e3a7bb6e663c5351571d93
commit-date: 2024-01-27
host: aarch64-apple-darwin
release: 1.77.0-nightly
LLVM version: 17.0.6
```

Thanks