### PR TITLE
fix(cubejs-client/react): types for useCubeQuery

### DIFF
--- a/docs/pages/reference/frontend/cubejs-client-react.mdx
+++ b/docs/pages/reference/frontend/cubejs-client-react.mdx
@@ -4,7 +4,7 @@
 
 ## `useCubeQuery`
 
->  **useCubeQuery**‹**TData**›(**query**: Query | Query[], **options?**: [UseCubeQueryOptions](#use-cube-query-options)): *[UseCubeQueryResult](#use-cube-query-result)‹TData›*
+>  **useCubeQuery**‹**TData**›(**query**: Query | Query[], **options?**: [UseCubeQueryOptions](#use-cube-query-options)): *[UseCubeQueryResult](#use-cube-query-result)‹Query, TData›*
 
 A React hook for executing Cube queries
 ```js
@@ -52,12 +52,13 @@ Name | Type | Description | Optional? |
 `subscribe` | `boolean` | Use continuous fetch behavior. See [Real-Time Data Fetch](real-time-data-fetch) | ✅ Yes |
 `castNumerics` | `boolean` | Pass `true` if you'd like all members with the `number` type to be automatically converted to JavaScript `Number` type. Note that this is a potentially unsafe operation since numbers more than [`Number.MAX_SAFE_INTEGER`][link-mdn-max-safe-integer] or less than `Number.MIN_SAFE_INTEGER` can't be represented as JavaScript `Number` | ✅ Yes |
 
-### `UseCubeQueryResult`
+### `UseCubeQueryResult<TQuery, TData>`
 
 Name | Type |
 ------ | ------ |
 error | Error &#124; null |
 isLoading | boolean |
+previousQuery | TQuery |
 progress | ProgressResponse |
 resultSet | ResultSet‹TData› &#124; null |
 

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -37,7 +37,7 @@ declare module '@cubejs-client/react' {
   type CubeProviderOptions = {
     castNumerics?: boolean;
   }
-  
+
   type CubeProviderProps = {
     cubejsApi: CubejsApi | null;
     options?: CubeProviderOptions;
@@ -450,6 +450,7 @@ declare module '@cubejs-client/react' {
     query: TQuery,
     options?: UseCubeQueryOptions,
   ): UseCubeQueryResult<
+    TQuery,
     unknown extends TData
       ? QueryRecordType<TQuery>
       : TData
@@ -461,7 +462,7 @@ declare module '@cubejs-client/react' {
      * A `CubejsApi` instance to use. Taken from the context if the param is not passed
      */
     cubejsApi?: CubejsApi;
-    
+
     /**
      * A `CubejsApi` instance to use. Taken from the context if the param is not passed
      */
@@ -484,11 +485,12 @@ declare module '@cubejs-client/react' {
     castNumerics?: boolean;
   };
 
-  type UseCubeQueryResult<TData> = {
+  type UseCubeQueryResult<TQuery, TData> = {
     error: Error | null;
     isLoading: boolean;
     resultSet: ResultSet<TData> | null;
     progress: ProgressResponse;
+    previousQuery: TQuery;
     refetch: () => Promise<void>;
   };
 


### PR DESCRIPTION
The type for useCubeQueryResult was out of date and prevented typescript libraries from using the actually returned value from useCubeQuery.

Unforunate that these types are not updated automatically or at least enforced in the library they're defined in.

**Check List**
- [N/A] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [N/A] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required