### PR TITLE
feat(duckdb-driver): pass Cube user agent

### DIFF
--- a/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
@@ -58,7 +58,12 @@ export class DuckDBDriver extends BaseDriver implements DriverInterface {
   protected async init(): Promise<InitPromise> {
     const token = getEnv('duckdbMotherDuckToken', this.config);
 
-    const db = new Database(token ? `md:?motherduck_token=${token}&custom_user_agent=Cube/${version}` : ':memory:');
+    const db = new Database(
+      token ? `md:?motherduck_token=${token}&custom_user_agent=Cube/${version}` : ':memory:',
+      {
+        custom_user_agent: `Cube/${version}`,
+      }
+    );
     // Under the hood all methods of Database uses internal default connection, but there is no way to expose it
     const defaultConnection = db.connect();
     const execAsync: (sql: string, ...params: any[]) => Promise<void> = promisify(defaultConnection.exec).bind(defaultConnection) as any;


### PR DESCRIPTION
DuckDB NodeJS API does not parse URL parameters for its options (the token parameter is parsed by MotherDuck extension, so it's special). We should pass the `custom_user_agent` in the config map like this:

```js
const db = new duckdb.Database(token ? `md:?motherduck_token=${token}` : ':memory:', {
    'custom_user_agent': `Cube/${version}`
});
```