### PR TITLE
fix: Revert drillMembers include in views as it's a breaking change. …

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -372,7 +372,6 @@ export class CubeSymbols {
           title: resolvedMember.title,
           description: resolvedMember.description,
           format: resolvedMember.format,
-          drillMembers: resolvedMember.drillMembers,
         };
       } else if (type === 'dimensions') {
         memberDefinition = {


### PR DESCRIPTION
…Need to re-introduce it through evaluation on cube level and validating drillMembers are included in view

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#7617 
