### PR TITLE
fix(cubesql): Enable constant folding for unary minus exprs

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -999,7 +999,7 @@ impl LogicalPlanAnalysis {
                 // TODO In case multiple node variant exists ConstantFolding::List will choose one which contains actual constants.
                 Some(ConstantFolding::List(list))
             }
-            LogicalPlanLanguage::AnyExpr(_) => {
+            LogicalPlanLanguage::AnyExpr(_) | LogicalPlanLanguage::NegativeExpr(_) => {
                 let expr = node_to_expr(
                     enode,
                     &egraph.analysis.cube_context,

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -301,7 +301,7 @@ pub fn get_test_tenant_ctx_customized(custom_templates: Vec<(String, String)>) -
                         "expressions/column_aliased".to_string(),
                         "{{expr}} {{quoted_alias}}".to_string(),
                     ),
-                    ("expressions/binary".to_string(), "{{ left }} {{ op }} {{ right }}".to_string()),
+                    ("expressions/binary".to_string(), "({{ left }} {{ op }} {{ right }})".to_string()),
                     ("expressions/is_null".to_string(), "{{ expr }} IS {% if negate %}NOT {% endif %}NULL".to_string()),
                     ("expressions/case".to_string(), "CASE{% if expr %}{{ expr }} {% endif %}{% for when, then in when_then %} WHEN {{ when }} THEN {{ then }}{% endfor %}{% if else_expr %} ELSE {{ else_expr }}{% endif %} END".to_string()),
                     ("expressions/sort".to_string(), "{{ expr }} {% if asc %}ASC{% else %}DESC{% endif %}{% if nulls_first %} NULLS FIRST {% endif %}".to_string()),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR enables constant folding for unary minus expressions (`-expr`), fixing a regression introduced with d5a935a. Related test is included.
