### PR TITLE
chore(cubesql): Rename SplitRules to OldSplitRules to prepare for mig…

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -8,7 +8,8 @@ use crate::{
             cost::BestCubePlan,
             rules::{
                 case::CaseRules, common::CommonRules, dates::DateRules, filters::FilterRules,
-                members::MemberRules, order::OrderRules, split::SplitRules, wrapper::WrapperRules,
+                members::MemberRules, old_split::OldSplitRules, order::OrderRules,
+                wrapper::WrapperRules,
             },
             LiteralExprValue, LogicalPlanLanguage, QueryParamIndex,
         },
@@ -513,7 +514,7 @@ impl Rewriter {
             Box::new(DateRules::new()),
             Box::new(OrderRules::new()),
             Box::new(CommonRules::new()),
-            Box::new(SplitRules::new(meta_context.clone(), config_obj.clone())),
+            Box::new(OldSplitRules::new(meta_context.clone(), config_obj.clone())),
             Box::new(CaseRules::new()),
         ];
         let mut rewrites = Vec::new();

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
@@ -6,8 +6,8 @@ pub mod common;
 pub mod dates;
 pub mod filters;
 pub mod members;
+pub mod old_split;
 pub mod order;
-pub mod split;
 pub mod utils;
 pub mod wrapper;
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
@@ -32,12 +32,12 @@ use datafusion::{
 use egg::{EGraph, Id, Rewrite, Subst, Var};
 use std::{fmt::Display, ops::Index, sync::Arc};
 
-pub struct SplitRules {
+pub struct OldSplitRules {
     meta_context: Arc<MetaContext>,
     config_obj: Arc<dyn ConfigObj>,
 }
 
-impl RewriteRules for SplitRules {
+impl RewriteRules for OldSplitRules {
     fn rewrite_rules(&self) -> Vec<Rewrite<LogicalPlanLanguage, LogicalPlanAnalysis>> {
         let mut rules = vec![
             transforming_rewrite(
@@ -4631,7 +4631,7 @@ impl RewriteRules for SplitRules {
     }
 }
 
-impl SplitRules {
+impl OldSplitRules {
     pub fn new(meta_context: Arc<MetaContext>, config_obj: Arc<dyn ConfigObj>) -> Self {
         Self {
             meta_context,

--- a/rust/cubesql/cubesql/src/compile/test/rewrite_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/test/rewrite_engine.rs
@@ -16,8 +16,8 @@ use crate::{
             converter::{CubeRunner, LogicalPlanToLanguageConverter},
             rewriter::RewriteRules,
             rules::{
-                dates::DateRules, filters::FilterRules, members::MemberRules, order::OrderRules,
-                split::SplitRules,
+                dates::DateRules, filters::FilterRules, members::MemberRules,
+                old_split::OldSplitRules, order::OrderRules,
             },
             LogicalPlanLanguage,
         },
@@ -70,7 +70,7 @@ pub fn rewrite_rules(
         Box::new(FilterRules::new(cube_context.meta.clone(), true)),
         Box::new(DateRules::new()),
         Box::new(OrderRules::new()),
-        Box::new(SplitRules::new(
+        Box::new(OldSplitRules::new(
             cube_context.meta.clone(),
             cube_context.sessions.server.config_obj.clone(),
         )),


### PR DESCRIPTION
…ration

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

