### PR TITLE
fix(native): Don't crash after query cancellation

### DIFF
--- a/packages/cubejs-backend-native/src/channel.rs
+++ b/packages/cubejs-backend-native/src/channel.rs
@@ -155,12 +155,10 @@ where
             Err(err) => Err(CubeError::internal(err.to_string())),
         };
 
-        tx.send(to_channel).map_err(|_| {
-            CubeError::internal(
-                "AsyncChannel: Unable to send result from JS back to Rust, channel closed"
-                    .to_string(),
-            )
-        })
+        if tx.send(to_channel).is_err() {
+            log::debug!("AsyncChannel: Unable to send result from JS back to Rust, channel closed");
+        }
+        Ok(())
     }));
 
     channel


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#7476 

**Description of Changes Made**

This PR changes the behavior of native sending data via `JsAsyncChannel`, ignoring the case when data couldn't be sent. This happens when a cancel request packet is received (which is done via a separate connection).
