### PR TITLE
fix(cubesql): Support new Metabase meta queries

### DIFF
--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__has_table_privilege.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__has_table_privilege.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT\n                    relname,\n                    has_table_privilege('ovr', relname, 'SELECT') \\\"select\\\",\n                    has_table_privilege('ovr', relname, 'INSERT') \\\"insert\\\"\n                FROM pg_class\n                ORDER BY relname ASC\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---------------------------+--------+--------+
+| relname                   | select | insert |
++---------------------------+--------+--------+
+| KibanaSampleDataEcommerce | true   | false  |
+| Logs                      | true   | false  |
+| NumberCube                | true   | false  |
+| WideCube                  | true   | false  |
++---------------------------+--------+--------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__has_table_privilege_default_user.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__has_table_privilege_default_user.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT\n                    relname,\n                    has_table_privilege(relname, 'SELECT') \\\"select\\\",\n                    has_table_privilege(relname, 'INSERT') \\\"insert\\\"\n                FROM pg_class\n                ORDER BY relname ASC\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---------------------------+--------+--------+
+| relname                   | select | insert |
++---------------------------+--------+--------+
+| KibanaSampleDataEcommerce | true   | false  |
+| Logs                      | true   | false  |
+| NumberCube                | true   | false  |
+| WideCube                  | true   | false  |
++---------------------------+--------+--------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__metabase_table_privilege_query.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__metabase_table_privilege_query.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(r#\"\n                with table_privileges as (\n\t select\n\t   NULL as role,\n\t   t.schemaname as schema,\n\t   t.objectname as table,\n\t   pg_catalog.has_table_privilege(current_user, '\"' || t.schemaname || '\"' || '.' || '\"' || t.objectname || '\"',  'UPDATE') as update,\n\t   pg_catalog.has_table_privilege(current_user, '\"' || t.schemaname || '\"' || '.' || '\"' || t.objectname || '\"',  'SELECT') as select,\n\t   pg_catalog.has_table_privilege(current_user, '\"' || t.schemaname || '\"' || '.' || '\"' || t.objectname || '\"',  'INSERT') as insert,\n\t   pg_catalog.has_table_privilege(current_user, '\"' || t.schemaname || '\"' || '.' || '\"' || t.objectname || '\"',  'DELETE') as delete\n\t from (\n\t   select schemaname, tablename as objectname from pg_catalog.pg_tables\n\t   union\n\t   select schemaname, viewname as objectname from pg_catalog.pg_views\n\t   union\n\t   select schemaname, matviewname as objectname from pg_catalog.pg_matviews\n\t ) t\n\t where t.schemaname !~ '^pg_'\n\t   and t.schemaname <> 'information_schema'\n\t   and pg_catalog.has_schema_privilege(current_user, t.schemaname, 'USAGE')\n\t)\n\tselect t.*\n\tfrom table_privileges t\n    order by t.schema, t.table\n                \"#.to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++------+--------+---------------------------+--------+--------+--------+--------+
+| role | schema | table                     | update | select | insert | delete |
++------+--------+---------------------------+--------+--------+--------+--------+
+| NULL | public | KibanaSampleDataEcommerce | false  | true   | false  | false  |
+| NULL | public | Logs                      | false  | true   | false  | false  |
+| NULL | public | NumberCube                | false  | true   | false  | false  |
+| NULL | public | WideCube                  | false  | true   | false  | false  |
++------+--------+---------------------------+--------+--------+--------+--------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR improves compatibility with Metabase v48, adding support for `pg_catalog.has_table_privilege` function. Related tests are included.