### PR TITLE
feat(cubesql): Support temporary tables

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/provider.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/provider.rs
@@ -14,7 +14,10 @@ use datafusion::{
 
 use crate::{
     compile::MetaContext,
-    sql::{session::DatabaseProtocol, ColumnType, SessionManager, SessionState},
+    sql::{
+        session::DatabaseProtocol, temp_tables::TempTableProvider, ColumnType, SessionManager,
+        SessionState,
+    },
     transport::V1CubeMetaExt,
     CubeError,
 };
@@ -272,7 +275,9 @@ impl DatabaseProtocol {
         table_provider: Arc<dyn datasource::TableProvider>,
     ) -> Result<String, CubeError> {
         let any = table_provider.as_any();
-        Ok(if let Some(t) = any.downcast_ref::<CubeTableProvider>() {
+        Ok(if let Some(t) = any.downcast_ref::<TempTableProvider>() {
+            t.name().to_string()
+        } else if let Some(t) = any.downcast_ref::<CubeTableProvider>() {
             t.table_name().to_string()
         } else if let Some(_) = any.downcast_ref::<PostgresSchemaColumnsProvider>() {
             "information_schema.columns".to_string()
@@ -399,23 +404,28 @@ impl DatabaseProtocol {
                 table.to_ascii_lowercase(),
             ),
             datafusion::catalog::TableReference::Bare { table } => {
-                if table.starts_with("pg_") {
-                    (
-                        context.session_state.database().unwrap_or("db".to_string()),
-                        "pg_catalog".to_string(),
-                        table.to_ascii_lowercase(),
-                    )
+                let table_lower = table.to_ascii_lowercase();
+                let schema = if context.session_state.temp_tables().has(&table_lower) {
+                    "pg_temp_3"
+                } else if table.starts_with("pg_") {
+                    "pg_catalog"
                 } else {
-                    (
-                        context.session_state.database().unwrap_or("db".to_string()),
-                        "public".to_string(),
-                        table.to_ascii_lowercase(),
-                    )
-                }
+                    "public"
+                };
+                (
+                    context.session_state.database().unwrap_or("db".to_string()),
+                    schema.to_string(),
+                    table_lower,
+                )
             }
         };
 
         match schema.as_str() {
+            "pg_temp_3" => {
+                if let Some(temp_table) = context.session_state.temp_tables().get(&table) {
+                    return Some(Arc::new(TempTableProvider::new(table, temp_table)));
+                }
+            }
             "public" => {
                 if let Some(cube) = context
                     .meta

--- a/rust/cubesql/cubesql/src/sql/mod.rs
+++ b/rust/cubesql/cubesql/src/sql/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod service;
 pub(crate) mod session;
 pub(crate) mod session_manager;
 pub(crate) mod statement;
+pub(crate) mod temp_tables;
 pub(crate) mod types;
 
 pub use auth_service::{

--- a/rust/cubesql/cubesql/src/sql/mysql/service.rs
+++ b/rust/cubesql/cubesql/src/sql/mysql/service.rs
@@ -224,6 +224,7 @@ impl MySqlConnection {
 
                     return Ok(QueryResponse::ResultSet(status, Box::new(response)))
                 }
+                crate::compile::QueryPlan::CreateTempTable(_, _, _, _, _) => return Err(CubeError::internal("CREATE TABLE is not supported over MySQL".to_string())),
             }
         }
 

--- a/rust/cubesql/cubesql/src/sql/postgres/extended.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/extended.rs
@@ -3,6 +3,7 @@ use crate::{
     sql::{
         dataframe::{batch_to_dataframe, DataFrame, TableValue},
         statement::PostgresStatementParamsBinder,
+        temp_tables::TempTable,
         writer::BatchWriter,
     },
     CubeError,
@@ -19,7 +20,7 @@ use datafusion::{
     physical_plan::SendableRecordBatchStream,
 };
 use futures::*;
-use pg_srv::protocol::{PortalCompletion, PortalSuspended};
+use pg_srv::protocol::{CommandComplete, PortalCompletion, PortalSuspended};
 
 use crate::transport::SpanId;
 use async_stream::stream;
@@ -509,6 +510,30 @@ impl Portal {
                                 }
                                 Err(err) => return yield Err(CubeError::panic(err).into()),
                             }
+                        }
+                        QueryPlan::CreateTempTable(_, plan, ctx, name, temp_tables) => {
+                            let df = DFDataFrame::new(ctx.state.clone(), &plan);
+                            let record_batch = df.collect();
+                            let row_count = match record_batch.await {
+                                Ok(record_batch) => {
+                                    let row_count: u32 = record_batch.iter().map(|batch| batch.num_rows() as u32).sum();
+                                    let temp_table = TempTable::new(Arc::clone(plan.schema()), vec![record_batch]);
+                                    let save_result = tokio::task::spawn_blocking(move || {
+                                        temp_tables.save(&name.to_ascii_lowercase(), temp_table)
+                                    }).await;
+                                    if let Err(err) = save_result {
+                                        return yield Err(err.into())
+                                    };
+                                    row_count
+                                }
+                                Err(err) => return yield Err(CubeError::panic(Box::new(err)).into()),
+                            };
+
+                            self.state = Some(PortalState::Finished(FinishedState { description }));
+
+                            return yield Ok(PortalBatch::Completion(PortalCompletion::Complete(
+                                CommandComplete::Select(row_count),
+                            )));
                         }
                     }
                 }

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -69,7 +69,7 @@ impl QueryPlanExt for QueryPlan {
         required_format: protocol::Format,
     ) -> Result<Option<protocol::RowDescription>, ConnectionError> {
         match &self {
-            QueryPlan::MetaOk(_, _) => Ok(None),
+            QueryPlan::MetaOk(_, _) | QueryPlan::CreateTempTable(_, _, _, _, _) => Ok(None),
             QueryPlan::MetaTabular(_, frame) => {
                 let mut result = vec![];
 

--- a/rust/cubesql/cubesql/src/sql/temp_tables.rs
+++ b/rust/cubesql/cubesql/src/sql/temp_tables.rs
@@ -1,0 +1,144 @@
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use datafusion::{
+    arrow::{
+        datatypes::{Schema, SchemaRef},
+        record_batch::RecordBatch,
+    },
+    datasource::TableProvider,
+    error::DataFusionError,
+    logical_plan::{DFSchema, DFSchemaRef, Expr},
+    physical_plan::{memory::MemoryExec, ExecutionPlan},
+};
+
+use crate::{CubeError, RWLockSync};
+
+#[derive(Debug)]
+pub struct TempTableManager {
+    temp_tables: RWLockSync<HashMap<String, Arc<TempTable>>>,
+}
+
+impl TempTableManager {
+    pub fn new() -> Self {
+        Self {
+            temp_tables: RWLockSync::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<TempTable>> {
+        self.temp_tables
+            .read()
+            .expect("failed to unlock temp tables for reading")
+            .get(name)
+            .cloned()
+    }
+
+    pub fn has(&self, name: &str) -> bool {
+        self.temp_tables
+            .read()
+            .expect("failed to unlock temp tables for reading")
+            .contains_key(name)
+    }
+
+    pub fn save(&self, name: &str, temp_table: TempTable) -> Result<(), CubeError> {
+        let mut guard = self
+            .temp_tables
+            .write()
+            .expect("failed to unlock temp tables for writing");
+
+        if guard.contains_key(name) {
+            return Err(CubeError::user(format!(
+                "relation \"{}\" already exists",
+                name
+            )));
+        }
+
+        guard.insert(name.to_string(), Arc::new(temp_table));
+        Ok(())
+    }
+
+    pub fn remove(&self, name: &str) -> Result<(), CubeError> {
+        let mut guard = self
+            .temp_tables
+            .write()
+            .expect("failed to unlock temp tables for writing");
+
+        if guard.remove(name).is_none() {
+            return Err(CubeError::user(format!(
+                "table \"{}\" does not exist",
+                name
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TempTable {
+    schema: SchemaRef,
+    record_batch: Vec<Vec<RecordBatch>>,
+}
+
+impl TempTable {
+    pub fn new(schema: DFSchemaRef, record_batch: Vec<Vec<RecordBatch>>) -> Self {
+        let arrow_schema = df_schema_to_arrow_schema(&schema);
+        Self {
+            schema: arrow_schema,
+            record_batch,
+        }
+    }
+}
+
+fn df_schema_to_arrow_schema(df_schema: &DFSchema) -> SchemaRef {
+    let arrow_schema = Schema::new_with_metadata(
+        df_schema
+            .fields()
+            .iter()
+            .map(|f| f.field().clone())
+            .collect(),
+        df_schema.metadata().clone(),
+    );
+    Arc::new(arrow_schema)
+}
+
+#[derive(Debug, Clone)]
+pub struct TempTableProvider {
+    name: String,
+    temp_table: Arc<TempTable>,
+}
+
+impl TempTableProvider {
+    pub fn new(name: String, temp_table: Arc<TempTable>) -> Self {
+        Self { name, temp_table }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[async_trait]
+impl TableProvider for TempTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.temp_table.schema)
+    }
+
+    async fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        Ok(Arc::new(MemoryExec::try_new(
+            &self.temp_table.record_batch,
+            self.schema(),
+            projection.clone(),
+        )?))
+    }
+}

--- a/rust/cubesql/cubesql/src/sql/types.rs
+++ b/rust/cubesql/cubesql/src/sql/types.rs
@@ -148,6 +148,7 @@ pub enum CommandCompletion {
     Deallocate,
     DeallocateAll,
     Discard(String),
+    DropTable,
 }
 
 impl CommandCompletion {
@@ -174,6 +175,7 @@ impl CommandCompletion {
             CommandCompletion::Discard(tp) => CommandComplete::Plain(format!("DISCARD {}", tp)),
             // ROWS COUNT
             CommandCompletion::Select(rows) => CommandComplete::Select(rows),
+            CommandCompletion::DropTable => CommandComplete::Plain("DROP TABLE".to_string()),
         }
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for temporary tables, allowing queries of form:
- `CREATE TEMPORARY TABLE tblname AS SELECT ...`
- `SELECT ... INTO TEMPORARY TABLE tblname FROM...`
- `DROP TABLE ...`

