### PR TITLE
fix(cubesql): `ungrouped` query can be routed to Cube Store

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -539,7 +539,7 @@ export class BaseQuery {
   }
 
   externalPreAggregationQuery() {
-    if (!this.options.preAggregationQuery && !this.options.disableExternalPreAggregations && this.externalQueryClass) {
+    if (!this.options.preAggregationQuery && !this.options.disableExternalPreAggregations && !this.ungrouped && this.externalQueryClass) {
       const preAggregationForQuery = this.preAggregations.findPreAggregationForQuery();
       if (preAggregationForQuery && preAggregationForQuery.preAggregation.external) {
         return true;
@@ -558,7 +558,7 @@ export class BaseQuery {
    * @returns {Array<string>}
    */
   buildSqlAndParams(exportAnnotatedSql) {
-    if (!this.options.preAggregationQuery && !this.options.disableExternalPreAggregations && this.externalQueryClass) {
+    if (!this.options.preAggregationQuery && !this.options.disableExternalPreAggregations && !this.ungrouped && this.externalQueryClass) {
       if (this.externalPreAggregationQuery()) { // TODO performance
         return this.externalQuery().buildSqlAndParams(exportAnnotatedSql);
       }

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -1500,5 +1500,27 @@ from
   `);
       expect(res.rows).toMatchSnapshot('powerbi_min_max_push_down');
     });
+
+    executePg('SQL API: powerbi min max ungrouped flag', async () => {
+      const res = await connection.query(`
+      select 
+  count(distinct("rows"."totalSales")) + max( 
+    case 
+      when "rows"."totalSales" is null then 1 
+      else 0 
+    end 
+  ) as "a0", 
+  min("rows"."totalSales") as "a1", 
+  max("rows"."totalSales") as "a2" 
+from 
+  ( 
+    select 
+      "totalSales" 
+    from 
+      "public"."ECommerce" "$Table" 
+  ) "rows" 
+  `);
+      expect(res.rows).toMatchSnapshot('powerbi_min_max_ungrouped_flag');
+    });
   });
 }

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -9,6 +9,16 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/postgres-driver SQL API: powerbi min max ungrouped flag: powerbi_min_max_ungrouped_flag 1`] = `
+Array [
+  Object {
+    "a0": "39",
+    "a1": 3.76,
+    "a2": 2399.96,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver filtering Customers: contains + dimensions, first 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -9,6 +9,16 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: powerbi min max ungrouped flag: powerbi_min_max_ungrouped_flag 1`] = `
+Array [
+  Object {
+    "a0": "39",
+    "a1": 3.76,
+    "a2": 2399.96,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver filtering Customers: contains + dimensions, first 1`] = `
 Array [
   Object {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

