### PR TITLE
feat(playground): vite build uses relative asset paths instead of absolute

### DIFF
--- a/packages/cubejs-playground/vite.config.ts
+++ b/packages/cubejs-playground/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => ({
+  base: './',
   build: {
     outDir: 'build',
     target: 'es2018',


### PR DESCRIPTION
When attempting to run Cube behind a reverse proxy, it is only possible to set the base path for the API endpoints of Cube. This renders the playground unusable inside a non root base path.

For example when using /cube as a base path behind a reverse proxy, I can get the index.html to load, from /cube/index.html but then requests for assets are made to /some-asset.js instead of /cube/some-asset.js

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Changes the path of bundled assets from absolute to relative. 

For example

    <script type="module" crossorigin src="/assets/index-4bed1a0c.js"></script>
 
Becomes

    <script type="module" crossorigin src="./assets/index-4bed1a0c.js"></script>

This allows Cube playground to be run inside a subdirectory (behind a reverse proxy, for example).

Adding `base: './'` to the Vite config is the only change required for this.

https://vitejs.dev/config/shared-options.html#base

As you can see in the docs, it's suggested for "embedded" applications, which I suppose encompasses those bundled in  containers such as Cube's playground.

In terms of backwards compatibility, it should be fine as currently you must run it on the root path, so applications running on the root path will go from `/asset...` to `./asset...` which resolves to `/asset...`.

Running `yarn build` in the  packages/cubejs-playground directory yields the following

```diff
diff --git a/build/index.html b/index-built.html
index 3b100ab4e..07b9dd75b 100644
--- a/build/index.html
+++ b/relative-build/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+    <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel="stylesheet" href="/antd.min.css">
+    <link rel="stylesheet" href="./antd.min.css">
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#000000" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="./manifest.json" />
     <style>
       #playground-root {
         height: 100%;
@@ -23,8 +23,8 @@
       }
     </style>
     <title>Cube Playground</title>
-    <script type="module" crossorigin src="/assets/index-1693b579.js"></script>
-    <link rel="stylesheet" href="/assets/index-af3b87a2.css">
+    <script type="module" crossorigin src="./assets/index-29693369.js"></script>
+    <link rel="stylesheet" href="./assets/index-af3b87a2.css">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
```