### PR TITLE
chore(cubesql): Introduce temp table memory limit

### DIFF
--- a/rust/cubesql/cubesql/src/sql/postgres/extended.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/extended.rs
@@ -520,7 +520,7 @@ impl Portal {
                                     let temp_table = TempTable::new(Arc::clone(plan.schema()), vec![record_batch]);
                                     let save_result = tokio::task::spawn_blocking(move || {
                                         temp_tables.save(&name.to_ascii_lowercase(), temp_table)
-                                    }).await;
+                                    }).await?;
                                     if let Err(err) = save_result {
                                         return yield Err(err.into())
                                     };

--- a/rust/cubesql/cubesql/src/sql/session.rs
+++ b/rust/cubesql/cubesql/src/sql/session.rs
@@ -3,7 +3,7 @@ use log::trace;
 use rand::Rng;
 use std::{
     collections::HashMap,
-    sync::{Arc, RwLock as RwLockSync},
+    sync::{Arc, RwLock as RwLockSync, Weak},
     time::{Duration, SystemTime},
 };
 use tokio_util::sync::CancellationToken;
@@ -118,6 +118,7 @@ impl SessionState {
         protocol: DatabaseProtocol,
         auth_context: Option<AuthContextRef>,
         auth_context_expiration: Duration,
+        session_manager: Weak<SessionManager>,
     ) -> Self {
         let mut rng = rand::thread_rng();
 
@@ -128,7 +129,7 @@ impl SessionState {
             client_port,
             protocol,
             variables: RwLockSync::new(None),
-            temp_tables: Arc::new(TempTableManager::new()),
+            temp_tables: Arc::new(TempTableManager::new(session_manager)),
             properties: RwLockSync::new(SessionProperties::new(None, None)),
             auth_context: RwLockSync::new((auth_context, SystemTime::now())),
             transaction: RwLockSync::new(TransactionState::None),

--- a/rust/cubesql/cubesql/src/sql/session_manager.rs
+++ b/rust/cubesql/cubesql/src/sql/session_manager.rs
@@ -2,7 +2,7 @@ use crate::{CubeError, RWLockAsync};
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicU32, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -18,6 +18,7 @@ pub struct SessionManager {
     // Sessions
     last_id: AtomicU32,
     sessions: RWLockAsync<HashMap<u32, Arc<Session>>>,
+    pub temp_table_size: AtomicUsize,
     // Backref
     pub server: Arc<ServerManager>,
 }
@@ -29,6 +30,7 @@ impl SessionManager {
         Self {
             last_id: AtomicU32::new(1),
             sessions: RWLockAsync::new(HashMap::new()),
+            temp_table_size: AtomicUsize::new(0),
             server,
         }
     }
@@ -51,6 +53,7 @@ impl SessionManager {
                 protocol,
                 None,
                 Duration::from_secs(self.server.config_obj.auth_expire_secs()),
+                Arc::downgrade(self),
             )),
         };
 
@@ -90,6 +93,11 @@ impl SessionManager {
     pub async fn drop_session(&self, connection_id: u32) {
         let mut guard = self.sessions.write().await;
 
-        guard.remove(&connection_id);
+        if let Some(connection) = guard.remove(&connection_id) {
+            self.temp_table_size.fetch_sub(
+                connection.state.temp_tables().physical_size(),
+                Ordering::SeqCst,
+            );
+        }
     }
 }

--- a/rust/cubesql/cubesql/src/sql/temp_tables.rs
+++ b/rust/cubesql/cubesql/src/sql/temp_tables.rs
@@ -1,4 +1,12 @@
-use std::{any::Any, collections::HashMap, sync::Arc};
+use std::{
+    any::Any,
+    collections::HashMap,
+    env,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Weak,
+    },
+};
 
 use async_trait::async_trait;
 use datafusion::{
@@ -14,15 +22,22 @@ use datafusion::{
 
 use crate::{CubeError, RWLockSync};
 
+use super::SessionManager;
+
 #[derive(Debug)]
 pub struct TempTableManager {
     temp_tables: RWLockSync<HashMap<String, Arc<TempTable>>>,
+    cached_size: AtomicUsize,
+    // Backref
+    session_manager: Weak<SessionManager>,
 }
 
 impl TempTableManager {
-    pub fn new() -> Self {
+    pub fn new(session_manager: Weak<SessionManager>) -> Self {
         Self {
             temp_tables: RWLockSync::new(HashMap::new()),
+            cached_size: AtomicUsize::new(0),
+            session_manager,
         }
     }
 
@@ -42,6 +57,19 @@ impl TempTableManager {
     }
 
     pub fn save(&self, name: &str, temp_table: TempTable) -> Result<(), CubeError> {
+        let session_manager = self
+            .session_manager
+            .upgrade()
+            .ok_or_else(|| CubeError::internal("session manager is unavailable".to_string()))?;
+
+        let size_session_limit = env::var("CUBESQL_TEMP_TABLE_SESSION_MEM")
+            .map(|v| v.parse::<usize>().unwrap())
+            .unwrap_or(10); // in MiB
+
+        let size_total_limit = env::var("CUBESQL_TEMP_TABLE_TOTAL_MEM")
+            .map(|v| v.parse::<usize>().unwrap())
+            .unwrap_or(100); // in MiB
+
         let mut guard = self
             .temp_tables
             .write()
@@ -54,24 +82,64 @@ impl TempTableManager {
             )));
         }
 
+        self.cached_size
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current_size| {
+                if current_size + temp_table.size > size_session_limit * 1024 * 1024 {
+                    return None;
+                }
+                session_manager
+                    .temp_table_size
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current_size| {
+                        if current_size + temp_table.size > size_total_limit * 1024 * 1024 {
+                            return None;
+                        }
+                        Some(current_size + temp_table.size)
+                    })
+                    .ok()?;
+                Some(current_size + temp_table.size)
+            })
+            .map_err(|_| {
+                CubeError::user(format!(
+                    "temporary table memory limit reached ({} MiB session, {} MiB total)",
+                    size_session_limit, size_total_limit,
+                ))
+            })?;
+
         guard.insert(name.to_string(), Arc::new(temp_table));
         Ok(())
     }
 
     pub fn remove(&self, name: &str) -> Result<(), CubeError> {
-        let mut guard = self
-            .temp_tables
-            .write()
-            .expect("failed to unlock temp tables for writing");
+        let session_manager = self
+            .session_manager
+            .upgrade()
+            .ok_or_else(|| CubeError::internal("session manager is unavailable".to_string()))?;
 
-        if guard.remove(name).is_none() {
+        let Some(temp_table) = ({
+            let mut guard = self
+                .temp_tables
+                .write()
+                .expect("failed to unlock temp tables for writing");
+
+            guard.remove(name)
+        }) else {
             return Err(CubeError::user(format!(
                 "table \"{}\" does not exist",
                 name
             )));
-        }
+        };
+
+        self.cached_size
+            .fetch_sub(temp_table.size, Ordering::SeqCst);
+        session_manager
+            .temp_table_size
+            .fetch_sub(temp_table.size, Ordering::SeqCst);
 
         Ok(())
+    }
+
+    pub fn physical_size(&self) -> usize {
+        self.cached_size.load(Ordering::SeqCst)
     }
 }
 
@@ -79,14 +147,31 @@ impl TempTableManager {
 pub struct TempTable {
     schema: SchemaRef,
     record_batch: Vec<Vec<RecordBatch>>,
+    size: usize,
 }
 
 impl TempTable {
     pub fn new(schema: DFSchemaRef, record_batch: Vec<Vec<RecordBatch>>) -> Self {
         let arrow_schema = df_schema_to_arrow_schema(&schema);
+        let size = record_batch
+            .iter()
+            .map(|record_batch| {
+                record_batch
+                    .iter()
+                    .map(|record_batch| {
+                        record_batch
+                            .columns()
+                            .iter()
+                            .map(|column| column.get_array_memory_size())
+                            .sum::<usize>()
+                    })
+                    .sum::<usize>()
+            })
+            .sum();
         Self {
             schema: arrow_schema,
             record_batch,
+            size,
         }
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR introduces memory limits for temporary tables enforced upon their creation. The limits are controlled with the env variables:
- `CUBESQL_TEMP_TABLE_SESSION_MEM` (default: 10 (MiB))
- `CUBESQL_TEMP_TABLE_TOTAL_MEM` (default: 100 (MiB))
It also fixes an issue when trying to create a temporary table with the name of an already existing temporary table would not yield an error but rather report that the table has been created successfully, although no action has actually been taken.
