### PR TITLE
fix(cubesql): Trim ".0" postfix when converting `Float to `Utf8`

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=9f2e2862f3f5e5efb1f83364b3ac8492f776a92d#9f2e2862f3f5e5efb1f83364b3ac8492f776a92d"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "arrow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=9f2e2862f3f5e5efb1f83364b3ac8492f776a92d#9f2e2862f3f5e5efb1f83364b3ac8492f776a92d"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
 dependencies = [
  "arrow",
  "base64 0.13.1",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=9f2e2862f3f5e5efb1f83364b3ac8492f776a92d#9f2e2862f3f5e5efb1f83364b3ac8492f776a92d"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "arrow",
  "chrono",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1188,7 +1188,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a93bb9641d201b2b42ee92321f07e87bbd357d0e#a93bb9641d201b2b42ee92321f07e87bbd357d0e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=18d735d8f1b71f3cfbf5e5757b3093b9c19a640f#18d735d8f1b71f3cfbf5e5757b3093b9c19a640f"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=9f2e2862f3f5e5efb1f83364b3ac8492f776a92d#9f2e2862f3f5e5efb1f83364b3ac8492f776a92d"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "a93bb9641d201b2b42ee92321f07e87bbd357d0e", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "18d735d8f1b71f3cfbf5e5757b3093b9c19a640f", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0.50"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -22254,4 +22254,18 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_cast_float_to_text() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "cast_float_to_text",
+            execute_query(
+                "SELECT (11.0::double precision)::text AS eleven;".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__cast_float_to_text.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__cast_float_to_text.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT (11.0::double precision)::text AS eleven;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++--------+
+| eleven |
++--------+
+| 11     |
++--------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@18d735d, altering the way `Float` types are converted to `Utf8`, trimming the ".0" postfix if a float has no fractional part. This is in accordance with how PostgreSQL converts floats to text, and does not affect `Decimal` (numeric) which retain their fractional part even if it is 0.
