### PR TITLE
fix(cubesql): Fix push down column remapping

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -901,10 +901,19 @@ impl CubeScanWrapperNode {
             };
             if !next_remapping.contains_key(&Column::from_name(&alias)) {
                 next_remapping.insert(original_alias_key, Column::from_name(&alias));
+                let original_relation = if let Expr::Column(column) = &original_expr {
+                    if column.relation.is_some() {
+                        &column.relation
+                    } else {
+                        &from_alias
+                    }
+                } else {
+                    &from_alias
+                };
                 next_remapping.insert(
                     Column {
                         name: original_alias.clone(),
-                        relation: from_alias.clone(),
+                        relation: original_relation.clone(),
                     },
                     Column {
                         name: alias.clone(),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with push down due to incorrect remapping with `FROM` table having several relations (join).
