### PR TITLE
chore(deps): bump es5-ext in /packages/cubejs-query-orchestrator to address security advisory

### DIFF
--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -34,7 +34,7 @@
     "@cubejs-backend/cubestore-driver": "^0.34.60",
     "@cubejs-backend/shared": "^0.34.60",
     "csv-write-stream": "^2.0.0",
-    "es5-ext": "0.10.53",
+    "es5-ext": "^0.10.63",
     "generic-pool": "^3.7.1",
     "ioredis": "^4.27.8",
     "lru-cache": "^6.0.0",
@@ -72,7 +72,7 @@
     ]
   },
   "resolutions": {
-    "es5-ext": "0.10.53",
+    "es5-ext": "^0.10.63",
     "minimist": "^1.2.6"
   }
 }


### PR DESCRIPTION
I was running into this security alert in my project due to the pinned version in this package. 

# es5-ext vulnerable to Regular Expression Denial of Service in `function#copy` and `function#toStringTokens`

## Impact
Passing functions with very long names or complex default argument names into function#copy orfunction#toStringTokens may put script to stall

## Patches
Fixed with https://github.com/medikoo/es5-ext/commit/3551cdd7b2db08b1632841f819d008757d28e8e2 and https://github.com/medikoo/es5-ext/commit/a52e95736690ad1d465ebcd9791d54570e294602
Published with v0.10.63

## Workarounds
No real workaround aside of refraining from using above utilities.

## References
https://github.com/medikoo/es5-ext/issues/201

## References
[GHSA-4gmj-3p3h-gm8h](https://github.com/medikoo/es5-ext/security/advisories/GHSA-4gmj-3p3h-gm8h)
https://nvd.nist.gov/vuln/detail/CVE-2024-27088
https://github.com/medikoo/es5-ext/issues/201
https://github.com/medikoo/es5-ext/commit/3551cdd7b2db08b1632841f819d008757d28e8e2
https://github.com/medikoo/es5-ext/commit/a52e95736690ad1d465ebcd9791d54570e294602
