### PR TITLE
fix(cubesql): Don't ignore second filter over same time dimension

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -22294,4 +22294,55 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_time_dimensions_filter_twice() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT customer_gender
+            FROM KibanaSampleDataEcommerce
+            WHERE
+                order_date BETWEEN '2024-01-01T00:00:00' AND '2025-01-01T00:00:00'
+                AND order_date BETWEEN '2024-03-01T00:00:00' AND '2024-06-01T00:00:00'
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: Some(vec![
+                    V1LoadRequestQueryTimeDimension {
+                        dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                        granularity: None,
+                        date_range: Some(json!(vec![
+                            "2024-01-01T00:00:00".to_string(),
+                            "2025-01-01T00:00:00".to_string(),
+                        ]))
+                    },
+                    V1LoadRequestQueryTimeDimension {
+                        dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                        granularity: None,
+                        date_range: Some(json!(vec![
+                            "2024-03-01T00:00:00".to_string(),
+                            "2024-06-01T00:00:00".to_string(),
+                        ]))
+                    },
+                ]),
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+                ungrouped: Some(true),
+            }
+        )
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -1742,7 +1742,13 @@ impl LanguageToLogicalPlanConverter {
                                 query_time_dimensions
                                     .into_iter()
                                     .unique_by(|td| {
-                                        (td.dimension.to_string(), td.granularity.clone())
+                                        (
+                                            td.dimension.to_string(),
+                                            td.granularity.clone(),
+                                            td.date_range
+                                                .as_ref()
+                                                .map(|range| serde_json::to_string(range).unwrap()),
+                                        )
                                     })
                                     .collect(),
                             )


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with queries having two `inDateRange` filters over the same time dimension. Sample query:
```
SELECT id
FROM Orders
WHERE
  completedAt BETWEEN '2019-02-01T00:00:00' AND '2020-01-01T00:00:00'
  AND completedAt BETWEEN '2019-06-01T00:00:00' AND '2020-06-01T00:00:00'
```
Related tests are included.
