### PR TITLE
chore(cubesql): Support distinct binary expression types

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "arrow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "async-trait",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.7",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "arrow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1012,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6dae83cb807fca991ae8bed6cea4f725441cf84e#6dae83cb807fca991ae8bed6cea4f725441cf84e"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
 dependencies = [
  "ahash 0.7.6",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "6dae83cb807fca991ae8bed6cea4f725441cf84e", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "b051b03cdc94761ec2aad37be0d8ed91776bd530", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0.50"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -1,4 +1,4 @@
-use std::{any::type_name, collections::HashMap, convert::TryFrom, sync::Arc, thread};
+use std::{any::type_name, collections::HashMap, sync::Arc, thread};
 
 use chrono::{Datelike, Days, Duration, Months, NaiveDate, NaiveDateTime, NaiveTime};
 use datafusion::{
@@ -6,10 +6,10 @@ use datafusion::{
         array::{
             new_null_array, Array, ArrayBuilder, ArrayRef, BooleanArray, BooleanBuilder,
             Float64Array, GenericStringArray, Int32Builder, Int64Array, Int64Builder,
-            IntervalDayTimeArray, IntervalDayTimeBuilder, IntervalYearMonthArray, ListArray,
-            ListBuilder, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
-            StructBuilder, TimestampMicrosecondArray, TimestampMillisecondArray,
-            TimestampNanosecondArray, TimestampSecondArray, UInt32Builder,
+            IntervalDayTimeBuilder, ListArray, ListBuilder, PrimitiveArray, PrimitiveBuilder,
+            StringArray, StringBuilder, StructBuilder, TimestampMicrosecondArray,
+            TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
+            UInt32Builder,
         },
         compute::{cast, cast_with_options, concat, CastOptions},
         datatypes::{
@@ -1430,120 +1430,6 @@ fn last_day_of_month(y: i32, m: u32) -> u32 {
         .pred_opt()
         .expect(&format!("Invalid year month: {}-{}", y, m))
         .day()
-}
-
-pub fn create_interval_mul_udf() -> ScalarUDF {
-    let fun = make_scalar_function(move |args: &[ArrayRef]| {
-        assert!(args.len() == 2);
-
-        let multiplicands = match args[1].data_type() {
-            DataType::Utf8 => {
-                cast_with_options(&args[1], &DataType::Int64, &CastOptions { safe: false })?
-            }
-            DataType::Int64 => Arc::clone(&args[1]),
-            t => {
-                return Err(DataFusionError::Execution(format!(
-                    "unsupported multiplicand type {}",
-                    t
-                )))
-            }
-        };
-
-        let multiplicands = downcast_primitive_arg!(multiplicands, "multiplicand", Int64Type);
-
-        match &args[0].data_type() {
-            DataType::Interval(IntervalUnit::YearMonth) => {
-                let intervals = downcast_primitive_arg!(args[0], "interval", IntervalYearMonthType);
-                let result = intervals
-                    .iter()
-                    .zip(multiplicands.iter())
-                    .map(|values| match values {
-                        (Some(interval), Some(multiplicand)) => {
-                            Some(interval * i32::try_from(multiplicand).ok()?)
-                        }
-                        _ => None,
-                    })
-                    .collect::<IntervalYearMonthArray>();
-                Ok(Arc::new(result))
-            }
-            DataType::Interval(IntervalUnit::DayTime) => {
-                let intervals = downcast_primitive_arg!(args[0], "interval", IntervalDayTimeType);
-                let result = intervals
-                    .iter()
-                    .zip(multiplicands.iter())
-                    .map(|values| match values {
-                        (Some(interval), Some(multiplicand)) => {
-                            let interval_value: u64 = interval as u64;
-                            let days: i32 = ((interval_value & 0xFFFFFFFF00000000) >> 32) as i32;
-                            let milliseconds: i32 = (interval_value & 0xFFFFFFFF) as i32;
-                            let multiplicand = i32::try_from(multiplicand).ok()?;
-                            let days_product = days * multiplicand;
-                            let milliseconds_product = milliseconds * multiplicand;
-                            let interval_product = (((days_product as u64) << 32)
-                                | (milliseconds_product as u64))
-                                as i64;
-                            Some(interval_product)
-                        }
-                        _ => None,
-                    })
-                    .collect::<IntervalDayTimeArray>();
-                Ok(Arc::new(result))
-            }
-            _ => Err(DataFusionError::Execution(
-                "unsupported interval type".to_string(),
-            )),
-        }
-    });
-
-    let return_type: ReturnTypeFunction = Arc::new(move |arg_types| {
-        if arg_types.len() != 2 {
-            return Err(DataFusionError::Execution(format!(
-                "\"interval_mul\" expects 2 arguments, {} given",
-                arg_types.len()
-            )));
-        }
-        match arg_types[0] {
-            DataType::Interval(_) => Ok(Arc::new(arg_types[0].clone())),
-            _ => Err(DataFusionError::Execution(
-                "first argument to \"interval_mul\" must be an interval".to_string(),
-            )),
-        }
-    });
-
-    ScalarUDF::new(
-        "interval_mul",
-        &Signature::one_of(
-            vec![
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::YearMonth),
-                    DataType::Int64,
-                ]),
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::DayTime),
-                    DataType::Int64,
-                ]),
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::MonthDayNano),
-                    DataType::Int64,
-                ]),
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::YearMonth),
-                    DataType::Utf8,
-                ]),
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::DayTime),
-                    DataType::Utf8,
-                ]),
-                TypeSignature::Exact(vec![
-                    DataType::Interval(IntervalUnit::MonthDayNano),
-                    DataType::Utf8,
-                ]),
-            ],
-            Volatility::Immutable,
-        ),
-        &return_type,
-        &fun,
-    )
 }
 
 fn postgres_datetime_format_to_iso(format: String) -> String {

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -52,9 +52,9 @@ use self::{
             create_dayofweek_udf, create_dayofyear_udf, create_db_udf, create_ends_with_udf,
             create_format_type_udf, create_generate_series_udtf, create_generate_subscripts_udtf,
             create_has_schema_privilege_udf, create_has_table_privilege_udf, create_hour_udf,
-            create_if_udf, create_inet_server_addr_udf, create_instr_udf, create_interval_mul_udf,
-            create_isnull_udf, create_json_build_object_udf, create_least_udf, create_locate_udf,
-            create_makedate_udf, create_measure_udaf, create_minute_udf, create_pg_backend_pid_udf,
+            create_if_udf, create_inet_server_addr_udf, create_instr_udf, create_isnull_udf,
+            create_json_build_object_udf, create_least_udf, create_locate_udf, create_makedate_udf,
+            create_measure_udaf, create_minute_udf, create_pg_backend_pid_udf,
             create_pg_datetime_precision_udf, create_pg_encoding_to_char_udf,
             create_pg_expandarray_udtf, create_pg_get_constraintdef_udf, create_pg_get_expr_udf,
             create_pg_get_indexdef_udf, create_pg_get_serial_sequence_udf,
@@ -1455,7 +1455,6 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_pg_get_serial_sequence_udf());
         ctx.register_udf(create_json_build_object_udf());
         ctx.register_udf(create_regexp_substr_udf());
-        ctx.register_udf(create_interval_mul_udf());
         ctx.register_udf(create_ends_with_udf());
         ctx.register_udf(create_position_udf());
         ctx.register_udf(create_date_to_timestamp_udf());
@@ -6205,12 +6204,12 @@ limit
 
     #[tokio::test]
     async fn test_date_add_sub_postgres() {
-        async fn check_fun(name: &str, t: &str, i: &str, expected: &str) {
+        async fn check_fun(op: &str, t: &str, i: &str, expected: &str) {
             assert_eq!(
                 execute_query(
                     format!(
-                        "SELECT {}(Str_to_date('{}', '%Y-%m-%d %H:%i:%s'), INTERVAL '{}') as result",
-                        name, t, i
+                        "SELECT Str_to_date('{}', '%Y-%m-%d %H:%i:%s') {} INTERVAL '{}' as result",
+                        t, op, i
                     ),
                     DatabaseProtocol::PostgreSQL
                 )
@@ -6228,11 +6227,11 @@ limit
         }
 
         async fn check_adds_to(t: &str, i: &str, expected: &str) {
-            check_fun("DATE_ADD", t, i, expected).await
+            check_fun("+", t, i, expected).await
         }
 
         async fn check_subs_to(t: &str, i: &str, expected: &str) {
-            check_fun("DATE_SUB", t, i, expected).await
+            check_fun("-", t, i, expected).await
         }
 
         check_adds_to("2021-01-01 00:00:00", "1 second", "2021-01-01T00:00:01.000").await;

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -972,7 +972,6 @@ impl LogicalPlanAnalysis {
                         || &fun.name == "date_sub"
                         || &fun.name == "date"
                         || &fun.name == "date_to_timestamp"
-                        || &fun.name == "interval_mul"
                     {
                         Self::eval_constant_expr(&egraph, &expr)
                     } else {
@@ -1062,22 +1061,6 @@ impl LogicalPlanAnalysis {
                     &SingleNodeIndex { egraph },
                 )
                 .ok()?;
-
-                match &expr {
-                    Expr::BinaryExpr { left, right, .. } => match (&**left, &**right) {
-                        (Expr::Literal(ScalarValue::IntervalYearMonth(_)), Expr::Literal(_))
-                        | (Expr::Literal(ScalarValue::IntervalDayTime(_)), Expr::Literal(_))
-                        | (Expr::Literal(ScalarValue::IntervalMonthDayNano(_)), Expr::Literal(_))
-                        | (Expr::Literal(_), Expr::Literal(ScalarValue::IntervalYearMonth(_)))
-                        | (Expr::Literal(_), Expr::Literal(ScalarValue::IntervalDayTime(_)))
-                        | (Expr::Literal(_), Expr::Literal(ScalarValue::IntervalMonthDayNano(_))) => {
-                            return None
-                        }
-                        _ => (),
-                    },
-                    _ => (),
-                }
-
                 Self::eval_constant_expr(&egraph, &expr)
             }
             _ => None,

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
@@ -293,66 +293,6 @@ impl RewriteRules for DateRules {
                 ),
             ),
             transforming_rewrite_with_root(
-                "binary-expr-interval-add-right",
-                binary_expr("?left", "+", "?interval"),
-                alias_expr(udf_expr("date_add", vec!["?left", "?interval"]), "?alias"),
-                self.transform_interval_binary_expr_with_chain_transform(
-                    "?interval",
-                    transform_original_expr_to_alias("?alias"),
-                ),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-interval-add-left",
-                binary_expr("?interval", "+", "?right"),
-                alias_expr(udf_expr("date_add", vec!["?right", "?interval"]), "?alias"),
-                self.transform_interval_binary_expr_with_chain_transform(
-                    "?interval",
-                    transform_original_expr_to_alias("?alias"),
-                ),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-interval-sub",
-                binary_expr("?left", "-", "?interval"),
-                alias_expr(udf_expr("date_sub", vec!["?left", "?interval"]), "?alias"),
-                self.transform_interval_binary_expr_with_chain_transform(
-                    "?interval",
-                    transform_original_expr_to_alias("?alias"),
-                ),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-interval-mul-right",
-                binary_expr("?left", "*", "?interval"),
-                alias_expr(
-                    udf_expr("interval_mul", vec!["?interval", "?left"]),
-                    "?alias",
-                ),
-                self.transform_interval_binary_expr_with_chain_transform(
-                    "?interval",
-                    transform_original_expr_to_alias("?alias"),
-                ),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-interval-mul-left",
-                binary_expr("?interval", "*", "?right"),
-                alias_expr(
-                    udf_expr("interval_mul", vec!["?interval", "?right"]),
-                    "?alias",
-                ),
-                self.transform_interval_binary_expr_with_chain_transform(
-                    "?interval",
-                    transform_original_expr_to_alias("?alias"),
-                ),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-interval-neg",
-                negative_expr("?interval"),
-                udf_expr(
-                    "interval_mul",
-                    vec!["?interval".to_string(), literal_int(-1)],
-                ),
-                self.transform_interval_binary_expr("?interval"),
-            ),
-            transforming_rewrite_with_root(
                 "redshift-dateadd-to-interval-cast-unwrap",
                 udf_expr(
                     "dateadd",
@@ -460,43 +400,6 @@ impl RewriteRules for DateRules {
 impl DateRules {
     pub fn new() -> Self {
         Self {}
-    }
-
-    fn transform_interval_binary_expr(
-        &self,
-        interval_var: &'static str,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, Id, &mut Subst) -> bool
-    {
-        self.transform_interval_binary_expr_with_chain_transform(interval_var, |_, _, _| true)
-    }
-
-    fn transform_interval_binary_expr_with_chain_transform<T>(
-        &self,
-        interval_var: &'static str,
-        chain_transform_fn: T,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, Id, &mut Subst) -> bool
-    where
-        T: Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, Id, &mut Subst) -> bool,
-    {
-        let interval_var = var!(interval_var);
-        move |egraph, root, subst| {
-            if let Some(ConstantFolding::Scalar(interval)) =
-                &egraph[subst[interval_var]].data.constant
-            {
-                match interval {
-                    ScalarValue::IntervalYearMonth(_)
-                    | ScalarValue::IntervalDayTime(_)
-                    | ScalarValue::IntervalMonthDayNano(_) => {
-                        if chain_transform_fn(egraph, root, subst) {
-                            return true;
-                        }
-                    }
-                    _ => (),
-                }
-            }
-
-            false
-        }
     }
 
     fn transform_interval_parts_to_interval(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@b051b03, adding support for distinct binary expression types. This removes hacks with the planned types and allows execution of binary expression with distinct types directly in DataFusion instead of rewriting such expressions into UDFs. The rewrite rules in questions have been removed, and tests have been altered accordingly.
