### PR TITLE
feat(cubesql): Parse timestamp strings as `Date32`

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "arrow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "async-trait",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
 dependencies = [
  "arrow",
  "base64 0.13.1",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "arrow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1012,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b051b03cdc94761ec2aad37be0d8ed91776bd530#b051b03cdc94761ec2aad37be0d8ed91776bd530"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=f32dc0f5d2de97433f53dbc18295558e04214ad8#f32dc0f5d2de97433f53dbc18295558e04214ad8"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "b051b03cdc94761ec2aad37be0d8ed91776bd530", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0.50"
 cubeclient = { path = "../cubeclient" }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@4ede2d0, adding support for parsing timestamp strings as date. This is in accordance with Postgres, which would disregard the time and timezone.
