### PR TITLE
feat(cubesql): Support `a ^ b` exponentiation

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "arrow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
 dependencies = [
  "arrow",
  "base64 0.13.1",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "arrow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1012,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06#4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=9ba81506496262494ee9fdf68fcc3fac533f22aa#9ba81506496262494ee9fdf68fcc3fac533f22aa"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=70e71d1829e6302333e965fde9d0ee56d6415ef4#70e71d1829e6302333e965fde9d0ee56d6415ef4"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "4ede2d0fb6e71c66e4fa83e2f6dbc1e994218b06", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "9ba81506496262494ee9fdf68fcc3fac533f22aa", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0.50"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -22344,4 +22344,14 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_exponentiate_op() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "exponentiate_op",
+            execute_query("SELECT 3^5 AS e".to_string(), DatabaseProtocol::PostgreSQL).await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -406,6 +406,7 @@ macro_rules! variant_field_struct {
                 Operator::Multiply => "*",
                 Operator::Divide => "/",
                 Operator::Modulo => "%",
+                Operator::Exponentiate => "^",
                 Operator::And => "AND",
                 Operator::Or => "OR",
                 Operator::Like => "LIKE",

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
@@ -5705,13 +5705,14 @@ impl OldSplitRules {
                     | Operator::Minus
                     | Operator::Multiply
                     | Operator::Divide
-                    | Operator::Modulo => {
+                    | Operator::Modulo
+                    | Operator::Exponentiate => {
                         let check_is_zero = match operator {
                             Operator::Plus
                             | Operator::Minus
                             | Operator::Divide
                             | Operator::Modulo => false,
-                            Operator::Multiply => true,
+                            Operator::Multiply | Operator::Exponentiate => true,
                             _ => continue,
                         };
 

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__exponentiate_op.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__exponentiate_op.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT 3^5 AS e\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-----+
+| e   |
++-----+
+| 243 |
++-----+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@9ba8150, adding support for exponentiation operator (`^`), allowing evaluation of expressions like `3^5`. Related test is included.
