### PR TITLE
fix(cubesql): Fix timestamp parsing format string

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -1047,10 +1047,10 @@ pub fn transform_response<V: ValueObject>(
                     field_name,
                     {
                         (FieldValue::String(s), builder) => {
-                            let timestamp = NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S.%f")
-                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S.%f"))
+                            let timestamp = NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S%.f")
+                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S%.f"))
                                 .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S"))
-                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S.%fZ"))
+                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S%.fZ"))
                                 .or_else(|_| {
                                     NaiveDate::parse_from_str(s.as_str(), "%Y-%m-%d").map(|date| {
                                         date.and_hms_opt(0, 0, 0).unwrap()
@@ -1083,10 +1083,10 @@ pub fn transform_response<V: ValueObject>(
                     field_name,
                     {
                         (FieldValue::String(s), builder) => {
-                            let timestamp = NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S.%f")
-                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S.%f"))
+                            let timestamp = NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S%.f")
+                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S%.f"))
                                 .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S"))
-                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S.%fZ"))
+                                .or_else(|_| NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%dT%H:%M:%S%.fZ"))
                                 .or_else(|_| {
                                     NaiveDate::parse_from_str(s.as_str(), "%Y-%m-%d").map(|date| {
                                         date.and_hms_opt(0, 0, 0).unwrap()

--- a/rust/cubesql/cubesql/src/compile/legacy_compiler.rs
+++ b/rust/cubesql/cubesql/src/compile/legacy_compiler.rs
@@ -125,7 +125,7 @@ impl CompiledExpression {
             CompiledExpression::DateLiteral(date) => Some(*date),
             CompiledExpression::StringLiteral(s) => {
                 if let Ok(datetime) =
-                    NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S.%f")
+                    NaiveDateTime::parse_from_str(s.as_str(), "%Y-%m-%d %H:%M:%S%.f")
                 {
                     return Some(Utc.from_utc_datetime(&datetime));
                 };
@@ -231,7 +231,7 @@ fn str_to_date_function(f: &ast::Function) -> CompilationResult<CompiledExpressi
         )));
     }
 
-    let parsed_date = NaiveDateTime::parse_from_str(date.as_str(), "%Y-%m-%d %H:%M:%S.%f")
+    let parsed_date = NaiveDateTime::parse_from_str(date.as_str(), "%Y-%m-%d %H:%M:%S%.f")
         .map_err(|e| {
             CompilationError::user(format!("Unable to parse {}, err: {}", date, e.to_string(),))
         })?;
@@ -258,7 +258,7 @@ fn date_function(f: &ast::Function, ctx: &QueryContext) -> CompilationResult<Com
     match compiled {
         date @ CompiledExpression::DateLiteral(_) => Ok(date),
         CompiledExpression::StringLiteral(ref input) => {
-            let parsed_date = NaiveDateTime::parse_from_str(input.as_str(), "%Y-%m-%d %H:%M:%S.%f")
+            let parsed_date = NaiveDateTime::parse_from_str(input.as_str(), "%Y-%m-%d %H:%M:%S%.f")
                 .map_err(|e| {
                     CompilationError::user(format!(
                         "Unable to parse {}, err: {}",

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -4117,7 +4117,7 @@ impl FilterRules {
             }
 
             fn increment_iso_timestamp_time(date_var: &String) -> String {
-                let timestamp = NaiveDateTime::parse_from_str(date_var, "%Y-%m-%dT%H:%M:%S.%fZ");
+                let timestamp = NaiveDateTime::parse_from_str(date_var, "%Y-%m-%dT%H:%M:%S%.fZ");
                 let value = match timestamp {
                     Ok(val) => format_iso_timestamp(
                         val.checked_add_signed(Duration::milliseconds(1)).unwrap(),
@@ -4128,7 +4128,7 @@ impl FilterRules {
             }
 
             fn decrement_iso_timestamp_time(date_var: &String) -> String {
-                let timestamp = NaiveDateTime::parse_from_str(date_var, "%Y-%m-%dT%H:%M:%S.%fZ");
+                let timestamp = NaiveDateTime::parse_from_str(date_var, "%Y-%m-%dT%H:%M:%S%.fZ");
                 let value = match timestamp {
                     Ok(val) => format_iso_timestamp(
                         val.checked_sub_signed(Duration::milliseconds(1)).unwrap(),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes `parse_from_str` calls, using the correct fractional second placeholder in the format string.
