### PR TITLE
fix: Render all distinct counts as `1` for ungrouped queries to not fail ratio measures

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2007,7 +2007,7 @@ export class BaseQuery {
     }
     if (this.ungrouped) {
       if (symbol.type === 'count' || symbol.type === 'countDistinct' || symbol.type === 'countDistinctApprox') {
-        const sql = symbol.type === 'countDistinct' || symbol.type === 'countDistinctApprox' ? evaluateSql : this.caseWhenStatement([{ sql: `(${evaluateSql}) IS NOT NULL`, label: `1` }]);
+        const sql = this.caseWhenStatement([{ sql: `(${evaluateSql}) IS NOT NULL`, label: `1` }]);
         return evaluateSql === '*' ? '1' : sql;
       } else {
         return evaluateSql;


### PR DESCRIPTION
Proper wrapping count distinct aggregation should be supported by flatten rewrites and fixes to cost function

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


