### PR TITLE
feat(cubestore): Queue - optimize list/pending operations

### DIFF
--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -99,12 +99,6 @@ sequenceDiagram
     participant CubeStore
 
     loop processQuery: Background execution
-        BackgroundQueryQueue->>QueueDriverInterface: getNextProcessingId
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: CACHE INCR ?
-        CubeStore-->>+BackgroundQueryQueue: number
-        deactivate CubeStore
-
         BackgroundQueryQueue->>QueueDriverInterface: retrieveForProcessing
         activate CubeStore
         QueueDriverInterface->>CubeStore: QUEUE RETRIEVE CONCURRENCY ?number ?path

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -155,6 +155,7 @@ impl RocksStoreDetails for RocksCacheStoreDetails {
         CacheItemRocksTable::new(table_ref.clone()).migrate()?;
         QueueItemRocksTable::new(table_ref.clone()).migrate()?;
         QueueResultRocksTable::new(table_ref.clone()).migrate()?;
+        QueueItemPayloadRocksTable::new(table_ref.clone()).migrate()?;
 
         table_ref
             .db

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -1,9 +1,12 @@
 use crate::cachestore::cache_eviction_manager::EvictionResult;
-use crate::cachestore::cache_rocksstore::{CachestoreInfo, QueueAddResponse};
+use crate::cachestore::cache_rocksstore::{
+    CachestoreInfo, QueueAddPayload, QueueAddResponse, QueueAllItem, QueueGetResponse,
+    QueueListItem,
+};
 use crate::cachestore::queue_item::QueueRetrieveResponse;
 use crate::cachestore::{
-    CacheItem, CacheStore, QueueItem, QueueItemStatus, QueueKey, QueueResult, QueueResultResponse,
-    RocksCacheStore,
+    CacheItem, CacheStore, QueueCancelResponse, QueueItem, QueueItemStatus, QueueKey, QueueResult,
+    QueueResultResponse, RocksCacheStore,
 };
 use crate::config::ConfigObj;
 use crate::metastore::{IdRow, MetaStoreEvent, MetaStoreFs, RocksPropertyRow};
@@ -204,7 +207,7 @@ impl CacheStore for LazyRocksCacheStore {
         self.init().await?.cache_incr(path).await
     }
 
-    async fn queue_all(&self, limit: Option<usize>) -> Result<Vec<IdRow<QueueItem>>, CubeError> {
+    async fn queue_all(&self, limit: Option<usize>) -> Result<Vec<QueueAllItem>, CubeError> {
         self.init().await?.queue_all(limit).await
     }
 
@@ -219,8 +222,8 @@ impl CacheStore for LazyRocksCacheStore {
         self.init().await?.queue_results_multi_delete(ids).await
     }
 
-    async fn queue_add(&self, item: QueueItem) -> Result<QueueAddResponse, CubeError> {
-        self.init().await?.queue_add(item).await
+    async fn queue_add(&self, payload: QueueAddPayload) -> Result<QueueAddResponse, CubeError> {
+        self.init().await?.queue_add(payload).await
     }
 
     async fn queue_truncate(&self) -> Result<(), CubeError> {
@@ -244,18 +247,19 @@ impl CacheStore for LazyRocksCacheStore {
         prefix: String,
         status_filter: Option<QueueItemStatus>,
         priority_sort: bool,
-    ) -> Result<Vec<IdRow<QueueItem>>, CubeError> {
+        with_payload: bool,
+    ) -> Result<Vec<QueueListItem>, CubeError> {
         self.init()
             .await?
-            .queue_list(prefix, status_filter, priority_sort)
+            .queue_list(prefix, status_filter, priority_sort, with_payload)
             .await
     }
 
-    async fn queue_get(&self, key: QueueKey) -> Result<Option<IdRow<QueueItem>>, CubeError> {
+    async fn queue_get(&self, key: QueueKey) -> Result<Option<QueueGetResponse>, CubeError> {
         self.init().await?.queue_get(key).await
     }
 
-    async fn queue_cancel(&self, key: QueueKey) -> Result<Option<IdRow<QueueItem>>, CubeError> {
+    async fn queue_cancel(&self, key: QueueKey) -> Result<Option<QueueCancelResponse>, CubeError> {
         self.init().await?.queue_cancel(key).await
     }
 

--- a/rust/cubestore/cubestore/src/cachestore/mod.rs
+++ b/rust/cubestore/cubestore/src/cachestore/mod.rs
@@ -5,6 +5,7 @@ mod compaction;
 mod lazy;
 mod listener;
 mod queue_item;
+mod queue_item_payload;
 mod queue_result;
 mod scheduler;
 
@@ -13,10 +14,12 @@ pub use cache_eviction_manager::{
 };
 pub use cache_item::CacheItem;
 pub use cache_rocksstore::{
-    CacheStore, CacheStoreRpcClient, CachestoreInfo, ClusterCacheStoreClient, QueueAddResponse,
-    QueueKey, QueueResultResponse, RocksCacheStore,
+    CacheStore, CacheStoreRpcClient, CachestoreInfo, ClusterCacheStoreClient, QueueAddPayload,
+    QueueAddResponse, QueueAllItem, QueueCancelResponse, QueueGetResponse, QueueKey, QueueListItem,
+    QueueResultResponse, RocksCacheStore,
 };
 pub use lazy::LazyRocksCacheStore;
 pub use queue_item::{QueueItem, QueueItemStatus, QueueResultAckEvent, QueueRetrieveResponse};
+pub use queue_item_payload::QueueItemPayload;
 pub use queue_result::QueueResult;
 pub use scheduler::CacheStoreSchedulerImpl;

--- a/rust/cubestore/cubestore/src/cachestore/queue_item.rs
+++ b/rust/cubestore/cubestore/src/cachestore/queue_item.rs
@@ -88,7 +88,7 @@ pub struct QueueItem {
 
 impl RocksEntity for QueueItem {
     fn version() -> u32 {
-        2
+        3
     }
 }
 

--- a/rust/cubestore/cubestore/src/cachestore/queue_item_payload.rs
+++ b/rust/cubestore/cubestore/src/cachestore/queue_item_payload.rs
@@ -1,0 +1,127 @@
+use crate::metastore::{
+    BaseRocksTable, IndexId, RocksEntity, RocksSecondaryIndex, RocksTable, TableId, TableInfo,
+};
+use crate::{base_rocks_secondary_index, rocks_table_new, CubeError};
+use chrono::serde::{ts_seconds, ts_seconds_option};
+use chrono::{DateTime, Duration, Utc};
+use rocksdb::WriteBatch;
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct QueueItemPayload {
+    // Immutable field
+    pub(crate) value: String,
+    #[serde(with = "ts_seconds_option")]
+    orphaned: Option<DateTime<Utc>>,
+    #[serde(with = "ts_seconds")]
+    created: DateTime<Utc>,
+}
+
+impl RocksEntity for QueueItemPayload {
+    fn version() -> u32 {
+        1
+    }
+}
+
+impl QueueItemPayload {
+    pub fn new(value: String, orphaned: Option<u32>) -> Self {
+        let created = Utc::now();
+
+        Self {
+            value,
+            orphaned: if let Some(orphaned) = orphaned {
+                Some(created + Duration::seconds(orphaned as i64))
+            } else {
+                None
+            },
+            created,
+        }
+    }
+
+    pub fn get_value(&self) -> &String {
+        &self.value
+    }
+
+    pub fn get_created(&self) -> &DateTime<Utc> {
+        &self.created
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum QueueItemPayloadRocksIndex {}
+
+pub struct QueueItemPayloadRocksTable<'a> {
+    db: crate::metastore::DbTableRef<'a>,
+}
+
+impl<'a> QueueItemPayloadRocksTable<'a> {
+    pub fn new(db: crate::metastore::DbTableRef<'a>) -> Self {
+        Self { db }
+    }
+}
+
+impl<'a> BaseRocksTable for QueueItemPayloadRocksTable<'a> {
+    fn enable_delete_event(&self) -> bool {
+        false
+    }
+
+    fn enable_update_event(&self) -> bool {
+        false
+    }
+
+    fn migrate_table(
+        &self,
+        batch: &mut WriteBatch,
+        _table_info: TableInfo,
+    ) -> Result<(), CubeError> {
+        self.migrate_table_by_truncate(batch)
+    }
+}
+
+rocks_table_new!(
+    QueueItemPayload,
+    QueueItemPayloadRocksTable,
+    TableId::QueueItemPayload,
+    { vec![] }
+);
+
+#[derive(Hash, Clone, Debug)]
+pub enum QueueItemPayloadIndexKey {}
+
+base_rocks_secondary_index!(QueueItemPayload, QueueItemPayloadRocksIndex);
+
+impl RocksSecondaryIndex<QueueItemPayload, QueueItemPayloadIndexKey>
+    for QueueItemPayloadRocksIndex
+{
+    fn typed_key_by(&self, _row: &QueueItemPayload) -> QueueItemPayloadIndexKey {
+        unimplemented!();
+    }
+
+    fn key_to_bytes(&self, _key: &QueueItemPayloadIndexKey) -> Vec<u8> {
+        unimplemented!();
+    }
+
+    fn is_unique(&self) -> bool {
+        unimplemented!();
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn is_ttl(&self) -> bool {
+        true
+    }
+
+    fn get_expire(&self, row: &QueueItemPayload) -> Option<DateTime<Utc>> {
+        if let Some(orphaned) = row.orphaned {
+            Some(orphaned.clone() + Duration::hours(1))
+        } else {
+            Some(row.get_created().clone() + Duration::hours(2))
+        }
+    }
+
+    fn get_id(&self) -> IndexId {
+        *self as IndexId
+    }
+}

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -84,7 +84,9 @@ use std::mem::take;
 use std::path::Path;
 use std::str::FromStr;
 
-use crate::cachestore::{CacheItem, QueueItem, QueueItemStatus, QueueResult, QueueResultAckEvent};
+use crate::cachestore::{
+    CacheItem, QueueItem, QueueItemPayload, QueueItemStatus, QueueResult, QueueResultAckEvent,
+};
 use crate::remotefs::LocalDirRemoteFs;
 use deepsize::DeepSizeOf;
 use snapshot_info::SnapshotInfo;
@@ -1231,6 +1233,9 @@ pub enum MetaStoreEvent {
 
     UpdateQueueResult(IdRow<QueueResult>, IdRow<QueueResult>),
     DeleteQueueResult(IdRow<QueueResult>),
+
+    UpdateQueueItemPayload(IdRow<QueueItemPayload>, IdRow<QueueItemPayload>),
+    DeleteQueueItemPayload(IdRow<QueueItemPayload>),
 }
 
 fn meta_store_merge(

--- a/rust/cubestore/cubestore/src/metastore/rocks_store.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_store.rs
@@ -80,7 +80,8 @@ enum_from_primitive! {
         CacheItems = 0x0C00,
         QueueItems = 0x0D00,
         QueueResults = 0x0E00,
-        TraceObjects = 0x0F00
+        TraceObjects = 0x0F00,
+        QueueItemPayload = 0x1000
 
     }
 }
@@ -103,6 +104,7 @@ impl TableId {
             TableId::QueueItems => true,
             TableId::QueueResults => true,
             TableId::TraceObjects => false,
+            TableId::QueueItemPayload => true,
         }
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -1,5 +1,6 @@
 use crate::cachestore::{
-    CacheItem, CacheStore, QueueItem, QueueItemStatus, QueueKey, QueueResult, QueueResultResponse,
+    CacheItem, CacheStore, QueueAddPayload, QueueAllItem, QueueCancelResponse, QueueGetResponse,
+    QueueItem, QueueItemStatus, QueueKey, QueueListItem, QueueResult, QueueResultResponse,
     QueueRetrieveResponse,
 };
 use crate::metastore::job::{Job, JobStatus, JobType};
@@ -785,7 +786,7 @@ impl CacheStore for CacheStoreMock {
         panic!("CacheStore mock!")
     }
 
-    async fn queue_all(&self, _limit: Option<usize>) -> Result<Vec<IdRow<QueueItem>>, CubeError> {
+    async fn queue_all(&self, _limit: Option<usize>) -> Result<Vec<QueueAllItem>, CubeError> {
         panic!("CacheStore mock!")
     }
 
@@ -802,9 +803,9 @@ impl CacheStore for CacheStoreMock {
 
     async fn queue_add(
         &self,
-        _item: QueueItem,
+        payload: QueueAddPayload,
     ) -> Result<crate::cachestore::QueueAddResponse, CubeError> {
-        panic!("CacheStore mock!")
+        panic!("CacheStore mock queue_add, payload: {:?}!", payload)
     }
 
     async fn queue_truncate(&self) -> Result<(), CubeError> {
@@ -825,15 +826,16 @@ impl CacheStore for CacheStoreMock {
         _prefix: String,
         _status_filter: Option<QueueItemStatus>,
         _priority_sort: bool,
-    ) -> Result<Vec<IdRow<QueueItem>>, CubeError> {
+        _with_payload: bool,
+    ) -> Result<Vec<QueueListItem>, CubeError> {
         panic!("CacheStore mock!")
     }
 
-    async fn queue_get(&self, _key: QueueKey) -> Result<Option<IdRow<QueueItem>>, CubeError> {
+    async fn queue_get(&self, _key: QueueKey) -> Result<Option<QueueGetResponse>, CubeError> {
         panic!("CacheStore mock!")
     }
 
-    async fn queue_cancel(&self, _key: QueueKey) -> Result<Option<IdRow<QueueItem>>, CubeError> {
+    async fn queue_cancel(&self, _key: QueueKey) -> Result<Option<QueueCancelResponse>, CubeError> {
         panic!("CacheStore mock!")
     }
 


### PR DESCRIPTION
This PR separates a payload field (can be a large string) from `QueueItem` to a separate table called `QueueItemPayload`. Why? Because we have commands that iterates over the whole data. For example `QUEUE LIST` or `QUEUE TO_CANCEL` or `QUEUE PENDING`. It's super expensive to read payload from RocksDB, and deserialize it.

For backward compatibility, I've bumped the version of QueueItem from `2` to `3`. For forward, and backward migration, Cache Store will truncate this table.

```
in_process::queue_list_bench
                        time:   [10.684 ms 10.769 ms 10.858 ms]
                        change: [-75.723% -74.952% -74.200%] (p = 0.00 < 0.05)
                        Performance has improved.
```