### PR TITLE
fix(cubesql): Don't push down Sort to Projection with Aggregate input

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
@@ -59,7 +59,10 @@ fn sort_push_down(
             // Sort can be pushed down to projection, however we only map specific expressions.
             // Complex expressions can't be pushed down, so if there are any, Sort is issued
             // before the projection.
-            if plan_has_projections(input) {
+            // We also don't push sort down to projection if its input is an aggregate,
+            // as that would conflict with SQL push down.
+            let input_is_aggregate = matches!(&**input, LogicalPlan::Aggregate(_));
+            if !input_is_aggregate && plan_has_projections(input) {
                 if let Some(sort_expr) = &sort_expr {
                     let rewrite_map = rewrite_map_for_projection(expr, schema);
                     if let Some(new_sort_expr) = sort_expr

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -22687,4 +22687,46 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
             displayable(physical_plan.as_ref()).indent()
         );
     }
+
+    #[tokio::test]
+    async fn test_sort_before_projection() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            SELECT
+                "source"."customer_gender" AS "customer_gender",
+                SUM("source"."taxful_total_price") AS "sum"
+            FROM (
+                SELECT
+                    "public"."KibanaSampleDataEcommerce"."customer_gender" AS "customer_gender",
+                    "public"."KibanaSampleDataEcommerce"."taxful_total_price" AS "taxful_total_price"
+                FROM "public"."KibanaSampleDataEcommerce"
+            ) AS "source"
+            GROUP BY "source"."customer_gender"
+            ORDER BY "source"."customer_gender" ASC
+            ;
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        assert!(logical_plan
+            .find_cube_scan_wrapper()
+            .wrapped_sql
+            .unwrap()
+            .sql
+            .contains("ORDER BY "));
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR changes `SortPushDown` optimizer behavior to avoid pushing `Sort` down to `Projection` if its input is an `Aggregate`. This fixes and issue with `ORDER BY` not being realiased correctly with SQL push down. Related test is included.