### PR TITLE
fix(cubesql): Flatten aliasing breaks wrapped select `ORDER BY` expre…

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -16,7 +16,7 @@ use cubeclient::models::V1LoadRequestQuery;
 use datafusion::{
     error::{DataFusionError, Result},
     logical_plan::{
-        plan::Extension, replace_col, replace_col_to_expr, Column, DFSchema, DFSchemaRef, Expr,
+        plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr,
         LogicalPlan, UserDefinedLogicalNode,
     },
     physical_plan::{aggregates::AggregateFunction, functions::BuiltinScalarFunction},
@@ -557,50 +557,11 @@ impl CubeScanWrapperNode {
                                 ungrouped_scan_node.clone(),
                             )
                             .await?;
-                            // Sort node always comes on top and pushed down to select so we need to replace columns here by appropriate column definitions
-                            let order_replace_map = projection_expr
-                                .iter()
-                                .chain(group_expr.iter())
-                                .chain(aggr_expr.iter())
-                                .map(|e| {
-                                    let name = expr_name(&e, &schema)?;
-                                    Ok(vec![
-                                        (
-                                            Column {
-                                                relation: alias.clone(),
-                                                name: name.clone(),
-                                            },
-                                            e.clone(),
-                                        ),
-                                        (
-                                            Column {
-                                                relation: None,
-                                                name: name,
-                                            },
-                                            e.clone(),
-                                        ),
-                                    ])
-                                })
-                                .collect::<Result<Vec<_>>>()?
-                                .into_iter()
-                                .flatten()
-                                .collect::<HashMap<_, _>>();
 
                             let (order, mut sql) = Self::generate_column_expr(
                                 plan.clone(),
                                 schema.clone(),
-                                order_expr
-                                    .iter()
-                                    .map(|o| {
-                                        replace_col_to_expr(
-                                            o.clone(),
-                                            &order_replace_map
-                                                .iter()
-                                                .map(|(k, v)| (k, v))
-                                                .collect(),
-                                        )
-                                    })
-                                    .collect::<Result<Vec<_>>>()?,
+                                order_expr.clone(),
                                 sql,
                                 generator.clone(),
                                 &column_remapping,
@@ -696,9 +657,9 @@ impl CubeScanWrapperNode {
                                                             DataFusionError::Execution(format!(
                                                                 "Can't find column {} in projection {:?} or aggregate {:?} or group {:?}",
                                                                 col_name,
-                                                                projection,
-                                                                aggregate,
-                                                                group_by
+                                                                projection_expr,
+                                                                aggr_expr,
+                                                                group_expr
                                                             ))
                                                         })?;
                                                     Ok(vec![
@@ -997,14 +958,14 @@ impl CubeScanWrapperNode {
                             .ok_or_else(|| {
                                 DataFusionError::Internal(format!(
                                     "Can't find column {} in ungrouped scan node",
-                                    c.name
+                                    c
                                 ))
                             })?
                             .0;
                         let member = scan_node.member_fields.get(field_index).ok_or_else(|| {
                             DataFusionError::Internal(format!(
                                 "Can't find member for column {} in ungrouped scan node",
-                                c.name
+                                c
                             ))
                         })?;
                         match member {

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -16,8 +16,8 @@ use cubeclient::models::V1LoadRequestQuery;
 use datafusion::{
     error::{DataFusionError, Result},
     logical_plan::{
-        plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr,
-        LogicalPlan, UserDefinedLogicalNode,
+        plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr, LogicalPlan,
+        UserDefinedLogicalNode,
     },
     physical_plan::{aggregates::AggregateFunction, functions::BuiltinScalarFunction},
     scalar::ScalarValue,

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13558,9 +13558,11 @@ ORDER BY
   "source"."dim3" ASC,
   "source"."dim4" ASC,
   "source"."pivot-grouping" ASC
-            "#.to_string(),
-            DatabaseProtocol::PostgreSQL
-        ).await;
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
 
         let physical_plan = query_plan.as_physical_plan().await.unwrap();
         println!(
@@ -13588,19 +13590,18 @@ ORDER BY
                 order: None,
                 limit: None,
                 offset: None,
-                filters: Some(vec![
-                    V1LoadRequestQueryFilterItem {
-                        member: Some("WideCube.dim1".to_string()),
-                        operator: Some("equals".to_string()),
-                        values: Some(vec!["foo".to_string()]),
-                        or: None,
-                        and: None,
-                    }
-                ]),
+                filters: Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("WideCube.dim1".to_string()),
+                    operator: Some("equals".to_string()),
+                    values: Some(vec!["foo".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
                 ungrouped: Some(true),
             }
         );
-        assert!(!query_plan.as_logical_plan()
+        assert!(!query_plan
+            .as_logical_plan()
             .find_cube_scan_wrapper()
             .wrapped_sql
             .unwrap()
@@ -13628,9 +13629,11 @@ FROM (
 ) AS "source"
 GROUP BY "source"."str0"
 ORDER BY "source"."str0" ASC
-            "#.to_string(),
-            DatabaseProtocol::PostgreSQL
-        ).await;
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
 
         let physical_plan = query_plan.as_physical_plan().await.unwrap();
         println!(
@@ -13652,7 +13655,8 @@ ORDER BY "source"."str0" ASC
                 ungrouped: Some(true),
             }
         );
-        assert!(!query_plan.as_logical_plan()
+        assert!(!query_plan
+            .as_logical_plan()
             .find_cube_scan_wrapper()
             .wrapped_sql
             .unwrap()

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13514,6 +13514,153 @@ ORDER BY
     }
 
     #[tokio::test]
+    async fn metabase_max_sum_wrapper() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+SELECT
+  "source"."dim2" AS "dim2",
+  "source"."dim3" AS "dim3",
+  "source"."dim4" AS "dim4",
+  "source"."pivot-grouping" AS "pivot-grouping",
+  MAX("source"."measure1") AS "max",
+  MAX("source"."measure2") AS "max_2",
+  SUM("source"."measure3") AS "sum",
+  MAX("source"."measure4") AS "max_3"
+FROM
+  (
+    SELECT
+      "public"."WideCube"."measure1" AS "measure1",
+      "public"."WideCube"."measure2" AS "measure2",
+      "public"."WideCube"."measure3" AS "measure3",
+      "public"."WideCube"."measure4" AS "measure4",
+      "public"."WideCube"."dim1" AS "dim1",
+      "public"."WideCube"."dim2" AS "dim2",
+      "public"."WideCube"."dim3" AS "dim3",
+      "public"."WideCube"."dim4" AS "dim4",
+      ABS(0) AS "pivot-grouping"
+    FROM
+      "public"."WideCube"
+    WHERE
+      "public"."WideCube"."dim1" = 'foo'
+  ) AS "source"
+GROUP BY
+  "source"."dim2",
+  "source"."dim3",
+  "source"."dim4",
+  "source"."pivot-grouping"
+ORDER BY
+  "source"."dim2" ASC,
+  "source"."dim3" ASC,
+  "source"."dim4" ASC,
+  "source"."pivot-grouping" ASC
+            "#.to_string(),
+            DatabaseProtocol::PostgreSQL
+        ).await;
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+
+        assert_eq!(
+            query_plan.as_logical_plan().find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![
+                    "WideCube.measure1".to_string(),
+                    "WideCube.measure2".to_string(),
+                    "WideCube.measure3".to_string(),
+                    "WideCube.measure4".to_string(),
+                ]),
+                dimensions: Some(vec![
+                    "WideCube.dim1".to_string(),
+                    "WideCube.dim2".to_string(),
+                    "WideCube.dim3".to_string(),
+                    "WideCube.dim4".to_string(),
+                ]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: Some(vec![
+                    V1LoadRequestQueryFilterItem {
+                        member: Some("WideCube.dim1".to_string()),
+                        operator: Some("equals".to_string()),
+                        values: Some(vec!["foo".to_string()]),
+                        or: None,
+                        and: None,
+                    }
+                ]),
+                ungrouped: Some(true),
+            }
+        );
+        assert!(!query_plan.as_logical_plan()
+            .find_cube_scan_wrapper()
+            .wrapped_sql
+            .unwrap()
+            .sql
+            .contains("ungrouped"));
+    }
+
+    #[tokio::test]
+    async fn metabase_sum_dim_wrapper() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+SELECT
+  "source"."str0" AS "str0",
+  SUM("source"."num1") AS "sum"
+FROM (
+  SELECT
+    "public"."WideCube"."dim1" AS "str0",
+    "public"."WideCube"."dim2" AS "num1"
+  FROM "public"."WideCube"
+) AS "source"
+GROUP BY "source"."str0"
+ORDER BY "source"."str0" ASC
+            "#.to_string(),
+            DatabaseProtocol::PostgreSQL
+        ).await;
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+
+        assert_eq!(
+            query_plan.as_logical_plan().find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec![]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+                ungrouped: Some(true),
+            }
+        );
+        assert!(!query_plan.as_logical_plan()
+            .find_cube_scan_wrapper()
+            .wrapped_sql
+            .unwrap()
+            .sql
+            .contains("ungrouped"));
+    }
+
+    #[tokio::test]
     async fn test_outer_aggr_simple_count() {
         let logical_plan = convert_select_to_query_plan(
             "

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -1077,7 +1077,8 @@ impl LanguageToLogicalPlanConverter {
             LogicalPlanLanguage::Projection(params) => {
                 let expr = match_expr_list_node!(node_by_id, to_expr, params[0], ProjectionExpr);
                 let input = Arc::new(self.to_logical_plan(params[1])?);
-                let expr = replace_qualified_col_with_flat_name_if_missing(expr, &input)?;
+                let expr =
+                    replace_qualified_col_with_flat_name_if_missing(expr, input.schema(), true)?;
                 let alias = match_data_node!(node_by_id, params[2], ProjectionAlias);
                 let input_schema = DFSchema::new_with_metadata(
                     exprlist_to_fields(&expr, input.schema())?,
@@ -1105,8 +1106,11 @@ impl LanguageToLogicalPlanConverter {
                 let input = Arc::new(self.to_logical_plan(params[0])?);
                 let window_expr =
                     match_expr_list_node!(node_by_id, to_expr, params[1], WindowWindowExpr);
-                let window_expr =
-                    replace_qualified_col_with_flat_name_if_missing(window_expr, &input)?;
+                let window_expr = replace_qualified_col_with_flat_name_if_missing(
+                    window_expr,
+                    input.schema(),
+                    true,
+                )?;
                 let mut window_fields: Vec<DFField> =
                     exprlist_to_fields(window_expr.iter(), input.schema())?;
                 window_fields.extend_from_slice(input.schema().fields());
@@ -1124,11 +1128,19 @@ impl LanguageToLogicalPlanConverter {
                 let aggr_expr =
                     match_expr_list_node!(node_by_id, to_expr, params[2], AggregateAggrExpr);
                 let group_expr = normalize_cols(
-                    replace_qualified_col_with_flat_name_if_missing(group_expr, &input)?,
+                    replace_qualified_col_with_flat_name_if_missing(
+                        group_expr,
+                        input.schema(),
+                        true,
+                    )?,
                     &input,
                 )?;
                 let aggr_expr = normalize_cols(
-                    replace_qualified_col_with_flat_name_if_missing(aggr_expr, &input)?,
+                    replace_qualified_col_with_flat_name_if_missing(
+                        aggr_expr,
+                        input.schema(),
+                        true,
+                    )?,
                     &input,
                 )?;
                 let all_expr = group_expr.iter().chain(aggr_expr.iter());
@@ -1147,7 +1159,8 @@ impl LanguageToLogicalPlanConverter {
             LogicalPlanLanguage::Sort(params) => {
                 let expr = match_expr_list_node!(node_by_id, to_expr, params[0], SortExp);
                 let input = Arc::new(self.to_logical_plan(params[1])?);
-                let expr = replace_qualified_col_with_flat_name_if_missing(expr, &input)?;
+                let expr =
+                    replace_qualified_col_with_flat_name_if_missing(expr, input.schema(), true)?;
 
                 LogicalPlan::Sort(Sort { expr, input })
             }
@@ -1235,7 +1248,8 @@ impl LanguageToLogicalPlanConverter {
             LogicalPlanLanguage::TableUDFs(params) => {
                 let expr = match_expr_list_node!(node_by_id, to_expr, params[0], TableUDFsExpr);
                 let input = Arc::new(self.to_logical_plan(params[1])?);
-                let expr = replace_qualified_col_with_flat_name_if_missing(expr, &input)?;
+                let expr =
+                    replace_qualified_col_with_flat_name_if_missing(expr, input.schema(), true)?;
                 let schema = build_table_udf_schema(&input, expr.as_slice())?;
 
                 LogicalPlan::TableUDFs(TableUDFs {
@@ -1908,15 +1922,27 @@ impl LanguageToLogicalPlanConverter {
                 let ungrouped = match_data_node!(node_by_id, params[13], WrappedSelectUngrouped);
 
                 let filter_expr = normalize_cols(
-                    replace_qualified_col_with_flat_name_if_missing(filter_expr, &from)?,
+                    replace_qualified_col_with_flat_name_if_missing(
+                        filter_expr,
+                        from.schema(),
+                        true,
+                    )?,
                     &from,
                 )?;
                 let group_expr = normalize_cols(
-                    replace_qualified_col_with_flat_name_if_missing(group_expr, &from)?,
+                    replace_qualified_col_with_flat_name_if_missing(
+                        group_expr,
+                        from.schema(),
+                        true,
+                    )?,
                     &from,
                 )?;
                 let aggr_expr = normalize_cols(
-                    replace_qualified_col_with_flat_name_if_missing(aggr_expr, &from)?,
+                    replace_qualified_col_with_flat_name_if_missing(
+                        aggr_expr,
+                        from.schema(),
+                        true,
+                    )?,
                     &from,
                 )?;
                 let projection_expr = if projection_expr.is_empty()
@@ -1929,7 +1955,11 @@ impl LanguageToLogicalPlanConverter {
                         .collect::<Vec<_>>()
                 } else {
                     normalize_cols(
-                        replace_qualified_col_with_flat_name_if_missing(projection_expr, &from)?,
+                        replace_qualified_col_with_flat_name_if_missing(
+                            projection_expr,
+                            from.schema(),
+                            true,
+                        )?,
                         &from,
                     )?
                 };
@@ -1954,16 +1984,49 @@ impl LanguageToLogicalPlanConverter {
                 let replace_map = all_expr_without_window
                     .iter()
                     .zip(without_window_fields.iter())
-                    .map(|(e, f)| (f.qualified_column(), e.clone()))
+                    .flat_map(|(e, f)| {
+                        vec![
+                            (
+                                Column {
+                                    relation: alias.clone(),
+                                    name: f.name().clone(),
+                                },
+                                e.clone(),
+                            ),
+                            (
+                                Column {
+                                    relation: None,
+                                    name: f.name().clone(),
+                                },
+                                e.clone(),
+                            ),
+                        ]
+                    })
                     .collect::<Vec<_>>();
                 let replace_map = replace_map
                     .iter()
                     .map(|(c, e)| (c, e))
                     .collect::<HashMap<_, _>>();
-                let window_expr_rebased = window_expr
-                    .iter()
-                    .map(|e| replace_col_to_expr(e.clone(), &replace_map))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let without_window_fields_schema = Arc::new(DFSchema::new_with_metadata(
+                    without_window_fields.clone(),
+                    HashMap::new(),
+                )?);
+                let window_expr_rebased = replace_qualified_col_with_flat_name_if_missing(
+                    window_expr,
+                    &without_window_fields_schema,
+                    true,
+                )?
+                .iter()
+                .map(|e| replace_col_to_expr(e.clone(), &replace_map))
+                .collect::<Result<Vec<_>, _>>()?;
+                let order_expr_rebased = replace_qualified_col_with_flat_name_if_missing(
+                    order_expr,
+                    &without_window_fields_schema,
+                    false,
+                )?
+                .iter()
+                .map(|e| replace_col_to_expr(e.clone(), &replace_map))
+                .collect::<Result<Vec<_>, _>>()?;
                 let schema = DFSchema::new_with_metadata(
                     // TODO support joins schema
                     without_window_fields
@@ -1995,7 +2058,7 @@ impl LanguageToLogicalPlanConverter {
                         having_expr,
                         limit,
                         offset,
-                        order_expr,
+                        order_expr_rebased,
                         alias,
                         ungrouped,
                     )),
@@ -2069,10 +2132,12 @@ pub fn expr_relation(expr: &Expr) -> Option<&str> {
 /// TODO: introduce fully qualified names for aliases in Datafusion and remove this function.
 fn replace_qualified_col_with_flat_name_if_missing(
     expr: Vec<Expr>,
-    from: &Arc<LogicalPlan>,
+    schema: &Arc<DFSchema>,
+    original_alias: bool,
 ) -> Result<Vec<Expr>, CubeError> {
     struct FlattenColumnReplacer<'a> {
         schema: &'a Arc<DFSchema>,
+        original_alias: bool,
     }
 
     impl<'a> ExprRewriter for FlattenColumnReplacer<'a> {
@@ -2084,15 +2149,20 @@ fn replace_qualified_col_with_flat_name_if_missing(
                         .field_with_unqualified_name(&c.flat_name())
                         .is_ok()
                     {
-                        // This code expects that it operates on Projection level.
-                        // Exposing this function to Aggregate or top level would most likely fail.
-                        Ok(Expr::Alias(
-                            Box::new(Expr::Column(Column {
+                        if self.original_alias {
+                            Ok(Expr::Alias(
+                                Box::new(Expr::Column(Column {
+                                    name: c.flat_name(),
+                                    relation: None,
+                                })),
+                                c.name.to_string(),
+                            ))
+                        } else {
+                            Ok(Expr::Column(Column {
                                 name: c.flat_name(),
                                 relation: None,
-                            })),
-                            c.name.to_string(),
-                        ))
+                            }))
+                        }
                     } else {
                         Ok(Expr::Column(c))
                     }
@@ -2108,7 +2178,8 @@ fn replace_qualified_col_with_flat_name_if_missing(
     expr.into_iter()
         .map(|e| {
             e.rewrite(&mut FlattenColumnReplacer {
-                schema: from.schema(),
+                schema,
+                original_alias,
             })
             .map_err(|e| CubeError::from(e))
         })

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/column.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/column.rs
@@ -1,8 +1,10 @@
 use crate::{
     compile::rewrite::{
-        analysis::LogicalPlanAnalysis, column_expr, column_name_to_member_vec, rewrite,
-        rules::wrapper::WrapperRules, transforming_rewrite, wrapper_pullup_replacer,
-        wrapper_pushdown_replacer, ColumnExprColumn, LogicalPlanLanguage,
+        analysis::{LogicalPlanAnalysis, Member},
+        column_expr, column_name_to_member_def_vec, column_name_to_member_vec, rewrite,
+        rules::wrapper::WrapperRules,
+        transforming_rewrite, wrapper_pullup_replacer, wrapper_pushdown_replacer, ColumnExprColumn,
+        LogicalPlanLanguage,
     },
     var, var_iter,
 };
@@ -79,20 +81,26 @@ impl WrapperRules {
         let column_name_var = var!(column_name_var);
         let members_var = var!(members_var);
         let dimension_var = var!(dimension_var);
-        let meta = self.meta_context.clone();
         move |egraph, subst| {
             for column in var_iter!(egraph[subst[column_name_var]], ColumnExprColumn).cloned() {
                 if let Some(member_name_to_expr) =
                     egraph[subst[members_var]].data.member_name_to_expr.clone()
                 {
-                    let column_name_to_member_name = column_name_to_member_vec(member_name_to_expr);
-                    if let Some((_, Some(member))) = column_name_to_member_name
+                    let column_name_to_member_name =
+                        column_name_to_member_def_vec(member_name_to_expr);
+                    if let Some((_, member)) = column_name_to_member_name
                         .iter()
                         .find(|(cn, _)| cn == &column.name)
                     {
-                        if meta.find_dimension_with_name(member.to_string()).is_some()
-                            || meta.is_synthetic_field(member.to_string())
-                        {
+                        if matches!(
+                            member,
+                            Member::Dimension { .. }
+                                | Member::TimeDimension { .. }
+                                | Member::Segment { .. }
+                                | Member::ChangeUser { .. }
+                                | Member::VirtualField { .. }
+                                | Member::LiteralMember { .. }
+                        ) {
                             let column_expr_column =
                                 egraph.add(LogicalPlanLanguage::ColumnExprColumn(
                                     ColumnExprColumn(column.clone()),

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -301,6 +301,7 @@ pub fn get_test_tenant_ctx_customized(custom_templates: Vec<(String, String)>) -
             ),
             ("Logs".to_string(), "default".to_string()),
             ("NumberCube".to_string(), "default".to_string()),
+            ("WideCube".to_string(), "default".to_string()),
         ]
         .into_iter()
         .collect(),


### PR DESCRIPTION
…ssions

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


