### PR TITLE
fix(cubesql): Remove binary expression associative rewrites

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -251,25 +251,6 @@ impl RewriteRules for MemberRules {
                 ),
                 self.push_down_limit("?skip", "?fetch", "?new_skip", "?new_fetch"),
             ),
-            // Binary expression associative properties
-            transforming_rewrite_with_root(
-                "binary-expr-addition-assoc",
-                binary_expr(binary_expr("?a", "+", "?b"), "+", "?c"),
-                alias_expr(
-                    binary_expr("?a", "+", binary_expr("?b", "+", "?c")),
-                    "?alias",
-                ),
-                transform_original_expr_to_alias("?alias"),
-            ),
-            transforming_rewrite_with_root(
-                "binary-expr-multi-assoc",
-                binary_expr(binary_expr("?a", "*", "?b"), "*", "?c"),
-                alias_expr(
-                    binary_expr("?a", "*", binary_expr("?b", "*", "?c")),
-                    "?alias",
-                ),
-                transform_original_expr_to_alias("?alias"),
-            ),
             // MOD function to binary expr
             transforming_rewrite_with_root(
                 "mod-fun-to-binary-expr",


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR removes binary expression associative rewrite rules as those happen to lead to self-references and conflict with other rules.