### PR TITLE
fix(cubesql): SQL push down of ORDER BY causes Invalid query format: …

### DIFF
--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -39,6 +39,7 @@ const getPivotQuery = (queryType, queries) => {
 };
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
+const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$/);
 const dimensionWithTime = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.(second|minute|hour|day|week|month|year))?$/);
 const memberExpression = Joi.object().keys({
   expression: Joi.func().required(),
@@ -102,8 +103,8 @@ const querySchema = Joi.object().keys({
     compareDateRange: Joi.array()
   }).oxor('dateRange', 'compareDateRange')),
   order: Joi.alternatives(
-    Joi.object().pattern(id, Joi.valid('asc', 'desc')),
-    Joi.array().items(Joi.array().min(2).ordered(id, Joi.valid('asc', 'desc')))
+    Joi.object().pattern(idOrMemberExpressionName, Joi.valid('asc', 'desc')),
+    Joi.array().items(Joi.array().min(2).ordered(idOrMemberExpressionName, Joi.valid('asc', 'desc')))
   ),
   segments: Joi.array().items(Joi.alternatives(id, memberExpression)),
   timezone: Joi.string(),

--- a/packages/cubejs-schema-compiler/src/adapter/BaseDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseDimension.ts
@@ -17,6 +17,7 @@ export class BaseDimension {
     if (dimension && dimension.expression) {
       this.expression = dimension.expression;
       this.expressionCubeName = dimension.cubeName;
+      // In case of SQL push down expressionName doesn't contain cube name. It's just a column name.
       this.expressionName = dimension.expressionName || `${dimension.cubeName}.${dimension.name}`;
       this.isMemberExpression = !!dimension.definition;
     }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
@@ -17,6 +17,7 @@ export class BaseMeasure {
     if (measure.expression) {
       this.expression = measure.expression;
       this.expressionCubeName = measure.cubeName;
+      // In case of SQL push down expressionName doesn't contain cube name. It's just a column name.
       this.expressionName = measure.expressionName || `${measure.cubeName}.${measure.name}`;
       this.isMemberExpression = !!measure.definition;
     }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseSegment.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseSegment.ts
@@ -16,6 +16,7 @@ export class BaseSegment {
     if (segment.expression) {
       this.expression = segment.expression;
       this.expressionCubeName = segment.cubeName;
+      // In case of SQL push down expressionName doesn't contain cube name. It's just a column name.
       this.expressionName = segment.expressionName || `${segment.cubeName}.${segment.name}`;
       this.isMemberExpression = !!segment.definition;
     }

--- a/packages/cubejs-testing/birdbox-fixtures/postgresql/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/postgresql/schema/Orders.js
@@ -21,12 +21,17 @@ cube(`Orders`, {
     toRemove: {
       type: `count`,
     },
+    numberTotal: {
+      sql: `${totalAmount}`,
+      type: `number`
+    }
   },
   dimensions: {
     id: {
       sql: `id`,
       type: `number`,
       primaryKey: true,
+      public: true,
     },
 
     status: {

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -17,6 +17,23 @@ Array [
 ]
 `;
 
+exports[`SQL API Postgres (Data) metabase max number: metabase max number 1`] = `
+Array [
+  Object {
+    "id": 2,
+    "numberTotal": 200,
+    "pivot-grouping": 0,
+    "status": "new",
+  },
+  Object {
+    "id": 1,
+    "numberTotal": 100,
+    "pivot-grouping": 0,
+    "status": "new",
+  },
+]
+`;
+
 exports[`SQL API Postgres (Data) no limit for non matching count push down: no limit for non matching count push down 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -210,7 +210,7 @@ FROM
     FROM
       "public"."Orders"
     WHERE
-      "public"."Orders"."id" = '1'
+      "public"."Orders"."status" = 'new'
   ) AS "source"
 GROUP BY
   "source"."id",

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -217,7 +217,7 @@ GROUP BY
   "source"."status",
   "source"."pivot-grouping"
 ORDER BY
-  "source"."id" ASC,
+  "source"."id" DESC,
   "source"."status" ASC,
   "source"."pivot-grouping" ASC
   `);

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -192,5 +192,36 @@ from
   `);
       expect(res.rows).toMatchSnapshot('no limit for non matching count push down');
     });
+
+    test('metabase max number', async () => {
+      const res = await connection.query(`
+SELECT
+  "source"."id" AS "id",
+  "source"."status" AS "status",
+  "source"."pivot-grouping" AS "pivot-grouping",
+  MAX("source"."numberTotal") AS "numberTotal"
+FROM
+  (
+    SELECT
+      "public"."Orders"."numberTotal" AS "numberTotal",
+      "public"."Orders"."id" AS "id",
+      "public"."Orders"."status" AS "status",
+      ABS(0) AS "pivot-grouping"
+    FROM
+      "public"."Orders"
+    WHERE
+      "public"."Orders"."id" = '1'
+  ) AS "source"
+GROUP BY
+  "source"."id",
+  "source"."status",
+  "source"."pivot-grouping"
+ORDER BY
+  "source"."id" ASC,
+  "source"."status" ASC,
+  "source"."pivot-grouping" ASC
+  `);
+      expect(res.rows).toMatchSnapshot('metabase max number');
+    });
   });
 });

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13607,6 +13607,14 @@ ORDER BY
             .unwrap()
             .sql
             .contains("ungrouped"));
+
+        assert!(query_plan
+            .as_logical_plan()
+            .find_cube_scan_wrapper()
+            .wrapped_sql
+            .unwrap()
+            .sql
+            .contains("[\"dim2\",\"asc\"]"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
…"order[0][0]" with value fails to match the required pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


