### PR TITLE
fix(cubestore): RocksStore - migrate table by truncate (unknown tables)

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/rocks_store.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_store.rs
@@ -437,7 +437,7 @@ impl RowKey {
         RowKey::try_from_bytes(bytes).unwrap()
     }
 
-    pub fn to_iterate_range(&self) -> impl rocksdb::IterateBounds {
+    pub fn to_iterate_range(&self) -> std::ops::Range<Vec<u8>> {
         let mut min = Vec::with_capacity(5);
         let mut max = Vec::with_capacity(5);
 
@@ -1591,6 +1591,21 @@ mod tests {
             .await
             .unwrap();
     }
+
+    #[test]
+    fn test_row_key_to_iterate_range() -> Result<(), CubeError> {
+        {
+            let row_key = RowKey::Table(TableId::CacheItems, 0);
+            let range = row_key.to_iterate_range();
+
+            assert_eq!(range.start, vec![1, 0, 0, 12, 0]);
+
+            assert_eq!(range.end, vec![1, 0, 0, 12, 1]);
+        }
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_snapshot_uploads() -> Result<(), CubeError> {
         let config = Config::test("test_snapshots_uploads").update_config(|mut c| {

--- a/rust/cubestore/cubestore/src/metastore/rocks_table.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_table.rs
@@ -463,7 +463,11 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         for index in Self::indexes() {
             log::trace!("Migrating by truncating rows from {:?} index", index);
             let total = self.delete_all_rows_from_index(index.get_id(), &mut batch)?;
-            log::trace!("Migrating by truncating rows from {:?} index: done ({} rows)", index, total);
+            log::trace!(
+                "Migrating by truncating rows from {:?} index: done ({} rows)",
+                index,
+                total
+            );
         }
 
         log::info!(


### PR DESCRIPTION
Hello!

Iterating without an upper bound leads to reading keys from next table, next index. Downgrading can lead to an unknown tableId on migration. Let's skip these errors by using a range iterator.

Debug of fixed version:

```
2024-03-28 14:22:12,368 TRACE [cubestore::metastore::rocks_store] <pid:50477> Migration for cachestore: started
2024-03-28 14:22:12,369 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating table QueueItems from [3, 1] to [2, 1]
2024-03-28 14:22:12,369 INFO  [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from QueueItemRocksTable table
row_key Table(QueueItems, 4262)
row_key Table(QueueItems, 4263)
row_key Table(QueueItems, 4264)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPath index
row_key SecondaryIndex(3329, [15, 249, 59, 57, 253, 112, 86, 67], 4264)
row_key SecondaryIndex(3329, [61, 0, 52, 15, 64, 107, 132, 62], 4262)
row_key SecondaryIndex(3329, [82, 234, 217, 91, 115, 57, 47, 211], 4263)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPath index: done (3 rows)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPrefixAndStatus index
row_key SecondaryIndex(3330, [214, 173, 163, 218, 121, 228, 186, 124], 4262)
row_key SecondaryIndex(3330, [214, 173, 163, 218, 121, 228, 186, 124], 4263)
row_key SecondaryIndex(3330, [214, 173, 163, 218, 121, 228, 186, 124], 4264)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPrefixAndStatus index: done (3 rows)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPrefix index
row_key SecondaryIndex(3331, [170, 109, 177, 83, 182, 58, 191, 21], 4262)
row_key SecondaryIndex(3331, [170, 109, 177, 83, 182, 58, 191, 21], 4263)
row_key SecondaryIndex(3331, [170, 109, 177, 83, 182, 58, 191, 21], 4264)
2024-03-28 14:22:12,370 TRACE [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from ByPrefix index: done (3 rows)
2024-03-28 14:22:12,370 INFO  [cubestore::metastore::rocks_table] <pid:50477> Migrating by truncating rows from QueueItemRocksTable table: done (3 rows)
2024-03-28 14:22:12,373 TRACE [cubestore::metastore::rocks_store] <pid:50477> Migration for cachestore: done
```

Thanks