### PR TITLE
fix(api-gateway): fixes an issue where queries t…

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1421,7 +1421,7 @@ class ApiGateway {
       const normalizedTotal = structuredClone(normalizedQuery);
       normalizedTotal.totalQuery = true;
       
-      delete normalizedTotal.order
+      delete normalizedTotal.order;
 
       normalizedTotal.limit = null;
       normalizedTotal.rowLimit = null;

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1420,9 +1420,13 @@ class ApiGateway {
     if (normalizedQuery.total) {
       const normalizedTotal = structuredClone(normalizedQuery);
       normalizedTotal.totalQuery = true;
+      
+      delete normalizedTotal.order
+
       normalizedTotal.limit = null;
       normalizedTotal.rowLimit = null;
       normalizedTotal.offset = null;
+
       const [totalQuery] = await this.getSqlQueriesInternal(
         context,
         [normalizedTotal],

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -367,7 +367,7 @@ export class BaseQuery {
   }
 
   defaultOrder() {
-    if (this.options.preAggregationQuery) {
+    if (this.options.preAggregationQuery || this.options.totalQuery) {
       return [];
     }
 


### PR DESCRIPTION
fix(api-gateway) fix(schema-compiler): fixes an issue where queries to get the total count of results were incorrectly applying sorting from the original query and also were getting default ordering applied when the query ordering was stripped out

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[#7446](https://github.com/cube-js/cube/issues/7446)

**Description of Changes Made (if issue reference is not provided)**

- updates api gateway to remove `order` field from queries that are getting a count of total results matching
- updates the base query's logic for defaulting `order` so that it does an early return and _does not_ default `order` if the query is getting the total (follows the same path as the logic doing an early return for preaggreation queries)
