### PR TITLE
chore(ci): Compile cross without rust-embedded/cross

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -768,10 +768,6 @@ jobs:
           OPENSSL_LIB_DIR: 'C:/vcpkg/packages/openssl_x64-windows/lib'
           OPENSSL_INCLUDE_DIR: 'C:/vcpkg/packages/openssl_x64-windows/include'
           LIBCLANG_PATH: 'C:\Program Files\LLVM\bin'
-      # Hotfix before https://github.com/actions/runner-images/pull/7125 will be released/rolled on the productions servers
-      - name: Hotfix for macOS (pkg-config)
-        if: contains(runner.os, 'macos')
-        run: brew install pkg-config
       - name: Build with Cargo
         run: |
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -635,25 +635,24 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
             executable_name: cubestored
-            cross: true
             strip: true
             compress: false
           - target: x86_64-unknown-linux-musl
             os: ubuntu-20.04
             executable_name: cubestored
-            cross: true
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
             compress: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-20.04
             executable_name: cubestored
-            cross: true
             # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
             strip: false
             # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
             compress: false
       fail-fast: false
+    container:
+      image: cubejs/rust-cross:${{ matrix.target }}-02042024
     steps:
       - uses: actions/checkout@v4
       - name: Disable rustup update (issue workaround for Windows)
@@ -675,15 +674,7 @@ jobs:
       - run: source .github/actions/${{ matrix.before_script }}.sh
         if: ${{ matrix.before_script }}
         shell: bash
-      - name: Build with Cross
-        if: ${{ matrix.cross }}
-        run: |
-          wget -c https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
-          chmod +x cross && sudo mv cross /usr/local/bin/cross
-          cd rust/cubestore
-          cross build --release --target=${{ matrix.target }}
       - name: Build with Cargo
-        if: ${{ !matrix.cross }}
         run: |
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
       - name: Compress binaries
@@ -726,7 +717,6 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2019
             executable_name: cubestored.exe
-            cross: false
             strip: true
             # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
@@ -735,7 +725,6 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-11
             executable_name: cubestored
-            cross: false
             strip: false
             compress: false
             # bsd tar has a different format with Sparse files which breaks download script
@@ -783,15 +772,7 @@ jobs:
       - name: Hotfix for macOS (pkg-config)
         if: contains(runner.os, 'macos')
         run: brew install pkg-config
-      - name: Build with Cross
-        if: ${{ matrix.cross }}
-        run: |
-          wget -c https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
-          chmod +x cross && sudo mv cross /usr/local/bin/cross
-          cd rust/cubestore
-          cross build --release --target=${{ matrix.target }}
       - name: Build with Cargo
-        if: ${{ !matrix.cross }}
         run: |
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
       - name: Compress binaries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -623,7 +623,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static'
       OPENSSL_STATIC: 1
     strategy:
       matrix:

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -213,7 +213,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
-      RUSTFLAGS: '-Ctarget-feature=+crt-static'
       OPENSSL_STATIC: 1
     strategy:
       matrix:

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -118,7 +118,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-  cross:
+  cubestore:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
@@ -127,29 +127,12 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
-          - aarch64-unknown-linux-gnu
         include:
-          - os: ubuntu-20.04
-            target: x86_64-unknown-linux-gnu
-            executable_name: cubestored
-            cross: true
-            strip: true
-            compress: false
-          - os: ubuntu-20.04
-            target: x86_64-unknown-linux-musl
-            executable_name: cubestored
-            cross: true
-            strip: true
-            # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
-            compress: false
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             executable_name: cubestored.exe
-            cross: false
             strip: true
             # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
@@ -157,17 +140,8 @@ jobs:
           - os: macos-11
             target: x86_64-apple-darwin
             executable_name: cubestored
-            cross: false
             strip: true
             compress: true
-          - os: ubuntu-20.04
-            target: aarch64-unknown-linux-gnu
-            executable_name: cubestored
-            cross: true
-            # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
-            strip: false
-            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
-            compress: false
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -207,19 +181,7 @@ jobs:
           OPENSSL_LIB_DIR: 'C:/vcpkg/packages/openssl_x64-windows/lib'
           OPENSSL_INCLUDE_DIR: 'C:/vcpkg/packages/openssl_x64-windows/include'
           LIBCLANG_PATH: 'C:\Program Files\LLVM\bin'
-      # Hotfix before https://github.com/actions/runner-images/pull/7125 will be released/rolled on the productions servers
-      - name: Hotfix for macOS (pkg-config)
-        if: contains(runner.os, 'macos')
-        run: brew install pkg-config
-      - name: Build with Cross
-        if: ${{ matrix.cross }}
-        run: |
-          wget -c https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz -O - | tar -xz
-          chmod +x cross && sudo mv cross /usr/local/bin/cross
-          cd rust/cubestore
-          cross build --release --target=${{ matrix.target }}
       - name: Build with Cargo
-        if: ${{ !matrix.cross }}
         run: |
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
       - name: Compress binaries
@@ -236,6 +198,79 @@ jobs:
       - name: Copy/paste OpenSSL to Archive (hotfix for Windows)
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: cp C:/vcpkg/packages/openssl_x64-windows/bin/*.dll cubestore-archive/bin
+      - name: Create archive for release
+        run: |
+          mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
+          cd cubestore-archive
+          tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
+      - uses: actions/upload-artifact@v2
+        with:
+          path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
+          name: cubestored-${{ matrix.target }}.tar.gz
+          retention-days: 1
+
+  cubestore_linux:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    env:
+      RUSTFLAGS: '-Ctarget-feature=+crt-static'
+      OPENSSL_STATIC: 1
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+        include:
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            executable_name: cubestored
+            strip: true
+            compress: false
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            executable_name: cubestored
+            strip: true
+            # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
+            compress: false
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            executable_name: cubestored
+            # Unable to recognise the format of the input file `rust/cubestore/target/aarch64-unknown-linux-gnu/release/cubestored'
+            strip: false
+            # UPX is broken, issue https://github.com/cube-js/cube/issues/4474
+            compress: false
+      fail-fast: false
+    container:
+      image: cubejs/rust-cross:${{ matrix.target }}-02042024
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-06-22
+          target: ${{ matrix.target }}
+          override: true
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./rust/cubestore -> target
+          prefix-key: v0-rust-cubestore-cross
+          key: target-${{ matrix.target }}
+      - name: Build with Cargo
+        run: |
+          cd rust/cubestore && cargo build --release --target=${{ matrix.target }}
+      - name: Compress binaries
+        uses: svenstaro/upx-action@v2
+        if: ${{ matrix.compress }}
+        with:
+          file: rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }}
+          args: --lzma
+          strip: ${{ matrix.strip }}
+      - name: Create folder for archive
+        run: |
+          mkdir cubestore-archive
+          mkdir cubestore-archive/bin
       - name: Create archive for release
         run: |
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}


### PR DESCRIPTION
There is a problem with the new Rust version (https://github.com/cube-js/cube/pull/7640) and rust-embedded/cross:

```
Failed to run rustc: rustc: error while loading shared libraries: libLLVM-17-rust-1.77.0-nightly.so: cannot open shared object file: No such file or directory
```

It's not a Rust bug; it's a bug somewhere in cross CLI.
Let's compile standalone binaries without using of that CLI.


