### PR TITLE
Update egg and remove some clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ lerna-debug.log
 tsconfig.tsbuildinfo
 .tool-versions
 testings/
+rust/cubesql/profile.json

--- a/packages/cubejs-backend-native/Cargo.toml
+++ b/packages/cubejs-backend-native/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.36"
 serde_derive = "1.0.115"
 serde = "1.0.115"
 serde_json = "1.0.56"
-log = "=0.4.11"
+log = "0.4.21"
 simple_logger = "1.7.0"
 uuid = { version = "0.8", features = ["v4"] }
 once_cell = "1.10"

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -1106,17 +1106,18 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "egg"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f1058c150e258252353a8f8e6d41036ced7d266390114d121abf2ace6e1b6b"
+version = "0.9.5"
+source = "git+https://github.com/egraphs-good/egg.git?rev=2f1514c58517e2f38acfe337175f843f156530cf#2f1514c58517e2f38acfe337175f843f156530cf"
 dependencies = [
+ "env_logger",
  "fxhash",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
  "indexmap 1.8.1",
  "instant",
  "log",
- "once_cell",
+ "saturating",
  "smallvec",
+ "symbol_table",
  "symbolic_expressions",
  "thiserror",
 ]
@@ -1140,6 +1141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1884,12 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if 0.1.10",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
@@ -3042,6 +3049,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3331,16 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "symbol_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32bf088d1d7df2b2b6711b06da3471bc86677383c57b27251e18c56df8deac14"
+dependencies = [
+ "ahash 0.7.6",
+ "hashbrown 0.12.1",
+]
 
 [[package]]
 name = "symbolic_expressions"

--- a/rust/cubesql/cubeclient/Cargo.toml
+++ b/rust/cubesql/cubeclient/Cargo.toml
@@ -28,4 +28,4 @@ features = ["json", "multipart", "rustls-tls"]
 [dev-dependencies]
 wiremock = "0.5"
 tokio = { version = "1", features = ["macros"] }
-log = "=0.4.11"
+log = "0.4.21"

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3.23"
 rand = "0.8.3"
 smallvec = "1.7.0"
 byteorder = "1.3.4"
-log = "=0.4.11"
+log = "0.4.21"
 rust_decimal = { version = "1.25", features = ["c-repr", "db-postgres"]}
 postgres-types = "0.2.3"
 # Locked, because starting from 1.15 this crate switch from chrono to time
@@ -48,7 +48,7 @@ nanoid = "0.3.0"
 tokio-util = { version = "0.6.2", features=["compat"] }
 comfy-table = "7.1.0"
 bitflags = "1.3.2"
-egg = "0.7.1"
+egg = {rev = "2f1514c58517e2f38acfe337175f843f156530cf", git = "https://github.com/egraphs-good/egg.git"}
 paste = "1.0.6"
 csv = "1.1.6"
 tracing = { version = "0.1.40", features = ["async-await"] }

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -31,10 +31,12 @@ use datafusion::{
 use egg::{Analysis, DidMerge, EGraph, Id};
 use std::{fmt::Debug, ops::Index, sync::Arc};
 
+pub type MemberNameToExpr = (Option<String>, Member, Expr);
+
 #[derive(Clone, Debug)]
 pub struct LogicalPlanData {
     pub original_expr: Option<OriginalExpr>,
-    pub member_name_to_expr: Option<Vec<(Option<String>, Member, Expr)>>,
+    pub member_name_to_expr: Option<Vec<MemberNameToExpr>>,
     pub trivial_push_down: Option<usize>,
     pub column: Option<Column>,
     pub expr_to_alias: Option<Vec<(Expr, String, Option<bool>)>>,
@@ -647,7 +649,7 @@ impl LogicalPlanAnalysis {
                         .next()
                         .unwrap();
                     let expr = original_expr(params[1])?;
-                    let name = expr_column_name(expr, &None);
+                    let name = expr_column_name(&expr, &None);
                     let column_expr = Expr::Column(Column {
                         relation: relation.clone(),
                         name,
@@ -1226,7 +1228,10 @@ impl LogicalPlanAnalysis {
 impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
     type Data = LogicalPlanData;
 
-    fn make(egraph: &EGraph<LogicalPlanLanguage, Self>, enode: &LogicalPlanLanguage) -> Self::Data {
+    fn make(
+        egraph: &mut EGraph<LogicalPlanLanguage, Self>,
+        enode: &LogicalPlanLanguage,
+    ) -> Self::Data {
         LogicalPlanData {
             original_expr: Self::make_original_expr(egraph, enode),
             member_name_to_expr: Self::make_member_name_to_expr(egraph, enode),

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -696,6 +696,8 @@ macro_rules! __plan_to_language {
         $($type_decl)*
 
         impl egg::Language for $name {
+            type Discriminant = std::mem::Discriminant<Self>;
+
             #[inline(always)]
             fn matches(&self, other: &Self) -> bool {
                 ::std::mem::discriminant(self) == ::std::mem::discriminant(other) &&
@@ -704,6 +706,7 @@ macro_rules! __plan_to_language {
 
             fn children(&self) -> &[egg::Id] { match self $children }
             fn children_mut(&mut self) -> &mut [egg::Id] { match self $children_mut }
+            fn discriminant(&self) -> Self::Discriminant { std::mem::discriminant(self) }
         }
 
         impl ::std::fmt::Display for $name {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -219,6 +219,7 @@ impl Rewriter {
                 .map(|v| v.parse::<u64>().unwrap())
                 .unwrap_or(30),
         ))
+        .with_scheduler(egg::SimpleScheduler)
         .with_egraph(egraph)
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -3769,7 +3769,7 @@ impl FilterRules {
         for alias_to_cube in var_iter!(egraph[subst[alias_to_cube_var]], FilterReplacerAliasToCube)
         {
             for column in var_iter!(egraph[subst[column_var]], ColumnExprColumn).cloned() {
-                let alias_name = expr_column_name(Expr::Column(column.clone()), &None);
+                let alias_name = expr_column_name(&Expr::Column(column.clone()), &None);
 
                 let member_name = aliases
                     .iter()

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -2,13 +2,13 @@ use crate::{
     compile::rewrite::{
         agg_fun_expr, aggregate, alias_expr, all_members,
         analysis::{ConstantFolding, LogicalPlanAnalysis, OriginalExpr},
-        binary_expr, cast_expr, change_user_expr, column_expr, column_name_to_member_def_vec,
-        column_name_to_member_to_aliases, column_name_to_member_vec, cross_join, cube_scan,
-        cube_scan_filters_empty_tail, cube_scan_members, cube_scan_members_empty_tail,
-        cube_scan_order_empty_tail, dimension_expr, expr_column_name, fun_expr, join, like_expr,
-        limit, list_concat_pushdown_replacer, list_concat_pushup_replacer, literal_expr,
-        literal_member, measure_expr, member_pushdown_replacer, member_replacer,
-        merged_members_replacer, original_expr_name, projection, referenced_columns, rewrite,
+        binary_expr, cast_expr, change_user_expr, column_expr, column_name_to_member_to_aliases,
+        column_name_to_member_vec, cross_join, cube_scan, cube_scan_filters_empty_tail,
+        cube_scan_members, cube_scan_members_empty_tail, cube_scan_order_empty_tail,
+        dimension_expr, expr_column_name, fun_expr, join, like_expr, limit,
+        list_concat_pushdown_replacer, list_concat_pushup_replacer, literal_expr, literal_member,
+        measure_expr, member_pushdown_replacer, member_replacer, merged_members_replacer,
+        original_expr_name, projection, referenced_columns, rewrite,
         rewriter::RewriteRules,
         rules::{replacer_push_down_node, replacer_push_down_node_substitute_rules, utils},
         segment_expr, table_scan, time_dimension_expr, transform_original_expr_to_alias,
@@ -1319,7 +1319,7 @@ impl MemberRules {
                             var_iter!(egraph[subst[alias_var]], ProjectionAlias).cloned()
                         {
                             let mut columns = HashSet::new();
-                            columns.extend(referenced_columns(referenced_expr.clone()).into_iter());
+                            columns.extend(referenced_columns(referenced_expr).into_iter());
                             if columns.iter().all(|c| {
                                 column_name_to_member_name
                                     .iter()
@@ -1446,12 +1446,10 @@ impl MemberRules {
                                     column_name_to_member_vec(member_name_to_expr);
 
                                 let mut columns = HashSet::new();
-                                columns.extend(
-                                    referenced_columns(referenced_group_expr.clone()).into_iter(),
-                                );
-                                columns.extend(
-                                    referenced_columns(referenced_aggr_expr.clone()).into_iter(),
-                                );
+                                columns
+                                    .extend(referenced_columns(referenced_group_expr).into_iter());
+                                columns
+                                    .extend(referenced_columns(referenced_aggr_expr).into_iter());
                                 // TODO default count member is not in the columns set but it should be there
 
                                 if columns.iter().all(|c| {
@@ -1744,55 +1742,46 @@ impl MemberRules {
                         .collect()
                 };
                 for alias_column in column_iter {
-                    let alias_name = expr_column_name(Expr::Column(alias_column), &None);
+                    let alias_name = expr_column_name(&Expr::Column(alias_column), &None);
 
-                    if let Some(left_member_name_to_expr) = egraph
+                    if let Some((member, member_alias)) = &egraph
                         .index(subst[old_members_var])
                         .data
-                        .member_name_to_expr
-                        .clone()
+                        .find_member(|_, member_alias| member_alias == &alias_name)
                     {
-                        let column_name_to_member =
-                            column_name_to_member_def_vec(left_member_name_to_expr);
+                        let cube_to_filter = if let Some(cube) = member.1.cube() {
+                            Some(cube)
+                        } else {
+                            alias_to_cube
+                                .iter()
+                                .find(|((alias, _), _)| alias == member_alias)
+                                .map(|(_, cube)| cube.to_string())
+                        };
+                        let filtered_alias_to_cube = if cube_to_filter.is_some() {
+                            alias_to_cube
+                                .clone()
+                                .into_iter()
+                                .filter(|(_, cube)| cube == cube_to_filter.as_ref().unwrap())
+                                .collect()
+                        } else {
+                            alias_to_cube.clone()
+                        };
 
-                        if let Some(member) = column_name_to_member
-                            .iter()
-                            .find(|(member_alias, _)| member_alias == &alias_name)
-                        {
-                            let cube_to_filter = if let Some(cube) = member.1.cube() {
-                                Some(cube)
-                            } else {
-                                alias_to_cube
-                                    .iter()
-                                    .find(|((alias, _), _)| alias == &member.0)
-                                    .map(|(_, cube)| cube.to_string())
-                            };
-                            let filtered_alias_to_cube = if cube_to_filter.is_some() {
-                                alias_to_cube
-                                    .clone()
-                                    .into_iter()
-                                    .filter(|(_, cube)| cube == cube_to_filter.as_ref().unwrap())
-                                    .collect()
-                            } else {
-                                alias_to_cube.clone()
-                            };
+                        // TODO remove unwrap
+                        let old_member = member.1.clone().add_to_egraph(egraph).unwrap();
+                        subst.insert(terminal_member, old_member);
 
-                            // TODO remove unwrap
-                            let old_member = member.1.add_to_egraph(egraph).unwrap();
-                            subst.insert(terminal_member, old_member);
+                        let filtered_member_pushdown_replacer_alias_to_cube =
+                            egraph.add(LogicalPlanLanguage::MemberPushdownReplacerAliasToCube(
+                                MemberPushdownReplacerAliasToCube(filtered_alias_to_cube),
+                            ));
 
-                            let filtered_member_pushdown_replacer_alias_to_cube =
-                                egraph.add(LogicalPlanLanguage::MemberPushdownReplacerAliasToCube(
-                                    MemberPushdownReplacerAliasToCube(filtered_alias_to_cube),
-                                ));
+                        subst.insert(
+                            filtered_member_pushdown_replacer_alias_to_cube_var,
+                            filtered_member_pushdown_replacer_alias_to_cube,
+                        );
 
-                            subst.insert(
-                                filtered_member_pushdown_replacer_alias_to_cube_var,
-                                filtered_member_pushdown_replacer_alias_to_cube,
-                            );
-
-                            return true;
-                        }
+                        return true;
                     }
                 }
             }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
@@ -95,7 +95,7 @@ impl OrderRules {
                     .clone()
                 {
                     let column_name_to_member_name = column_name_to_member_vec(member_name_to_expr);
-                    let referenced_columns = referenced_columns(referenced_expr.clone());
+                    let referenced_columns = referenced_columns(referenced_expr);
                     if referenced_columns
                         .iter()
                         .all(|c| column_name_to_member_name.iter().any(|(cn, _)| cn == c))
@@ -131,7 +131,7 @@ impl OrderRules {
             if let Some(OriginalExpr::Expr(expr)) =
                 egraph[subst[expr_var]].data.original_expr.clone()
             {
-                let column_name = expr_column_name(expr.clone(), &None);
+                let column_name = expr_column_name(&expr, &None);
                 for asc in var_iter!(egraph[subst[asc_var]], SortExprAsc) {
                     let asc = *asc;
                     for column_name_to_member in var_iter!(


### PR DESCRIPTION
This PR adds a few optimizations around the use of egg.

1. It updates egg from the older 0.7 to a new, unreleased version. It is currently pinned to [this commit](https://github.com/egraphs-good/egg/commit/2f1514c58517e2f38acfe337175f843f156530cf) on the main egg repo.
    - The latest released egg version has an e-matching performance regression from 0.7; the above commit fixed that.
2. Many of the appliers are called very frequently and perform heavyweight manipulations over datafusion expressions. This commit reduces the amount of work done in these appliers. I only updated the appliers whose impact I could measure from the `cargo bench` benchmarks, so others may need to be adjusted if they are not represented in that benchmark suite.

Benchmark improvements over main:
```shell
$ CUBESQL_SQL_PUSH_DOWN=true cargo bench --bench=benchmarks
split_query             time:   [143.99 ms 145.36 ms 147.01 ms]
                        change: [-34.749% -33.456% -31.971%] (p = 0.00 < 0.05)
                        Performance has improved.
split_query_count_distinct
                        time:   [142.47 ms 143.23 ms 144.06 ms]
                        change: [-36.599% -35.486% -34.630%] (p = 0.00 < 0.05)
                        Performance has improved.

wrapped_query           time:   [142.44 ms 145.00 ms 147.06 ms]
                        change: [-44.871% -44.049% -43.271%] (p = 0.00 < 0.05)
                        Performance has improved.

power_bi_wrap           time:   [271.55 ms 272.97 ms 274.13 ms]
                        change: [-67.368% -67.093% -66.815%] (p = 0.00 < 0.05)
                        Performance has improved.

power_bi_sum_wrap       time:   [709.83 ms 712.04 ms 714.11 ms]
                        change: [-66.278% -66.126% -65.985%] (p = 0.00 < 0.05)
                        Performance has improved.
```
