### PR TITLE
fix(cubesql): Disallow ematching cycles

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "git+https://github.com/egraphs-good/egg.git?rev=2f1514c58517e2f38acfe337175f843f156530cf#2f1514c58517e2f38acfe337175f843f156530cf"
+source = "git+https://github.com/egraphs-good/egg.git?rev=7e60716cc757448bd672f2dc28ef9a0d074dce71#7e60716cc757448bd672f2dc28ef9a0d074dce71"
 dependencies = [
  "env_logger",
  "fxhash",
@@ -866,6 +866,8 @@ dependencies = [
  "indexmap 1.9.3",
  "instant",
  "log",
+ "num-bigint",
+ "num-traits",
  "saturating",
  "smallvec",
  "symbol_table",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -1107,7 +1107,7 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "git+https://github.com/egraphs-good/egg.git?rev=2f1514c58517e2f38acfe337175f843f156530cf#2f1514c58517e2f38acfe337175f843f156530cf"
+source = "git+https://github.com/egraphs-good/egg.git?rev=7e60716cc757448bd672f2dc28ef9a0d074dce71#7e60716cc757448bd672f2dc28ef9a0d074dce71"
 dependencies = [
  "env_logger",
  "fxhash",
@@ -1115,6 +1115,8 @@ dependencies = [
  "indexmap 1.8.1",
  "instant",
  "log",
+ "num-bigint",
+ "num-traits",
  "saturating",
  "smallvec",
  "symbol_table",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -48,7 +48,7 @@ nanoid = "0.3.0"
 tokio-util = { version = "0.6.2", features=["compat"] }
 comfy-table = "7.1.0"
 bitflags = "1.3.2"
-egg = {rev = "2f1514c58517e2f38acfe337175f843f156530cf", git = "https://github.com/egraphs-good/egg.git"}
+egg = {rev = "7e60716cc757448bd672f2dc28ef9a0d074dce71", git = "https://github.com/egraphs-good/egg.git"}
 paste = "1.0.6"
 csv = "1.1.6"
 tracing = { version = "0.1.40", features = ["async-await"] }

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -1303,4 +1303,8 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
             }
         }
     }
+
+    fn allow_ematching_cycles(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps egraphs-good/egg@7e60716 and makes an attempt to resolve singularities (`AST node limit reached` error) by using a new `allow_ematching_cycles` option. Related test is included.
