### PR TITLE
fix(gateway): Improve meta performance

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -521,10 +521,11 @@ class ApiGateway {
       })).filter(cube => cube.config.measures?.length || cube.config.dimensions?.length || cube.config.segments?.length);
   }
 
-  public async meta({ context, res, includeCompilerId }: {
+  public async meta({ context, res, includeCompilerId, onlyCompilerId }: {
     context: RequestContext,
     res: MetaResponseResultFn,
-    includeCompilerId?: boolean
+    includeCompilerId?: boolean,
+    onlyCompilerId?: boolean
   }) {
     const requestStarted = new Date();
 
@@ -533,8 +534,16 @@ class ApiGateway {
       const compilerApi = await this.getCompilerApi(context);
       const metaConfig = await compilerApi.metaConfig({
         requestId: context.requestId,
-        includeCompilerId
+        includeCompilerId: includeCompilerId || onlyCompilerId
       });
+      if (onlyCompilerId) {
+        const response: { cubes: any[], compilerId?: string } = {
+          cubes: [],
+          compilerId: metaConfig.compilerId
+        };
+        res(response);
+        return;
+      }
       const cubesConfig = includeCompilerId ? metaConfig.cubes : metaConfig;
       const cubes = this.filterVisibleItemsInMeta(context, cubesConfig).map(cube => cube.config);
       const response: { cubes: any[], compilerId?: string } = { cubes };

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -506,8 +506,9 @@ class ApiGateway {
   }
 
   private filterVisibleItemsInMeta(context: RequestContext, cubes: any[]) {
+    const isDevMode = getEnv('devMode');
     function visibilityFilter(item) {
-      return getEnv('devMode') || context.signedWithPlaygroundAuthSecret || item.isVisible;
+      return isDevMode || context.signedWithPlaygroundAuthSecret || item.isVisible;
     }
 
     return cubes

--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -96,7 +96,8 @@ export class SQLServer {
                   resolve(message);
                 }
               },
-              includeCompilerId: true
+              includeCompilerId: true,
+              onlyCompilerId
             });
           } catch (e) {
             reject(e);


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR improves performance of api-gateway by fixing two issues:
- With `onlyCompilerId` flag, `meta` fn would still process cube information, then reject it. This is now fixed, no extra processing is done once we have the `compilerId`.
- `filterVisibleItemsInMeta`, used in quite a few places, would call `getEnv` in a filter inside a map, which greatly hits performance as the cube amount grows. This is now resolved, `getEnv` is only called once for each invocation.
