### PR TITLE
Warn in rolling window pages that Redshift does not support month or year intervals

### DIFF
--- a/docs/pages/guides/recipes/data-modeling/period-over-period.mdx
+++ b/docs/pages/guides/recipes/data-modeling/period-over-period.mdx
@@ -17,6 +17,12 @@ _previous period_.
 these `rolling_window` measures and uses them in a calculation, e.g.,
 divides or subtracts them.
 
+<WarningBox>
+
+Please note that Redshift does not support intervals of type month or year.
+
+</WarningBox>
+
 The following data model allows to calculate a month-over-month change of
 some value. `current_month_sum` and `previous_month_sum` measures define
 two rolling windows and the `month_over_month_ratio` measure divides

--- a/docs/pages/reference/data-model/measures.mdx
+++ b/docs/pages/reference/data-model/measures.mdx
@@ -257,6 +257,12 @@ with a defined date range.
 
 </WarningBox>
 
+<WarningBox>
+
+Please note that Redshift does not support intervals of type month or year.
+
+</WarningBox>
+
 These parameters have a format defined as
 `(-?\d+) (minute|hour|day|week|month|year)`. The `trailing` and `leading`
 parameters can also be set to an `unbounded` value, which means infinite size


### PR DESCRIPTION
Add warning box to two pages: Please note that Redshift does not support intervals of type month or year.

Context: https://cubedevinc.slack.com/archives/C021C7NT7RT/p1715293531642229

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
