### PR TITLE
fix(cubesql): Fix Databricks identifier quotes

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -117,6 +117,8 @@ export class DatabricksQuery extends BaseQuery {
     templates.functions.RTRIM = 'RTRIM({{ args|reverse|join(", ") }})';
     templates.functions.DATEDIFF = 'DATEDIFF({{ date_part }}, DATE_TRUNC(\'{{ date_part }}\', {{ args[1] }}), DATE_TRUNC(\'{{ date_part }}\', {{ args[2] }}))';
     templates.expressions.timestamp_literal = 'from_utc_timestamp(\'{{ value }}\', \'UTC\')';
+    templates.quotes.identifiers = '`';
+    templates.quotes.escape = '``';
     return templates;
   }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes Databricks dialect, specifying correct identifier quotes (`) for SQL push down.