### PR TITLE
fix(cubesql): Make param render respect dialect's reuse params flag

### DIFF
--- a/packages/cubejs-backend-native/src/channel.rs
+++ b/packages/cubejs-backend-native/src/channel.rs
@@ -268,6 +268,10 @@ fn get_sql_templates(
     sql_generator: Arc<Root<JsObject>>,
 ) -> Result<SqlTemplates, CubeError> {
     let sql_generator = sql_generator.to_inner(cx);
+    let reuse_params = sql_generator
+        .get::<JsBoolean, _, _>(cx, "shouldReuseParams")
+        .map_cube_err("Can't get shouldReuseParams")?
+        .value(cx);
     let sql_templates = sql_generator
         .get::<JsFunction, _, _>(cx, "sqlTemplates")
         .map_cube_err("Can't get sqlTemplates")?;
@@ -309,7 +313,7 @@ fn get_sql_templates(
         }
     }
 
-    SqlTemplates::new(templates_map)
+    SqlTemplates::new(templates_map, reuse_params)
 }
 
 // TODO impl drop for SqlGenerator

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -1575,5 +1575,27 @@ from
   `);
       expect(res.rows).toMatchSnapshot('post_aggregate_percentage_of_total');
     });
+
+    executePg('SQL API: reuse params', async () => {
+      const connection = await createPostgresClient();
+      const res = await connection.query(`
+    select
+      date_trunc('year', "orderDate") as "c0",
+      sum("ECommerce"."totalSales") as "m0"
+    from
+      "ECommerce" as "ECommerce"
+    where
+      date_trunc('year', "orderDate") in (
+        CAST('2019-01-01 00:00:00.0' AS timestamp),
+        CAST('2020-01-01 00:00:00.0' AS timestamp),
+        CAST('2021-01-01 00:00:00.0' AS timestamp),
+        CAST('2022-01-01 00:00:00.0' AS timestamp),
+        CAST('2023-01-01 00:00:00.0' AS timestamp)
+      )
+    group by
+      date_trunc('year', "orderDate")
+  `);
+      expect(res.rows).toMatchSnapshot('reuse_params');
+    });
   });
 }

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-full.test.ts.snap
@@ -27,6 +27,15 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/athena-driver SQL API: reuse params: reuse_params 1`] = `
+Array [
+  Object {
+    "c0": 2020-01-01T00:00:00.000Z,
+    "m0": 17371.904,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/athena-driver SQL API: ungrouped pre-agg: ungrouped_pre_agg 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -27,6 +27,15 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/postgres-driver SQL API: reuse params: reuse_params 1`] = `
+Array [
+  Object {
+    "c0": 2020-01-01T00:00:00.000Z,
+    "m0": 17371.904,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver SQL API: ungrouped pre-agg: ungrouped_pre_agg 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -27,6 +27,15 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: reuse params: reuse_params 1`] = `
+Array [
+  Object {
+    "c0": 2020-01-01T00:00:00.000Z,
+    "m0": 17371.904,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: ungrouped pre-agg: ungrouped_pre_agg 1`] = `
 Array [
   Object {

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -81,8 +81,10 @@ impl SqlQuery {
             .ok_or_else(|| DataFusionError::Execution("Missing param match".to_string()))?
             .parse::<usize>()
             .map_err(|e| DataFusionError::Execution(format!("Can't parse param index: {}", e)))?;
-        if let Some(rendered_param) = rendered_params.get(&param) {
-            return Ok((param, rendered_param.clone(), false));
+        if sql_templates.reuse_params {
+            if let Some(rendered_param) = rendered_params.get(&param) {
+                return Ok((param, rendered_param.clone(), false));
+            }
         }
         Ok((
             param,

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -389,6 +389,7 @@ OFFSET {{ offset }}{% endif %}"#.to_string(),
                 ]
                     .into_iter().chain(custom_templates.into_iter())
                     .collect(),
+                    false,
             )
                 .unwrap(),
         ),

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -331,6 +331,7 @@ impl TransportService for HttpTransport {
 #[derive(Debug)]
 pub struct SqlTemplates {
     pub templates: HashMap<String, String>,
+    pub reuse_params: bool,
     jinja: Environment<'static>,
 }
 
@@ -349,7 +350,7 @@ pub struct TemplateColumn {
 }
 
 impl SqlTemplates {
-    pub fn new(templates: HashMap<String, String>) -> Result<Self, CubeError> {
+    pub fn new(templates: HashMap<String, String>, reuse_params: bool) -> Result<Self, CubeError> {
         let mut jinja = Environment::new();
         for (name, template) in templates.iter() {
             jinja
@@ -362,7 +363,11 @@ impl SqlTemplates {
                 })?;
         }
 
-        Ok(Self { templates, jinja })
+        Ok(Self {
+            templates,
+            jinja,
+            reuse_params,
+        })
     }
 
     pub fn aggregate_function_name(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes param render on SQL API side, making it respect reuse params flag of the dialect.
