### PR TITLE
fix(cubesql): Do not generate large graphs for large `IN` filters

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -3300,8 +3300,8 @@ impl FilterRules {
 
         move |egraph, subst| {
             let expr_id = subst[expr_val];
-            let (list, scalar) = match &egraph[subst[list_var]].data.constant_in_list {
-                Some(list) if list.len() > 0 => (list.clone(), list[0].clone()),
+            let scalar = match &egraph[subst[list_var]].data.constant_in_list {
+                Some(list) if list.len() == 1 => list[0].clone(),
                 _ => return false,
             };
 
@@ -3319,34 +3319,11 @@ impl FilterRules {
                 ));
                 let literal_expr = egraph.add(LogicalPlanLanguage::LiteralExpr([literal_expr]));
 
-                let mut return_binary_expr = egraph.add(LogicalPlanLanguage::BinaryExpr([
+                let return_binary_expr = egraph.add(LogicalPlanLanguage::BinaryExpr([
                     expr_id,
                     operator,
                     literal_expr,
                 ]));
-
-                for scalar in list.into_iter().skip(1) {
-                    let literal_expr = egraph.add(LogicalPlanLanguage::LiteralExprValue(
-                        LiteralExprValue(scalar),
-                    ));
-                    let literal_expr = egraph.add(LogicalPlanLanguage::LiteralExpr([literal_expr]));
-
-                    let right_binary_expr = egraph.add(LogicalPlanLanguage::BinaryExpr([
-                        expr_id,
-                        operator,
-                        literal_expr,
-                    ]));
-
-                    let or = egraph.add(LogicalPlanLanguage::BinaryExprOp(BinaryExprOp(
-                        Operator::Or,
-                    )));
-
-                    return_binary_expr = egraph.add(LogicalPlanLanguage::BinaryExpr([
-                        return_binary_expr,
-                        or,
-                        right_binary_expr,
-                    ]));
-                }
 
                 subst.insert(return_binary_expr_var, return_binary_expr);
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR addresses an issue with large `IN` list filters generating a large rewrite graph. `transform_filter_in_to_equal` would generate a binary expression for each value. This is now only applied if there is just one value in the list.
