### PR TITLE
chore(cubesql): Fix rounding error in reuse params test query

### DIFF
--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -1581,7 +1581,7 @@ from
       const res = await connection.query(`
     select
       date_trunc('year', "orderDate") as "c0",
-      sum("ECommerce"."totalSales") as "m0"
+      round(sum("ECommerce"."totalSales")) as "m0"
     from
       "ECommerce" as "ECommerce"
     where

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-full.test.ts.snap
@@ -31,7 +31,7 @@ exports[`Queries with the @cubejs-backend/athena-driver SQL API: reuse params: r
 Array [
   Object {
     "c0": 2020-01-01T00:00:00.000Z,
-    "m0": 17371.904,
+    "m0": 17372,
   },
 ]
 `;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -31,7 +31,7 @@ exports[`Queries with the @cubejs-backend/postgres-driver SQL API: reuse params:
 Array [
   Object {
     "c0": 2020-01-01T00:00:00.000Z,
-    "m0": 17371.904,
+    "m0": 17372,
   },
 ]
 `;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -31,7 +31,7 @@ exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: reuse params
 Array [
   Object {
     "c0": 2020-01-01T00:00:00.000Z,
-    "m0": 17371.904,
+    "m0": 17372,
   },
 ]
 `;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue in `cubejs-testing-drivers` with the newly introduced reuse params query test, wrapping the result of the sum in a `ROUND` function, preventing rounding errors.
