### PR TITLE
chore(cubesql): Remove pass through `date_trunc` and `date_part` rules

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/dates.rs
@@ -90,18 +90,6 @@ impl SplitRules {
             false,
             rules,
         );
-        self.single_arg_pass_through_rules(
-            "date-trunc-pass-through",
-            |expr| self.fun_expr("DateTrunc", vec![literal_expr("?granularity"), expr]),
-            false,
-            rules,
-        );
-        self.single_arg_pass_through_rules(
-            "date-part-pass-through",
-            |expr| self.fun_expr("DatePart", vec![literal_expr("?granularity"), expr]),
-            false,
-            rules,
-        );
     }
 
     fn transform_date_part(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR removes `date_trunc` and `date_part` pass through rules. This resolves an issue with queries containing a lot of `date_part` calls in `SELECT` exploding with AST nodes.
