### PR TITLE
docs/data-modeling: Adding compareDateRange example

### DIFF
--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -279,9 +279,11 @@ However, unlike regular queries, they provide a convenient way to retrieve
 measure values for *more than one date range* for a time dimension.
 
 You can make a compare date range query by using the `compareDateRange`
-option with the [REST API][ref-rest-api-query-format-options-tdf].
+option with the [REST API][ref-rest-api-query-format-options-tdf]. Note that
+you also need to set the `queryType` parameter of the [`/v1/load`
+endpoint][ref-rest-api-load] to `regular`.
 
-### Example
+#### Example
 
 ```json
 {
@@ -306,8 +308,6 @@ option with the [REST API][ref-rest-api-query-format-options-tdf].
   "limit": 100
 }
 ```
-
-**NOTE:** `compareDateRange` queries may require to set `queryType` to be run.
 
 See [this blog post][blog-compare-date-range] for more details and examples.
 
@@ -359,6 +359,7 @@ Additionally, note that ungrouped queries have additional requirements for
 [ref-apis]: /product/apis-integrations
 [ref-sql-api]: /product/apis-integrations/sql-api
 [ref-rest-api]: /product/apis-integrations/rest-api
+[ref-rest-api-load]: /reference/rest-api#v1load
 [ref-graphql-api]: /product/apis-integrations/graphql-api
 [ref-data-sources]: /product/configuration/data-sources
 [ref-rest-api-query-format-options]: /product/apis-integrations/rest-api/query-format#query-properties

--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -95,28 +95,30 @@ The same query using the REST API syntax looks as follows:
 
 ```json
 {
-  "dimensions": [
-    "users.state",
-    "users.city",
-    "orders.status"
-  ],
-  "measures": [
-    "orders.count"
-  ],
-  "filters": [
-    {
-      "member": "users.state",
-      "operator": "notEquals",
-      "values": ["us-wa"]
-    }
-  ],
-  "timeDimensions": [
-    {
-      "dimension": "orders.created_at",
-      "dateRange": ["2020-01-01", "2021-01-01"]
-    }
-  ],
-  "limit": 10
+  "query" : {
+    "dimensions": [
+      "users.state",
+      "users.city",
+      "orders.status"
+    ],
+    "measures": [
+      "orders.count"
+    ],
+    "filters": [
+      {
+        "member": "users.state",
+        "operator": "notEquals",
+        "values": ["us-wa"]
+      }
+    ],
+    "timeDimensions": [
+      {
+        "dimension": "orders.created_at",
+        "dateRange": ["2020-01-01", "2021-01-01"]
+      }
+    ],
+    "limit": 10
+  }
 }
 ```
 

--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -276,12 +276,43 @@ Similarly to [regular queries](#regular-query), they include lists of
 dimensions and measures, filters, etc. and return a result set.
 
 However, unlike regular queries, they provide a convenient way to retrieve
-measure values for *more than one date range* for a time dimension. See [this
-blog post][blog-compare-date-range] for more details and examples.
+measure values for *more than one date range* for a time dimension.
 
 You can make a compare date range query by using the `compareDateRange`
-option with the [REST API][ref-rest-api-query-format-options-tdf]. For the SQL
-API, you can write an equivalent query using the `UNION ALL` statement.
+option with the [REST API][ref-rest-api-query-format-options-tdf].
+
+### Example
+
+```json
+{
+  "queryType": "multi",
+  "query": {
+    "dimensions": ["orders.city"],
+    "measures": ["orders.amount"],
+    "filters": [
+      {
+        "member": "orders.status",
+        "operator": "equals",
+        "values": ["shipped"]
+      }
+    ],
+    "timeDimensions": [{
+      "dimension": "orders.created_at",
+      "compareDateRange": [
+        ["2024-01-01", "2024-12-31"],
+        ["2023-01-01", "2023-12-31"],
+        ["2022-01-01", "2022-12-31"],
+      ],
+      "granularity": "year",
+    }],
+  "limit": 100
+  }
+}
+```
+
+See [this blog post][blog-compare-date-range] for more details and examples.
+
+For the SQL API, you can write an equivalent query using the `UNION ALL` statement.
 
 ### Total query
 

--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -95,30 +95,28 @@ The same query using the REST API syntax looks as follows:
 
 ```json
 {
-  "query" : {
-    "dimensions": [
-      "users.state",
-      "users.city",
-      "orders.status"
-    ],
-    "measures": [
-      "orders.count"
-    ],
-    "filters": [
-      {
-        "member": "users.state",
-        "operator": "notEquals",
-        "values": ["us-wa"]
-      }
-    ],
-    "timeDimensions": [
-      {
-        "dimension": "orders.created_at",
-        "dateRange": ["2020-01-01", "2021-01-01"]
-      }
-    ],
-    "limit": 10
-  }
+  "dimensions": [
+    "users.state",
+    "users.city",
+    "orders.status"
+  ],
+  "measures": [
+    "orders.count"
+  ],
+  "filters": [
+    {
+      "member": "users.state",
+      "operator": "notEquals",
+      "values": ["us-wa"]
+    }
+  ],
+  "timeDimensions": [
+    {
+      "dimension": "orders.created_at",
+      "dateRange": ["2020-01-01", "2021-01-01"]
+    }
+  ],
+  "limit": 10
 }
 ```
 
@@ -287,30 +285,29 @@ option with the [REST API][ref-rest-api-query-format-options-tdf].
 
 ```json
 {
-  "queryType": "multi",
-  "query": {
-    "dimensions": ["orders.city"],
-    "measures": ["orders.amount"],
-    "filters": [
-      {
-        "member": "orders.status",
-        "operator": "equals",
-        "values": ["shipped"]
-      }
+  "dimensions": ["orders.city"],
+  "measures": ["orders.amount"],
+  "filters": [
+    {
+      "member": "orders.status",
+      "operator": "equals",
+      "values": ["shipped"]
+    }
+  ],
+  "timeDimensions": [{
+    "dimension": "orders.created_at",
+    "compareDateRange": [
+      ["2024-01-01", "2024-12-31"],
+      ["2023-01-01", "2023-12-31"],
+      ["2022-01-01", "2022-12-31"],
     ],
-    "timeDimensions": [{
-      "dimension": "orders.created_at",
-      "compareDateRange": [
-        ["2024-01-01", "2024-12-31"],
-        ["2023-01-01", "2023-12-31"],
-        ["2022-01-01", "2022-12-31"],
-      ],
-      "granularity": "year",
-    }],
+    "granularity": "year",
+  }],
   "limit": 100
-  }
 }
 ```
+
+**NOTE:** `compareDateRange` queries may require to set `queryType` to be run.
 
 See [this blog post][blog-compare-date-range] for more details and examples.
 

--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -272,7 +272,7 @@ GROUP BY 1, 2;
 ### Compare date range query
 
 **Compare date range queries are special cases of regular queries.**
-Similarly to [regular queries](#regular-queries), they include lists of
+Similarly to [regular queries](#regular-query), they include lists of
 dimensions and measures, filters, etc. and return a result set.
 
 However, unlike regular queries, they provide a convenient way to retrieve
@@ -286,7 +286,7 @@ API, you can write an equivalent query using the `UNION ALL` statement.
 ### Total query
 
 **Total queries are special cases of regular queries.**
-Similarly to [regular queries](#regular-queries), they include lists of
+Similarly to [regular queries](#regular-query), they include lists of
 dimensions and measures, filters, etc. and return a result set.
 
 In addition to that, they provide a convenient way to retrieve the total number
@@ -300,7 +300,7 @@ equivalent query using the `UNION ALL` statement.
 
 ### Ungrouped query
 
-Similarly to [regular queries](#regular-queries), ungrouped queries include
+Similarly to [regular queries](#regular-query), ungrouped queries include
 lists of dimensions and measures, filters, etc. and return a result set.
 
 However, unlike for regular queries, Cube will not add the


### PR DESCRIPTION
**Check List**
- [ ] ~Tests has been run in packages where changes made if available~
- [ ] ~Linter has been run for changed code~
- [ ] ~Tests for the changes have been added if not covered yet~
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
N/A

**Description of Changes Made (if issue reference is not provided)**
While reading the docs, it took me a few searches to figure out how to make use of the `compareDateRange` functionality through plain REST API. Just thought on adding an example for quick reference, but kept the references to the [Comparing Data over Different Time Periods](https://cube.dev/blog/comparing-data-over-different-time-periods) blogpost