### PR TITLE
fix(query-orchestrator): Support range intersection for timestamp wit…

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -1898,7 +1898,7 @@ export class PreAggregationPartitionRangeLoader {
       throw new Error(`Date range expected to be a string array but ${range} found`);
     }
 
-    if (range[0].length !== 23 || range[1].length !== 23) {
+    if ((range[0].length !== 23 && range[0].length !== 26) || (range[1].length !== 23 && range[0].length !== 26)) {
       throw new Error(`Date range expected to be in YYYY-MM-DDTHH:mm:ss.SSS format but ${range} found`);
     }
   }

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 /* globals describe, jest, beforeEach, test, expect */
 import R from 'ramda';
+import { PreAggregationPartitionRangeLoader } from '../../src';
 
 class MockDriver {
   constructor() {
@@ -367,6 +368,26 @@ describe('PreAggregations', () => {
       const { preAggregationsTablesToTempTables: result } = await preAggregations.loadAllPreAggregationsIfNeeded(basicQueryExternal);
       expect(result[0][1].targetTableName).toMatch(/stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il_1893709044209/);
       expect(result[0][1].lastUpdatedAt).toEqual(1893709044209);
+    });
+  });
+
+  describe('intersectDateRanges', () => {
+    test('6 timestamps - valid intersection', () => {
+      expect(PreAggregationPartitionRangeLoader.intersectDateRanges(
+        ['2024-01-05T00:00:00.000000', '2024-01-05T23:59:59.999999'],
+        ['2024-01-01T00:00:00.000000', '2024-01-32T23:59:59.999999'],
+      )).toEqual(
+        ['2024-01-05T00:00:00.000000', '2024-01-05T23:59:59.999999']
+      );
+    });
+
+    test('3 timestamps - valid intersection', () => {
+      expect(PreAggregationPartitionRangeLoader.intersectDateRanges(
+        ['2024-01-05T00:00:00.000', '2024-01-05T23:59:59.999'],
+        ['2024-01-01T00:00:00.000', '2024-01-32T23:59:59.999'],
+      )).toEqual(
+        ['2024-01-05T00:00:00.000', '2024-01-05T23:59:59.999']
+      );
     });
   });
 });


### PR DESCRIPTION
…h 6 digits

Fix https://github.com/cube-js/cube/issues/8320