### PR TITLE
fix(cubesql): Support `DATE_TRUNC` equals literal string

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -4383,11 +4383,6 @@ limit
                     },
                     V1LoadRequestQueryTimeDimension {
                         dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
-                        granularity: Some("year".to_string()),
-                        date_range: None,
-                    },
-                    V1LoadRequestQueryTimeDimension {
-                        dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
                         granularity: Some("month".to_string()),
                         date_range: None,
                     }
@@ -23385,21 +23380,14 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                 measures: Some(vec![]),
                 dimensions: Some(vec![]),
                 segments: Some(vec![]),
-                time_dimensions: Some(vec![
-                    V1LoadRequestQueryTimeDimension {
-                        dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
-                        granularity: Some("quarter".to_string()),
-                        date_range: Some(json!(vec![
-                            "2024-01-01T00:00:00.000Z".to_string(),
-                            "2024-12-31T23:59:59.999Z".to_string(),
-                        ])),
-                    },
-                    V1LoadRequestQueryTimeDimension {
-                        dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
-                        granularity: Some("quarter".to_string()),
-                        date_range: None,
-                    },
-                ]),
+                time_dimensions: Some(vec![V1LoadRequestQueryTimeDimension {
+                    dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                    granularity: Some("quarter".to_string()),
+                    date_range: Some(json!(vec![
+                        "2024-01-01T00:00:00.000Z".to_string(),
+                        "2024-12-31T23:59:59.999Z".to_string(),
+                    ])),
+                },]),
                 order: None,
                 limit: None,
                 offset: None,

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -1597,7 +1597,7 @@ impl LanguageToLogicalPlanConverter {
                                         TimeDimensionDateRange
                                     );
                                     let expr = self.to_expr(params[3])?;
-                                    query_time_dimensions.push(V1LoadRequestQueryTimeDimension {
+                                    let query_time_dimension = V1LoadRequestQueryTimeDimension {
                                         dimension: dimension.to_string(),
                                         granularity: granularity.clone(),
                                         date_range: date_range.map(|date_range| {
@@ -1608,7 +1608,10 @@ impl LanguageToLogicalPlanConverter {
                                                     .collect(),
                                             )
                                         }),
-                                    });
+                                    };
+                                    if !query_time_dimensions.contains(&query_time_dimension) {
+                                        query_time_dimensions.push(query_time_dimension);
+                                    }
                                     if let Some(granularity) = &granularity {
                                         fields.push((
                                             DFField::new(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes a rewrite rule that is supposed to support expressions of form `date_trunc(…) = literal`, but does not support strings or constant folded expressions. Related test is included.
