### PR TITLE
fix(cubesql): Don't show meta OLAP queries in query history

### DIFF
--- a/rust/cubesql/cubesql/src/sql/postgres/extended.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/extended.rs
@@ -58,6 +58,13 @@ pub enum PreparedStatement {
         description: Option<protocol::RowDescription>,
         span_id: Option<Arc<SpanId>>,
     },
+    Error {
+        /// Prepared statement can be declared from SQL or protocol (Parser)
+        from_sql: bool,
+        sql: String,
+        created: DateTime<Utc>,
+        span_id: Option<Arc<SpanId>>,
+    },
 }
 
 impl PreparedStatement {
@@ -65,6 +72,7 @@ impl PreparedStatement {
         match self {
             PreparedStatement::Empty { created, .. } => created,
             PreparedStatement::Query { created, .. } => created,
+            PreparedStatement::Error { created, .. } => created,
         }
     }
 
@@ -73,6 +81,7 @@ impl PreparedStatement {
         match self {
             PreparedStatement::Empty { .. } => "".to_string(),
             PreparedStatement::Query { query, .. } => query.to_string(),
+            PreparedStatement::Error { sql, .. } => sql.clone(),
         }
     }
 
@@ -80,6 +89,7 @@ impl PreparedStatement {
         match self {
             PreparedStatement::Empty { from_sql, .. } => from_sql.clone(),
             PreparedStatement::Query { from_sql, .. } => from_sql.clone(),
+            PreparedStatement::Error { from_sql, .. } => from_sql.clone(),
         }
     }
 
@@ -87,6 +97,7 @@ impl PreparedStatement {
         match self {
             PreparedStatement::Empty { .. } => None,
             PreparedStatement::Query { parameters, .. } => Some(&parameters.parameters),
+            PreparedStatement::Error { .. } => None,
         }
     }
 
@@ -103,6 +114,10 @@ impl PreparedStatement {
 
                 Ok(statement)
             }
+            PreparedStatement::Error { .. } => Err(CubeError::internal(
+                "It's not possible to bind errored prepared statements (it's a bug)".to_string(),
+            )
+            .into()),
         }
     }
 
@@ -110,6 +125,7 @@ impl PreparedStatement {
         match self {
             PreparedStatement::Empty { span_id, .. } => span_id.clone(),
             PreparedStatement::Query { span_id, .. } => span_id.clone(),
+            PreparedStatement::Error { span_id, .. } => span_id.clone(),
         }
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR changes the behavior of `isDataQuery` flag, instead passing it as `false` by default on `Prepare` step, when query is parsed, and then passing the updated value only on `Execute` step. This avoids duplicated entries in query history for the same query with, for instance, Tablaeu, which would parse the query and get its meta result first, then repeat the same steps, but next time execute the query.
