### PR TITLE
feat: Timestamp subtraction, epoch extraction from intervals

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -635,7 +635,6 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "arrow",
  "chrono",
@@ -744,7 +743,6 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -777,7 +775,6 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -788,7 +785,6 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -801,7 +797,6 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "ahash 0.7.7",
  "arrow",
@@ -812,7 +807,6 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
 dependencies = [
  "ahash 0.7.7",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "arrow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1012,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "ahash 0.7.6",
  "arrow",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3#1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e61a28ad884aa7674150a410576437dd313808f6#e61a28ad884aa7674150a410576437dd313808f6"
 dependencies = [
  "ahash 0.7.6",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1cc8eea44c5bb9359df97d1b24ad3aeabadbe1a3", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e61a28ad884aa7674150a410576437dd313808f6", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0.50"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -6059,6 +6059,201 @@ limit
     }
 
     #[tokio::test]
+    async fn test_date_minus_date_postgres() {
+        async fn check_date_minus_date(left: &str, right: &str, expected: &str) {
+            let column_name = "result";
+            assert_eq!(
+                execute_query(
+                    format!(
+                        r#"SELECT (CAST('{left}' AS TIMESTAMP) -
+                     CAST('{right}' AS TIMESTAMP)) AS "{column_name}""#
+                    ),
+                    DatabaseProtocol::PostgreSQL
+                )
+                .await
+                .unwrap(),
+                format!(
+                    "+-{empty:-<width$}-+\
+                    \n| {column_name:width$} |\
+                    \n+-{empty:-<width$}-+\
+                    \n| {expected:width$} |\
+                    \n+-{empty:-<width$}-+",
+                    empty = "",
+                    width = expected.len().max(column_name.len())
+                )
+            );
+        }
+
+        // TODO: Postgres output: "28 days 00:34:56.123457" here and below.
+        check_date_minus_date(
+            "2021-03-02 12:34:56.123456789",
+            "2021-02-02 12:00:00.000",
+            "0 years 0 mons 28 days 0 hours 34 mins 56.123456789 secs",
+        )
+        .await;
+
+        // TODO: The formatting of this fractional seconds value is incorrect (with its negative sign).
+        // Postgres output: "-28 days -00:34:56.123457"
+        check_date_minus_date(
+            "2021-02-02 12:00:00.000",
+            "2021-03-02 12:34:56.123456789",
+            "0 years 0 mons -28 days 0 hours -34 mins -56.-123456789 secs",
+        )
+        .await;
+
+        // Postgres output: "89 days 01:34:56.123457"
+        check_date_minus_date(
+            "2021-05-02 13:34:56.123456789",
+            "2021-02-02 12:00:00.000",
+            "0 years 0 mons 89 days 1 hours 34 mins 56.123456789 secs",
+        )
+        .await;
+
+        // Postgres output: "-89 days -01:34:56.123457"
+        check_date_minus_date(
+            "2021-02-02 12:00:00.000",
+            "2021-05-02 13:34:56.123456789",
+            "0 years 0 mons -89 days -1 hours -34 mins -56.-123456789 secs",
+        )
+        .await;
+
+        // Postgres output: "819 days 01:34:56.123457"
+        check_date_minus_date(
+            "2023-05-02 13:34:56.123456789",
+            "2021-02-02 12:00:00.000",
+            "0 years 0 mons 819 days 1 hours 34 mins 56.123456789 secs",
+        )
+        .await;
+
+        // Postgres output: "-819 days -01:34:56.123457"
+        check_date_minus_date(
+            "2021-02-02 12:00:00.000",
+            "2023-05-02 13:34:56.123456789",
+            "0 years 0 mons -819 days -1 hours -34 mins -56.-123456789 secs",
+        )
+        .await;
+
+        // Check the result being zero, of course.
+        // Postgres output: "00:00:00"
+        check_date_minus_date(
+            "2021-02-02 12:34:56",
+            "2021-02-02 12:34:56.000",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.00 secs",
+        )
+        .await;
+        check_date_minus_date(
+            "2021-02-02 12:34:56.789112358",
+            "2021-02-02 12:34:56.789112358",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.00 secs",
+        )
+        .await;
+
+        // Postgres treats 60 seconds the same here.
+        check_date_minus_date(
+            "2001-02-04 00:00:00.000",
+            "2001-02-03 23:59:60.000",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.00 secs",
+        )
+        .await;
+
+        // Perhaps out of scope for this test, document pluralizaton of interval rendering.
+        // Postgres output: "1 day 01:01:01"
+        // Note the lack of pluralization.
+        check_date_minus_date(
+            "2000-02-29 01:01:01.000",
+            "2000-02-28 00:00:00.000",
+            "0 years 0 mons 1 days 1 hours 1 mins 1.00 secs",
+        )
+        .await;
+
+        // Postgres output: "-1 days -01:01:01"
+        check_date_minus_date(
+            "2000-02-28 00:00:00.000",
+            "2000-02-29 01:01:01.000",
+            "0 years 0 mons -1 days -1 hours -1 mins -1.00 secs",
+        )
+        .await;
+
+        // TODO: This is the WRONG VALUE.  See batch_to_dataframe.
+        // Postgres output: 00:00:00.001
+        check_date_minus_date(
+            "2000-02-29 00:00:00.000",
+            "2000-02-28 23:59:59.999",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.1000000 secs",
+        )
+        .await;
+
+        // TODO: This is the WRONG VALUE.
+        check_date_minus_date(
+            "2000-02-25 14:00:00.000",
+            "2000-02-25 13:59:59.999",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.1000000 secs",
+        )
+        .await;
+
+        check_date_minus_date(
+            "2000-02-25 14:00:00.000",
+            "2000-02-25 13:59:59.900",
+            "0 years 0 mons 0 days 0 hours 0 mins 0.100000000 secs",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_extract_epoch_from_interval() {
+        // Note that we haven't implemented any other extract fields on intervals, aside from epoch.
+        async fn check_extract_epoch(timestamp: &str, expected: &str) {
+            let column_name = "result";
+            assert_eq!(
+                execute_query(
+                    format!(r#"SELECT EXTRACT(EPOCH FROM CAST('{timestamp}' AS INTERVAL)) AS "{column_name}""#),
+                    DatabaseProtocol::PostgreSQL
+                ).await.unwrap(),
+                format!("+-{empty:-<width$}-+\
+                    \n| {column_name:width$} |\
+                    \n+-{empty:-<width$}-+\
+                    \n| {expected:width$} |\
+                    \n+-{empty:-<width$}-+",
+                    empty = "",
+                    width = expected.len().max(column_name.len())
+                )
+            );
+        }
+
+        // Postgres is rendered: "5.000000"
+        check_extract_epoch("5 seconds", "5").await;
+        check_extract_epoch("0 seconds", "0").await;
+        check_extract_epoch("1 day", "86400").await;
+        check_extract_epoch("1 day 25 seconds", "86425").await;
+        for i in 0..11 {
+            check_extract_epoch(&format!("{} month", i), &(86400 * 30 * i).to_string()).await;
+            check_extract_epoch(
+                &format!("{} month 1 day", i),
+                &(86400 * (30 * i + 1)).to_string(),
+            )
+            .await;
+            check_extract_epoch(
+                &format!("{} month 32 day", i),
+                &(86400 * (30 * i + 32)).to_string(),
+            )
+            .await;
+            check_extract_epoch(
+                &format!("{} months", i + 12),
+                &(86400 * (365 + 30 * i) + 86400 / 4).to_string(),
+            )
+            .await;
+            check_extract_epoch(
+                &format!("{} months 32 days", i + 12),
+                &(86400 * (365 + 30 * i + 32) + 86400 / 4).to_string(),
+            )
+            .await;
+        }
+
+        // TODO: Postgres surely does 5.123457.
+        check_extract_epoch("5.123456789 seconds", "5.123456789").await;
+    }
+
+    #[tokio::test]
     async fn test_date_add_sub_postgres() {
         async fn check_fun(op: &str, t: &str, i: &str, expected: &str) {
             assert_eq!(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This updates a git commit pointer to arrow-datafusion for https://github.com/cube-js/arrow-datafusion/pull/158 and adds tests.

Some test values are rendered pretty screwily because of another bug outside the scope of this feature, involving formatting in IntervalValue::as_postgresql_str and misconstructed IntervalValues in batch_to_dataframe.  That needs to be fixed but is seemingly a separate issue.

Edit: The test values will be fixed in the branch interval-rendering.