### PR TITLE
perf(cubesql): Make incremental rule scheduler distinguish between generation 0 and 1

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -35,7 +35,7 @@ pub type MemberNameToExpr = (Option<String>, Member, Expr);
 
 #[derive(Clone, Debug)]
 pub struct LogicalPlanData {
-    pub time: usize,
+    pub iteration_timestamp: usize,
     pub original_expr: Option<OriginalExpr>,
     pub member_name_to_expr: Option<Vec<MemberNameToExpr>>,
     pub trivial_push_down: Option<usize>,
@@ -222,7 +222,9 @@ impl Member {
 
 #[derive(Clone)]
 pub struct LogicalPlanAnalysis {
-    pub time: usize,
+    /* This is 0, when creating the EGraph.  It's set to 1 before iteration 0,
+    2 before the iteration 1, etc. */
+    pub iteration_timestamp: usize,
     cube_context: Arc<CubeContext>,
     planner: Arc<DefaultPhysicalPlanner>,
 }
@@ -254,7 +256,7 @@ impl<'a> Index<Id> for SingleNodeIndex<'a> {
 impl LogicalPlanAnalysis {
     pub fn new(cube_context: Arc<CubeContext>, planner: Arc<DefaultPhysicalPlanner>) -> Self {
         Self {
-            time: 0,
+            iteration_timestamp: 0,
             cube_context,
             planner,
         }
@@ -1257,7 +1259,7 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
         enode: &LogicalPlanLanguage,
     ) -> Self::Data {
         LogicalPlanData {
-            time: egraph.analysis.time,
+            iteration_timestamp: egraph.analysis.iteration_timestamp,
             original_expr: Self::make_original_expr(egraph, enode),
             member_name_to_expr: Self::make_member_name_to_expr(egraph, enode),
             trivial_push_down: Self::make_trivial_push_down(egraph, enode),
@@ -1297,7 +1299,7 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
             | column_name
             | filter_operators
             | is_empty_list
-            | self.merge_max_field(&mut a.time, b.time)
+            | self.merge_max_field(&mut a.iteration_timestamp, b.iteration_timestamp)
     }
 
     fn modify(egraph: &mut EGraph<LogicalPlanLanguage, Self>, id: Id) {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -221,7 +221,7 @@ impl Rewriter {
         ))
         .with_scheduler(IncrementalScheduler::default())
         .with_hook(|runner| {
-            runner.egraph.analysis.time = runner.iterations.len();
+            runner.egraph.analysis.iteration_timestamp = runner.iterations.len() + 1;
             Ok(())
         })
         .with_egraph(egraph)
@@ -584,11 +584,10 @@ impl egg::RewriteScheduler<LogicalPlanLanguage, LogicalPlanAnalysis> for Increme
         if iteration != self.current_iter {
             self.current_iter = iteration;
             self.current_eclasses.clear();
-            self.current_eclasses.extend(
-                egraph
-                    .classes()
-                    .filter_map(|class| (class.data.time + 1 >= iteration).then(|| class.id)),
-            );
+            self.current_eclasses
+                .extend(egraph.classes().filter_map(|class| {
+                    (class.data.iteration_timestamp >= iteration).then(|| class.id)
+                }));
         };
         assert_eq!(iteration, self.current_iter);
         rewrite.searcher.search_eclasses_with_limit(


### PR DESCRIPTION
This adds a fix to #8340 to make the nodes added at EGraph creation have distinguishable timestamp values from those created by the first round of rewrites.  This improves performance on some benchmarks and, unsurprisingly, not some others.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

Benchmark results.
```
split_query             time:   [11.687 ms 11.699 ms 11.708 ms]
                        change: [-1.0177% -0.3939% +0.7496%] (p = 0.54 > 0.05)
split_query_count_distinct
                        time:   [11.566 ms 11.573 ms 11.578 ms]
                        change: [-1.7806% -1.7163% -1.6513%] (p = 0.00 < 0.05)
wrapped_query           time:   [12.530 ms 12.568 ms 12.593 ms]
                        change: [-0.9316% -0.7545% -0.5633%] (p = 0.00 < 0.05)
power_bi_wrap           time:   [13.211 ms 13.267 ms 13.349 ms]
                        change: [-0.8045% -0.5273% -0.1190%] (p = 0.01 < 0.05)
power_bi_sum_wrap       time:   [24.299 ms 24.368 ms 24.432 ms]
                        change: [-0.7381% -0.4565% -0.1522%] (p = 0.01 < 0.05)
long_in_expr            time:   [22.042 ms 22.052 ms 22.064 ms]
                        change: [-1.4001% -1.2850% -1.1538%] (p = 0.00 < 0.05)
long_simple_in_number_expr_1k
                        time:   [2.7445 ms 2.7551 ms 2.7661 ms]
                        change: [-26.533% -26.267% -25.986%] (p = 0.00 < 0.05)
long_simple_in_str_expr_50
                        time:   [1.9801 ms 1.9808 ms 1.9818 ms]
                        change: [-4.3754% -4.2817% -4.1894%] (p = 0.00 < 0.05)
long_simple_in_str_expr_1k
                        time:   [4.6824 ms 4.7132 ms 4.7701 ms]
                        change: [-17.597% -15.514% -13.339%] (p = 0.00 < 0.05)
tableau_logical_17      time:   [1.7931 ms 1.7969 ms 1.8002 ms]
                        change: [-1.3414% -1.1633% -0.9818%] (p = 0.00 < 0.05)
tableau_bugs_b8888      time:   [10.947 ms 10.957 ms 10.972 ms]
                        change: [-0.8267% -0.6318% -0.4508%] (p = 0.00 < 0.05)
ts_last_day_redshift    time:   [8.6565 ms 8.6616 ms 8.6692 ms]
                        change: [-1.3985% -1.2047% -1.0097%] (p = 0.00 < 0.05)
```