### PR TITLE
chore(cubesql): Set opt-level to 1 in dev debug builds

### DIFF
--- a/packages/cubejs-backend-native/Cargo.toml
+++ b/packages/cubejs-backend-native/Cargo.toml
@@ -9,6 +9,9 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 exclude = ["index.node"]
 
+[profile.dev]
+opt-level = 1
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
This avoids stack overflows in datafusion, caused by very inefficient Rust stack layout in opt-level 0, that makes the
sql_expr_to_logical_expr function, called recursively, use 50KB stack frames.  (Some other functions use 90KB or over 100KB, as well.)

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required
