### PR TITLE
chore(ci): Bump macOS from 11 to 12

### DIFF
--- a/.github/workflows/birdbox.yml
+++ b/.github/workflows/birdbox.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-12, windows-2019]
         node-version: [18.x]
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        os-version: ["macos-11"]
+        os-version: ["macos-12"]
         target: ["x86_64-apple-darwin", "aarch64-apple-darwin"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "fallback"]
         include:
@@ -731,7 +731,7 @@ jobs:
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
             tar_executable: tar
           - target: x86_64-apple-darwin
-            os: macos-11
+            os: macos-12
             executable_name: cubestored
             strip: false
             compress: false

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -193,7 +193,7 @@ jobs:
       matrix:
         # We do not need to test under all versions, we do it under linux
         node-version: [18.x]
-        os-version: ["macos-11"]
+        os-version: ["macos-12"]
         target: ["x86_64-apple-darwin", "aarch64-apple-darwin"]
         include:
           - target: x86_64-apple-darwin

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -204,7 +204,7 @@ jobs:
             # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             executable_name: cubestored
             strip: true

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -137,7 +137,7 @@ jobs:
             # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             executable_name: cubestored
             strip: true


### PR DESCRIPTION
This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.