### PR TITLE
Upgrade to Oracle Database Free

### DIFF
--- a/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
@@ -5,9 +5,9 @@ import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract
 
 export class OracleDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
-    const version = process.env.TEST_ORACLE_VERSION || options.version || '21.3.0';
+    const version = process.env.TEST_ORACLE_VERSION || options.version || '23.4.0';
 
-    const container = new GenericContainer(`gvenzl/oracle-xe:${version}`)
+    const container = new GenericContainer(`gvenzl/oracle-free:${version}`)
       .withEnv('ORACLE_PASSWORD', 'test')
       .withWaitStrategy(Wait.forLogMessage('DATABASE IS READY TO USE'))
       .withExposedPorts(1521);


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
Hey all,

Thanks a lot for using my Oracle Database images.
I have noticed that you are still using the old Oracle Database XE version of my images.

Oracle has discontinued Oracle Database XE and instead offers Oracle Database Free as the successor, which was first released last year.

The database editions are compatible, hence nothing should break or change other than the connect string and the Docker image tag.

I have taken the liberty to provide the modifications based on what I could find in the repository.

Thanks,