### PR TITLE
Ci updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/actions/init-ci/action.yaml
+++ b/.github/actions/init-ci/action.yaml
@@ -7,11 +7,11 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js ${{ inputs.node }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node }}
     - name: Cache node modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # npm cache files are stored in `~/.npm` on Linux/macOS
         path: ~/.npm

--- a/.github/workflows/birdbox.yml
+++ b/.github/workflows/birdbox.yml
@@ -34,11 +34,11 @@ jobs:
         if: contains(runner.os, 'windows')
         shell: bash
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Restore lerna
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -52,7 +52,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -95,11 +95,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Restore lerna
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -113,7 +113,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -158,11 +158,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Restore lerna
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -176,7 +176,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
       - id: get-tag
-        run: echo "::set-output name=sha::$(git rev-list -n 1 $(git tag --contains $SHA))"
+        run: echo "sha=$(git rev-list -n 1 $(git tag --contains $SHA))" >> $GITHUB_OUTPUT
         env:
           SHA: ${{ github.sha }}
       - id: get-tag-out

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -69,7 +69,7 @@ jobs:
         if: contains(runner.os, 'windows')
         shell: bash
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -77,7 +77,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/drivers-tests.yml
+++ b/.github/workflows/drivers-tests.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
       - id: get-tag
-        run: echo "::set-output name=sha::$(git rev-list -n 1 $(git tag --contains $SHA))"
+        run: echo "sha=$(git rev-list -n 1 $(git tag --contains $SHA))" >> $GITHUB_OUTPUT
         env:
           SHA: ${{ github.sha }}
       - id: get-tag-out

--- a/.github/workflows/drivers-tests.yml
+++ b/.github/workflows/drivers-tests.yml
@@ -92,17 +92,22 @@ jobs:
       image: cubejs/rust-cross:${{ matrix.target }}-02042024
 
     steps:
+      - name: install Curl
+        run: |
+          apt-get update
+          apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
           target: ${{ matrix.target }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Yarn
@@ -123,7 +128,7 @@ jobs:
         run: cd packages/cubejs-backend-native && npm run native:build-release
       - name: Setup cross compilation
         if: (matrix.target == 'aarch64-unknown-linux-gnu')
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         with:
           PYO3_CROSS_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Build native (with Python)
@@ -183,7 +188,7 @@ jobs:
     if: (needs['latest-tag-sha'].outputs.sha != github.sha)
     strategy:
       matrix:
-        node: 
+        node:
           - 18.x
         database:
           - athena
@@ -202,7 +207,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
@@ -215,7 +220,7 @@ jobs:
         shell: bash
       - name: Restore yarn cache
         # We don't want to save it on finish, restore only!
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -223,7 +228,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:

--- a/.github/workflows/examples-publish.yml
+++ b/.github/workflows/examples-publish.yml
@@ -24,7 +24,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/building-an-open-source-data-stack-with-clickhouse-and-cube-workshop/*,examples/building-an-open-source-data-stack-with-clickhouse-and-cube-workshop/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -50,7 +50,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/building-an-open-source-data-stack-with-clickhouse-and-cube-workshop/*,examples/building-an-open-source-data-stack-with-clickhouse-and-cube-workshop/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -76,7 +76,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/apollo-federation-with-cube/*,examples/apollo-federation-with-cube/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -101,7 +101,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/ksql/*,examples/ksql/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -126,7 +126,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/hasura-remote-schema-with-cube/*,examples/hasura-remote-schema-with-cube/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -151,7 +151,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/angular-dashboard-with-material-ui/*,examples/angular-dashboard-with-material-ui/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -176,7 +176,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/compare-date-range/*,examples/compare-date-range/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -200,7 +200,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/clickhouse-dashboard/*,examples/clickhouse-dashboard/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -224,7 +224,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/d3-dashboard/*,examples/d3-dashboard/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -248,7 +248,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/data-blending/*,examples/data-blending/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -272,7 +272,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/drill-downs/*,examples/drill-downs/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -296,7 +296,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/ecom-backend/*,examples/ecom-backend/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -321,7 +321,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/external-rollups/*,examples/external-rollups/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -345,7 +345,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/hacktoberfest/*,examples/hacktoberfest/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -370,7 +370,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/mapbox/*,examples/mapbox/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -394,7 +394,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/react-dashboard/*,examples/react-dashboard/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -418,7 +418,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/react-muze/*,examples/react-muze/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -442,7 +442,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/real-time-dashboard/*,examples/real-time-dashboard/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -466,7 +466,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/web-analytics/*,examples/web-analytics/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -490,7 +490,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/auth0/*,examples/auth0/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -514,7 +514,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/bigquery-public-datasets/*,examples/bigquery-public-datasets/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -538,7 +538,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/google-charts-moma/*,examples/google-charts-moma/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -563,7 +563,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/deepnote/*,examples/deepnote/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -589,7 +589,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/graphql-api-metrics-dashboard/*,examples/graphql-api-metrics-dashboard/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -614,7 +614,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/multi-tenant-analytics/*,examples/multi-tenant-analytics/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -638,7 +638,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/multitenancy-workshop/*,examples/multitenancy-workshop/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -662,7 +662,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/aws-web-analytics/*,examples/aws-web-analytics/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
@@ -687,7 +687,7 @@ jobs:
           paths: '.github/workflows/examples-publish.yml,.github/actions/deploy-example.sh,examples/event-analytics/*,examples/event-analytics/**'
 
       - if: steps.modified.outputs.modified
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
       - id: get-tag
-        run: echo "::set-output name=sha::$(git rev-list -n 1 $(git tag --contains $SHA))"
+        run: echo "sha=$(git rev-list -n 1 $(git tag --contains $SHA))" >> $GITHUB_OUTPUT
         env:
           SHA: ${{ github.sha }}
       - id: get-tag-out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -408,9 +408,9 @@ jobs:
             MAJOR=${MINOR%.*}
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -485,9 +485,9 @@ jobs:
           elif [ "${{ github.event_name }}" = "push" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}-jdk"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -583,9 +583,9 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR}${{ matrix.postfix }},${DOCKER_IMAGE}:${MAJOR}${{ matrix.postfix }},${DOCKER_IMAGE}:${{ matrix.tag }}"
           fi
 
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Get yarn cache directory path
@@ -30,7 +31,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -41,7 +42,7 @@ jobs:
       - name: Copy yarn.lock file
         run: cp yarn.lock packages/cubejs-docker
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -90,14 +91,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
           target: ${{ matrix.target }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Yarn
@@ -109,7 +111,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -118,7 +120,7 @@ jobs:
       - name: Copy yarn.lock file
         run: cp yarn.lock packages/cubejs-docker
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -136,7 +138,7 @@ jobs:
         run: cd packages/cubejs-backend-native && npm run native:build-release
       - name: Setup cross compilation
         if: (matrix.target == 'aarch64-unknown-linux-gnu')
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         with:
           PYO3_CROSS_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Build native (with Python)
@@ -201,10 +203,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
           target: ${{ matrix.target }}
       - name: Install Python
@@ -213,7 +216,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -221,7 +224,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -232,7 +235,7 @@ jobs:
       - name: Copy yarn.lock file
         run: cp yarn.lock packages/cubejs-docker
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -297,10 +300,11 @@ jobs:
         run: rustup set auto-self-update disable
         shell: bash
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Python
         uses: actions/setup-python@v4
@@ -308,7 +312,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -316,7 +320,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -327,7 +331,7 @@ jobs:
       - name: Copy yarn.lock file
         run: cp yarn.lock packages/cubejs-docker
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -592,7 +596,7 @@ jobs:
         with:
           version: v0.9.1
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ matrix.target }}-buildx-${{ matrix.tag }}-${{ github.sha }}
@@ -668,11 +672,12 @@ jobs:
         if: contains(runner.os, 'windows')
         shell: bash
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -747,11 +752,12 @@ jobs:
         if: contains(runner.os, 'windows')
         shell: bash
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -770,7 +776,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install -y --force llvm --version 18.1.2
       - name: Set Env Variables for Windows
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         if: ${{ startsWith(matrix.os, 'windows') }}
         with:
           OPENSSL_DIR: 'C:/vcpkg/packages/openssl_x64-windows'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,13 +54,14 @@ jobs:
           # pulls all commits (needed for codecov)
           fetch-depth: 2
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -68,7 +69,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -77,7 +78,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -106,16 +107,21 @@ jobs:
     if: (needs['latest-tag-sha'].outputs.sha != github.sha)
 
     steps:
+      - name: Install cUrl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Get yarn cache directory path
@@ -123,7 +129,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -132,7 +138,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -153,16 +159,21 @@ jobs:
     if: (needs['latest-tag-sha'].outputs.sha != github.sha)
 
     steps:
+      - name: Install cUrl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Get yarn cache directory path
@@ -170,7 +181,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -179,7 +190,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -232,7 +243,7 @@ jobs:
           cd rust/cubestore
           cargo build --release -j 4
       - name: 'Upload cubestored-x86_64-unknown-linux-gnu-release artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cubestored-x86_64-unknown-linux-gnu-release
           path: ./rust/cubestore/target/release/cubestored
@@ -269,7 +280,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -277,7 +288,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -286,7 +297,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -298,7 +309,7 @@ jobs:
       - name: Lerna tsc
         run: yarn tsc
       - name: Download cubestored-x86_64-unknown-linux-gnu-release artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./rust/cubestore/target/release/
           name: cubestored-x86_64-unknown-linux-gnu-release
@@ -330,13 +341,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -344,7 +356,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -353,7 +365,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -399,7 +411,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get yarn cache directory path
@@ -407,7 +419,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -416,7 +428,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -432,7 +444,7 @@ jobs:
       - name: Lerna tsc
         run: yarn tsc
       - name: Download cubestored-x86_64-unknown-linux-gnu-release artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: rust/cubestore/downloaded/latest/bin/
           name: cubestored-x86_64-unknown-linux-gnu-release
@@ -537,7 +549,7 @@ jobs:
           push: true
           tags: localhost:5000/cubejs/cube:${{ matrix.tag }}
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Get yarn cache directory path
@@ -545,7 +557,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -554,7 +566,7 @@ jobs:
       - name: Set Yarn version
         run: yarn policies set-version v1.22.19
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -625,7 +637,7 @@ jobs:
           yarn run cypress:install
           yarn run cypress:birdbox
       - name: Upload screenshots on failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-docker-dev-${{ matrix.name }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -466,7 +466,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - id: get-tag
-        run: echo "::set-output name=tag::$(git tag --contains $GITHUB_SHA)"
+        run: echo "tag=$(git tag --contains $GITHUB_SHA)" >> $GITHUB_OUTPUT
         env:
           GITHUB_SHA: ${{ github.sha }}
 
@@ -485,7 +485,7 @@ jobs:
         env:
           SHA: ${{ github.sha }}
       - id: get-tag
-        run: echo "::set-output name=sha::$(git rev-list -n 1 $(git tag --contains $SHA))"
+        run: echo "sha=$(git rev-list -n 1 $(git tag --contains $SHA))" >> $GITHUB_OUTPUT
         env:
           SHA: ${{ github.sha }}
       - id: get-tag-out

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -21,13 +21,18 @@ jobs:
     name: Check fmt/clippy
 
     steps:
+      - name: install Curl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -107,13 +112,18 @@ jobs:
       image: cubejs/rust-cross:${{ matrix.target }}-02042024
 
     steps:
+      - name: install Curl
+        run: |
+          apt-get update
+          apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
@@ -122,7 +132,7 @@ jobs:
           key: cubesql-${{ runner.OS }}-${{ matrix.target }}-${{ matrix.node-version }}
           shared-key: cubesql-${{ runner.OS }}-${{ matrix.target }}-${{ matrix.node-version }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Yarn
@@ -133,14 +143,14 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -159,7 +169,7 @@ jobs:
         run: yarn run native:build-debug
       - name: Setup cross compilation
         if: (matrix.target == 'aarch64-unknown-linux-gnu')
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         with:
           PYO3_CROSS_PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Build native (with Python)
@@ -214,10 +224,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
           target: ${{ matrix.target }}
       - name: Install Python
@@ -226,7 +237,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set Yarn version
@@ -236,14 +247,14 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:
@@ -296,10 +307,11 @@ jobs:
         run: rustup set auto-self-update disable
         shell: bash
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2023-12-13
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - name: Install Python
         uses: actions/setup-python@v4
@@ -307,7 +319,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Set Yarn version
@@ -317,14 +329,14 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn install
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         env:
           CUBESTORE_SKIP_POST_INSTALL: true
         with:

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -36,13 +36,18 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           echo "After"
           df -h
+      - name: Install cUrl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -151,7 +156,7 @@ jobs:
         with:
           version: v0.9.1
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ matrix.target }}-buildx-${{ github.sha }}
@@ -233,7 +238,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install -y --force llvm --version 18.1.2
       - name: Set Env Variables for Windows
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         if: ${{ startsWith(matrix.os, 'windows') }}
         with:
           OPENSSL_DIR: 'C:/vcpkg/packages/openssl_x64-windows'
@@ -263,7 +268,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz
@@ -305,11 +310,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -335,7 +341,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -143,9 +143,9 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:build-1${GITHUB_RUN_NUMBER}${{ matrix.postfix }}"
           fi
 
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -41,13 +41,18 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           echo "After"
           df -h
+      - name: Install cUrl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -101,7 +106,7 @@ jobs:
         with:
           version: v0.9.1
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ matrix.target }}-buildx-${{ github.sha }}
@@ -166,7 +171,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install -y --force llvm --version 18.1.2
       - name: Set Env Variables for Windows
-        uses: allenevans/set-env@v3.0.0
+        uses: allenevans/set-env@v4.0.0
         if: ${{ startsWith(matrix.os, 'windows') }}
         with:
           OPENSSL_DIR: 'C:/vcpkg/packages/openssl_x64-windows'
@@ -196,7 +201,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz
@@ -236,13 +241,18 @@ jobs:
     container:
       image: cubejs/rust-cross:${{ matrix.target }}-02042024
     steps:
+      - name: install Curl
+        run: |
+          apt-get update
+          apt-get install -y curl
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2024-01-29
           target: ${{ matrix.target }}
-          override: true
+          # override: true # this is by default on
+          rustflags: ""
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -268,7 +278,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           version: v0.9.1
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ matrix.target }}-buildx-${{ github.sha }}
@@ -201,7 +201,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v2
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz
@@ -278,7 +278,7 @@ jobs:
           mv rust/cubestore/target/${{ matrix.target }}/release/${{ matrix.executable_name }} cubestore-archive/bin/${{ matrix.executable_name }}
           cd cubestore-archive
           tar -cvzf cubestored-${{ matrix.target }}.tar.gz *
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v2
         with:
           path: cubestore-archive/cubestored-${{ matrix.target }}.tar.gz
           name: cubestored-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
To experiment with failing jobs in parallel with https://github.com/cube-js/cube/pull/8379

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

We have too many outdated actions. Some use super old node versions. Here is an attempt to update all actions to latest.

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3, actions/cache/restore@v3, nick-invision/retry@v2
> .....

Also updated obsolete `echo "::save-state name={name}::{value}"`. More info can be found [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
