### PR TITLE
feat: Make graceful shutdown add fatal messages in postgres

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -1,6 +1,7 @@
 import {
   setupLogger,
   registerInterface,
+  shutdownInterface,
   execSql,
   SqlInterfaceInstance,
   Request as NativeRequest,
@@ -329,5 +330,9 @@ export class SQLServer {
 
   public async close(): Promise<void> {
     // @todo Implement
+  }
+
+  public async shutdown(): Promise<void> {
+    await shutdownInterface(this.sqlInterfaceInstance!);
   }
 }

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -332,8 +332,6 @@ export const shutdownInterface = async (instance: SqlInterfaceInstance): Promise
   const native = loadNative();
 
   await native.shutdownInterface(instance);
-
-  await new Promise((resolve) => setTimeout(resolve, 2000));
 };
 
 export const execSql = async (instance: SqlInterfaceInstance, sqlQuery: string, stream: any, securityContext?: any): Promise<void> => {

--- a/rust/cubesql/cubesql/src/bin/cubesqld.rs
+++ b/rust/cubesql/cubesql/src/bin/cubesqld.rs
@@ -5,7 +5,7 @@ use cubesql::{
 
 use log::Level;
 use simple_logger::SimpleLogger;
-use std::env;
+use std::{env, sync::Arc};
 
 use tokio::runtime::Builder;
 
@@ -39,14 +39,14 @@ fn main() {
     let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
     runtime.block_on(async move {
         config.configure().await;
-        let services = config.cube_services().await;
+        let services = Arc::new(config.cube_services().await);
         log::debug!("Cube SQL Start");
         stop_on_ctrl_c(&services).await;
         services.wait_processing_loops().await.unwrap();
     });
 }
 
-async fn stop_on_ctrl_c(s: &CubeServices) {
+async fn stop_on_ctrl_c(s: &Arc<CubeServices>) {
     let s = s.clone();
     tokio::spawn(async move {
         let mut counter = 0;

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -37,6 +37,8 @@ use uuid::Uuid;
 
 pub struct AsyncPostgresShim {
     socket: TcpStream,
+    // If empty, this means socket is on a message boundary.
+    partial_write_buf: bytes::BytesMut,
     // Extended query
     cursors: HashMap<String, Cursor>,
     portals: HashMap<String, Portal>,
@@ -225,19 +227,34 @@ impl From<ErrorResponse> for ConnectionError {
 
 impl AsyncPostgresShim {
     pub async fn run_on(
+        shutdown_interruptor: CancellationToken,
         socket: TcpStream,
         session: Arc<Session>,
         logger: Arc<dyn ContextLogger>,
     ) -> Result<(), ConnectionError> {
         let mut shim = Self {
             socket,
+            partial_write_buf: bytes::BytesMut::new(),
             cursors: HashMap::new(),
             portals: HashMap::new(),
             session,
             logger,
         };
 
-        match shim.run().await {
+        let run_result = tokio::select! {
+            _ = shutdown_interruptor.cancelled() => {
+                // We flush the partially written buf and add the fatal message -- it's another
+                // place's responsibility to impose a timeout and abort us.
+                shim.socket.write_all_buf(&mut shim.partial_write_buf).await?;
+                shim.partial_write_buf = bytes::BytesMut::new();
+                shim.write_admin_shutdown_fatal_message().await?;
+                shim.socket.shutdown().await?;
+                return Ok(());
+            }
+            res = shim.run() => res,
+        };
+
+        match run_result {
             Err(e) => {
                 if let ConnectionError::Protocol(ProtocolError::IO { source, .. }, _) = &e {
                     if source.kind() == ErrorKind::BrokenPipe
@@ -250,6 +267,7 @@ impl AsyncPostgresShim {
                 } else if let ConnectionError::CompilationError(CompilationError::Fatal(_, _), _) =
                     &e
                 {
+                    assert!(shim.partial_write_buf.is_empty());
                     shim.write(e.to_error_response()).await?;
                     shim.socket.shutdown().await?;
                     return Ok(());
@@ -262,6 +280,16 @@ impl AsyncPostgresShim {
                 return Ok(());
             }
         }
+    }
+
+    fn admin_shutdown_error() -> ConnectionError {
+        ConnectionError::Protocol(
+            ProtocolError::ErrorResponse {
+                source: ErrorResponse::admin_shutdown(),
+                backtrace: Backtrace::disabled(),
+            },
+            None,
+        )
     }
 
     pub async fn run(&mut self) -> Result<(), ConnectionError> {
@@ -536,7 +564,7 @@ impl AsyncPostgresShim {
         &mut self,
         message: Vec<Message>,
     ) -> Result<(), ConnectionError> {
-        buffer::write_messages(&mut self.socket, message).await?;
+        buffer::write_messages(&mut self.partial_write_buf, &mut self.socket, message).await?;
 
         Ok(())
     }
@@ -546,8 +574,12 @@ impl AsyncPostgresShim {
         completion: PortalCompletion,
     ) -> Result<(), ConnectionError> {
         match completion {
-            PortalCompletion::Complete(c) => buffer::write_message(&mut self.socket, c).await?,
-            PortalCompletion::Suspended(s) => buffer::write_message(&mut self.socket, s).await?,
+            PortalCompletion::Complete(c) => {
+                buffer::write_message(&mut self.partial_write_buf, &mut self.socket, c).await?
+            }
+            PortalCompletion::Suspended(s) => {
+                buffer::write_message(&mut self.partial_write_buf, &mut self.socket, s).await?
+            }
         }
 
         Ok(())
@@ -557,7 +589,18 @@ impl AsyncPostgresShim {
         &mut self,
         message: Message,
     ) -> Result<(), ConnectionError> {
-        buffer::write_message(&mut self.socket, message).await?;
+        buffer::write_message(&mut self.partial_write_buf, &mut self.socket, message).await?;
+
+        Ok(())
+    }
+
+    pub async fn write_admin_shutdown_fatal_message(&mut self) -> Result<(), ConnectionError> {
+        buffer::write_message(
+            &mut bytes::BytesMut::new(),
+            &mut self.socket,
+            Self::admin_shutdown_error().to_error_response(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -617,7 +660,12 @@ impl AsyncPostgresShim {
                     startup_message.major, startup_message.minor,
                 ),
             );
-            buffer::write_message(&mut self.socket, error_response).await?;
+            buffer::write_message(
+                &mut self.partial_write_buf,
+                &mut self.socket,
+                error_response,
+            )
+            .await?;
             return Ok(StartupState::Denied);
         }
 
@@ -628,7 +676,12 @@ impl AsyncPostgresShim {
                 protocol::ErrorCode::InvalidAuthorizationSpecification,
                 "no PostgreSQL user name specified in startup packet".to_string(),
             );
-            buffer::write_message(&mut self.socket, error_response).await?;
+            buffer::write_message(
+                &mut self.partial_write_buf,
+                &mut self.socket,
+                error_response,
+            )
+            .await?;
             return Ok(StartupState::Denied);
         }
 
@@ -675,7 +728,12 @@ impl AsyncPostgresShim {
                 protocol::ErrorCode::InvalidPassword,
                 format!("password authentication failed for user \"{}\"", &user),
             );
-            buffer::write_message(&mut self.socket, error_response).await?;
+            buffer::write_message(
+                &mut self.partial_write_buf,
+                &mut self.socket,
+                error_response,
+            )
+            .await?;
 
             return Ok(false);
         }
@@ -875,14 +933,14 @@ impl AsyncPostgresShim {
                             }
 
                             match chunk {
-                                PortalBatch::Rows(writer) if writer.has_data() => buffer::write_direct(&mut self.socket, writer).await?,
+                                PortalBatch::Rows(writer) if writer.has_data() => buffer::write_direct(&mut self.partial_write_buf, &mut self.socket, writer).await?,
                                 PortalBatch::Completion(completion) => {
                                     self.session.state.end_query();
 
                                     // TODO:
                                     match completion {
-                                        PortalCompletion::Complete(c) => buffer::write_message(&mut self.socket, c).await?,
-                                        PortalCompletion::Suspended(s) => buffer::write_message(&mut self.socket, s).await?,
+                                        PortalCompletion::Complete(c) => buffer::write_message(&mut self.partial_write_buf, &mut self.socket, c).await?,
+                                        PortalCompletion::Suspended(s) => buffer::write_message(&mut self.partial_write_buf, &mut self.socket, s).await?,
                                     }
 
                                     return Ok(());
@@ -1609,7 +1667,7 @@ impl AsyncPostgresShim {
                         },
                         PortalBatch::Rows(writer) => {
                             if writer.has_data() {
-                                buffer::write_direct(&mut self.socket, writer).await?
+                                buffer::write_direct(&mut self.partial_write_buf, &mut self.socket, writer).await?
                             }
                         }
                         PortalBatch::Completion(completion) => return self.write_completion(completion).await,

--- a/rust/cubesql/cubesql/src/sql/postgres/writer.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/writer.rs
@@ -394,7 +394,7 @@ mod tests {
         writer.write_value(true)?;
         writer.end_row()?;
 
-        buffer::write_direct(&mut cursor, writer).await?;
+        buffer::write_direct(&mut BytesMut::new(), &mut cursor, writer).await?;
 
         assert_eq!(
             cursor.get_ref()[0..],
@@ -422,7 +422,7 @@ mod tests {
         writer.write_value(true)?;
         writer.end_row()?;
 
-        buffer::write_direct(&mut cursor, writer).await?;
+        buffer::write_direct(&mut BytesMut::new(), &mut cursor, writer).await?;
 
         assert_eq!(
             cursor.get_ref()[0..],
@@ -450,7 +450,7 @@ mod tests {
         writer.write_value(Decimal128Value::new(2, 15))?;
         writer.end_row()?;
 
-        buffer::write_direct(&mut cursor, writer).await?;
+        buffer::write_direct(&mut BytesMut::new(), &mut cursor, writer).await?;
 
         assert_eq!(
             cursor.get_ref()[0..],
@@ -488,7 +488,7 @@ mod tests {
         writer.write_value(ListValue::new(Arc::new(col.finish()) as ArrayRef))?;
         writer.end_row()?;
 
-        buffer::write_direct(&mut cursor, writer).await?;
+        buffer::write_direct(&mut BytesMut::new(), &mut cursor, writer).await?;
 
         assert_eq!(
             cursor.get_ref()[0..],


### PR DESCRIPTION
Aside from fatal error message injection, we also add logic to wait on and properly join the postgres connections and tasks.  Otherwise we would not properly gracefully shut down.

One easily reversible decision made was to avoid passing the CancellationToken down recursively and instead track partially written socket buffers.  Because we have other CancellationTokens floating around in query logic (which IIRC are not actually used -- nothing triggers them) that might have a reason to change in the future.