### PR TITLE
feat(api-gateway): add meta about query in gql

### DIFF
--- a/docs/pages/product/apis-integrations/queries.mdx
+++ b/docs/pages/product/apis-integrations/queries.mdx
@@ -325,7 +325,7 @@ the query. This is useful for creating user interfaces with
 [pagination][ref-pagination-recipe].
 
 You can make a total query by using the `total` option with the [REST
-API][ref-rest-api-query-format-options]. For the SQL API, you can write an
+API][ref-rest-api-query-format-options] or [GraphQL API][ref-ref-graphql-api-args]. For the SQL API, you can write an
 equivalent query using the `UNION ALL` statement.
 
 ### Ungrouped query

--- a/docs/pages/reference/graphql-api.mdx
+++ b/docs/pages/reference/graphql-api.mdx
@@ -29,12 +29,14 @@ query {
 - **`where` ([`RootWhereInput`](#root-where-input)):** Represents a SQL `WHERE` clause.
 - **`limit` (`Int`):** A [row limit][ref-row-limit] for your query.
 - **`offset` (`Int`):** The number of initial rows to be skipped for your query. The default value is `0`.
+- **`total` (`Boolean`):**  If set to true, Cube will run a total query and return the total number of rows as if no row limit or offset are set in the query. The default value is false.
 - **`timezone` (`String`):** The [time zone][ref-time-zone] for your query. You can set the
 desired time zone in the [TZ Database Name](https://en.wikipedia.org/wiki/Tz_database)
 format, e.g., `America/Los_Angeles`.
 - **`renewQuery` (`Boolean`):** If `renewQuery` is set to `true`, Cube will renew all `refreshKey` for queries and query results in the foreground. The default value is `false`.
 - **`ungrouped` (`Boolean`):** If set to `true`, Cube will run an
 [ungrouped query][ref-ungrouped-query].
+- **`meta` (`Boolean`):** If set to `true`, Cube will return metadata about the query.
 
 [ref-recipe-pagination]: /guides/recipes/queries/pagination
 

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -262,16 +262,14 @@ class ApiGateway {
           schema,
           extensions: (requestInfo) => {
             const context = requestInfo.context as GraphQLRequestContext;
-            const { resultMeta } = context;
+            const { meta } = context;
 
-            if (!resultMeta) {
-              return {
-                resultMeta: undefined
-              };
+            if (!meta) {
+              return undefined;
             }
 
             return {
-              resultMeta,
+              meta,
             };
           },
         

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -40,6 +40,7 @@ import {
   PreAggJobStatusItem,
   PreAggJobStatusResponse,
   SqlApiRequest, MetaResponseResultFn,
+  GraphQLRequestContext,
 } from './types/request';
 import {
   CheckAuthInternalOptions,
@@ -259,6 +260,21 @@ class ApiGateway {
         }
         return graphqlHTTP({
           schema,
+          extensions: (requestInfo) => {
+            const context = requestInfo.context as GraphQLRequestContext;
+            const { resultMeta } = context;
+
+            if (!resultMeta) {
+              return {
+                resultMeta: undefined
+              };
+            }
+
+            return {
+              resultMeta,
+            };
+          },
+        
           context: {
             req,
             apiGateway: this
@@ -1525,6 +1541,7 @@ class ApiGateway {
         return res;
       })
     );
+    // TODO: Add total for all queries
     response.total = normalizedQuery.total
       ? Number(total.data[0][QueryAlias.TOTAL_COUNT])
       : undefined;

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -1,4 +1,4 @@
-import R, { pick } from 'ramda';
+import R from 'ramda';
 import moment from 'moment-timezone';
 
 import {
@@ -673,10 +673,10 @@ export function makeSchema(metaConfig: { config: Cube }[]): GraphQLSchema {
           
           if (args.meta) {
             ctx.meta = { ...(ctx.meta || {}),
-              [info.path.key]: pick([
+              [info.path.key]: R.pick([
                 ...(args.total ? ['total'] : []),
                 'dbType', 'extDbType', 'external', 'lastRefreshTime', 'slowQuery'], results) };
-          } else if (args.total) ctx.meta = { ...(ctx.meta || {}), [info.path.key]: pick(['total'], results) };
+          } else if (args.total) ctx.meta = { ...(ctx.meta || {}), [info.path.key]: R.pick(['total'], results) };
 
           return results.data.map(entry => R.toPairs(entry)
             .reduce((res, pair) => {

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -66,7 +66,7 @@ interface GraphQLRequestContext {
   req: Request & {
     context: ExtendedRequestContext;
   },
-  resultMeta?: object,
+  meta?: object,
   apiGateway: ApiGateway
 }
 

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -6,8 +6,10 @@
  */
 
 import type { Request as ExpressRequest } from 'express';
+import type { ApiGateway } from 'src/gateway';
 import { RequestType, ApiType, ResultType } from './strings';
 import { Query } from './query';
+import type { QueryType } from './enums';
 
 /**
  * Network request context interface.
@@ -58,6 +60,14 @@ interface Request extends ExpressRequest {
    * @deprecated
    */
   authInfo?: any,
+}
+
+interface GraphQLRequestContext {
+  req: Request & {
+    context: ExtendedRequestContext;
+  },
+  resultMeta?: object,
+  apiGateway: ApiGateway
 }
 
 /**
@@ -123,7 +133,7 @@ type BaseRequest = {
  */
 type QueryRequest = BaseRequest & {
   query: Record<string, any> | Record<string, any>[];
-  queryType?: RequestType;
+  queryType?: RequestType | QueryType;
   apiType?: ApiType;
   resType?: ResultType
   memberToAlias?: Record<string, string>;
@@ -207,6 +217,7 @@ export {
   RequestContext,
   RequestExtension,
   ExtendedRequestContext,
+  GraphQLRequestContext,
   Request,
   SqlApiRequest,
   QueryRewriteFn,

--- a/packages/cubejs-api-gateway/test/graphql.test.ts
+++ b/packages/cubejs-api-gateway/test/graphql.test.ts
@@ -150,6 +150,7 @@ describe('GraphQL Schema', () => {
     const app = express();
 
     app.use('/graphql', jsonParser, (req, res) => {
+      // @ts-ignore
       const schema = makeSchema(metaConfig);
   
       return graphqlHTTP({
@@ -174,6 +175,7 @@ describe('GraphQL Schema', () => {
     const GRAPHQL_QUERIES_PATH = `${process.cwd()}/test/graphql-queries/base.gql`;
     
     app.use('/graphql', jsonParser, (req, res) => {
+      // @ts-ignore
       const schema = makeSchema(metaConfig);
     
       return graphqlHTTP({
@@ -196,6 +198,7 @@ describe('GraphQL Schema', () => {
     });
     
     test('should make valid schema', () => {
+      // @ts-ignore
       const schema = makeSchema(metaConfig);
       expectValidSchema(schema);
     });
@@ -226,6 +229,7 @@ describe('GraphQL Schema', () => {
     const app = express();
 
     app.use('/graphql', jsonParser, (req, res) => {
+      // @ts-ignore
       const schema = makeSchema(metaConfigSnakeCase);
       
       return graphqlHTTP({


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

This PR adds `extensions.meta` which is equivalent to all metadata about query result that is available via the REST API /load endpoint. The load endpoint returns metadata such as `total` and others but these were not available through the graphql API.

Here is an example of getting total/query-meta from GraphQL API: 
Query: 
```gql
query GetTotal {
  users: cube(total: true, limit: 1, meta: true) {
    users {
      email
    }
  }
  users_with_total: cube(total: true, limit: 1) {
    users {
      email
    }
  }
}
```
Response: 
```json
{
  "data": {
    "users": [
      {
        "users": {
          "email": "nurul@voyagesms.com"
        }
      }
    ],
    "users_with_total": [
      {
        "users": {
          "email": "nurul@voyagesms.com"
        }
      }
    ]
  },
  "extensions": {
    "meta": {
      "users": {
        "total": 5,
        "dbType": "postgres",
        "extDbType": "cubestore",
        "external": false,
        "lastRefreshTime": "2024-07-03T12:27:17.147Z",
        "slowQuery": false
      },
      "users_with_total": {
        "total": 5
      }
    }
  }
}
```

So this PR is enabling feature like getting the `total` via GraphQL API which wasn't possible previously and opens up adding other metadata if needed. 
