### PR TITLE
feat: Smart and Semi-Fast shutdown

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -7,6 +7,7 @@ import {
   Request as NativeRequest,
   LoadRequestMeta,
 } from '@cubejs-backend/native';
+import type { ShutdownMode } from '@cubejs-backend/native';
 import { displayCLIWarning, getEnv } from '@cubejs-backend/shared';
 
 import * as crypto from 'crypto';
@@ -332,7 +333,7 @@ export class SQLServer {
     // @todo Implement
   }
 
-  public async shutdown(): Promise<void> {
-    await shutdownInterface(this.sqlInterfaceInstance!);
+  public async shutdown(mode: ShutdownMode): Promise<void> {
+    await shutdownInterface(this.sqlInterfaceInstance!, mode);
   }
 }

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -328,10 +328,12 @@ export const registerInterface = async (options: SQLInterfaceOptions): Promise<S
   });
 };
 
-export const shutdownInterface = async (instance: SqlInterfaceInstance): Promise<void> => {
+export type ShutdownMode = 'fast' | 'semifast' | 'smart';
+
+export const shutdownInterface = async (instance: SqlInterfaceInstance, shutdownMode: ShutdownMode): Promise<void> => {
   const native = loadNative();
 
-  await native.shutdownInterface(instance);
+  await native.shutdownInterface(instance, shutdownMode);
 };
 
 export const execSql = async (instance: SqlInterfaceInstance, sqlQuery: string, stream: any, securityContext?: any): Promise<void> => {

--- a/packages/cubejs-backend-native/test/server.js
+++ b/packages/cubejs-backend-native/test/server.js
@@ -138,7 +138,7 @@ const meta_fixture = require('./meta');
     console.log('SIGINT signal');
 
     try {
-      await native.shutdownInterface(server);
+      await native.shutdownInterface(server, 'fast');
     } catch (e) {
       console.log(e);
     } finally {

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -298,7 +298,7 @@ describe('SQLInterface', () => {
 
       await connection.end();
     } finally {
-      await native.shutdownInterface(instance);
+      await native.shutdownInterface(instance, 'fast');
     }
   });
 
@@ -349,7 +349,7 @@ describe('SQLInterface', () => {
 
       expect(rows).toBe(100000);
 
-      await native.shutdownInterface(instance);
+      await native.shutdownInterface(instance, 'fast');
     } else {
       expect(process.env.CUBESQL_STREAM_MODE).toBeFalsy();
     }

--- a/packages/cubejs-server/src/server.ts
+++ b/packages/cubejs-server/src/server.ts
@@ -231,7 +231,7 @@ export class CubejsServer {
 
       if (this.sqlServer) {
         locks.push(
-          this.sqlServer.shutdown()
+          this.sqlServer.shutdown(graceful && (signal === 'SIGTERM') ? 'semifast' : 'fast')
         );
       }
 

--- a/packages/cubejs-server/src/server/container.ts
+++ b/packages/cubejs-server/src/server/container.ts
@@ -444,6 +444,7 @@ export class ServerContainer {
               process.exit(1);
             }
           } else {
+            console.log(`Recevied ${signal} signal, terminating with process exit`);
             process.exit(0);
           }
         });

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -58,6 +58,8 @@
     "smoke:crate:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-crate.test.js",
     "smoke:firebolt": "jest --verbose -i dist/test/smoke-firebolt.test.js",
     "smoke:firebolt:snapshot": "jest --updateSnapshot --verbose -i dist/test/smoke-firebolt.test.js",
+    "smoke:graceful-shutdown": "jest --verbose -i dist/test/smoke-graceful-shutdown.test.js",
+    "smoke:graceful-shutdown:snapshot": "jest --updateSnapshot --verbose -i dist/test/smoke-graceful-shutdown.test.js",
     "smoke:lambda": "jest --verbose -i dist/test/smoke-lambda.test.js",
     "smoke:lambda:snapshot": "jest --updateSnapshot --verbose -i dist/test/smoke-lambda.test.js",
     "smoke:materialize": "jest --verbose -i dist/test/smoke-materialize.test.js",

--- a/packages/cubejs-testing/src/birdbox.ts
+++ b/packages/cubejs-testing/src/birdbox.ts
@@ -222,11 +222,17 @@ function prepareTestData(type: DriverType, schemas?: Schemas) {
   }
 }
 
+// Some logic to kill Cube in stop is more precise if we know killCube is only used to send signals
+// that get the process terminated.
+type KillCubeSignal = 'SIGINT' | 'SIGTERM';
+
 /**
  * Birdbox object interface.
  */
 export interface BirdBox {
   stop: () => Promise<void>;
+  killCube: (signal: KillCubeSignal) => void;
+  onCubeExit: () => Promise<number | null>;
   stdout: internal.Readable | null;
   configuration: {
     playgroundUrl: string;
@@ -246,11 +252,21 @@ export async function startBirdBoxFromContainer(
   if (process.env.TEST_CUBE_HOST) {
     const host = process.env.TEST_CUBE_HOST || 'localhost';
     const port = process.env.TEST_CUBE_PORT || '8888';
+    const pid = process.env.TEST_CUBE_PID ? Number(process.env.TEST_CUBE_PID) : null;
 
     return {
       stop: async () => {
         process.stdout.write('[Birdbox] Closed\n');
       },
+      killCube: (signal: KillCubeSignal) => {
+        if (pid !== null) {
+          process.kill(pid, signal);
+        } else {
+          process.stdout.write(`[Birdbox] Cannot kill Cube instance running in TEST_CUBE_HOST mode without TEST_CUBE_PID defined\n`);
+          throw new Error('Attempted to use killCube while running with TEST_CUBE_HOST');
+        }
+      },
+      onCubeExit: (): Promise<number | null> => Promise.reject(new Error('onCubeExit not implemented')), // TODO: Implement
       stdout: null,
       configuration: {
         playgroundUrl: `http://${host}:${port}`,
@@ -407,6 +423,15 @@ export async function startBirdBoxFromContainer(
         process.stdout.write('[Birdbox] Closed\n');
       }
     },
+    killCube: (signal: KillCubeSignal) => {
+      process.stdout.write(`[Birdbox] killCube (with signal ${signal}) not implemented for containers\n`);
+      throw new Error('killCube not implemented for containers');
+    },
+    onCubeExit: (): Promise<number | null> => {
+      const _ = 0;
+      return Promise.reject(new Error('onCubeExit not implemented for containers'));
+      // TODO: Implement.
+    },
     configuration: {
       playgroundUrl: `http://${host}:${playgroundPort}`,
       apiUrl: `http://${host}:${port}/cubejs-api/v1`,
@@ -557,6 +582,11 @@ export async function startBirdBoxFromCli(
     ...options.env,
   };
 
+  let exitResolve: (code: number | null) => void;
+  const exitPromise = new Promise<number | null>((res, _rej) => {
+    exitResolve = res;
+  });
+
   try {
     cli = spawn(
       options.useCubejsServerBinary
@@ -587,6 +617,10 @@ export async function startBirdBoxFromCli(
         process.stdout.write(msg);
       });
     }
+    cli.on('exit', (code, signal) => {
+      process.stdout.write(`[Birdbox] Child process '${cli.pid}' exited with 'exit' event code ${code}, signal ${signal}\n`);
+      exitResolve(code);
+    });
     await pausePromise(10 * 1000);
   } catch (e) {
     process.stdout.write(`Error spawning cube: ${e}\n`);
@@ -594,6 +628,7 @@ export async function startBirdBoxFromCli(
     db.stop();
   }
 
+  let sentKillSignal = false;
   return {
     // @ts-expect-error
     stdout: cli.stdout,
@@ -609,12 +644,30 @@ export async function startBirdBoxFromCli(
         process.stdout.write('[Birdbox] Done with DB\n');
       }
       if (cli.pid) {
-        process.kill(-cli.pid, 'SIGINT');
+        process.stdout.write(`[Birdbox] Killing process group '${cli.pid}'\n`);
+        // Here, normally, we kill the process group by passing -cli.pid (a negative value), but
+        // with killCube we just kill the main process, and then can't kill any process group --
+        // maybe that test has poor cleanup actions.
+        try {
+          process.kill(-cli.pid, 'SIGINT');
+        } catch (error) {
+          if (!sentKillSignal) {
+            throw error;
+          }
+        }
       }
       if (options.log === Log.PIPE) {
         process.stdout.write('[Birdbox] Closed\n');
       }
     },
+    killCube: (signal: KillCubeSignal) => {
+      process.stdout.write(`[Birdbox] Killing Cube (pid = '${cli.pid}') with signal ${signal}\n`);
+      if (cli.pid) {
+        process.kill(cli.pid, signal);
+        sentKillSignal = true;
+      }
+    },
+    onCubeExit: (): Promise<number | null> => exitPromise,
     configuration: {
       playgroundUrl: 'http://127.0.0.1:4000',
       apiUrl: 'http://127.0.0.1:4000/cubejs-api/v1',

--- a/packages/cubejs-testing/test/__snapshots__/smoke-graceful-shutdown.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-graceful-shutdown.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`graceful shutdown PgClient Graceful Shutdown Finishing Transaction: sql_orders 1`] = `
+Array [
+  Object {
+    "cn": "2",
+    "status": "processed",
+  },
+  Object {
+    "cn": "2",
+    "status": "new",
+  },
+  Object {
+    "cn": "1",
+    "status": "shipped",
+  },
+]
+`;
+
+exports[`graceful shutdown PgClient Graceful Shutdown SIGINT: sql_orders 1`] = `
+Array [
+  Object {
+    "cn": "2",
+    "status": "processed",
+  },
+  Object {
+    "cn": "2",
+    "status": "new",
+  },
+  Object {
+    "cn": "1",
+    "status": "shipped",
+  },
+]
+`;
+
+exports[`graceful shutdown PgClient Graceful Shutdown SIGTERM: sql_orders 1`] = `
+Array [
+  Object {
+    "cn": "2",
+    "status": "processed",
+  },
+  Object {
+    "cn": "2",
+    "status": "new",
+  },
+  Object {
+    "cn": "1",
+    "status": "shipped",
+  },
+]
+`;

--- a/packages/cubejs-testing/test/smoke-graceful-shutdown.test.ts
+++ b/packages/cubejs-testing/test/smoke-graceful-shutdown.test.ts
@@ -1,0 +1,303 @@
+import { StartedTestContainer } from 'testcontainers';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { afterAll, beforeAll, expect, jest } from '@jest/globals';
+import { Client as PgClient } from 'pg';
+import { PostgresDBRunner } from '@cubejs-backend/testing-shared';
+import { getBirdbox } from '../src';
+import {
+  DEFAULT_CONFIG,
+  JEST_AFTER_ALL_DEFAULT_TIMEOUT,
+  JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+} from './smoke-tests';
+
+describe('graceful shutdown', () => {
+  jest.setTimeout(60 * 5 * 1000);
+  let db: StartedTestContainer;
+
+  // For when graceful shutdown is not supposed to timeout, vs. for when it is supposed
+  // to timeout.
+  const longGracefulTimeoutSecs = 30;
+  const shortGracefulTimeoutSecs = 1;
+
+  const pgPort = 5656; // Make random?  (Value and comment taken from smoke-cubesql.)
+  let connectionId = 0;
+
+  // Since we use 'error' and 'end' events for some tests, it is necessary or wise to let the event
+  // loop spin around once before asserting.
+  const yieldImmediate = () => new Promise(setImmediate);
+
+  function unconnectedPostgresClient(user: string, password: string) {
+    connectionId++;
+    const currentConnId = connectionId;
+
+    console.debug(`[pg] new connection ${currentConnId}`);
+
+    const conn = new PgClient({
+      database: 'db',
+      port: pgPort,
+      host: 'localhost',
+      user,
+      password,
+      ssl: false,
+    });
+    conn.on('end', () => {
+      console.debug(`[pg] end ${currentConnId}`);
+    });
+
+    return conn;
+  }
+
+  const makeBirdbox = (gracefulTimeoutSecs: number) => getBirdbox(
+    'postgres',
+    {
+      ...DEFAULT_CONFIG,
+      //
+      CUBESQL_LOG_LEVEL: 'trace',
+      //
+      CUBEJS_DB_TYPE: 'postgres',
+      CUBEJS_DB_HOST: db.getHost(),
+      CUBEJS_DB_PORT: `${db.getMappedPort(5432)}`,
+      CUBEJS_DB_NAME: 'test',
+      CUBEJS_DB_USER: 'test',
+      CUBEJS_DB_PASS: 'test',
+      //
+      CUBEJS_PG_SQL_PORT: `${pgPort}`,
+      CUBESQL_SQL_PUSH_DOWN: 'true',
+      CUBESQL_STREAM_MODE: 'true',
+
+      CUBEJS_GRACEFUL_SHUTDOWN: gracefulTimeoutSecs.toString(),
+    },
+    {
+      schemaDir: 'smoke/schema',
+      cubejsConfig: 'smoke/cube.js',
+    },
+  );
+
+  beforeAll(async () => {
+    db = await PostgresDBRunner.startContainer({});
+  }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
+
+  afterAll(async () => {
+    await db.stop();
+  }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+  const clientless = async (signal: 'SIGTERM' | 'SIGINT') => {
+    const birdbox = await makeBirdbox(longGracefulTimeoutSecs);
+    try {
+      birdbox.killCube(signal);
+      const code = await birdbox.onCubeExit();
+      expect(code).toEqual(0);
+    } finally {
+      await birdbox.stop();
+    }
+  };
+
+  test('Clientless Graceful Shutdown SIGTERM', async () => {
+    await clientless('SIGTERM');
+  });
+
+  test('Clientless Graceful Shutdown SIGINT', async () => {
+    await clientless('SIGINT');
+  });
+
+  const betweenQueries = async (signal: 'SIGTERM' | 'SIGINT') => {
+    const birdbox = await makeBirdbox(longGracefulTimeoutSecs);
+    try {
+      const connection: PgClient = unconnectedPostgresClient('admin', 'admin_password');
+
+      let endResolve: () => void;
+      const endPromise = new Promise<void>((res, _rej) => {
+        endResolve = res;
+      });
+      await connection.connect();
+
+      connection.on('end', () => { endResolve(); });
+      let logTerminationErrors = true;
+      let shutdownErrors = 0;
+      connection.on('error', (e: Error) => {
+        const err = e as any;
+        if (err.severity === 'FATAL' && err.code === '57P01') {
+          shutdownErrors += 1;
+        } else if (logTerminationErrors && err.message !== 'Connection terminated unexpectedly') {
+          console.log(err);
+        }
+      });
+      try {
+        const res = await connection.query(
+          'SELECT COUNT(*) as cn, "status" FROM Orders GROUP BY 2 ORDER BY cn DESC'
+        );
+        expect(res.rows).toMatchSnapshot('sql_orders');
+
+        logTerminationErrors = false;
+        birdbox.killCube(signal);
+        const code = await birdbox.onCubeExit();
+        expect(code).toEqual(0);
+      } finally {
+        // Normally the connection ends by server shutdown, and this .end() call returns
+        // a Promise which never gets fulfilled.
+        const _ = connection.end();
+        await endPromise;
+      }
+      expect(shutdownErrors).toEqual(1);
+    } finally {
+      await birdbox.stop();
+    }
+  };
+
+  test('PgClient Graceful Shutdown SIGTERM', async () => {
+    await betweenQueries('SIGTERM');
+  });
+
+  test('PgClient Graceful Shutdown SIGINT', async () => {
+    await betweenQueries('SIGINT');
+  });
+
+  const midTransaction = async (signal: 'SIGTERM' | 'SIGINT') => {
+    const birdbox = await makeBirdbox(signal === 'SIGTERM' ? shortGracefulTimeoutSecs : longGracefulTimeoutSecs);
+    try {
+      const connection: PgClient = unconnectedPostgresClient('admin', 'admin_password');
+
+      let endResolve: () => void;
+      const endPromise = new Promise<void>((res, _rej) => {
+        endResolve = res;
+      });
+      await connection.connect();
+
+      let connectionEnded = false;
+      connection.on('end', () => {
+        connectionEnded = true;
+        endResolve();
+      });
+      let logTerminationErrors = true;
+      let shutdownErrors = 0;
+      let expectedShutdownErrors: number;
+      connection.on('error', (e: Error) => {
+        const err = e as any;
+        if (err.severity === 'FATAL' && err.code === '57P01') {
+          shutdownErrors += 1;
+        } else if (logTerminationErrors && err.message !== 'Connection terminated unexpectedly') {
+          console.log(err);
+        }
+      });
+      try {
+        const res = await connection.query(
+          'BEGIN'
+        );
+        expect(res.command).toEqual('BEGIN');
+
+        // Sanity check: our SQL api client connection is still open.  (I mean, we haven't even
+        // killed Cube.)
+        await yieldImmediate();
+        expect(connectionEnded).toBe(false);
+
+        logTerminationErrors = false;
+        birdbox.killCube(signal);
+        const code = await birdbox.onCubeExit();
+
+        /* This test may be overspecifying -- we have no requirement that the exit code be non-zero
+        if graceful shutdown times out.  But for testing purposes, it does provide a handy way to
+        determine which mechanism caused the server to shut down. */
+        if (signal === 'SIGTERM') {
+          expectedShutdownErrors = 0;
+          expect(code).not.toEqual(0);
+        } else {
+          expectedShutdownErrors = 1;
+          expect(code).toEqual(0);
+        }
+      } finally {
+        // Normally the connection ends by server shutdown, and this .end() call returns
+        // a Promise which never gets fulfilled.  So we sign up for and wait for the event.
+        const _ = connection.end();
+        await endPromise;
+      }
+
+      await yieldImmediate();
+      expect(shutdownErrors).toEqual(expectedShutdownErrors);
+    } finally {
+      await birdbox.stop();
+    }
+  };
+
+  test('PgClient Graceful Shutdown Mid-Transaction SIGTERM', async () => {
+    await midTransaction('SIGTERM');
+  });
+
+  test('PgClient Graceful Shutdown Mid-Transaction SIGINT', async () => {
+    await midTransaction('SIGINT');
+  });
+
+  const waitForTransaction = async (signal: 'SIGTERM') => {
+    const birdbox = await makeBirdbox(longGracefulTimeoutSecs);
+    try {
+      const connection: PgClient = unconnectedPostgresClient('admin', 'admin_password');
+
+      let endResolve: () => void;
+      const endPromise = new Promise<void>((res, _rej) => {
+        endResolve = res;
+      });
+      await connection.connect();
+
+      let connectionEnded = false;
+      connection.on('end', () => {
+        connectionEnded = true;
+        endResolve();
+      });
+      let logTerminationErrors = true;
+      let shutdownErrors = 0;
+      connection.on('error', (e: Error) => {
+        const err = e as any;
+        if (err.severity === 'FATAL' && err.code === '57P01') {
+          shutdownErrors += 1;
+        } else if (logTerminationErrors && err.message !== 'Connection terminated unexpectedly') {
+          console.log(err);
+        }
+      });
+      try {
+        // 1. Begin a transaction
+        const beginRes = await connection.query(
+          'BEGIN'
+        );
+        expect(beginRes.command).toEqual('BEGIN');
+
+        // 2. Kill Cube with SIGTERM.
+        birdbox.killCube(signal);
+
+        // 3. Run a query (because why not?).
+        const selectRes = await connection.query(
+          'SELECT COUNT(*) as cn, "status" FROM Orders GROUP BY 2 ORDER BY cn DESC'
+        );
+        expect(selectRes.rows).toMatchSnapshot('sql_orders');
+
+        // Our SQL api client connection is still open.
+        await yieldImmediate();
+        expect(connectionEnded).toBe(false);
+
+        logTerminationErrors = false;
+
+        // 4. Commit the transaction (or rollback).
+        const commitRes = await connection.query(
+          'COMMIT'
+        );
+        expect(commitRes.command).toEqual('COMMIT');
+
+        // 5. Now wait for the Cube exit result.
+        const code = await birdbox.onCubeExit();
+        expect(code).toEqual(0);
+      } finally {
+        // Normally the connection ends by server shutdown, and this .end() call returns
+        // a Promise which never gets fulfilled.  So we sign up for and wait for the event.
+        const _ = connection.end();
+        await endPromise;
+      }
+
+      await yieldImmediate();
+      expect(shutdownErrors).toEqual(1);
+    } finally {
+      await birdbox.stop();
+    }
+  };
+
+  test('PgClient Graceful Shutdown Finishing Transaction', async () => {
+    await waitForTransaction('SIGTERM');
+  });
+});

--- a/rust/cubesql/cubesql/src/bin/cubesqld.rs
+++ b/rust/cubesql/cubesql/src/bin/cubesqld.rs
@@ -1,5 +1,5 @@
 use cubesql::{
-    config::{Config, CubeServices},
+    config::{processing_loop::ShutdownMode, Config, CubeServices},
     telemetry::{LocalReporter, ReportingLogger},
 };
 
@@ -58,7 +58,7 @@ async fn stop_on_ctrl_c(s: &Arc<CubeServices>) {
             counter += 1;
             if counter == 1 {
                 log::info!("Received Ctrl+C, shutting down.");
-                s.stop_processing_loops().await.ok();
+                s.stop_processing_loops(ShutdownMode::Fast).await.ok();
             } else if counter == 3 {
                 log::info!("Received Ctrl+C 3 times, exiting immediately.");
                 std::process::exit(130); // 130 is the default exit code when killed by a signal.

--- a/rust/cubesql/cubesql/src/config/mod.rs
+++ b/rust/cubesql/cubesql/src/config/mod.rs
@@ -4,7 +4,7 @@ pub mod processing_loop;
 use crate::{
     config::{
         injection::{DIService, Injector},
-        processing_loop::ProcessingLoop,
+        processing_loop::{ProcessingLoop, ShutdownMode},
     },
     sql::{PostgresServer, ServerManager, SessionManager, SqlAuthDefaultImpl, SqlAuthService},
     transport::{HttpTransport, TransportService},
@@ -60,12 +60,15 @@ impl CubeServices {
         Ok(futures)
     }
 
-    pub async fn stop_processing_loops(&self) -> Result<(), CubeError> {
+    pub async fn stop_processing_loops(
+        &self,
+        shutdown_mode: ShutdownMode,
+    ) -> Result<(), CubeError> {
         if self.injector.has_service_typed::<PostgresServer>().await {
             self.injector
                 .get_service_typed::<PostgresServer>()
                 .await
-                .stop_processing()
+                .stop_processing(shutdown_mode)
                 .await?;
         }
 

--- a/rust/cubesql/cubesql/src/config/processing_loop.rs
+++ b/rust/cubesql/cubesql/src/config/processing_loop.rs
@@ -1,9 +1,21 @@
 use crate::CubeError;
 use async_trait::async_trait;
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum ShutdownMode {
+    // Note that these values are ordered from least-urgent to most-urgent.
+
+    // Postgres "Smart" mode leaves connections up until the client terminates them.
+    Smart,
+    // Shuts down connections when they have no pending operations.
+    SemiFast,
+    // Sends fatal error messages to clients and shuts down as soon as it can.  Same as Postgres "Fast" mode.
+    Fast,
+}
+
 #[async_trait]
 pub trait ProcessingLoop: Send + Sync {
     async fn processing_loop(&self) -> Result<(), CubeError>;
 
-    async fn stop_processing(&self) -> Result<(), CubeError>;
+    async fn stop_processing(&self, mode: ShutdownMode) -> Result<(), CubeError>;
 }

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -219,8 +219,15 @@ impl From<Box<bincode::ErrorKind>> for CubeError {
     }
 }
 
-impl From<tokio::sync::watch::error::SendError<bool>> for CubeError {
-    fn from(v: tokio::sync::watch::error::SendError<bool>) -> Self {
+impl
+    From<tokio::sync::watch::error::SendError<Option<crate::config::processing_loop::ShutdownMode>>>
+    for CubeError
+{
+    fn from(
+        v: tokio::sync::watch::error::SendError<
+            Option<crate::config::processing_loop::ShutdownMode>,
+        >,
+    ) -> Self {
         CubeError::internal(v.to_string())
     }
 }

--- a/rust/cubesql/cubesql/src/sql/postgres/service.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/service.rs
@@ -65,7 +65,7 @@ impl ProcessingLoop for PostgresServer {
                                 break;
                             }
                             None => {
-                                panic!("Unreachable None case greater than some other value");
+                                unreachable!("mode compared greater than something; it can't be None");
                             }
                         }
                     } else {
@@ -172,7 +172,7 @@ impl ProcessingLoop for PostgresServer {
                             _ => {
                                 // Because of comparisons made, the smallest and 2nd smallest
                                 // Option<ShutdownMode> values are impossible.
-                                panic!("Unreachable mode={:?} case", active_shutdown_mode);
+                                unreachable!("impossible mode value, where mode={:?}", active_shutdown_mode);
                             }
                         }
                     } else {

--- a/rust/cubesql/cubesql/src/sql/postgres/service.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/service.rs
@@ -8,7 +8,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    config::processing_loop::ProcessingLoop,
+    config::processing_loop::{ProcessingLoop, ShutdownMode},
     sql::{session::DatabaseProtocol, SessionManager},
     telemetry::{ContextLogger, SessionLogger},
     CubeError,
@@ -19,8 +19,8 @@ use super::shim::AsyncPostgresShim;
 pub struct PostgresServer {
     // options
     address: String,
-    close_socket_rx: RwLock<watch::Receiver<bool>>,
-    close_socket_tx: watch::Sender<bool>,
+    close_socket_rx: RwLock<watch::Receiver<Option<ShutdownMode>>>,
+    close_socket_tx: watch::Sender<Option<ShutdownMode>>,
     // reference
     session_manager: Arc<SessionManager>,
 }
@@ -34,19 +34,40 @@ impl ProcessingLoop for PostgresServer {
 
         println!("🔗 Cube SQL (pg) is listening on {}", self.address);
 
-        let shim_cancellation_token = CancellationToken::new();
+        let fast_shutdown_interruptor = CancellationToken::new();
+        let semifast_shutdown_interruptor = CancellationToken::new();
 
         let mut joinset = tokio::task::JoinSet::new();
+        let mut active_shutdown_mode: Option<ShutdownMode> = None;
 
         loop {
             let mut stop_receiver = self.close_socket_rx.write().await;
             let (socket, _) = tokio::select! {
-                res = stop_receiver.changed() => {
-                    if res.is_err() || *stop_receiver.borrow() {
-                        trace!("[pg] Stopping processing_loop via channel");
+                _ = stop_receiver.changed() => {
+                    let mode = *stop_receiver.borrow();
+                    if mode > active_shutdown_mode {
+                        active_shutdown_mode = mode;
+                        match active_shutdown_mode {
+                            Some(ShutdownMode::Fast) => {
+                                trace!("[pg] Stopping processing_loop via channel, fast mode");
 
-                        shim_cancellation_token.cancel();
-                        break;
+                                fast_shutdown_interruptor.cancel();
+                                break;
+                            }
+                            Some(ShutdownMode::SemiFast) => {
+                                trace!("[pg] Stopping processing_loop via channel, semifast mode");
+
+                                semifast_shutdown_interruptor.cancel();
+                                break;
+                            }
+                            Some(ShutdownMode::Smart) => {
+                                trace!("[pg] Stopping processing_loop via interruptor, smart mode");
+                                break;
+                            }
+                            None => {
+                                panic!("Unreachable None case greater than some other value");
+                            }
+                        }
                     } else {
                         continue;
                     }
@@ -87,10 +108,12 @@ impl ProcessingLoop for PostgresServer {
             let connection_id = session.state.connection_id;
             let session_manager = self.session_manager.clone();
 
-            let connection_interruptor = shim_cancellation_token.clone();
+            let fast_shutdown_interruptor = fast_shutdown_interruptor.clone();
+            let semifast_shutdown_interruptor = semifast_shutdown_interruptor.clone();
             let join_handle: tokio::task::JoinHandle<()> = tokio::spawn(async move {
                 let handler = AsyncPostgresShim::run_on(
-                    connection_interruptor,
+                    fast_shutdown_interruptor,
+                    semifast_shutdown_interruptor,
                     socket,
                     session.clone(),
                     logger.clone(),
@@ -121,24 +144,64 @@ impl ProcessingLoop for PostgresServer {
             });
         }
 
+        // Close the listening socket (so we _visibly_ stop accepting incoming connections) before
+        // we wait for the outstanding connection tasks finish.
+        std::mem::drop(listener);
+
         // Now that we've had the stop signal, wait for outstanding connection tasks to finish
         // cleanly.
-        while let Some(_) = joinset.join_next().await {
-            // We do nothing here, same as the join_next() handler in the loop.
+
+        loop {
+            let mut stop_receiver = self.close_socket_rx.write().await;
+            tokio::select! {
+                _ = stop_receiver.changed() => {
+                    let mode = *stop_receiver.borrow();
+                    if mode > active_shutdown_mode {
+                        active_shutdown_mode = mode;
+                        match active_shutdown_mode {
+                            Some(ShutdownMode::Fast) => {
+                                trace!("[pg] Stopping processing_loop via channel: upgrading to fast mode");
+
+                                fast_shutdown_interruptor.cancel();
+                            }
+                            Some(ShutdownMode::SemiFast) => {
+                                trace!("[pg] Stopping processing_loop via channel: upgrading to semifast mode");
+
+                                semifast_shutdown_interruptor.cancel();
+                            }
+                            _ => {
+                                // Because of comparisons made, the smallest and 2nd smallest
+                                // Option<ShutdownMode> values are impossible.
+                                panic!("Unreachable mode={:?} case", active_shutdown_mode);
+                            }
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+                res = joinset.join_next() => {
+                    if let None = res {
+                        break;
+                    } else {
+                        // We do nothing here, same as the other join_next() cleanup in the prior loop.
+                        continue;
+                    }
+                }
+            }
         }
 
         Ok(())
     }
 
-    async fn stop_processing(&self) -> Result<(), CubeError> {
-        self.close_socket_tx.send(true)?;
+    async fn stop_processing(&self, mode: ShutdownMode) -> Result<(), CubeError> {
+        self.close_socket_tx.send(Some(mode))?;
         Ok(())
     }
 }
 
 impl PostgresServer {
     pub fn new(address: String, session_manager: Arc<SessionManager>) -> Arc<Self> {
-        let (close_socket_tx, close_socket_rx) = watch::channel(false);
+        let (close_socket_tx, close_socket_rx) = watch::channel(None::<ShutdownMode>);
         Arc::new(Self {
             address,
             session_manager,

--- a/rust/cubesql/cubesql/src/sql/session.rs
+++ b/rust/cubesql/cubesql/src/sql/session.rs
@@ -199,6 +199,18 @@ impl SessionState {
         }
     }
 
+    pub fn has_current_query(&self) -> bool {
+        let guard = self
+            .query
+            .read()
+            .expect("failed to unlock query for has_current_query");
+
+        match &*guard {
+            QueryState::None => false,
+            QueryState::Active { .. } => true,
+        }
+    }
+
     pub fn end_query(&self) {
         let mut guard = self
             .query


### PR DESCRIPTION
"Smart" matches the behavior of Postgres -- it stops accepting connections but lets them keep running -- and right now it's not possible.  "Semi-Fast" is willing to end a connection once it has nothing active going on and is triggered by SIGTERM (when graceful shutdown is configured to be enabled).