### PR TITLE
fix(cubesql): Fix incorrect `dateRange` when filtering over `date_trunc`'d column in outer query

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -591,16 +591,16 @@ fn column_name_to_member_to_aliases(
         .collect::<Vec<_>>()
 }
 
-fn member_name_by_alias(
+fn member_name_to_expr_by_alias(
     egraph: &EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>,
     id: Id,
     alias: &str,
-) -> Option<String> {
+) -> Option<MemberNameToExpr> {
     egraph
         .index(id)
         .data
         .find_member(|_, a| a == alias)
-        .and_then(|(m, _a)| m.0.clone())
+        .map(|(m, _a)| m.clone())
 }
 
 fn referenced_columns(referenced_expr: &[Expr]) -> Vec<String> {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#8344 

**Description of Changes Made (if issue reference is not provided)**

This PR fixes an issue with a filter transformation that would transform expression like `col = literal_timestamp` into `dateRange` with the same start and end date; this is generally valid, with the exception of when the `col` is a time dimension **with granularity set**. This case was unhandled, and the filter was incorrect; this is now fixed. Related test is included.
