### PR TITLE
fix(postgres-driver): Don't throw errors for pseudo fields like `__user`

### DIFF
--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -33,6 +33,8 @@ const NativeTypeToPostgresType: Record<string, string> = {};
 Object.entries(types.builtins).forEach(([key, value]) => {
   NativeTypeToPostgresType[value] = key;
 });
+// pg-types lacks the default `unknown` type since it's a pseudo-type
+NativeTypeToPostgresType['705'] = 'UNKNOWN';
 
 const PostgresToGenericType: Record<string, GenericDataBaseType> = {
   // bpchar (“blank-padded char”, the internal name of the character data type)

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -221,6 +221,19 @@ Array [
 ]
 `;
 
+exports[`SQL API Postgres (Data) select null in subquery with streaming 1`] = `
+Array [
+  Object {
+    "usr": null,
+    "val": 789,
+  },
+  Object {
+    "usr": null,
+    "val": 987,
+  },
+]
+`;
+
 exports[`SQL API Postgres (Data) tableau bi fiscal year query: result 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -399,9 +399,21 @@ describe('SQL API', () => {
 
     test('where segment is false', async () => {
       const query =
-        'SELECT value AS val FROM "SegmentTest" WHERE segment_eq_1 IS FALSE ORDER BY value;';
+        'SELECT value AS val, * FROM "SegmentTest" WHERE segment_eq_1 IS FALSE ORDER BY value;';
       const res = await connection.query(query);
       expect(res.rows.map((x) => x.val)).toEqual([789, 987]);
+    });
+
+    test('select null in subquery with streaming', async () => {
+      const query = `
+      SELECT * FROM (
+        SELECT NULL AS "usr", 
+        value AS val 
+        FROM "SegmentTest" WHERE segment_eq_1 IS FALSE 
+        ORDER BY value
+      ) "y";`;
+      const res = await connection.query(query);
+      expect(res.rows).toMatchSnapshot();
     });
 
     test('tableau bi fiscal year query', async () => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adapted from 393b193.
This PR resolves an issue when running queries like `SELECT field, * FROM ...` with `CUBESQL_STREAM_MODE` set to `true`. As the query contains pseudo fields like `__user`, those are interpreted as `unknown` type with oid `705`. This oid is not defined as part of the `pg-types` library, so we define it locally. Related test is included.
