### PR TITLE
fix(cubesql): Fix "unable to represent JsFunction in Python" in queries when using python for cube configuration

### DIFF
--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -41,8 +41,8 @@ const getPivotQuery = (queryType, queries) => {
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$/);
 const dimensionWithTime = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.(second|minute|hour|day|week|month|year))?$/);
-const memberExpression = Joi.object().keys({
-  expression: Joi.func().required(),
+const parsedMemberExpression = Joi.object().keys({
+  expression: Joi.array().items(Joi.string()).min(1).required(),
   cubeName: Joi.string().required(),
   name: Joi.string().required(),
   expressionName: Joi.string(),
@@ -52,6 +52,9 @@ const memberExpression = Joi.object().keys({
     id: Joi.number().required(),
     subId: Joi.number()
   })
+});
+const memberExpression = parsedMemberExpression.keys({
+  expression: Joi.func().required(),
 });
 
 const operators = [
@@ -95,8 +98,8 @@ const oneCondition = Joi.object().keys({
 
 const querySchema = Joi.object().keys({
   // TODO add member expression alternatives only for SQL API queries?
-  measures: Joi.array().items(Joi.alternatives(id, memberExpression)),
-  dimensions: Joi.array().items(Joi.alternatives(dimensionWithTime, memberExpression)),
+  measures: Joi.array().items(Joi.alternatives(id, memberExpression, parsedMemberExpression)),
+  dimensions: Joi.array().items(Joi.alternatives(dimensionWithTime, memberExpression, parsedMemberExpression)),
   filters: Joi.array().items(oneFilter, oneCondition),
   timeDimensions: Joi.array().items(Joi.object().keys({
     dimension: id.required(),
@@ -111,7 +114,7 @@ const querySchema = Joi.object().keys({
     Joi.object().pattern(idOrMemberExpressionName, Joi.valid('asc', 'desc')),
     Joi.array().items(Joi.array().min(2).ordered(idOrMemberExpressionName, Joi.valid('asc', 'desc')))
   ),
-  segments: Joi.array().items(Joi.alternatives(id, memberExpression)),
+  segments: Joi.array().items(Joi.alternatives(id, memberExpression, parsedMemberExpression)),
   timezone: Joi.string(),
   limit: Joi.number().integer().min(0),
   offset: Joi.number().integer().min(0),

--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -158,6 +158,7 @@ export class SQLServer {
               sqlQuery,
               streaming,
               context,
+              memberExpressions: true,
               res: (response) => {
                 if ('error' in response) {
                   reject({

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -10,7 +10,6 @@ import {
   TimeMember,
   FilterOperator,
   QueryTimeDimensionGranularity,
-  QueryOrderType,
 } from './strings';
 import { ResultType } from './enums';
 

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -45,8 +45,8 @@ type GroupingSet = {
     subId?: null | number
 };
 
-type MemberExpression = {
-  expression: Function;
+type ParsedMemberExpression = {
+  expression: string[];
   cubeName: string;
   name: string;
   expressionName: string;
@@ -54,12 +54,17 @@ type MemberExpression = {
   groupingSet?: GroupingSet
 };
 
+type MemberExpression = Omit<ParsedMemberExpression, 'expression'> & {
+  expression: Function;
+};
+
 /**
- * Query datetime dimention interface.
+ * Query datetime dimension interface.
  */
 interface QueryTimeDimension {
   dimension: Member;
   dateRange?: string[] | string;
+  compareDateRange?: string[];
   granularity?: QueryTimeDimensionGranularity;
 }
 
@@ -67,11 +72,11 @@ interface QueryTimeDimension {
  * Incoming network query data type.
  */
 interface Query {
-  measures: (Member | MemberExpression)[];
-  dimensions?: (Member | TimeMember | MemberExpression)[];
+  measures: (Member | MemberExpression | ParsedMemberExpression)[];
+  dimensions?: (Member | TimeMember | MemberExpression | ParsedMemberExpression)[];
   filters?: (QueryFilter | LogicalAndFilter | LogicalOrFilter)[];
   timeDimensions?: QueryTimeDimension[];
-  segments?: (Member | MemberExpression)[];
+  segments?: (Member | MemberExpression | ParsedMemberExpression)[];
   limit?: null | number;
   offset?: number;
   total?: boolean;
@@ -108,4 +113,5 @@ export {
   NormalizedQueryFilter,
   NormalizedQuery,
   MemberExpression,
+  ParsedMemberExpression,
 };

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -61,9 +61,9 @@ interface Request extends ExpressRequest {
 }
 
 /**
- * Function that should provides basic query conversion mechanic.
+ * Function that should provide basic query conversion mechanic.
  * Used as a part of a main configuration object of the server-core
- * to provide extendabillity to a query processing logic.
+ * to provide extendability to a query processing logic.
  */
 type QueryRewriteFn =
   (query: Query, context: RequestContext) => Promise<Query>;
@@ -71,7 +71,7 @@ type QueryRewriteFn =
 /**
  * Function that should provides a logic for extracting security
  * context from the request. Used as a part of a main configuration
- * object of the server-core to provide extendabillity to a query
+ * object of the server-core to provide extendability to a query
  * security processing logic.
  * @todo any could be changed to unknown?
  * @todo Maybe we can add type limitations?
@@ -80,9 +80,9 @@ type SecurityContextExtractorFn =
   (ctx: Readonly<RequestContext>) => any;
 
 /**
- * Function that should provides a logic for extracting request
- * extesion context from the request. Used as a part of a main
- * configuration object of the server-core to provide extendabillity
+ * Function that should provide a logic for extracting request
+ * extension context from the request. Used as a part of a main
+ * configuration object of the server-core to provide extendability
  * to a query processing logic.
  */
 type ExtendContextFn =
@@ -99,7 +99,7 @@ type MetaResponseResultFn = (message: MetaResponse | ErrorResponse) => void;
 /**
  * Function that should provides a logic for the response result
  * processing. Used as a part of a main configuration object of the
- * server-core to provide extendabillity for this logic.
+ * server-core to provide extendability for this logic.
  * @todo any could be changed to unknown?
  * @todo Maybe we can add type limitations?
  */

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -140,6 +140,7 @@ type SqlApiRequest = BaseRequest & {
   apiType?: ApiType;
   queryKey: any;
   streaming?: boolean;
+  memberExpressions?: boolean;
 };
 
 /**

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -397,7 +397,7 @@ describe('API Gateway', () => {
             req.authInfo = authorization;
           }
         },
-        queryRewrite: async (query, context) => {
+        queryRewrite: async (query, _context) => {
           query.limit = 2;
           return query;
         }
@@ -732,6 +732,8 @@ describe('API Gateway', () => {
       expect(res.body).toMatchObject(successResult);
     };
 
+    /*
+     Test using this is commented out below
     const wrongPayloadsTestFactory = ({ route, wrongPayloads, scope }: {
       route: string,
       method: string,
@@ -757,6 +759,7 @@ describe('API Gateway', () => {
         expect(res.body.error).toBe(payload.result.error);
       }
     };
+    */
 
     const testConfigs = [
       { route: 'context', successResult: { basePath: 'awesomepathtotest' } },

--- a/packages/cubejs-api-gateway/test/permissions.test.ts
+++ b/packages/cubejs-api-gateway/test/permissions.test.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import request from 'supertest';
-import { ApiGateway, ApiGatewayOptions, Query, Request } from '../src';
+import { ApiGateway, ApiGatewayOptions } from '../src';
 import {
   compilerApi,
   DataSourceStorageMock,
@@ -37,7 +37,7 @@ function createApiGateway(
 describe('Gateway Api Scopes', () => {
   test('CUBEJS_DEFAULT_API_SCOPES', async () => {
     process.env.CUBEJS_DEFAULT_API_SCOPES = '';
-    
+
     let res: request.Response;
     const { app, apiGateway } = createApiGateway();
 
@@ -77,17 +77,17 @@ describe('Gateway Api Scopes', () => {
     const { app, apiGateway } = createApiGateway({
       contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
     });
-  
+
     await request(app)
       .get('/readyz')
       .set('Authorization', AUTH_TOKEN)
       .expect(200);
-  
+
     await request(app)
       .get('/livez')
       .set('Authorization', AUTH_TOKEN)
       .expect(200);
-  
+
     apiGateway.release();
   });
 


### PR DESCRIPTION
- **fix typos**
- **Add unparsedMemberExpressionValidator for query**

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
