### PR TITLE
chore(deps): Bump sasl2-sys to 0.1.22+2.1.28

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "sasl2-sys"
-version = "0.1.20+2.1.28"
+version = "0.1.22+2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e645bd98535fc8fd251c43ba7c7c1f9be1e0369c99b6a5ea719052a773e655c"
+checksum = "05f2a7f7efd9fc98b3a9033272df10709f5ee3fa0eabbd61a527a3a1ed6bd3c6"
 dependencies = [
  "cc",
  "duct",


### PR DESCRIPTION
This versions includes fix for https://github.com/MaterializeInc/rust-sasl/issues/51, which includes unreleased patch for vendored version of cyrus-sasl

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

At the moment `sasl2-sys` have `version = "0.1.20+2.1.28"` in Cargo.lock. This version contains vendored code of cyrus-sasl, that contains a bug (invalid autoconf header check), that leads to warning on older GCC, and that warning turns to error in GCC 14. It looks like this (and there's one more for `clock`):
```
[sasl2-sys 0.1.20+2.1.28] saslutil.c: In function 'sasl_mkchal':
[sasl2-sys 0.1.20+2.1.28] saslutil.c:280:3: error: implicit declaration of function 'time' [-Wimplicit-function-declaration]
[sasl2-sys 0.1.20+2.1.28]   280 |   time(&now);
[sasl2-sys 0.1.20+2.1.28]       |   ^~~~
[sasl2-sys 0.1.20+2.1.28] saslutil.c:66:1: note: 'time' is defined in header '<time.h>'; this is probably fixable by adding '#include <time.h>'
[sasl2-sys 0.1.20+2.1.28]    65 | #include "saslint.h"
[sasl2-sys 0.1.20+2.1.28]   +++ |+#include <time.h>
[sasl2-sys 0.1.20+2.1.28]    66 | #include <saslutil.h>
```
More on GCC change here, look for `implicit-function-declaration` 
https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors
cyrus-sasl already fixed that in master, but haven't released new version yet:
https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262
sasl2-sys have backported that fix in as a patch to vendored version here:
https://github.com/MaterializeInc/rust-sasl/commit/0186e52cef8ae0a5abac45099a546b800a7c0dc2

I've basically ran `cargo update sasl2-sys`, that's it.
