### PR TITLE
fix(server-core): Headers sent multiple times from dev-server handlers crashes it

### DIFF
--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -113,7 +113,7 @@ export class DevServer {
       });
 
       const tablesSchema = await driver.tablesSchema();
-      
+
       this.cubejsServer.event('Dev Server DB Schema Load Success');
       if (Object.keys(tablesSchema || {}).length === 0) {
         this.cubejsServer.event('Dev Server DB Schema Load Empty');
@@ -164,17 +164,17 @@ export class DevServer {
 
       await fs.emptyDir(path.join(options.schemaPath, 'cubes'));
       await fs.emptyDir(path.join(options.schemaPath, 'views'));
-      
+
       await fs.writeFile(path.join(options.schemaPath, 'views', 'example_view.yml'), `# In Cube, views are used to expose slices of your data graph and act as data marts.
-# You can control which measures and dimensions are exposed to BIs or data apps, 
+# You can control which measures and dimensions are exposed to BIs or data apps,
 # as well as the direction of joins between the exposed cubes.
 # You can learn more about views in documentation here - https://cube.dev/docs/schema/reference/view
 
 
-# The following example shows a view defined on top of orders and customers cubes. 
-# Both orders and customers cubes are exposed using the "includes" parameter to 
+# The following example shows a view defined on top of orders and customers cubes.
+# Both orders and customers cubes are exposed using the "includes" parameter to
 # control which measures and dimensions are exposed.
-# Prefixes can also be applied when exposing measures or dimensions. 
+# Prefixes can also be applied when exposing measures or dimensions.
 # In this case, the customers' city dimension is prefixed with the cube name,
 # resulting in "customers_city" when querying the view.
 
@@ -189,10 +189,10 @@ export class DevServer {
 #
 #           - total_amount
 #           - count
-#      
+#
 #       - join_path: orders.customers
 #         prefix: true
-#         includes: 
+#         includes:
 #           - city`);
       await Promise.all(files.map(file => fs.writeFile(path.join(options.schemaPath, 'cubes', file.fileName), file.content)));
 
@@ -530,15 +530,15 @@ export class DevServer {
       if (!variables.CUBEJS_API_SECRET) {
         variables.CUBEJS_API_SECRET = options.apiSecret;
       }
-      
+
       let envs: Record<string, string> = {};
       const envPath = path.join(process.cwd(), '.env');
       if (fs.existsSync(envPath)) {
         envs = dotenv.parse(fs.readFileSync(envPath));
       }
-      
+
       const schemaPath = envs.CUBEJS_SCHEMA_PATH || process.env.CUBEJS_SCHEMA_PATH || 'model';
-      
+
       variables.CUBEJS_EXTERNAL_DEFAULT = 'true';
       variables.CUBEJS_SCHEDULED_REFRESH_DEFAULT = 'true';
       variables.CUBEJS_DEV_MODE = 'true';

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -596,7 +596,7 @@ export class DevServer {
       try {
         await schemaConverter.generate();
       } catch (error) {
-        res.status(400).json({ error: (error as Error).message || error });
+        return res.status(400).json({ error: (error as Error).message || error });
       }
 
       schemaConverter.getSourceFiles().forEach(({ cubeName: currentCubeName, fileName, source }) => {
@@ -605,7 +605,7 @@ export class DevServer {
         }
       });
 
-      res.json('ok');
+      return res.json('ok');
     }));
   }
 

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -77,9 +77,10 @@ export class DevServer {
       try {
         await handler(req, res, next);
       } catch (e) {
-        console.error(((e as Error).stack || e).toString());
-        this.cubejsServer.event('Dev Server Error', { error: ((e as Error).stack || e).toString() });
-        res.status(500).json({ error: ((e as Error).stack || e).toString() });
+        const errorString = ((e as Error).stack || e).toString();
+        console.error(errorString);
+        this.cubejsServer.event('Dev Server Error', { error: errorString });
+        res.status(500).json({ error: errorString });
       }
     };
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

Due to forgotten return, one of request handlers tries to send response twice, leading to rejection, which gets caught, but error handler tries to send response one more time, throwing another exception, and crashing process with unhandled rejection.