### PR TITLE
chore: Align .editorconfig indents with rustfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.rs]
+indent_size = 4


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

.editorconfig have `indent_size = 2` for everything, but current rustfmt rules uses 4. My IDE got coufused, used 2 on editin save, then reformatted with rustfmt to 4, back and forth. 
