### PR TITLE
fix(cubejs-questdb-driver): fix obsolete column name in SHOW TABLES

### DIFF
--- a/packages/cubejs-questdb-driver/src/QuestDriver.ts
+++ b/packages/cubejs-questdb-driver/src/QuestDriver.ts
@@ -206,11 +206,7 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
 
   // eslint-disable-next-line camelcase
   public async getTablesQuery(_schemaName: string): Promise<({ table_name?: string, TABLE_NAME?: string })[]> {
-    const response = await this.query('SHOW TABLES', []);
-
-    return response.map((row: any) => ({
-      table_name: row.table,
-    }));
+    return await this.query('SHOW TABLES', []);
   }
 
   public async tableColumnTypes(table: string) {

--- a/packages/cubejs-questdb-driver/src/QuestDriver.ts
+++ b/packages/cubejs-questdb-driver/src/QuestDriver.ts
@@ -206,7 +206,7 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
 
   // eslint-disable-next-line camelcase
   public async getTablesQuery(_schemaName: string): Promise<({ table_name?: string, TABLE_NAME?: string })[]> {
-    return await this.query('SHOW TABLES', []);
+    return this.query('SHOW TABLES', []);
   }
 
   public async tableColumnTypes(table: string) {

--- a/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
@@ -4,7 +4,7 @@ import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract
 
 export class QuestDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
-    const version = process.env.TEST_QUEST_DB_VERSION || options.version || '7.2';
+    const version = process.env.TEST_QUEST_DB_VERSION || options.version || '8.0.3';
 
     const container = new GenericContainer(`questdb/questdb:${version}`)
       .withExposedPorts(8812)


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

QuestDB returns `table_name` column name instead of `table` from `SHOW TABLES;` SQL starting from v7.3.3.

**Description of Changes Made (if issue reference is not provided)**

* Fix the column name
* Update integration tests to use the latest QuestDB version
