### PR TITLE
fix(cubesql): Transform `IN` filter with one value to `=` with all expressions

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1536,6 +1536,10 @@ fn inlist_expr(expr: impl Display, list: impl Display, negated: impl Display) ->
     format!("(InListExpr {} {} {})", expr, list, negated)
 }
 
+fn inlist_expr_list(exprs: Vec<impl Display>) -> String {
+    flat_list_expr("InListExprList", exprs, true)
+}
+
 fn insubquery_expr(expr: impl Display, subquery: impl Display, negated: impl Display) -> String {
     format!("(InSubqueryExpr {} {} {})", expr, subquery, negated)
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR alters the rewrite rule `in-filter-equal`, allowing all expressions to be transformed, not just constants. Related test is included.
