### PR TITLE
perf(cubesql): More complete usage of member_name_to_expr caching

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -46,7 +46,12 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use egg::{EGraph, Rewrite, Subst, Var};
-use std::{collections::HashSet, fmt::Display, ops::Index, sync::Arc};
+use std::{
+    collections::HashSet,
+    fmt::Display,
+    ops::{Index, IndexMut},
+    sync::Arc,
+};
 
 pub struct FilterRules {
     meta_context: Arc<MetaContext>,
@@ -2617,13 +2622,18 @@ impl FilterRules {
         let filter_aliases_var = filter_aliases_var.parse().unwrap();
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for expr_op in var_iter!(egraph[subst[op_var]], BinaryExprOp) {
+            let expr_ops: Vec<_> = var_iter!(egraph[subst[op_var]], BinaryExprOp)
+                .cloned()
+                .collect();
+            for expr_op in expr_ops {
                 if let Some(ConstantFolding::Scalar(literal)) =
-                    &egraph[subst[constant_var]].data.constant
+                    &egraph[subst[constant_var]].data.constant.clone()
                 {
-                    for aliases in
+                    let aliases_es: Vec<_> =
                         var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
-                    {
+                            .cloned()
+                            .collect();
+                    for aliases in aliases_es {
                         if let Some((member_name, granularity, cube)) =
                             Self::filter_member_name_with_granularity(
                                 egraph,
@@ -2850,9 +2860,13 @@ impl FilterRules {
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
             if let Some(ConstantFolding::Scalar(literal)) =
-                &egraph[subst[literal_var]].data.constant
+                &egraph[subst[literal_var]].data.constant.clone()
             {
-                for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+                let aliases_es: Vec<Vec<(String, String)>> =
+                    var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                        .cloned()
+                        .collect();
+                for aliases in aliases_es {
                     let literal_value = match literal {
                         ScalarValue::Utf8(Some(literal_value)) => literal_value.to_string(),
                         _ => continue,
@@ -3002,7 +3016,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<Vec<(String, String)>> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some((left_member_name, _)) = Self::filter_member_name(
                     egraph,
                     subst,
@@ -3047,7 +3065,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<Vec<(String, String)>> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some((left_member_name, _)) = Self::filter_member_name(
                     egraph,
                     subst,
@@ -3141,8 +3163,18 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for year in var_iter!(egraph[subst[year_var]], LiteralExprValue) {
-                for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let years: Vec<ScalarValue> = var_iter!(egraph[subst[year_var]], LiteralExprValue)
+                .cloned()
+                .collect();
+            if years.is_empty() {
+                return false;
+            }
+            let aliases_es: Vec<Vec<(String, String)>> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for year in years {
+                for aliases in aliases_es.iter() {
                     if let ScalarValue::Int64(Some(year)) = year {
                         let year = year.clone();
                         if year < 1000 || year > 9999 {
@@ -3208,12 +3240,27 @@ impl FilterRules {
         let filter_aliases_var = filter_aliases_var.parse().unwrap();
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for expr_op in var_iter!(egraph[subst[op_var]], BinaryExprOp) {
-                for literal in var_iter!(egraph[subst[literal_var]], LiteralExprValue) {
-                    for aliases in
-                        var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
-                    {
-                        if expr_op == &Operator::Eq {
+            let expr_ops: Vec<Operator> = var_iter!(egraph[subst[op_var]], BinaryExprOp)
+                .cloned()
+                .collect();
+            if expr_ops.is_empty() {
+                return false;
+            }
+            let literals: Vec<ScalarValue> =
+                var_iter!(egraph[subst[literal_var]], LiteralExprValue)
+                    .cloned()
+                    .collect();
+            if literals.is_empty() {
+                return false;
+            }
+            let aliases_es: Vec<Vec<(String, String)>> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for expr_op in expr_ops {
+                for literal in literals.iter() {
+                    for aliases in aliases_es.iter() {
+                        if expr_op == Operator::Eq {
                             if literal == &ScalarValue::Boolean(Some(true))
                                 || literal == &ScalarValue::Utf8(Some("true".to_string()))
                             {
@@ -3336,7 +3383,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<_> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some(list) = &egraph[subst[list_var]].data.constant_in_list {
                     let values = list
                         .into_iter()
@@ -3458,7 +3509,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<_> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some((member_name, cube)) = Self::filter_member_name(
                     egraph,
                     subst,
@@ -3550,7 +3605,7 @@ impl FilterRules {
     }
 
     fn filter_member_name(
-        egraph: &EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>,
+        egraph: &mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>,
         subst: &Subst,
         meta_context: &Arc<MetaContext>,
         alias_to_cube_var: Var,
@@ -3571,7 +3626,7 @@ impl FilterRules {
     }
 
     fn filter_member_name_with_granularity(
-        egraph: &EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>,
+        egraph: &mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>,
         subst: &Subst,
         meta_context: &Arc<MetaContext>,
         alias_to_cube_var: Var,
@@ -3579,9 +3634,18 @@ impl FilterRules {
         members_var: Var,
         aliases: &Vec<(String, String)>,
     ) -> Option<(String, Option<String>, V1CubeMeta)> {
-        for alias_to_cube in var_iter!(egraph[subst[alias_to_cube_var]], FilterReplacerAliasToCube)
-        {
-            for column in var_iter!(egraph[subst[column_var]], ColumnExprColumn).cloned() {
+        let alias_to_cubes: Vec<_> =
+            var_iter!(egraph[subst[alias_to_cube_var]], FilterReplacerAliasToCube)
+                .cloned()
+                .collect();
+        if alias_to_cubes.is_empty() {
+            return None;
+        }
+        let columns: Vec<_> = var_iter!(egraph[subst[column_var]], ColumnExprColumn)
+            .cloned()
+            .collect();
+        for alias_to_cube in alias_to_cubes {
+            for column in columns.iter() {
                 let alias_name = expr_column_name(&Expr::Column(column.clone()), &None);
 
                 let member_name = aliases
@@ -3593,9 +3657,9 @@ impl FilterRules {
                 } else {
                     // TODO: aliases are not enough?
                     egraph
-                        .index(subst[members_var])
+                        .index_mut(subst[members_var])
                         .data
-                        .find_member_by_alias_immutably(&alias_name)
+                        .find_member_by_alias(&alias_name)
                         .map(|((member_name, member, _), _)| {
                             let member_name: Option<String> = member_name.clone();
                             if let Member::TimeDimension { granularity, .. } = member {
@@ -3614,7 +3678,7 @@ impl FilterRules {
                         return Some((member_name, granularity, cube));
                     }
                 } else if let Some((_, cube)) =
-                    meta_context.find_cube_by_column(alias_to_cube, &column)
+                    meta_context.find_cube_by_column(&alias_to_cube, &column)
                 {
                     if let Some(original_name) = Self::original_member_name(&cube, &column.name) {
                         return Some((original_name, granularity, cube));
@@ -3663,7 +3727,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<_> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some((member_name, cube)) = Self::filter_member_name(
                     egraph,
                     subst,
@@ -3746,7 +3814,11 @@ impl FilterRules {
         let filter_aliases_var = var!(filter_aliases_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<_> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 if let Some((member_name, cube)) = Self::filter_member_name(
                     egraph,
                     subst,
@@ -4290,17 +4362,33 @@ impl FilterRules {
         let filter_values_var = var!(filter_values_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            for escape_char in var_iter!(egraph[subst[escape_char_var]], LikeExprEscapeChar) {
+            let escape_chars: Vec<Option<char>> =
+                var_iter!(egraph[subst[escape_char_var]], LikeExprEscapeChar)
+                    .cloned()
+                    .collect();
+            if escape_chars.is_empty() {
+                return false;
+            }
+            let literals: Vec<ScalarValue> =
+                var_iter!(egraph[subst[literal_var]], LiteralExprValue)
+                    .cloned()
+                    .collect();
+            if literals.is_empty() {
+                return false;
+            }
+            for escape_char in escape_chars {
                 if let Some('!') = escape_char {
-                    for literal in var_iter!(egraph[subst[literal_var]], LiteralExprValue) {
+                    for literal in literals.iter() {
                         let literal_value = match &literal {
                             ScalarValue::Utf8(Some(literal_value)) => literal_value.to_string(),
                             _ => continue,
                         };
 
-                        for aliases in
+                        let aliases_es: Vec<_> =
                             var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
-                        {
+                                .cloned()
+                                .collect();
+                        for aliases in aliases_es {
                             if let Some((member_name, cube)) = Self::filter_member_name(
                                 egraph,
                                 subst,
@@ -4466,16 +4554,20 @@ impl FilterRules {
         let new_filter_var = var!(new_filter_var);
         let meta_context = self.meta_context.clone();
         move |egraph, subst| {
-            let Some(list) = &egraph[subst[list_var]].data.constant_in_list else {
+            let Some(list) = &egraph[subst[list_var]].data.constant_in_list.clone() else {
                 return false;
             };
             let Some(ConstantFolding::Scalar(ScalarValue::Utf8(Some(granularity)))) =
-                &egraph[subst[granularity_var]].data.constant
+                &egraph[subst[granularity_var]].data.constant.clone()
             else {
                 return false;
             };
 
-            for aliases in var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases) {
+            let aliases_es: Vec<_> =
+                var_iter!(egraph[subst[filter_aliases_var]], FilterReplacerAliases)
+                    .cloned()
+                    .collect();
+            for aliases in aliases_es {
                 let Some((member_name, cube)) = Self::filter_member_name(
                     egraph,
                     subst,

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1,14 +1,15 @@
 use crate::{
     compile::rewrite::{
         agg_fun_expr, aggregate, alias_expr, all_members,
-        analysis::{ConstantFolding, LogicalPlanAnalysis, OriginalExpr},
-        binary_expr, cast_expr, change_user_expr, column_expr, column_name_to_member_to_aliases,
-        column_name_to_member_vec, cross_join, cube_scan, cube_scan_filters_empty_tail,
-        cube_scan_members, cube_scan_members_empty_tail, cube_scan_order_empty_tail,
-        dimension_expr, expr_column_name, fun_expr, join, like_expr, limit,
-        list_concat_pushdown_replacer, list_concat_pushup_replacer, literal_expr, literal_member,
-        measure_expr, member_pushdown_replacer, member_replacer, merged_members_replacer,
-        original_expr_name, projection, referenced_columns, rewrite,
+        analysis::{
+            ConstantFolding, LogicalPlanAnalysis, LogicalPlanData, MemberNamesToExpr, OriginalExpr,
+        },
+        binary_expr, cast_expr, change_user_expr, column_expr, cross_join, cube_scan,
+        cube_scan_filters_empty_tail, cube_scan_members, cube_scan_members_empty_tail,
+        cube_scan_order_empty_tail, dimension_expr, expr_column_name, fun_expr, join, like_expr,
+        limit, list_concat_pushdown_replacer, list_concat_pushup_replacer, literal_expr,
+        literal_member, measure_expr, member_pushdown_replacer, member_replacer,
+        merged_members_replacer, original_expr_name, projection, referenced_columns, rewrite,
         rewriter::RewriteRules,
         rules::{
             replacer_flat_push_down_node_substitute_rules, replacer_push_down_node,
@@ -1327,59 +1328,70 @@ impl MemberRules {
         let member_pushdown_replacer_alias_to_cube_var =
             var!(member_pushdown_replacer_alias_to_cube_var);
         move |egraph, subst| {
+            let members_id: Id = subst[members_var];
             if let Some(referenced_expr) = &egraph
                 .index(subst[projection_expr_var])
                 .data
                 .referenced_expr
             {
-                for alias_to_cube in
-                    var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube).cloned()
-                {
-                    if let Some(member_name_to_expr) = egraph
-                        .index(subst[members_var])
-                        .data
-                        .member_name_to_expr
-                        .as_ref()
-                        .map(|x| x.list.clone())
-                    {
-                        let column_name_to_member_name =
-                            column_name_to_member_vec(member_name_to_expr);
+                if egraph.index(members_id).data.member_name_to_expr.is_some() {
+                    let aliases_to_cube: Vec<_> =
+                        var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube)
+                            .cloned()
+                            .collect();
+                    let projection_aliases: Vec<_> =
+                        var_iter!(egraph[subst[alias_var]], ProjectionAlias)
+                            .cloned()
+                            .collect();
 
-                        for projection_alias in
-                            var_iter!(egraph[subst[alias_var]], ProjectionAlias).cloned()
-                        {
-                            let mut columns = HashSet::new();
-                            columns.extend(referenced_columns(referenced_expr).into_iter());
-                            if columns.iter().all(|c| {
-                                column_name_to_member_name
-                                    .iter()
-                                    .find(|(cn, _)| c == cn)
-                                    .is_some()
-                            }) {
-                                let replaced_alias_to_cube =
-                                    Self::replace_alias(&alias_to_cube, &projection_alias);
-                                let new_alias_to_cube =
-                                    egraph.add(LogicalPlanLanguage::CubeScanAliasToCube(
-                                        CubeScanAliasToCube(replaced_alias_to_cube.clone()),
-                                    ));
-                                subst.insert(new_alias_to_cube_var, new_alias_to_cube.clone());
+                    if !aliases_to_cube.is_empty() && !projection_aliases.is_empty() {
+                        // TODO: We could, more generally, cache referenced_columns(referenced_expr), which calls expr_column_name.
+                        let mut columns = HashSet::new();
+                        columns.extend(referenced_columns(referenced_expr).into_iter());
 
-                                let member_pushdown_replacer_alias_to_cube = egraph.add(
-                                    LogicalPlanLanguage::MemberPushdownReplacerAliasToCube(
-                                        MemberPushdownReplacerAliasToCube(
-                                            Self::member_replacer_alias_to_cube(
-                                                &alias_to_cube,
-                                                &projection_alias,
+                        for alias_to_cube in aliases_to_cube {
+                            for projection_alias in &projection_aliases {
+                                let all_some = {
+                                    let member_name_to_exprs: &mut MemberNamesToExpr = &mut egraph
+                                        .index_mut(members_id)
+                                        .data
+                                        .member_name_to_expr
+                                        .as_mut()
+                                        .unwrap();
+                                    columns.iter().all(|c| {
+                                        LogicalPlanData::do_find_member_by_alias(
+                                            member_name_to_exprs,
+                                            c,
+                                        )
+                                        .is_some()
+                                    })
+                                };
+                                if all_some {
+                                    let replaced_alias_to_cube =
+                                        Self::replace_alias(&alias_to_cube, &projection_alias);
+                                    let new_alias_to_cube =
+                                        egraph.add(LogicalPlanLanguage::CubeScanAliasToCube(
+                                            CubeScanAliasToCube(replaced_alias_to_cube.clone()),
+                                        ));
+                                    subst.insert(new_alias_to_cube_var, new_alias_to_cube.clone());
+
+                                    let member_pushdown_replacer_alias_to_cube = egraph.add(
+                                        LogicalPlanLanguage::MemberPushdownReplacerAliasToCube(
+                                            MemberPushdownReplacerAliasToCube(
+                                                Self::member_replacer_alias_to_cube(
+                                                    &alias_to_cube,
+                                                    &projection_alias,
+                                                ),
                                             ),
                                         ),
-                                    ),
-                                );
-                                subst.insert(
-                                    member_pushdown_replacer_alias_to_cube_var,
-                                    member_pushdown_replacer_alias_to_cube,
-                                );
+                                    );
+                                    subst.insert(
+                                        member_pushdown_replacer_alias_to_cube_var,
+                                        member_pushdown_replacer_alias_to_cube,
+                                    );
 
-                                return true;
+                                    return true;
+                                }
                             }
                         }
                     }
@@ -1449,42 +1461,45 @@ impl MemberRules {
             var!(member_pushdown_replacer_alias_to_cube_var);
         let new_pushdown_join_var = var!(new_pushdown_join_var);
         move |egraph, subst| {
-            for alias_to_cube in
-                var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube).cloned()
-            {
+            let aliases_to_cube: Vec<_> =
+                var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube)
+                    .cloned()
+                    .collect();
+
+            for alias_to_cube in aliases_to_cube {
                 if let Some(referenced_group_expr) =
                     &egraph.index(subst[group_expr_var]).data.referenced_expr
                 {
                     if let Some(referenced_aggr_expr) =
                         &egraph.index(subst[aggregate_expr_var]).data.referenced_expr
                     {
+                        let mut columns = HashSet::new();
+                        columns.extend(referenced_columns(referenced_group_expr).into_iter());
+                        columns.extend(referenced_columns(referenced_aggr_expr).into_iter());
+
                         let new_pushdown_join = referenced_aggr_expr.is_empty();
 
-                        for can_pushdown_join in var_iter!(
+                        let can_pushdown_joins: Vec<_> = var_iter!(
                             egraph[subst[can_pushdown_join_var]],
                             CubeScanCanPushdownJoin
                         )
                         .cloned()
-                        {
-                            if let Some(member_name_to_expr) = egraph
-                                .index(subst[members_var])
+                        .collect();
+
+                        for can_pushdown_join in can_pushdown_joins {
+                            if let Some(member_names_to_expr) = &mut egraph
+                                .index_mut(subst[members_var])
                                 .data
                                 .member_name_to_expr
-                                .as_ref()
-                                .map(|x| x.list.clone())
                             {
-                                let member_column_names =
-                                    column_name_to_member_vec(member_name_to_expr);
-
-                                let mut columns = HashSet::new();
-                                columns
-                                    .extend(referenced_columns(referenced_group_expr).into_iter());
-                                columns
-                                    .extend(referenced_columns(referenced_aggr_expr).into_iter());
                                 // TODO default count member is not in the columns set but it should be there
 
                                 if columns.iter().all(|c| {
-                                    member_column_names.iter().find(|(cn, _)| c == cn).is_some()
+                                    LogicalPlanData::do_find_member_by_alias(
+                                        member_names_to_expr,
+                                        c,
+                                    )
+                                    .is_some()
                                 }) {
                                     let member_pushdown_replacer_alias_to_cube = egraph.add(
                                         LogicalPlanLanguage::MemberPushdownReplacerAliasToCube(
@@ -2644,46 +2659,59 @@ impl MemberRules {
         let left_aliases_var = var!(left_aliases_var);
         let right_aliases_var = var!(right_aliases_var);
         move |egraph, subst| {
-            if let Some(member_name_to_expr) = egraph
+            if egraph
                 .index(subst[left_aliases_var])
                 .data
                 .member_name_to_expr
-                .as_ref()
-                .map(|x| x.list.clone())
+                .is_some()
             {
-                let column_name_to_member_name = column_name_to_member_vec(member_name_to_expr);
-                let left_aliases = column_name_to_member_to_aliases(column_name_to_member_name);
-
-                if let Some(member_name_to_expr) = egraph
+                if egraph
                     .index(subst[right_aliases_var])
                     .data
                     .member_name_to_expr
-                    .as_ref()
-                    .map(|x| x.list.clone())
+                    .is_some()
                 {
-                    let column_name_to_member_name = column_name_to_member_vec(member_name_to_expr);
-                    let right_aliases =
-                        column_name_to_member_to_aliases(column_name_to_member_name);
-                    for left_join_on in var_iter!(egraph[subst[left_on_var]], JoinLeftOn) {
-                        for join_on in left_join_on.iter() {
+                    let left_join_ons: Vec<Vec<_>> =
+                        var_iter!(egraph[subst[left_on_var]], JoinLeftOn)
+                            .map(|elem| elem.iter().cloned().collect())
+                            .collect();
+                    for left_join_on in left_join_ons {
+                        for join_on in left_join_on {
+                            let member_names_to_expr_left = &mut egraph
+                                .index_mut(subst[left_aliases_var])
+                                .data
+                                .member_name_to_expr
+                                .as_mut()
+                                .unwrap();
+
+                            // TODO: Avoid the join_on.*.clone() calls (should be trivial).
                             let mut column_name = join_on.name.clone();
                             if let Some(name) = find_column_by_alias(
                                 &column_name,
-                                &left_aliases,
+                                member_names_to_expr_left,
                                 &join_on.relation.clone().unwrap_or_default(),
                             ) {
                                 column_name = name.split(".").last().unwrap().to_string();
                             }
 
                             if column_name == "__cubeJoinField" {
-                                for right_join_on in
+                                let right_join_ons: Vec<Vec<_>> =
                                     var_iter!(egraph[subst[right_on_var]], JoinRightOn)
-                                {
+                                        .map(|elem| elem.iter().cloned().collect())
+                                        .collect();
+                                for right_join_on in right_join_ons {
                                     for join_on in right_join_on.iter() {
+                                        let member_names_to_expr_right = &mut egraph
+                                            .index_mut(subst[right_aliases_var])
+                                            .data
+                                            .member_name_to_expr
+                                            .as_mut()
+                                            .unwrap();
+
                                         let mut column_name = join_on.name.clone();
                                         if let Some(name) = find_column_by_alias(
                                             &column_name,
-                                            &right_aliases,
+                                            member_names_to_expr_right,
                                             &join_on.relation.clone().unwrap_or_default(),
                                         ) {
                                             column_name =
@@ -2864,16 +2892,15 @@ pub fn min_granularity(granularity_a: &String, granularity_b: &String) -> Option
 
 fn find_column_by_alias(
     column_name: &String,
-    aliases: &Vec<(String, String)>,
+    member_names_to_expr: &mut MemberNamesToExpr,
     cube_alias: &String,
 ) -> Option<String> {
-    if let Some((_, name)) = aliases
-        .iter()
-        .find(|(a, _)| a == &format!("{}.{}", cube_alias, column_name))
-    {
-        return Some(name.to_string());
+    if let Some((tuple, _)) = LogicalPlanData::do_find_member_by_alias(
+        member_names_to_expr,
+        &format!("{}.{}", cube_alias, column_name),
+    ) {
+        return tuple.0.clone();
     }
-
     None
 }
 


### PR DESCRIPTION
Makes column_name_to_member_vec do caching, removes some of its calls.  But also, we replace a bunch of usage of `find_member_by_alias_immutably` with the mutable, caching version.

Most benchmarks do the same or better.  `long_simple_in_number_expr_1k` is one which gets worse, at +9%.  A few of the numbers:

```
power_bi_wrap                    -8.5660%
power_bi_sum_wrap                -9.1824%
long_in_expr                    -12.923%
long_simple_in_number_expr_1k    +9.1547%
```

The main source of *worse* performance would come from pre-emptively copying out and cloning vectors that were previously iterated in-place to avoid holding multiple mutable references to the EGraph.  We could probably deal with that efficiently by using RefCell in the member_name_to_expr field, but we don't do that here.


**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required
