### PR TITLE
chore(ci): update testcontainers for integration tests

### DIFF
--- a/packages/cubejs-crate-driver/package.json
+++ b/packages/cubejs-crate-driver/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.35.0",
     "@cubejs-backend/testing-shared": "^0.35.63",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "publishConfig": {

--- a/packages/cubejs-druid-driver/package.json
+++ b/packages/cubejs-druid-driver/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^27",
     "@types/node": "^16",
     "jest": "^27",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "publishConfig": {

--- a/packages/cubejs-elasticsearch-driver/package.json
+++ b/packages/cubejs-elasticsearch-driver/package.json
@@ -33,7 +33,7 @@
     "@cubejs-backend/linter": "^0.35.0",
     "@types/jest": "^27",
     "jest": "^27",
-    "testcontainers": "^8.12"
+    "testcontainers": "^10.10.4"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-elasticsearch-driver/test/ElasticSearchOpenDistro.integration.js
+++ b/packages/cubejs-elasticsearch-driver/test/ElasticSearchOpenDistro.integration.js
@@ -11,12 +11,17 @@ describe('ElasticSearchDriver OpenDistro', () => {
   const version = process.env.TEST_ELASTIC_OPENDISTRO_VERSION || '1.13.1';
 
   const startContainer = () => new GenericContainer(`amazon/opendistro-for-elasticsearch:${version}`)
-    .withEnv('discovery.type', 'single-node')
-    .withEnv('bootstrap.memory_lock', 'true')
-    .withEnv('ES_JAVA_OPTS', '-Xms512m -Xmx512m')
+    .withEnvironment({
+      'discovery.type': 'single-node',
+      'bootstrap.memory_lock': 'true',
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m',
+    })
     .withExposedPorts(9200)
     .withHealthCheck({
-      test: 'curl -k -u admin:admin --silent --fail https://localhost:9200/_cluster/health || exit 1',
+      test: [
+        'CMD-SHELL',
+        'curl -k -u admin:admin --silent --fail https://localhost:9200/_cluster/health || exit 1'
+      ],
       interval: 3 * 1000,
       startPeriod: 15 * 1000,
       timeout: 500,

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.35.0",
     "@types/generic-pool": "^3.1.9",
-    "testcontainers": "^9.8.0",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "jest": {

--- a/packages/cubejs-mysql-aurora-serverless-driver/docker-compose.yml
+++ b/packages/cubejs-mysql-aurora-serverless-driver/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       timeout: 20s
       interval: 15s
       retries: 5
-      start_period: 20s
 
   router:
     image: koxudaxi/local-data-api:${TEST_LOCAL_DATA_API_VERSION:-0.6.4}

--- a/packages/cubejs-mysql-aurora-serverless-driver/package.json
+++ b/packages/cubejs-mysql-aurora-serverless-driver/package.json
@@ -31,7 +31,7 @@
     "@cubejs-backend/linter": "^0.35.0",
     "@types/data-api-client": "^1.2.1",
     "jest": "^27",
-    "testcontainers": "^8.12"
+    "testcontainers": "^10.10.4"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-mysql-aurora-serverless-driver/test/AuroraServerlessMySqlDriver.integration.js
+++ b/packages/cubejs-mysql-aurora-serverless-driver/test/AuroraServerlessMySqlDriver.integration.js
@@ -21,8 +21,10 @@ describe('AuroraServerlessMySqlDriver', () => {
     );
 
     env = await dc
-      .withEnv('TEST_MYSQL_VERSION', process.env.TEST_MYSQL_VERSION || '5.6.50')
-      .withEnv('TEST_LOCAL_DATA_API_VERSION', process.env.TEST_LOCAL_DATA_API_VERSION || '0.6.4')
+      .withEnvironment({
+        TEST_MYSQL_VERSION: process.env.TEST_MYSQL_VERSION || '5.6.50',
+        TEST_LOCAL_DATA_API_VERSION: process.env.TEST_LOCAL_DATA_API_VERSION || '0.6.4',
+      })
       .withWaitStrategy('mysql', Wait.forHealthCheck())
       .up();
 

--- a/packages/cubejs-mysql-driver/package.json
+++ b/packages/cubejs-mysql-driver/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^27",
     "jest": "^27",
     "stream-to-array": "^2.3.0",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "eslintConfig": {

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.35.0",
     "@cubejs-backend/testing-shared": "^0.35.63",
-    "testcontainers": "^8.4.0",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "publishConfig": {

--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -42,7 +42,7 @@
     "@types/jest": "^27",
     "jest": "^27",
     "should": "^13.2.3",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "jest": {

--- a/packages/cubejs-questdb-driver/package.json
+++ b/packages/cubejs-questdb-driver/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.35.0",
     "@cubejs-backend/testing-shared": "^0.35.63",
-    "testcontainers": "^8.4.0",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2"
   },
   "publishConfig": {

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -80,7 +80,7 @@
     "request-promise": "^4.2.4",
     "source-map-support": "^0.5.19",
     "sqlstring": "^2.3.1",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2",
     "uuid": "^8.3.2"
   },

--- a/packages/cubejs-schema-compiler/test/integration/clickhouse/ClickHouseDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/clickhouse/ClickHouseDbRunner.js
@@ -84,7 +84,7 @@ export class ClickHouseDbRunner {
   testQueries = async (queries, prepareDataSet) => {
     if (!this.container && !process.env.TEST_CLICKHOUSE_HOST) {
       this.container = await new GenericContainer(`clickhouse/clickhouse-server:${this.clickHouseVersion}`)
-        .withExposedPorts(8123)
+        .withExposedPorts(this.port())
         .start();
     }
 
@@ -110,15 +110,15 @@ export class ClickHouseDbRunner {
     // DateTime64: toStartOfDay, toStartOfHour, toStartOfMinute, toStartOfFiveMinutes, toStartOfTenMinutes, toStartOfFifteenMinutes, timeSlot.
     //
     // https://clickhouse.com/docs/en/operations/settings/settings#enable-extended-results-for-datetime-functions
-    const extendedDateTimeResultsOptions = this.supportsExtendedDateTimeResults ? { 
-      enable_extended_results_for_datetime_functions: '1' 
+    const extendedDateTimeResultsOptions = this.supportsExtendedDateTimeResults ? {
+      enable_extended_results_for_datetime_functions: '1'
     } : {};
 
     for (const [query, params] of queries) {
       requests.push(clickHouse.querying(formatSql(query, params), {
         dataObjects: true,
-        queryOptions: { 
-          session_id: clickHouse.sessionId, 
+        queryOptions: {
+          session_id: clickHouse.sessionId,
           join_use_nulls: '1',
           ...extendedDateTimeResultsOptions
         }
@@ -132,6 +132,10 @@ export class ClickHouseDbRunner {
 
   testQuery = async (queryAndParams, prepareDataSet) => this.testQueries([queryAndParams], prepareDataSet)
     .then(res => res[0]);
+
+  port() {
+    return 8123;
+  }
 }
 
 //

--- a/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
@@ -93,11 +93,16 @@ export class MSSqlDbRunner extends BaseDbRunner {
     const version = process.env.TEST_MSSQL_VERSION || '2017-latest';
 
     return new GenericContainer(`mcr.microsoft.com/mssql/server:${version}`)
-      .withEnv('ACCEPT_EULA', 'Y')
-      .withEnv('MSSQL_PID', 'Developer')
-      .withEnv('MSSQL_SA_PASSWORD', this.password())
+      .withEnvironment({
+        ACCEPT_EULA: 'Y',
+        MSSQL_PID: 'Developer',
+        MSSQL_SA_PASSWORD: this.password(),
+      })
       .withHealthCheck({
-        test: `/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${this.password()} -Q "SELECT 1" || exit 1`,
+        test: [
+          'CMD-SHELL',
+          `/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${this.password()} -Q "SELECT 1" || exit 1`
+        ],
         interval: 2 * 1000,
         timeout: 3 * 1000,
         retries: 5,

--- a/packages/cubejs-schema-compiler/test/integration/mysql/MySqlDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/mysql/MySqlDbRunner.js
@@ -83,10 +83,10 @@ export class MySqlDbRunner extends BaseDbRunner {
     const version = process.env.TEST_MYSQL_VERSION || '5.7';
 
     return new GenericContainer(`mysql:${version}`)
-      .withEnv('MYSQL_ROOT_PASSWORD', this.password())
+      .withEnvironment({ MYSQL_ROOT_PASSWORD: this.password() })
       .withExposedPorts(this.port())
       // workaround for MySQL 8 unsupported auth
-      .withCmd('--default-authentication-plugin=mysql_native_password')
+      .withCommand(['--default-authentication-plugin=mysql_native_password'])
       .start();
   }
 

--- a/packages/cubejs-schema-compiler/test/integration/postgres/PostgresDBRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/PostgresDBRunner.js
@@ -125,10 +125,12 @@ export class PostgresDBRunner extends BaseDbRunner {
   async containerLazyInit() {
     const version = process.env.TEST_PGSQL_VERSION || '9.6.8';
 
-    return new GenericContainer('postgres', version)
-      .withEnv('POSTGRES_USER', 'root')
-      .withEnv('POSTGRES_DB', 'model_test')
-      .withEnv('POSTGRES_PASSWORD', this.password())
+    return new GenericContainer(`postgres:${version}`)
+      .withEnvironment({
+        POSTGRES_USER: 'root',
+        POSTGRES_DB: 'model_test',
+        POSTGRES_PASSWORD: this.password(),
+      })
       .withExposedPorts(this.port())
       // .withHealthCheck({
       //   test: 'pg_isready -U root -d model_test',

--- a/packages/cubejs-testing-drivers/package.json
+++ b/packages/cubejs-testing-drivers/package.json
@@ -73,7 +73,7 @@
     "jsonwebtoken": "^8.5.1",
     "pg": "^8.7.3",
     "ramda": "^0.28.0",
-    "testcontainers": "^9.3.0",
+    "testcontainers": "^10.10.4",
     "typescript": "~5.2.2",
     "yaml": "^1.10.2",
     "yargs": "^17.7.1"

--- a/packages/cubejs-testing-shared/package.json
+++ b/packages/cubejs-testing-shared/package.json
@@ -26,7 +26,7 @@
     "@cubejs-backend/shared": "^0.35.63",
     "dedent": "^0.7.0",
     "node-fetch": "^2.6.7",
-    "testcontainers": "^8.12"
+    "testcontainers": "^10.10.4"
   },
   "devDependencies": {
     "@cubejs-backend/linter": "^0.35.0",

--- a/packages/cubejs-testing-shared/src/db-container-runners/clickhouse.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/clickhouse.ts
@@ -11,10 +11,8 @@ export class ClickhouseDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(10 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/crate.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/crate.ts
@@ -11,10 +11,8 @@ export class CrateDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(10 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/cubestore.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/cubestore.ts
@@ -6,17 +6,15 @@ export class CubeStoreDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
     const version = process.env.TEST_CUBESTORE_VERSION || options.version || 'latest';
 
-    const builder = new GenericContainer(`cubejs/cubestore:${version}`)
+    const container = new GenericContainer(`cubejs/cubestore:${version}`)
       .withStartupTimeout(10 * 1000)
       .withExposedPorts(3030);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        builder.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
-    return builder.start();
+    return container.start();
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/materialize.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/materialize.ts
@@ -12,10 +12,8 @@ export class MaterializeDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(10 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/mssql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/mssql.ts
@@ -7,17 +7,17 @@ export class MssqlDbRunner extends DbRunnerAbstract {
     const version = process.env.TEST_MSSQL_VERSION || options.version || '2017-latest';
 
     const container = new GenericContainer(`mcr.microsoft.com/mssql/server:${version}`)
-      .withEnv('ACCEPT_EULA', 'Y')
-      .withEnv('MSSQL_SA_PASSWORD', process.env.TEST_DB_PASSWORD || 'Test1test')
+      .withEnvironment({
+        ACCEPT_EULA: 'Y',
+        MSSQL_SA_PASSWORD: process.env.TEST_DB_PASSWORD || 'Test1test',
+      })
       .withExposedPorts(1433)
       .withWaitStrategy(Wait.forLogMessage('Service Broker manager has started'))
       .withStartupTimeout(30 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
@@ -7,9 +7,11 @@ export class MysqlDBRunner extends DbRunnerAbstract {
     const version = process.env.TEST_MYSQL_VERSION || options.version || '5.7';
 
     const builder = new GenericContainer(`mysql:${version}`)
-      .withEnv('MYSQL_ROOT_PASSWORD', process.env.TEST_DB_PASSWORD || 'Test1test')
+      .withEnvironment({
+        MYSQL_ROOT_PASSWORD: process.env.TEST_DB_PASSWORD || 'Test1test',
+      })
       .withHealthCheck({
-        test: 'mysqladmin ping -h localhost',
+        test: ['CMD-SHELL', 'mysqladmin ping -h localhost'],
         interval: 5 * 1000,
         timeout: 2 * 1000,
         retries: 3,
@@ -23,14 +25,12 @@ export class MysqlDBRunner extends DbRunnerAbstract {
        * workaround for MySQL 8 and unsupported auth in mysql package
        * @link https://github.com/mysqljs/mysql/pull/2233
        */
-      builder.withCmd(['--default-authentication-plugin=mysql_native_password']);
+      builder.withCommand(['--default-authentication-plugin=mysql_native_password']);
     }
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        builder.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      builder.withBindMounts(binds);
     }
 
     return builder.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
@@ -6,7 +6,7 @@ export class MysqlDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
     const version = process.env.TEST_MYSQL_VERSION || options.version || '5.7';
 
-    const builder = new GenericContainer(`mysql:${version}`)
+    const container = new GenericContainer(`mysql:${version}`)
       .withEnvironment({
         MYSQL_ROOT_PASSWORD: process.env.TEST_DB_PASSWORD || 'Test1test',
       })
@@ -25,14 +25,14 @@ export class MysqlDBRunner extends DbRunnerAbstract {
        * workaround for MySQL 8 and unsupported auth in mysql package
        * @link https://github.com/mysqljs/mysql/pull/2233
        */
-      builder.withCommand(['--default-authentication-plugin=mysql_native_password']);
+      container.withCommand(['--default-authentication-plugin=mysql_native_password']);
     }
 
     if (options.volumes) {
       const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
-      builder.withBindMounts(binds);
+      container.withBindMounts(binds);
     }
 
-    return builder.start();
+    return container.start();
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
@@ -8,15 +8,15 @@ export class OracleDBRunner extends DbRunnerAbstract {
     const version = process.env.TEST_ORACLE_VERSION || options.version || '23.4.0';
 
     const container = new GenericContainer(`gvenzl/oracle-free:${version}`)
-      .withEnv('ORACLE_PASSWORD', 'test')
+      .withEnvironment({
+        ORACLE_PASSWORD: 'test'
+      })
       .withWaitStrategy(Wait.forLogMessage('DATABASE IS READY TO USE'))
       .withExposedPorts(1521);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/postgres.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/postgres.ts
@@ -8,9 +8,11 @@ export class PostgresDBRunner extends DbRunnerAbstract {
     const version = process.env.TEST_PGSQL_VERSION || options.version || '9.6.8';
 
     const container = new GenericContainer(`postgres:${version}`)
-      .withEnv('POSTGRES_USER', 'test')
-      .withEnv('POSTGRES_DB', 'test')
-      .withEnv('POSTGRES_PASSWORD', 'test')
+      .withEnvironment({
+        POSTGRES_USER: 'test',
+        POSTGRES_DB: 'test',
+        POSTGRES_PASSWORD: 'test',
+      })
       .withExposedPorts(5432)
       // .withHealthCheck({
       //   test: 'pg_isready -U root -d model_test',
@@ -23,10 +25,8 @@ export class PostgresDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(10 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/prestodb.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/prestodb.ts
@@ -12,10 +12,8 @@ export class PrestoDbRunner extends DbRunnerAbstract {
       .withStartupTimeout(30 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
@@ -11,10 +11,8 @@ export class QuestDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(10 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing-shared/src/db-container-runners/trino.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/trino.ts
@@ -12,10 +12,8 @@ export class TrinoDBRunner extends DbRunnerAbstract {
       .withStartupTimeout(30 * 1000);
 
     if (options.volumes) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const { source, target, bindMode } of options.volumes) {
-        container.withBindMount(source, target, bindMode);
-      }
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
     }
 
     return container.start();

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -102,7 +102,7 @@
     "http-proxy": "^1.18.1",
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.2",
-    "testcontainers": "^8.12",
+    "testcontainers": "^10.10.4",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/packages/cubejs-testing/src/birdbox.ts
+++ b/packages/cubejs-testing/src/birdbox.ts
@@ -325,12 +325,7 @@ export async function startBirdBoxFromContainer(
   }
 
   if (options.env) {
-    for (const k of Object.keys(options.env)) {
-      const val = options.env[k];
-      if (val) {
-        dc = dc.withEnv(k, val);
-      }
-    }
+    dc = dc.withEnvironment(options.env as any);
   }
   if (options.log === Log.PIPE) {
     process.stdout.write(
@@ -340,16 +335,12 @@ export async function startBirdBoxFromContainer(
 
   const env = await dc
     .withStartupTimeout(30 * 1000)
-    .withEnv(
-      'BIRDBOX_CUBEJS_VERSION',
-      process.env.BIRDBOX_CUBEJS_VERSION
-    )
-    .withEnv(
-      'BIRDBOX_CUBESTORE_VERSION',
-      process.env.BIRDBOX_CUBESTORE_VERSION
-    )
-    .withEnv('CUBEJS_TELEMETRY', 'false')
-    .withEnv('CUBEJS_SCHEMA_PATH', 'schema')
+    .withEnvironment({
+      BIRDBOX_CUBEJS_VERSION: process.env.BIRDBOX_CUBEJS_VERSION,
+      BIRDBOX_CUBESTORE_VERSION: process.env.BIRDBOX_CUBESTORE_VERSION,
+      CUBEJS_TELEMETRY: 'false',
+      CUBEJS_SCHEMA_PATH: 'schema',
+    })
     .up();
 
   const host = '127.0.0.1';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8720,32 +8720,12 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
+"@types/node@*", "@types/node@12.12.50", "@types/node@^12", "@types/node@^14", "@types/node@^16", "@types/node@^18":
   version "18.19.42"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.42.tgz#b54ed4752c85427906aab40917b0f7f3d724bf72"
   integrity sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@12.12.50":
-  version "12.12.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
-  integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
-
-"@types/node@^12":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
-
-"@types/node@^14":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
-
-"@types/node@^16":
-  version "16.18.104"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.104.tgz#33d5f4886c54133af0ff02445e57c5254025ee53"
-  integrity sha512-OF3keVCbfPlkzxnnDBUZJn1RiCJzKeadjiW0xTEb0G1SUJ5gDVb3qnzZr2T4uIFvsbKJbXy1v2DN7e2zaEY7jQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -8789,7 +8769,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
+"@types/ramda@0.27.40", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
   version "0.27.40"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.40.tgz#99f307356fe553095ee4d3c2af2b0eb3af7a8413"
   integrity sha512-V99ZfTH2tqVYdLDAlgh2uT+N074HPgqnAsMjALKSBqogYd0HbuuGMqNukJ6fk9Ml/Htaus76fsc4Yh3p7q1VdQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8435,6 +8435,15 @@
     "@types/docker-modem" "*"
     "@types/node" "*"
 
+"@types/dockerode@^3.3.29":
+  version "3.3.30"
+  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.30.tgz#df766a75a9cf1fc6d3cdde7d5329f749fd59d457"
+  integrity sha512-MuxQQ7yQ+VzLbrIV2D8K2YqOYBd5Mz4yGbauEipFcn894bLnGwewNKXGKLlb7wpXTG4dn+13lk51qPXmKJ2+YA==
+  dependencies:
+    "@types/docker-modem" "*"
+    "@types/node" "*"
+    "@types/ssh2" "*"
+
 "@types/dockerode@^3.3.8":
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.9.tgz#8c6e519fd4d0d86717b2c6a864904f4e6aa8af40"
@@ -8749,12 +8758,32 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.12.50", "@types/node@^12", "@types/node@^14", "@types/node@^16", "@types/node@^18":
+"@types/node@*":
   version "18.19.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.41.tgz#27695cf2cac63f22c202b9217c0bcf3fb192a2f0"
   integrity sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@12.12.50":
+  version "12.12.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
+  integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
+
+"@types/node@^12":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^14":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+
+"@types/node@^16":
+  version "16.18.103"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.103.tgz#5557c7c32a766fddbec4b933b1d5c365f89b20a4"
+  integrity sha512-gOAcUSik1nR/CRC3BsK8kr6tbmNIOTpvb1sT+v5Nmmys+Ho8YtnIHP90wEsVK4hTcHndOqPVIlehEGEA5y31bA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -8798,7 +8827,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@0.27.40", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
+"@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
   version "0.27.40"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.40.tgz#99f307356fe553095ee4d3c2af2b0eb3af7a8413"
   integrity sha512-V99ZfTH2tqVYdLDAlgh2uT+N074HPgqnAsMjALKSBqogYd0HbuuGMqNukJ6fk9Ml/Htaus76fsc4Yh3p7q1VdQ==
@@ -10619,6 +10648,19 @@ archiver@^5.3.1:
     tar-stream "^2.2.0"
     zip-stream "^4.1.0"
 
+archiver@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.2.tgz#99991d5957e53bd0303a392979276ac4ddccf3b0"
+  integrity sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==
+  dependencies:
+    archiver-utils "^2.1.0"
+    async "^3.2.4"
+    buffer-crc32 "^0.2.1"
+    readable-stream "^3.6.0"
+    readdir-glob "^1.1.2"
+    tar-stream "^2.2.0"
+    zip-stream "^4.1.0"
+
 are-we-there-yet@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
@@ -10864,6 +10906,11 @@ async-lock@^1.4.0:
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.0.tgz#c8b6630eff68fbbdd8a5b6eb763dac3bfbb8bf02"
   integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
 
+async-lock@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.1.tgz#56b8718915a9b68b10fce2f2a9a3dddf765ef53f"
+  integrity sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==
+
 async-mutex@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
@@ -10910,7 +10957,7 @@ async@^3.2.1, async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
-async@^3.2.5:
+async@^3.2.4, async@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
@@ -11016,6 +11063,11 @@ axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
+
+b4a@^1.6.4:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.6.tgz#a4cc349a3851987c3c4ac2d7785c18744f6da9ba"
+  integrity sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==
 
 babel-core@7.0.0-bridge.0:
   version "7.0.0-bridge.0"
@@ -11250,6 +11302,39 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+bare-events@^2.0.0, bare-events@^2.2.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.4.2.tgz#3140cca7a0e11d49b3edc5041ab560659fd8e1f8"
+  integrity sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==
+
+bare-fs@^2.1.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-2.3.1.tgz#cdbd63dac7a552dfb2b87d18c822298d1efd213d"
+  integrity sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==
+  dependencies:
+    bare-events "^2.0.0"
+    bare-path "^2.0.0"
+    bare-stream "^2.0.0"
+
+bare-os@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-2.4.0.tgz#5de5e3ba7704f459c9656629edca7cc736e06608"
+  integrity sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==
+
+bare-path@^2.0.0, bare-path@^2.1.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-2.1.3.tgz#594104c829ef660e43b5589ec8daef7df6cedb3e"
+  integrity sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==
+  dependencies:
+    bare-os "^2.1.0"
+
+bare-stream@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.1.3.tgz#070b69919963a437cc9e20554ede079ce0a129b2"
+  integrity sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==
+  dependencies:
+    streamx "^2.18.0"
 
 base64-arraybuffer@0.1.4:
   version "0.1.4"
@@ -13565,6 +13650,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
+  dependencies:
+    ms "2.1.2"
+
 debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -14006,6 +14098,13 @@ docker-compose@^0.23.19:
   integrity sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==
   dependencies:
     yaml "^1.10.2"
+
+docker-compose@^0.24.8:
+  version "0.24.8"
+  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.24.8.tgz#6c125e6b9e04cf68ced47e2596ef2bb93ee9694e"
+  integrity sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==
+  dependencies:
+    yaml "^2.2.2"
 
 docker-modem@^3.0.0:
   version "3.0.3"
@@ -15576,6 +15675,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.7"
@@ -20576,7 +20680,7 @@ minimatch@^3.0.5, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -21134,6 +21238,13 @@ node-fetch@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -23696,10 +23807,26 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, pr
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 properties-reader@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.2.0.tgz#41d837fe143d8d5f2386b6a869a1975c0b2c595c"
   integrity sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==
+  dependencies:
+    mkdirp "^1.0.4"
+
+properties-reader@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.3.0.tgz#f3ab84224c9535a7a36e011ae489a79a13b472b2"
+  integrity sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==
   dependencies:
     mkdirp "^1.0.4"
 
@@ -23854,6 +23981,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue-tick@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/queue-tick/-/queue-tick-1.0.1.tgz#f6f07ac82c1fd60f82e098b417a80e52f1f4c142"
+  integrity sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==
 
 quick-lru@^4.0.1:
   version "4.0.1"
@@ -24736,6 +24868,13 @@ readdir-glob@^1.0.0:
   integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
   dependencies:
     minimatch "^3.0.4"
+
+readdir-glob@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.3.tgz#c3d831f51f5e7bfa62fa2ffbe4b508c640f09584"
+  integrity sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==
+  dependencies:
+    minimatch "^5.1.0"
 
 readdir-scoped-modules@^1.0.0:
   version "1.1.0"
@@ -26530,6 +26669,17 @@ stream-to-array@^2.3.0:
   dependencies:
     any-promise "^1.1.0"
 
+streamx@^2.15.0, streamx@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.18.0.tgz#5bc1a51eb412a667ebfdcd4e6cf6a6fc65721ac7"
+  integrity sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==
+  dependencies:
+    fast-fifo "^1.3.2"
+    queue-tick "^1.0.1"
+    text-decoder "^1.1.0"
+  optionalDependencies:
+    bare-events "^2.2.0"
+
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
@@ -26988,6 +27138,17 @@ tar-fs@^2.0.0, tar-fs@^2.1.1:
     pump "^3.0.0"
     tar-stream "^2.1.4"
 
+tar-fs@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.0.6.tgz#eaccd3a67d5672f09ca8e8f9c3d2b89fa173f217"
+  integrity sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==
+  dependencies:
+    pump "^3.0.0"
+    tar-stream "^3.1.5"
+  optionalDependencies:
+    bare-fs "^2.1.1"
+    bare-path "^2.1.0"
+
 tar-fs@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.1.tgz#e44086c1c60d31a4f0cf893b1c4e155dabfae9e2"
@@ -27021,6 +27182,15 @@ tar-stream@^2.0.0, tar-stream@^2.1.4, tar-stream@^2.2.0:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar-stream@^3.1.5:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.1.7.tgz#24b3fb5eabada19fe7338ed6d26e5f7c482e792b"
+  integrity sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==
+  dependencies:
+    b4a "^1.6.4"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
 
 tar@^4.4.12:
   version "4.4.19"
@@ -27221,6 +27391,27 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+testcontainers@^10.10.4:
+  version "10.10.4"
+  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-10.10.4.tgz#35b39be446f8511029e34429e2854c6464143dae"
+  integrity sha512-/vAEbFfF0m8oU+LmnRcETxKCQ28t+zC5Mkdi1QfydrR9HCFEsj1M4UrKWwiCbOa1Y2gLUZ3JX6553oxZb6n7zw==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    "@types/dockerode" "^3.3.29"
+    archiver "^5.3.2"
+    async-lock "^1.4.1"
+    byline "^5.0.0"
+    debug "^4.3.5"
+    docker-compose "^0.24.8"
+    dockerode "^3.3.5"
+    get-port "^5.1.1"
+    node-fetch "^2.7.0"
+    proper-lockfile "^4.1.2"
+    properties-reader "^2.3.0"
+    ssh-remote-port-forward "^1.0.4"
+    tar-fs "^3.0.6"
+    tmp "^0.2.3"
+
 testcontainers@^8.12, testcontainers@^8.4.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-8.12.0.tgz#236dfaec40887348d28bfcd19ebd047eb32f712a"
@@ -27278,6 +27469,13 @@ testcontainers@^9.8.0:
     properties-reader "^2.2.0"
     ssh-remote-port-forward "^1.0.4"
     tar-fs "^2.1.1"
+
+text-decoder@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.1.1.tgz#5df9c224cebac4a7977720b9f083f9efa1aefde8"
+  integrity sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==
+  dependencies:
+    b4a "^1.6.4"
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -27450,6 +27648,11 @@ tmp@^0.2.1, tmp@~0.2.1:
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
     rimraf "^3.0.0"
+
+tmp@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -29211,6 +29414,11 @@ yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.2.2:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e"
+  integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
 
 yargs-parser@20.2.4:
   version "20.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8241,20 +8241,6 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/archiver@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-5.3.1.tgz#02991e940a03dd1a32678fead4b4ca03d0e387ca"
-  integrity sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==
-  dependencies:
-    "@types/glob" "*"
-
-"@types/archiver@^5.3.2":
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-5.3.2.tgz#a9f0bcb0f0b991400e7766d35f6e19d163bdadcc"
-  integrity sha512-IctHreBuWE5dvBDz/0WeKtyVKVRs4h75IblxOACL92wU66v+HGAfEYAOyXkOFphvRJMhuXdI9huDXpX0FC6lCw==
-  dependencies:
-    "@types/readdir-glob" "*"
-
 "@types/babel__code-frame@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.6.tgz#20a899c0d29fba1ddf5c2156a10a2bda75ee6f29"
@@ -8419,22 +8405,6 @@
     "@types/node" "*"
     "@types/ssh2" "*"
 
-"@types/dockerode@^3.3.15":
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.16.tgz#3f6c90385a34af40ca8e07e20d26dea4d520eb7b"
-  integrity sha512-ZAX2VrkTjwjk1808T8m6vMr+CFXSLiDD+tkEkLThI+v83AfzlYQZEWfZKwFyk1PWopSXkdDunmIhrF7sxt+zWg==
-  dependencies:
-    "@types/docker-modem" "*"
-    "@types/node" "*"
-
-"@types/dockerode@^3.3.16":
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.17.tgz#6070d12831a0518adf4755d831bb947bfec1255c"
-  integrity sha512-rhH719FBhfwFcL45AixUE5YWnXsdYEEnGhp/HWubOTowZMcsE4wDANvZi+EOrDLzYy2jI3EougA8par/ILi5Ww==
-  dependencies:
-    "@types/docker-modem" "*"
-    "@types/node" "*"
-
 "@types/dockerode@^3.3.29":
   version "3.3.30"
   resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.30.tgz#df766a75a9cf1fc6d3cdde7d5329f749fd59d457"
@@ -8443,14 +8413,6 @@
     "@types/docker-modem" "*"
     "@types/node" "*"
     "@types/ssh2" "*"
-
-"@types/dockerode@^3.3.8":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.9.tgz#8c6e519fd4d0d86717b2c6a864904f4e6aa8af40"
-  integrity sha512-SYRN5FF/qmwpxUT6snJP5D8k0wgoUKOGVs625XvpRJOOUi6s//UYI4F0tbyE3OmzpI70Fo1+aqpzX27zCrInww==
-  dependencies:
-    "@types/docker-modem" "*"
-    "@types/node" "*"
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
@@ -8759,9 +8721,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "18.19.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.41.tgz#27695cf2cac63f22c202b9217c0bcf3fb192a2f0"
-  integrity sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==
+  version "18.19.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.42.tgz#b54ed4752c85427906aab40917b0f7f3d724bf72"
+  integrity sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==
   dependencies:
     undici-types "~5.26.4"
 
@@ -8781,9 +8743,9 @@
   integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/node@^16":
-  version "16.18.103"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.103.tgz#5557c7c32a766fddbec4b933b1d5c365f89b20a4"
-  integrity sha512-gOAcUSik1nR/CRC3BsK8kr6tbmNIOTpvb1sT+v5Nmmys+Ho8YtnIHP90wEsVK4hTcHndOqPVIlehEGEA5y31bA==
+  version "16.18.104"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.104.tgz#33d5f4886c54133af0ff02445e57c5254025ee53"
+  integrity sha512-OF3keVCbfPlkzxnnDBUZJn1RiCJzKeadjiW0xTEb0G1SUJ5gDVb3qnzZr2T4uIFvsbKJbXy1v2DN7e2zaEY7jQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -8905,13 +8867,6 @@
   dependencies:
     "@types/node" "*"
     safe-buffer "~5.1.1"
-
-"@types/readdir-glob@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/readdir-glob/-/readdir-glob-1.1.1.tgz#27ac2db283e6aa3d110b14ff9da44fcd1a5c38b1"
-  integrity sha512-ImM6TmoF8bgOwvehGviEj3tRdRBbQujr1N+0ypaln/GWjaerOB26jb93vsRHmdMtvVQZQebOlqt2HROark87mQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/redis@^2.8.28":
   version "2.8.32"
@@ -10635,19 +10590,6 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
-archiver@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.1.tgz#21e92811d6f09ecfce649fbefefe8c79e57cbbb6"
-  integrity sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==
-  dependencies:
-    archiver-utils "^2.1.0"
-    async "^3.2.3"
-    buffer-crc32 "^0.2.1"
-    readable-stream "^3.6.0"
-    readdir-glob "^1.0.0"
-    tar-stream "^2.2.0"
-    zip-stream "^4.1.0"
-
 archiver@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.2.tgz#99991d5957e53bd0303a392979276ac4ddccf3b0"
@@ -10900,11 +10842,6 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async-lock@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.0.tgz#c8b6630eff68fbbdd8a5b6eb763dac3bfbb8bf02"
-  integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
 
 async-lock@^1.4.1:
   version "1.4.1"
@@ -14085,20 +14022,6 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-docker-compose@^0.23.17:
-  version "0.23.17"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.17.tgz#8816bef82562d9417dc8c790aa4871350f93a2ba"
-  integrity sha512-YJV18YoYIcxOdJKeFcCFihE6F4M2NExWM/d4S1ITcS9samHKnNUihz9kjggr0dNtsrbpFNc7/Yzd19DWs+m1xg==
-  dependencies:
-    yaml "^1.10.2"
-
-docker-compose@^0.23.19:
-  version "0.23.19"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.19.tgz#9947726e2fe67bdfa9e8efe1ff15aa0de2e10eb8"
-  integrity sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==
-  dependencies:
-    yaml "^1.10.2"
-
 docker-compose@^0.24.8:
   version "0.24.8"
   resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.24.8.tgz#6c125e6b9e04cf68ced47e2596ef2bb93ee9694e"
@@ -14115,14 +14038,6 @@ docker-modem@^3.0.0:
     readable-stream "^3.5.0"
     split-ca "^1.0.1"
     ssh2 "^1.4.0"
-
-dockerode@^3.3.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.3.tgz#7504db10d23866c6f267e7b0b7b4a75fc2203e8d"
-  integrity sha512-lvKV6/NGf2/CYLt5V4c0fd6Fl9XZSCo1Z2HBT9ioKrKLMB2o+gA62Uza8RROpzGvYv57KJx2dKu+ZwSpB//OIA==
-  dependencies:
-    docker-modem "^3.0.0"
-    tar-fs "~2.0.1"
 
 dockerode@^3.3.5:
   version "3.3.5"
@@ -23816,13 +23731,6 @@ proper-lockfile@^4.1.2:
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
-properties-reader@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.2.0.tgz#41d837fe143d8d5f2386b6a869a1975c0b2c595c"
-  integrity sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==
-  dependencies:
-    mkdirp "^1.0.4"
-
 properties-reader@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.3.0.tgz#f3ab84224c9535a7a36e011ae489a79a13b472b2"
@@ -24861,13 +24769,6 @@ readable-stream@^4.2.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readdir-glob@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4"
-  integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
-  dependencies:
-    minimatch "^3.0.4"
 
 readdir-glob@^1.1.2:
   version "1.1.3"
@@ -27128,7 +27029,7 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar-fs@^2.0.0, tar-fs@^2.1.1:
+tar-fs@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
@@ -27411,64 +27312,6 @@ testcontainers@^10.10.4:
     ssh-remote-port-forward "^1.0.4"
     tar-fs "^3.0.6"
     tmp "^0.2.3"
-
-testcontainers@^8.12, testcontainers@^8.4.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-8.12.0.tgz#236dfaec40887348d28bfcd19ebd047eb32f712a"
-  integrity sha512-6qQqKirdURAXH/V6sVnfbgqLAJK/vxP2ED6qcwiLfsZ6McPkF5TGDAPzkVZUmdrx62H3RzuTTdXGoPcLP7KG6g==
-  dependencies:
-    "@balena/dockerignore" "^1.0.2"
-    "@types/archiver" "^5.3.1"
-    "@types/dockerode" "^3.3.8"
-    archiver "^5.3.1"
-    byline "^5.0.0"
-    debug "^4.3.4"
-    docker-compose "^0.23.17"
-    dockerode "^3.3.1"
-    get-port "^5.1.1"
-    properties-reader "^2.2.0"
-    ssh-remote-port-forward "^1.0.4"
-    tar-fs "^2.1.1"
-
-testcontainers@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-9.3.0.tgz#9986bfd1453284d3cc1093c1b77d85409fc228e4"
-  integrity sha512-KSnLqCfbY3FuCqOAvoJhMMbov2tdnavkahTiOTrXK+jcNiIts5ad7Hcd9LN80GWFLzJ//T6S17GpWxBJKXCj0g==
-  dependencies:
-    "@balena/dockerignore" "^1.0.2"
-    "@types/archiver" "^5.3.2"
-    "@types/dockerode" "^3.3.15"
-    archiver "^5.3.1"
-    async-lock "^1.4.0"
-    byline "^5.0.0"
-    debug "^4.3.4"
-    docker-compose "^0.23.19"
-    dockerode "^3.3.5"
-    get-port "^5.1.1"
-    node-fetch "^2.6.9"
-    properties-reader "^2.2.0"
-    ssh-remote-port-forward "^1.0.4"
-    tar-fs "^2.1.1"
-
-testcontainers@^9.8.0:
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-9.8.0.tgz#03d8798ad047e7673e934934b5504bc0a2f14e4e"
-  integrity sha512-61IlJeVrUbS5JlAgM/N0koFnRxsID+vDap7CUmgaHXSGxmFofCiokB7kD96c1BtDWGOznrd7lTAPGSkd3RVkPA==
-  dependencies:
-    "@balena/dockerignore" "^1.0.2"
-    "@types/archiver" "^5.3.2"
-    "@types/dockerode" "^3.3.16"
-    archiver "^5.3.1"
-    async-lock "^1.4.0"
-    byline "^5.0.0"
-    debug "^4.3.4"
-    docker-compose "^0.23.19"
-    dockerode "^3.3.5"
-    get-port "^5.1.1"
-    node-fetch "^2.6.9"
-    properties-reader "^2.2.0"
-    ssh-remote-port-forward "^1.0.4"
-    tar-fs "^2.1.1"
 
 text-decoder@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
This PR updates testcontainer package used in schema-compiler to the latests (10.10 atm) and makes related changes in test code runners