### PR TITLE
fix(cubesql): Apply `IN`->`=` transformation with push down disabled

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1572,8 +1572,8 @@ fn inlist_expr(expr: impl Display, list: impl Display, negated: impl Display) ->
     format!("(InListExpr {} {} {})", expr, list, negated)
 }
 
-fn inlist_expr_list(exprs: Vec<impl Display>) -> String {
-    flat_list_expr("InListExprList", exprs, true)
+fn inlist_expr_list(exprs: Vec<impl Display>, is_flat: bool) -> String {
+    flat_list_expr("InListExprList", exprs, is_flat)
 }
 
 fn insubquery_expr(expr: impl Display, subquery: impl Display, negated: impl Display) -> String {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -54,6 +54,12 @@ pub struct FilterRules {
     eval_stable_functions: bool,
 }
 
+impl FilterRules {
+    fn inlist_expr_list(&self, exprs: Vec<impl Display>) -> String {
+        inlist_expr_list(exprs, self.config_obj.push_down_pull_up_split())
+    }
+}
+
 impl RewriteRules for FilterRules {
     fn rewrite_rules(&self) -> Vec<Rewrite<LogicalPlanLanguage, LogicalPlanAnalysis>> {
         let mut rules = vec![
@@ -394,7 +400,7 @@ impl RewriteRules for FilterRules {
             transforming_rewrite(
                 "in-filter-equal",
                 filter_replacer(
-                    inlist_expr("?expr", inlist_expr_list(vec!["?elem"]), "?negated"),
+                    inlist_expr("?expr", self.inlist_expr_list(vec!["?elem"]), "?negated"),
                     "?alias_to_cube",
                     "?members",
                     "?filter_aliases",


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes a regression introduced with 671e067 which broke `IN`->`=` transformation when push down is set to `false`.
