### PR TITLE
Update passing-dynamic-parameters-in-a-query.mdx

### DIFF
--- a/docs/pages/guides/recipes/data-modeling/passing-dynamic-parameters-in-a-query.mdx
+++ b/docs/pages/guides/recipes/data-modeling/passing-dynamic-parameters-in-a-query.mdx
@@ -10,7 +10,7 @@ redirect_from:
 In some cases we may want to let a user select a filter value and be able to 
 use that value in calculations without filtering the entire query.
 
-In this exmaple, we want to know the ratio between the number of people in a particular city and
+In this example, we want to know the ratio between the number of people in a particular city and
 the total number of women in the country. The user can specify the city for the
 filter. The trick is to get the value of the city from the user and use it in
 the calculation. In the recipe below, we can learn how to join the data table
@@ -77,7 +77,7 @@ cubes:
         sql: id
         type: count
         filters:
-          - sql: "gender = 'female'"
+          - sql: "gender = 'female' and city = city_filter" 
 
       - name: number_of_people_of_any_gender_in_the_city:
         sql: id


### PR DESCRIPTION
# It will return (total_number_of_women * number_of_city), If you didn't not add  "city=city_filter" filter to where clause. 

I tried in SQL SERVER to validate it. Please check it in CUBE before you merge.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
