### PR TITLE
chore(ci): fix integration tests run

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
@@ -89,6 +89,17 @@ export class MSSqlDbRunner extends BaseDbRunner {
     return process.env.TEST_DB_PASSWORD || 'Test1test';
   }
 
+  sqlcmdPrefix(version) {
+    if (version === '2017-latest') {
+      return '/opt/mssql-tools/bin/';
+    }
+
+    // Thanks, Microsoft the last 2019 Version that has same path is "2019-CU27-ubuntu-20.04"
+    // Starting with "2019-latest" published on 08/01/2024 - new path is "/opt/mssql-tools18/bin/"
+    // @see https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2019/cumulativeupdate28#3217207
+    return '/opt/mssql-tools18/bin/';
+  }
+
   async containerLazyInit() {
     const version = process.env.TEST_MSSQL_VERSION || '2017-latest';
 
@@ -98,18 +109,19 @@ export class MSSqlDbRunner extends BaseDbRunner {
         MSSQL_PID: 'Developer',
         MSSQL_SA_PASSWORD: this.password(),
       })
+      .withExposedPorts(this.port())
       .withHealthCheck({
         test: [
           'CMD-SHELL',
-          `/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${this.password()} -Q "SELECT 1" || exit 1`
+          `${this.sqlcmdPrefix(version)}sqlcmd -C -l 1 -S localhost -U sa -P ${this.password()} -Q "SELECT 1" || exit 1`
         ],
-        interval: 2 * 1000,
-        timeout: 3 * 1000,
-        retries: 5,
-        startPeriod: 10 * 1000,
+        interval: 1000,
+        timeout: 1100,
+        retries: 20,
+        startPeriod: 2 * 1000,
       })
-      .withExposedPorts(this.port())
       .withWaitStrategy(Wait.forHealthCheck())
+      .withStartupTimeout(10 * 1000)
       .start();
   }
 


### PR DESCRIPTION
This fixes:
* Ms sql server integration test due to latests changes in `2019-latest` docker image.
* Postgres integration test and introduces correct postges readyness check including possible initdb flow.