### PR TITLE
BUG: Fix QueryBuilder to AVOID Maximum recursive updates exceeded

### DIFF
--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -393,7 +393,6 @@ export default {
         this.skipHeuristics = false;
       }
 
-      this.prevValidatedQuery = validatedQuery;
       return validatedQuery;
     },
   },

--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -393,6 +393,9 @@ export default {
         this.skipHeuristics = false;
       }
 
+      if (JSON.stringify(this.prevValidatedQuery) !== JSON.stringify(validatedQuery)) {
+        this.prevValidatedQuery = validatedQuery;
+      }
       return validatedQuery;
     },
   },

--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -381,11 +381,17 @@ export default {
         };
 
         this.chartType = chartType || this.chartType;
-        this.pivotConfig = ResultSet.getNormalizedPivotConfig(
+        let pivot = ResultSet.getNormalizedPivotConfig(
           validatedQuery,
           pivotConfig !== undefined ? pivotConfig : this.pivotConfig
         );
-        this.copyQueryFromProps(validatedQuery);
+        if (!areQueriesEqual(this.pivotConfig, pivot)) {
+          this.pivotConfig = pivot;
+        }
+
+        if (!areQueriesEqual(this.prevValidatedQuery, validatedQuery)) {
+          this.copyQueryFromProps(validatedQuery);
+        }
       }
 
       // query heuristics should only apply on query change (not applied to the initial query)
@@ -393,7 +399,7 @@ export default {
         this.skipHeuristics = false;
       }
 
-      if (JSON.stringify(this.prevValidatedQuery) !== JSON.stringify(validatedQuery)) {
+      if (!areQueriesEqual(this.prevValidatedQuery, validatedQuery)) {
         this.prevValidatedQuery = validatedQuery;
       }
       return validatedQuery;

--- a/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
@@ -1082,5 +1082,47 @@ describe('QueryBuilder.vue', () => {
         );
       });
     });
+    it('calls copyQueryFromProps if query is changed', async () => {
+      const cube = createCubeApi();
+      jest
+        .spyOn(cube, 'request')
+        .mockImplementation(fetchMock(load))
+        .mockImplementationOnce(fetchMock(meta));
+
+      const copyQueryFromProps = jest.spyOn(QueryBuilder.methods, 'copyQueryFromProps');
+
+      const wrapper = shallowMount(QueryBuilder, {
+        propsData: {
+          cubeApi: cube,
+          query: {
+            measures: ['Orders.count'],
+            timeDimensions: [
+              {
+                dimension: 'Orders.createdAt',
+              },
+            ],
+          },
+        },
+      });
+      await flushPromises();
+
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.measures.length).toEqual(1);
+      expect(wrapper.vm.measures[0].name).toEqual('Orders.count');
+
+      await wrapper.vm.$nextTick();
+
+      expect(copyQueryFromProps).toHaveBeenCalled();
+      expect(copyQueryFromProps).toHaveBeenCalledTimes(1);
+      const initialValidatedQuery = {
+        measures: ['measure1'],
+        dimensions: ['dimension1'],
+      };
+      wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+      await wrapper.vm.$nextTick();
+
+      expect(copyQueryFromProps).toHaveBeenCalledTimes(2);
+      copyQueryFromProps.mockRestore();
+    });
   });
 });

--- a/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
@@ -506,9 +506,9 @@ describe('QueryBuilder.vue', () => {
     it('filters with boolean logical operators without explicit set', async () => {
       const cube = createCubeApi();
       jest
-          .spyOn(cube, 'request')
-          .mockImplementation(fetchMock(load))
-          .mockImplementationOnce(fetchMock(meta));
+        .spyOn(cube, 'request')
+        .mockImplementation(fetchMock(load))
+        .mockImplementationOnce(fetchMock(meta));
 
       const filter = {
         or: [
@@ -901,18 +901,20 @@ describe('QueryBuilder.vue', () => {
 
         const cube = createCubeApi();
         jest
-            .spyOn(cube, 'request')
-            .mockImplementation(fetchMock(load))
-            .mockImplementationOnce(fetchMock(meta));
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
 
         const wrapper = shallowMount(QueryBuilder, {
           propsData: {
             cubeApi: cube,
             query: {
               measures: ['Orders.count'],
-              timeDimensions: [{
-                dimension: 'Orders.createdAt',
-              }],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
             },
           },
         });
@@ -928,23 +930,99 @@ describe('QueryBuilder.vue', () => {
         expect(wrapper.vm.pivotConfig).toEqual(expectedPivotForLine);
         expect(wrapper.vm.chartType).toBe('line');
       });
+      it('should not reassign validatedQuery if it has not changed', async () => {
+        const cube = createCubeApi();
+        jest
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
+
+        const wrapper = shallowMount(QueryBuilder, {
+          propsData: {
+            cubeApi: cube,
+            query: {
+              measures: ['Orders.count'],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
+            },
+          },
+        });
+
+        const initialValidatedQuery = {
+          measures: ['measure1'],
+          dimensions: ['dimension1'],
+        };
+        wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+
+        wrapper.setData({
+          measures: [{ name: 'measure1' }],
+          dimensions: [{ name: 'dimension1' }],
+        });
+
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.prevValidatedQuery.measures).toEqual(initialValidatedQuery.measures);
+        expect(wrapper.vm.prevValidatedQuery.dimensions).toEqual(initialValidatedQuery.dimensions);
+      });
+
+      it('should reassign validatedQuery if it has changed', async () => {
+        const cube = createCubeApi();
+        jest
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
+
+        const wrapper = shallowMount(QueryBuilder, {
+          propsData: {
+            cubeApi: cube,
+            query: {
+              measures: ['Orders.count'],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
+            },
+          },
+        });
+        const initialValidatedQuery = {
+          measures: ['measure1'],
+          dimensions: ['dimension1'],
+        };
+        wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+
+        wrapper.setData({
+          measures: [{ name: 'measure2' }],
+          dimensions: [{ name: 'dimension1' }],
+        });
+
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.prevValidatedQuery.measures).not.toEqual(initialValidatedQuery.measures);
+        expect(wrapper.vm.prevValidatedQuery.dimensions).toEqual(initialValidatedQuery.dimensions);
+      });
     });
     describe('orderMembers', () => {
       it('does not contain time dimension if granularity is set to none', async () => {
         const cube = createCubeApi();
         jest
-            .spyOn(cube, 'request')
-            .mockImplementation(fetchMock(load))
-            .mockImplementationOnce(fetchMock(meta));
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
 
         const wrapper = shallowMount(QueryBuilder, {
           props: {
             cubeApi: cube,
             query: {
               measures: ['Orders.count'],
-              timeDimensions: [{
-                dimension: 'Orders.createdAt',
-              }],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
             },
           },
         });
@@ -953,32 +1031,34 @@ describe('QueryBuilder.vue', () => {
 
         expect(wrapper.vm.orderMembers.length).toBe(1);
         expect(wrapper.vm.orderMembers).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                id: 'Orders.count',
-                title: 'Orders Count',
-                order: 'none',
-              }),
-            ])
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 'Orders.count',
+              title: 'Orders Count',
+              order: 'none',
+            }),
+          ])
         );
       });
 
       it('contains time dimension if granularity is not none', async () => {
         const cube = createCubeApi();
         jest
-            .spyOn(cube, 'request')
-            .mockImplementation(fetchMock(load))
-            .mockImplementationOnce(fetchMock(meta));
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
 
         const wrapper = shallowMount(QueryBuilder, {
           props: {
             cubeApi: cube,
             query: {
               measures: ['Orders.count'],
-              timeDimensions: [{
-                dimension: 'Orders.createdAt',
-                granularity: 'day',
-              }],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                  granularity: 'day',
+                },
+              ],
             },
           },
         });
@@ -987,18 +1067,18 @@ describe('QueryBuilder.vue', () => {
 
         expect(wrapper.vm.orderMembers.length).toBe(2);
         expect(wrapper.vm.orderMembers).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                id: 'Orders.createdAt',
-                title: 'Orders Created at',
-                order: 'none'
-              }),
-              expect.objectContaining({
-                id: 'Orders.count',
-                title: 'Orders Count',
-                order: 'none',
-              })
-            ])
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 'Orders.createdAt',
+              title: 'Orders Created at',
+              order: 'none',
+            }),
+            expect.objectContaining({
+              id: 'Orders.count',
+              title: 'Orders Count',
+              order: 'none',
+            }),
+          ])
         );
       });
     });


### PR DESCRIPTION
fix: Maximum recursive updates exceeded

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Passing a dynamic query to the query builder, can cause "Maximum recursive updates exceeded"

**Description of Changes Made (if issue reference is not provided)**

Avoiding the preValidatedQuery mutation inside the computed block, the error is no loger thronw
