### PR TITLE
fix(cubesql): Split PowerBI count distinct expression

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -19459,4 +19459,50 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
         assert!(sql.contains(" AS DOUBLE PRECISION)"));
         assert!(sql.contains(" AS DECIMAL(38,10))"));
     }
+
+    #[tokio::test]
+    async fn test_powerbi_count_distinct_with_max_case() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            select
+                "rows"."customer_gender" as "customer_gender",
+                count(distinct("rows"."countDistinct")) + max(
+                    case
+                        when "rows"."countDistinct" is null then 1
+                        else 0
+                    end
+                ) as "a0"
+            from
+                "public"."KibanaSampleDataEcommerce" "rows"
+            group by
+                "customer_gender"
+            limit
+                1000001
+            ;"#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.countDistinct".to_string()]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: Some(1000001),
+                offset: None,
+                filters: None,
+                ungrouped: None,
+            }
+        )
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_bi_workarounds.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_bi_workarounds.rs
@@ -1,0 +1,57 @@
+use cubeclient::models::V1LoadRequestQuery;
+
+use crate::{
+    compile::{
+        test::{convert_select_to_query_plan, init_testing_logger},
+        Rewriter,
+    },
+    sql::session::DatabaseProtocol,
+};
+
+use super::LogicalPlanTestUtils;
+
+#[tokio::test]
+async fn test_powerbi_count_distinct_with_max_case() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan(
+        r#"
+        select
+            "rows"."customer_gender" as "customer_gender",
+            count(distinct("rows"."countDistinct")) + max(
+                case
+                    when "rows"."countDistinct" is null then 1
+                    else 0
+                end
+            ) as "a0"
+        from
+            "public"."KibanaSampleDataEcommerce" "rows"
+        group by
+            "customer_gender"
+        limit
+            1000001
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .as_logical_plan();
+
+    assert_eq!(
+        logical_plan.find_cube_scan().request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.countDistinct".to_string()]),
+            dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+            segments: Some(vec![]),
+            time_dimensions: None,
+            order: None,
+            limit: Some(1000001),
+            offset: None,
+            filters: None,
+            ungrouped: None,
+        }
+    )
+}

--- a/rust/cubesql/cubesql/src/compile/test/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/test/utils.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use datafusion::logical_plan::{plan::Extension, Filter, LogicalPlan, PlanVisitor};
+
+use crate::{
+    compile::engine::df::{scan::CubeScanNode, wrapper::CubeScanWrapperNode},
+    CubeError,
+};
+
+pub trait LogicalPlanTestUtils {
+    fn find_cube_scan(&self) -> CubeScanNode;
+
+    fn find_cube_scan_wrapper(&self) -> CubeScanWrapperNode;
+
+    fn find_cube_scans(&self) -> Vec<CubeScanNode>;
+
+    fn find_filter(&self) -> Option<Filter>;
+}
+
+impl LogicalPlanTestUtils for LogicalPlan {
+    fn find_cube_scan(&self) -> CubeScanNode {
+        let cube_scans = find_cube_scans_deep_search(Arc::new(self.clone()), true);
+        if cube_scans.len() != 1 {
+            panic!("The plan includes not 1 cube_scan!");
+        }
+
+        cube_scans[0].clone()
+    }
+
+    fn find_cube_scan_wrapper(&self) -> CubeScanWrapperNode {
+        match self {
+            LogicalPlan::Extension(Extension { node }) => {
+                if let Some(wrapper_node) = node.as_any().downcast_ref::<CubeScanWrapperNode>() {
+                    wrapper_node.clone()
+                } else {
+                    panic!("Root plan node is not cube_scan_wrapper!");
+                }
+            }
+            _ => panic!("Root plan node is not extension!"),
+        }
+    }
+
+    fn find_cube_scans(&self) -> Vec<CubeScanNode> {
+        find_cube_scans_deep_search(Arc::new(self.clone()), true)
+    }
+
+    fn find_filter(&self) -> Option<Filter> {
+        find_filter_deep_search(Arc::new(self.clone()))
+    }
+}
+
+pub fn find_cube_scans_deep_search(
+    parent: Arc<LogicalPlan>,
+    panic_if_empty: bool,
+) -> Vec<CubeScanNode> {
+    pub struct FindCubeScanNodeVisitor(Vec<CubeScanNode>);
+
+    impl PlanVisitor for FindCubeScanNodeVisitor {
+        type Error = CubeError;
+
+        fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
+            if let LogicalPlan::Extension(ext) = plan {
+                if let Some(scan_node) = ext.node.as_any().downcast_ref::<CubeScanNode>() {
+                    self.0.push(scan_node.clone());
+                } else if let Some(wrapper_node) =
+                    ext.node.as_any().downcast_ref::<CubeScanWrapperNode>()
+                {
+                    wrapper_node.wrapped_plan.accept(self)?;
+                }
+            }
+            Ok(true)
+        }
+    }
+
+    let mut visitor = FindCubeScanNodeVisitor(Vec::new());
+    parent.accept(&mut visitor).unwrap();
+
+    if panic_if_empty && visitor.0.len() == 0 {
+        panic!("No CubeScanNode was found in plan");
+    }
+
+    visitor.0
+}
+
+pub fn find_filter_deep_search(parent: Arc<LogicalPlan>) -> Option<Filter> {
+    pub struct FindFilterNodeVisitor(Option<Filter>);
+
+    impl PlanVisitor for FindFilterNodeVisitor {
+        type Error = CubeError;
+
+        fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
+            if let LogicalPlan::Filter(filter) = plan {
+                self.0 = Some(filter.clone());
+            }
+            Ok(true)
+        }
+    }
+
+    let mut visitor = FindFilterNodeVisitor(None);
+    parent.accept(&mut visitor).unwrap();
+    visitor.0
+}


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR splits PowerBI `COUNT(DISTINCT(...)) + MAX(CASE ...)` expression, ignoring NULL values, as we can't count them as distinct yet. Related test is included.