### PR TITLE
fix(cubesql): Fix non-injective functions split rules, make them variadic

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/functions.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/functions.rs
@@ -32,6 +32,10 @@ impl SplitRules {
             ("Substr", false),
             ("Lpad", false),
             ("Rpad", false),
+            ("Coalesce", false),
+            ("NullIf", false),
+            ("Left", false),
+            ("Right", false),
         ];
 
         for (fn_name, with_projection) in fns {
@@ -49,32 +53,6 @@ impl SplitRules {
         self.single_arg_pass_through_rules(
             "is-not-null",
             |expr| is_not_null_expr(expr),
-            false,
-            rules,
-        );
-        // coalesce, nullif, left and right are a bit harder, variadic rule breaks some tests
-        // TODO Support them properly
-        self.single_arg_pass_through_rules(
-            "coalesce-constant",
-            |expr| self.fun_expr("Coalesce", vec![expr, literal_expr("?literal")]),
-            false,
-            rules,
-        );
-        self.single_arg_pass_through_rules(
-            "nullif-constant",
-            |expr| self.fun_expr("NullIf", vec![expr, literal_expr("?literal")]),
-            false,
-            rules,
-        );
-        self.single_arg_pass_through_rules(
-            "left-constant",
-            |expr| self.fun_expr("Left", vec![expr, literal_expr("?literal")]),
-            false,
-            rules,
-        );
-        self.single_arg_pass_through_rules(
-            "right-constant",
-            |expr| self.fun_expr("Right", vec![expr, literal_expr("?literal")]),
             false,
             rules,
         );

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/functions.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/functions.rs
@@ -53,30 +53,29 @@ impl SplitRules {
             rules,
         );
         // coalesce, nullif, left and right are a bit harder, variadic rule breaks some tests
-        // And projection split seems wrong here
         // TODO Support them properly
         self.single_arg_pass_through_rules(
             "coalesce-constant",
             |expr| self.fun_expr("Coalesce", vec![expr, literal_expr("?literal")]),
-            true,
+            false,
             rules,
         );
         self.single_arg_pass_through_rules(
             "nullif-constant",
             |expr| self.fun_expr("NullIf", vec![expr, literal_expr("?literal")]),
-            true,
+            false,
             rules,
         );
         self.single_arg_pass_through_rules(
             "left-constant",
             |expr| self.fun_expr("Left", vec![expr, literal_expr("?literal")]),
-            true,
+            false,
             rules,
         );
         self.single_arg_pass_through_rules(
             "right-constant",
             |expr| self.fun_expr("Right", vec![expr, literal_expr("?literal")]),
-            true,
+            false,
             rules,
         );
         self.single_arg_pass_through_rules("negative", |expr| negative_expr(expr), true, rules);

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_coalesce_from_dimension.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_coalesce_from_dimension.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: context.execute_query(query).await.unwrap()
+---
++--------+
+| result |
++--------+
+| (none) |
+| ab__cd |
+| abcd   |
+| foo    |
++--------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_left_from_dimension.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_left_from_dimension.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: context.execute_query(query).await.unwrap()
+---
++--------+
+| result |
++--------+
+| (n     |
+| ab     |
+| fo     |
+| NULL   |
++--------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_nullif_from_dimension.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_nullif_from_dimension.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: context.execute_query(query).await.unwrap()
+---
++--------+
+| result |
++--------+
+| ab__cd |
+| abcd   |
+| foo    |
+| NULL   |
++--------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_right_from_dimension.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__noninjective_right_from_dimension.snap
@@ -1,0 +1,12 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: context.execute_query(query).await.unwrap()
+---
++--------+
+| result |
++--------+
+| cd     |
+| e)     |
+| oo     |
+| NULL   |
++--------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Rules for splitting functions like coalesce now does **not** allow projection split, but does pick up columns from any argument.

### Examples

`COALESCE(foo, '(none)')` + `GROUP BY`
**Before**
`Projection(CubeScan)`, which is incorrect, it can return two rows with same grouping key
**After**
`Aggregation(CubeScan)`, would re-argregate result from CubeScan

`COALESCE(foo, bar, '(none)')`
**Before**
Would not detect `bar` column at all
**After**
Would detect CubeScan with two members.

