### PR TITLE
fix(schema-compiler): incorrect sql for query with same dimension with different granularities

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1794,8 +1794,9 @@ export class BaseQuery {
   }
 
   keyDimensions(primaryKeyDimensions) {
+    // The same dimension with different granularities maybe requested, so it's not enough to filter only by dimension
     return R.uniqBy(
-      (d) => d.dimension, this.dimensionsForSelect()
+      (d) => `${d.dimension}${d.granularity ?? ''}`, this.dimensionsForSelect()
         .concat(primaryKeyDimensions)
     );
   }


### PR DESCRIPTION
This PR fixes a wrong SQL generated for query that includes same time dimension few times but with different granularities.

Example:
```js
{
  measures: [
    'cards.count'
  ],
  timeDimensions: [
    {
      dimension: 'cards.createdAt',
      granularity: 'quarter',
    },
    {
      dimension: 'cards.createdAt',
      granularity: 'month',
    }
  ],
  filters: [],
}
```

Only one time dimension was included in generated SQL. Now the generated SQL includes both!