### PR TITLE
fix(cubestore): Docker - install ca-certificates, fix #8568

### DIFF
--- a/rust/cubestore/Dockerfile
+++ b/rust/cubestore/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /cube
 
 RUN set -ex; \
     apt-get update; \
-    apt-get install -y libssl3
+    apt-get install -y libssl3 ca-certificates
 
 COPY --from=builder /build/cubestore/target/release/cubestored .
 


### PR DESCRIPTION
Fix #8568

In https://github.com/cube-js/cube/pull/8554/commits/54a15e918285667bb7b0d5c1f033d8d6450cc682, i've removed curl, but it requires ca-certificates.

Let's install ca-certificates.

ca-certitifcates -> openssl (3 for booworm) -> libssl3
