### PR TITLE
chore(cubesql): Don't push down aggregate to grouped query with filters

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1494,6 +1494,10 @@ impl MemberRules {
                     if !empty_filters {
                         return false;
                     }
+                    if referenced_aggr_expr.len() == 0 {
+                        continue;
+                    }
+                    return false;
                 }
             }
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR is a fix for #8577, improving grouped push down handling.
