### PR TITLE
feat(cubejs-api-gateway): Support returning new security context from check_auth

### DIFF
--- a/docs/pages/product/auth.mdx
+++ b/docs/pages/product/auth.mdx
@@ -249,7 +249,7 @@ module.exports = {
   checkAuth: async (req, auth) => {
     try {
       const userInfo = await getUserFromLDAP(req.get("X-LDAP-User-ID"));
-      return { securityContext: userInfo };
+      return { security_context: userInfo };
     } catch {
       throw new Error("Could not authenticate user from LDAP");
     }

--- a/docs/pages/product/auth.mdx
+++ b/docs/pages/product/auth.mdx
@@ -230,7 +230,7 @@ Cube caches JWKS by default when
 
 Cube also allows you to provide your own JWT verification logic by setting a
 [`checkAuth()`][ref-config-check-auth] function in the `cube.js` configuration
-file. This function is expected to verify a JWT and assigns its' claims to the
+file. This function is expected to verify a JWT and return its claims as the
 security context.
 
 <WarningBox>
@@ -249,7 +249,7 @@ module.exports = {
   checkAuth: async (req, auth) => {
     try {
       const userInfo = await getUserFromLDAP(req.get("X-LDAP-User-ID"));
-      req.securityContext = userInfo;
+      return { securityContext: userInfo };
     } catch {
       throw new Error("Could not authenticate user from LDAP");
     }

--- a/docs/pages/reference/configuration/config.mdx
+++ b/docs/pages/reference/configuration/config.mdx
@@ -1087,15 +1087,10 @@ Default implementation parses [JSON Web Token (JWT)][link-jwt] in `Authorization
 header and sets payload to `securityContext` if it's verified. More
 information on how to generate these tokens is [here][ref-sec-ctx].
 
-You can set `securityContext = userContextObj` inside the middleware if you
-want to customize [`SECURITY_CONTEXT`][ref-schema-cube-ref-ctx-sec-ctx].
+You can return object with `securityContext: userContextObj` field inside the middleware
+if you want to customize [`SECURITY_CONTEXT`][ref-schema-cube-ref-ctx-sec-ctx].
 
-<ReferenceBox>
-
-Currently, assigning to security context doesn't work in Python.
-Please [track this issue](https://github.com/cube-js/cube/issues/8133).
-
-</ReferenceBox>
+Also, in JS config you can set it directly in request object.
 
 You can use empty `check_auth` function to disable built-in security or
 raise an exception to fail the authentication check.
@@ -1110,7 +1105,11 @@ def check_auth(ctx: dict, token: str) -> None:
   context = ctx['securityContext']
 
   if token == 'my_secret_token':
-    return
+    return {
+      "securityContext": {
+        "user_id": 42
+      }
+    }
 
   raise Exception('Access denied')
 ```

--- a/docs/pages/reference/configuration/config.mdx
+++ b/docs/pages/reference/configuration/config.mdx
@@ -1079,18 +1079,14 @@ environment documentation][ref-exec-environment-globals].
 
 ### `check_auth`
 
-Used in both REST and WebSockets API.
+Used in the [REST API][ref-rest-api]. Default implementation parses the [JSON
+Web Token][link-jwt] in the `Authorization` header, verifies it, and sets its
+payload to the `securityContext`. [Read more][ref-sec-ctx] about JWT generation.
 
 Called on each request.
 
-Default implementation parses [JSON Web Token (JWT)][link-jwt] in `Authorization`
-header and sets payload to `securityContext` if it's verified. More
-information on how to generate these tokens is [here][ref-sec-ctx].
-
-You can return object with `securityContext: userContextObj` field inside the middleware
-if you want to customize [`SECURITY_CONTEXT`][ref-schema-cube-ref-ctx-sec-ctx].
-
-Also, in JS config you can set it directly in request object.
+You can return an object with the `securityContext` field if you want to
+customize [`SECURITY_CONTEXT`][ref-schema-cube-ref-ctx-sec-ctx].
 
 You can use empty `check_auth` function to disable built-in security or
 raise an exception to fail the authentication check.
@@ -1106,8 +1102,8 @@ def check_auth(ctx: dict, token: str) -> None:
 
   if token == 'my_secret_token':
     return {
-      "securityContext": {
-        "user_id": 42
+      'securityContext': {
+        'user_id': 42
       }
     }
 
@@ -1118,7 +1114,11 @@ def check_auth(ctx: dict, token: str) -> None:
 module.exports = {
   checkAuth: ({ securityContext }, token) => {
     if (token === 'my_secret_token') {
-      return;
+      return {
+        securityContext: {
+          user_id: 42
+        }
+      }
     }
 
     throw new Error('Access denied');

--- a/docs/pages/reference/configuration/config.mdx
+++ b/docs/pages/reference/configuration/config.mdx
@@ -1085,7 +1085,7 @@ payload to the `securityContext`. [Read more][ref-sec-ctx] about JWT generation.
 
 Called on each request.
 
-You can return an object with the `securityContext` field if you want to
+You can return an object with the `security_context` field if you want to
 customize [`SECURITY_CONTEXT`][ref-schema-cube-ref-ctx-sec-ctx].
 
 You can use empty `check_auth` function to disable built-in security or
@@ -1098,11 +1098,9 @@ from cube import config
 
 @config('check_auth')
 def check_auth(ctx: dict, token: str) -> None:
-  context = ctx['securityContext']
-
   if token == 'my_secret_token':
     return {
-      'securityContext': {
+      'security_context': {
         'user_id': 42
       }
     }
@@ -1112,10 +1110,10 @@ def check_auth(ctx: dict, token: str) -> None:
 
 ```javascript
 module.exports = {
-  checkAuth: ({ securityContext }, token) => {
+  checkAuth: (ctx, token) => {
     if (token === 'my_secret_token') {
       return {
-        securityContext: {
+        security_context: {
           user_id: 42
         }
       }

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2161,8 +2161,8 @@ class ApiGateway {
       const result = await fn(req, auth);
 
       // checkAuth from config can return new security context, e.g from Python config
-      if (result?.securityContext) {
-        req.securityContext = result?.securityContext;
+      if (result?.security_context) {
+        req.securityContext = result?.security_context;
       }
 
       // We renamed authInfo to securityContext, but users can continue to use both ways

--- a/packages/cubejs-api-gateway/src/types/auth.ts
+++ b/packages/cubejs-api-gateway/src/types/auth.ts
@@ -39,15 +39,19 @@ interface JWTOptions {
   claimsNamespace?: string,
 }
 
+type CheckAuthResponse = {
+  securityContext?: unknown,
+};
+
 /**
  * Function that should provides basic auth mechanic. Used as a part
  * of a main configuration object of the server-core to provide base
- * auth logic.
+ * auth logic. Can return new security context.
  * @todo ctx can be passed from SubscriptionServer that will cause
  * incapability with Express.Request
  */
 type CheckAuthFn =
-  (ctx: any, authorization?: string) => Promise<void> | void;
+  (ctx: any, authorization?: string) => Promise<void | CheckAuthResponse> | CheckAuthResponse | void;
 
 /**
  * Result of the SQL auth workflow.

--- a/packages/cubejs-api-gateway/src/types/auth.ts
+++ b/packages/cubejs-api-gateway/src/types/auth.ts
@@ -40,7 +40,7 @@ interface JWTOptions {
 }
 
 type CheckAuthResponse = {
-  securityContext?: unknown,
+  'security_context'?: unknown,
 };
 
 /**

--- a/packages/cubejs-api-gateway/test/auth.test.ts
+++ b/packages/cubejs-api-gateway/test/auth.test.ts
@@ -277,7 +277,7 @@ describe('test authorization', () => {
           };
 
           return {
-            securityContext,
+            security_context: securityContext,
           };
         }
 

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -255,6 +255,54 @@ describe('API Gateway', () => {
     expect(queryRewrite.mock.calls.length).toEqual(1);
   });
 
+  test('query transform with checkAuth with return', async () => {
+    const queryRewrite = jest.fn(async (query: Query, context) => {
+      expect(context.securityContext).toEqual({
+        exp: 2475857705,
+        iat: 1611857705,
+        uid: 5
+      });
+
+      expect(context.authInfo).toEqual({
+        exp: 2475857705,
+        iat: 1611857705,
+        uid: 5
+      });
+
+      return query;
+    });
+
+    const { app } = await createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {
+        checkAuth: (req: Request, authorization) => {
+          if (authorization) {
+            return {
+              securityContext: jwt.verify(authorization, API_SECRET),
+            };
+          }
+
+          return {};
+        },
+        queryRewrite
+      }
+    );
+
+    const res = await request(app)
+      .get(
+        '/cubejs-api/v1/load?query={"measures":["Foo.bar"],"filters":[{"dimension":"Foo.id","operator":"equals","values":[null]}]}'
+      )
+      // console.log(generateAuthToken({ uid: 5, }));
+      .set('Authorization', 'Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjUsImlhdCI6MTYxMTg1NzcwNSwiZXhwIjoyNDc1ODU3NzA1fQ.tTieqdIcxDLG8fHv8YWwfvg_rPVe1XpZKUvrCdzVn3g')
+      .expect(200);
+
+    console.log(res.body);
+    expect(res.body && res.body.data).toStrictEqual([{ 'Foo.bar': 42 }]);
+
+    expect(queryRewrite.mock.calls.length).toEqual(1);
+  });
+
   test('null filter values', async () => {
     const { app } = await createApiGateway();
 

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -279,7 +279,7 @@ describe('API Gateway', () => {
         checkAuth: (req: Request, authorization) => {
           if (authorization) {
             return {
-              securityContext: jwt.verify(authorization, API_SECRET),
+              security_context: jwt.verify(authorization, API_SECRET),
             };
           }
 

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -351,7 +351,7 @@ export const buildSqlAndParams = (cubeEvaluator: any): String => {
 export interface PyConfiguration {
   repositoryFactory?: (ctx: unknown) => Promise<unknown>,
   logger?: (msg: string, params: Record<string, any>) => void,
-  checkAuth?: (req: unknown, authorization: string) => Promise<{ securityContext?: unknown }>
+  checkAuth?: (req: unknown, authorization: string) => Promise<{ 'security_context'?: unknown }>
   queryRewrite?: (query: unknown, ctx: unknown) => Promise<unknown>
   contextToApiScopes?: () => Promise<string[]>
 }
@@ -382,9 +382,9 @@ export const pythonLoadConfig = async (content: string, options: { fileName: str
         simplifyExpressRequest(req),
         authorization,
       );
-      const securityContext = nativeResult?.securityContext;
+      const securityContext = nativeResult?.security_context;
       return {
-        ...(securityContext ? { securityContext } : {})
+        ...(securityContext ? { security_context: securityContext } : {})
       };
     };
   }

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -351,7 +351,7 @@ export const buildSqlAndParams = (cubeEvaluator: any): String => {
 export interface PyConfiguration {
   repositoryFactory?: (ctx: unknown) => Promise<unknown>,
   logger?: (msg: string, params: Record<string, any>) => void,
-  checkAuth?: (req: unknown, authorization: string) => Promise<void>
+  checkAuth?: (req: unknown, authorization: string) => Promise<{ securityContext?: unknown }>
   queryRewrite?: (query: unknown, ctx: unknown) => Promise<unknown>
   contextToApiScopes?: () => Promise<string[]>
 }
@@ -377,10 +377,16 @@ export const pythonLoadConfig = async (content: string, options: { fileName: str
 
   if (config.checkAuth) {
     const nativeCheckAuth = config.checkAuth;
-    config.checkAuth = async (req: ExpressRequest, authorization: string) => nativeCheckAuth(
-      simplifyExpressRequest(req),
-      authorization,
-    );
+    config.checkAuth = async (req: ExpressRequest, authorization: string) => {
+      const nativeResult = await nativeCheckAuth(
+        simplifyExpressRequest(req),
+        authorization,
+      );
+      const securityContext = nativeResult?.securityContext;
+      return {
+        ...(securityContext ? { securityContext } : {})
+      };
+    };
   }
 
   if (config.extendContext) {

--- a/packages/cubejs-backend-native/test/config.py
+++ b/packages/cubejs-backend-native/test/config.py
@@ -15,6 +15,14 @@ def query_rewrite(query, ctx):
 @config
 async def check_auth(req, authorization):
     print('[python] check_auth req=', req, ' authorization=', authorization)
+    return {
+      'securityContext': {
+        'sub': '1234567890',
+        'iat': 1516239022,
+        'user_id': 42
+      },
+      'ignoredField': 'should not be visible'
+    }
 
 @config
 async def repository_factory(ctx):

--- a/packages/cubejs-backend-native/test/config.py
+++ b/packages/cubejs-backend-native/test/config.py
@@ -16,7 +16,7 @@ def query_rewrite(query, ctx):
 async def check_auth(req, authorization):
     print('[python] check_auth req=', req, ' authorization=', authorization)
     return {
-      'securityContext': {
+      'security_context': {
         'sub': '1234567890',
         'iat': 1516239022,
         'user_id': 42

--- a/packages/cubejs-backend-native/test/python.test.ts
+++ b/packages/cubejs-backend-native/test/python.test.ts
@@ -58,7 +58,7 @@ suite('Python Config', () => {
     );
 
     expect(result).toEqual({
-      securityContext: {
+      security_context: {
         sub: '1234567890',
         iat: 1516239022,
         user_id: 42

--- a/packages/cubejs-backend-native/test/python.test.ts
+++ b/packages/cubejs-backend-native/test/python.test.ts
@@ -52,10 +52,18 @@ suite('Python Config', () => {
       throw new Error('checkAuth was not defined in config.py');
     }
 
-    await config.checkAuth(
+    const result = await config.checkAuth(
       { requestId: 'test' },
       'MY_SECRET_TOKEN'
     );
+
+    expect(result).toEqual({
+      securityContext: {
+        sub: '1234567890',
+        iat: 1516239022,
+        user_id: 42
+      },
+    });
   });
 
   test('context_to_api_scopes', async () => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#8133

**Description of Changes Made (if issue reference is not provided)**

This is useful with Python configs, where input checkAuth context is a copy of original context
