### PR TITLE
fix(schema-compiler): correct string concatenation and casting for MS SQL

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -58,6 +58,14 @@ export class MssqlQuery extends BaseQuery {
     return new MssqlFilter(this, filter);
   }
 
+  public castToString(sql) {
+    return `CAST(${sql} as VARCHAR)`;
+  }
+
+  public concatStringsSql(strings: string[]) {
+    return strings.join(' + ');
+  }
+
   public convertTz(field) {
     return `TODATETIMEOFFSET(${field}, '${moment().tz(this.timezone).format('Z')}')`;
   }


### PR DESCRIPTION
In MS SQL there is no `"string" || "string"` operator, instead simple `+` is used.