### PR TITLE
fix(schema-compiler): correct string casting for MySQL

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -28,6 +28,10 @@ export class MysqlQuery extends BaseQuery {
     return new MysqlFilter(this, filter);
   }
 
+  public castToString(sql) {
+    return `CAST(${sql} as CHAR)`;
+  }
+
   public convertTz(field) {
     return `CONVERT_TZ(${field}, @@session.time_zone, '${moment().tz(this.timezone).format('Z')}')`;
   }


### PR DESCRIPTION
In MySQL there is no such type `TEXT` so casting from BaseQuery must be overridden.