### PR TITLE
fix(schema-compiler): correct string casting for BigQuery

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -36,6 +36,10 @@ class BigqueryFilter extends BaseFilter {
 }
 
 export class BigqueryQuery extends BaseQuery {
+  public castToString(sql) {
+    return `CAST(${sql} as STRING)`;
+  }
+
   public convertTz(field) {
     return `DATETIME(${field}, '${this.timezone}')`;
   }


### PR DESCRIPTION
In BigQuery there is no such type TEXT so casting from BaseQuery must be overridden.