### PR TITLE
fix(schema-compiler): correct string casting for Databricks

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -25,6 +25,10 @@ export class DatabricksQuery extends BaseQuery {
     return new DatabricksFilter(this, filter);
   }
 
+  public castToString(sql: string): string {
+    return `CAST(${sql} as STRING)`;
+  }
+
   public hllInit(sql: string) {
     return `hll_sketch_agg(${sql})`;
   }


### PR DESCRIPTION
In Databricks there is no such type TEXT so casting from BaseQuery must be overridden.