### PR TITLE
fix(schema-compiler): Support `CURRENT_DATE` SQL push down for BigQuery

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -169,6 +169,7 @@ export class BigqueryQuery extends BaseQuery {
     templates.functions.DATEDIFF = 'DATETIME_DIFF(CAST({{ args[2] }} AS DATETIME), CAST({{ args[1] }} AS DATETIME), {{ date_part }})';
     // DATEADD is being rewritten to DATE_ADD
     // templates.functions.DATEADD = 'DATETIME_ADD(CAST({{ args[2] }} AS DATETTIME), INTERVAL {{ interval }} {{ date_part }})';
+    templates.functions.CURRENTDATE = 'CURRENT_DATE';
     delete templates.functions.TO_CHAR;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
     templates.expressions.interval = 'INTERVAL {{ interval }}';


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `CURRENT_DATE` expression SQL push down in BigQuery. Like PostgreSQL, BigQuery has the 
function with the same name that can be called without arguments.