### PR TITLE
Implement parallel e-graph search

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -610,16 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +777,7 @@ dependencies = [
  "postgres-types",
  "pretty_assertions",
  "rand",
+ "rayon",
  "regex",
  "rust_decimal",
  "serde",
@@ -991,7 +982,7 @@ checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 [[package]]
 name = "egg"
 version = "0.9.5"
-source = "git+https://github.com/cube-js/egg.git?rev=952f8c2a1033e5da097d23c523b0d8e392eb532b#952f8c2a1033e5da097d23c523b0d8e392eb532b"
+source = "git+https://github.com/cube-js/egg.git?rev=d091507133f9620c4e820cb4cfdd7b00df2d991c#d091507133f9620c4e820cb4cfdd7b00df2d991c"
 dependencies = [
  "env_logger",
  "fxhash",
@@ -2463,26 +2454,22 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -46,7 +46,7 @@ mockall = "0.8.1"
 tokio-util = { version = "0.7", features=["compat"] }
 comfy-table = "7.1.0"
 bitflags = "1.3.2"
-egg = { rev = "952f8c2a1033e5da097d23c523b0d8e392eb532b", git = "https://github.com/cube-js/egg.git" }
+egg = { rev = "d091507133f9620c4e820cb4cfdd7b00df2d991c", git = "https://github.com/cube-js/egg.git" } # cube/upstream-varargs
 paste = "1.0.6"
 csv = "1.1.6"
 tracing = { version = "0.1.40", features = ["async-await"] }
@@ -59,6 +59,7 @@ minijinja = { version = "1", features = ["json", "loader"] }
 lru = "0.12.1"
 sha2 = "0.10.8"
 bigdecimal = "0.4.2"
+rayon = "1.10.0"
 
 
 [dev-dependencies]


### PR DESCRIPTION
This PR implements parallel e-graph search based on an `egg` API I just added. The new API doesn't do parallelism, just enables clients to do it themselves.

I have not measured the effects of the parallelism just yet.
