### PR TITLE
feat(schema-compiler): Reference granularities in a proxy dimension

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2197,6 +2197,10 @@ export class BaseQuery {
       this.pushMemberNameForCollectionIfNecessary(cubeName, name);
     }
     const memberPathArray = [cubeName, name];
+    // Member path needs to be expanded to granularity if subPropertyName is provided.
+    // Without this: failures with Maximum call stack size exceeded.
+    // During resolving and members collection safeEvaluateSymbolContext().memberChildren is set,
+    // so path is recursively pushed to memberChildren.
     if (subPropertyName && symbol.type === 'time') {
       memberPathArray.push('granularities', subPropertyName);
     }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2197,7 +2197,7 @@ export class BaseQuery {
       this.pushMemberNameForCollectionIfNecessary(cubeName, name);
     }
     const memberPathArray = [cubeName, name];
-    if (internalPropertyName && symbol.type === 'time' && symbol.granularities[internalPropertyName]) {
+    if (internalPropertyName && symbol.type === 'time' && internalPropertyName) {
       memberPathArray.push('granularities', internalPropertyName);
     }
     const memberPath = this.cubeEvaluator.pathFromArray(memberPathArray);

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2381,7 +2381,7 @@ export class BaseQuery {
       }
       return self.evaluateSymbolSql(nextCubeName, name, resolvedSymbol);
     }, {
-      sqlResolveFn: options.sqlResolveFn || ((symbol, cube, pn, ppn) => self.evaluateSymbolSql(cube, pn, symbol, false, ppn)),
+      sqlResolveFn: options.sqlResolveFn || ((symbol, cube, propName, subPropName) => self.evaluateSymbolSql(cube, propName, symbol, false, subPropName)),
       cubeAliasFn: self.cubeAlias.bind(self),
       contextSymbols: this.parametrizedContextSymbols(),
       query: this,

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2199,7 +2199,7 @@ export class BaseQuery {
     const memberPathArray = [cubeName, name];
     // Member path needs to be expanded to granularity if subPropertyName is provided.
     // Without this: failures with Maximum call stack size exceeded.
-    // During resolving and members collection safeEvaluateSymbolContext().memberChildren is set,
+    // During resolving within dimensionSql() and members collection safeEvaluateSymbolContext().memberChildren is set,
     // so path is recursively pushed to memberChildren.
     if (subPropertyName && symbol.type === 'time') {
       memberPathArray.push('granularities', subPropertyName);

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -26,7 +26,7 @@ import { BaseTimeDimension } from './BaseTimeDimension';
 import { ParamAllocator } from './ParamAllocator';
 import { PreAggregations } from './PreAggregations';
 import { SqlParser } from '../parser/SqlParser';
-import {Granularity} from "./Granularity";
+import { Granularity } from './Granularity';
 
 const DEFAULT_PREAGGREGATIONS_SCHEMA = 'stb_pre_aggregations';
 

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -33,8 +33,7 @@ export class Granularity {
       const customGranularity = this.query.cacheValue(
         ['customGranularity', timeDimension.dimension, this.granularity],
         () => query.cubeEvaluator
-          .byPath('dimensions', timeDimension.dimension)
-          .granularities?.[this.granularity]
+          .resolveSubProperty([...query.cubeEvaluator.parsePath('dimensions', timeDimension.dimension), 'granularities', this.granularity])
       );
 
       if (!customGranularity) {

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -33,7 +33,7 @@ export class Granularity {
       const customGranularity = this.query.cacheValue(
         ['customGranularity', timeDimension.dimension, this.granularity],
         () => query.cubeEvaluator
-          .resolveSubProperty([...query.cubeEvaluator.parsePath('dimensions', timeDimension.dimension), 'granularities', this.granularity])
+          .resolveGranularity([...query.cubeEvaluator.parsePath('dimensions', timeDimension.dimension), 'granularities', this.granularity])
       );
 
       if (!customGranularity) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -86,7 +86,7 @@ export class CubeEvaluator extends CubeSymbols {
     for (const cube of validCubes) {
       this.evaluatedCubes[cube.name] = this.prepareCube(cube, errorReporter);
     }
-    
+
     this.byFileName = R.groupBy(v => v.fileName, validCubes);
     this.primaryKeys = R.fromPairs(
       validCubes.map((v) => {
@@ -128,21 +128,21 @@ export class CubeEvaluator extends CubeSymbols {
     if (cube.isView && (cube.includedMembers || []).length) {
       const includedCubeNames: string[] = R.uniq(cube.includedMembers.map(it => it.memberPath.split('.')[0]));
       const includedMemberPaths: string[] = R.uniq(cube.includedMembers.map(it => it.memberPath));
-      
+
       if (!cube.hierarchies) {
         for (const cubeName of includedCubeNames) {
           const { hierarchies } = this.evaluatedCubes[cubeName] || {};
-  
+
           if (Array.isArray(hierarchies) && hierarchies.length) {
             const filteredHierarchies = hierarchies.map(it => {
               const levels = it.levels.filter(level => includedMemberPaths.includes(level));
-  
+
               return {
                 ...it,
                 levels
               };
             }).filter(it => it.levels.length);
-  
+
             cube.hierarchies = [...(cube.hierarchies || []), ...filteredHierarchies];
           }
         }
@@ -420,15 +420,15 @@ export class CubeEvaluator extends CubeSymbols {
     return Object.keys(this.evaluatedCubes);
   }
 
-  public isMeasure(measurePath: string): boolean {
+  public isMeasure(measurePath: string | string[]): boolean {
     return this.isInstanceOfType('measures', measurePath);
   }
 
-  public isDimension(path: string): boolean {
+  public isDimension(path: string | string[]): boolean {
     return this.isInstanceOfType('dimensions', path);
   }
 
-  public isSegment(path: string): boolean {
+  public isSegment(path: string | string[]): boolean {
     return this.isInstanceOfType('segments', path);
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -552,7 +552,7 @@ export class CubeSymbols {
           if (refProperty) {
             return () => this.withSymbolsCallContext(
               () => sqlResolveFn(cube[refProperty], cubeName, refProperty),
-              { ...this.resolveSymbolsCallContext }
+              { ...this.resolveSymbolsCallContext, joinHints }
             );
           }
 
@@ -586,7 +586,7 @@ export class CubeSymbols {
           };
         }
         if (cube[propertyName]) {
-          return this.cubeReferenceProxy(cubeName, undefined, propertyName);
+          return this.cubeReferenceProxy(cubeName, joinHints, propertyName);
         }
         if (self.symbols[propertyName]) {
           return this.cubeReferenceProxy(propertyName, joinHints);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -586,12 +586,7 @@ export class CubeSymbols {
           };
         }
         if (cube[propertyName]) {
-          return {
-            toString: () => this.withSymbolsCallContext(
-              () => sqlResolveFn(cube[propertyName], cubeName, propertyName),
-              { ...this.resolveSymbolsCallContext, joinHints },
-            ),
-          };
+          return this.cubeReferenceProxy(cubeName, undefined, propertyName);
         }
         if (self.symbols[propertyName]) {
           return this.cubeReferenceProxy(propertyName, joinHints);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -385,6 +385,7 @@ export class CubeSymbols {
         };
       } else if (type === 'dimensions') {
         memberDefinition = {
+          ...(resolvedMember.granularities ? { granularities: resolvedMember.granularities } : {}),
           sql,
           type: resolvedMember.type,
           meta: resolvedMember.meta,

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -581,9 +581,8 @@ export class CubeSymbols {
         }
         if (refProperty &&
           cube[refProperty].type === 'time' &&
-          (self.resolveSubProperty([cubeName, refProperty, 'granularities', propertyName], cube) ||
-           (typeof propertyName === 'string' && /^(second|minute|hour|day|week|month|quarter|year)$/i.test(propertyName))
-          )) {
+          self.resolveGranularity([cubeName, refProperty, 'granularities', propertyName], cube)
+        ) {
           return {
             toString: () => this.withSymbolsCallContext(
               () => sqlResolveFn(cube[refProperty], cubeName, refProperty, propertyName),
@@ -606,17 +605,20 @@ export class CubeSymbols {
   }
 
   /**
-   * Tries to resolve subProperty object.
-   *
-   * For now, it only resolves custom granularities in time dimensions.
-   * In the future, it possibly will be extended to support globally defined granularities
-   * or even other subProperties.
+   * Tries to resolve Granularity object.
+   * For predefined granularity it constructs it on the fly.
    * @param {string|string[]} path
    * @param [refCube] Optional cube object to operate on
    */
-  resolveSubProperty(path, refCube) {
+  resolveGranularity(path, refCube) {
     const [cubeName, dimName, gr, granName] = Array.isArray(path) ? path : path.split('.');
     const cube = refCube || this.symbols[cubeName];
+
+    // Predefined granularity
+    if (typeof granName === 'string' && /^(second|minute|hour|day|week|month|quarter|year)$/i.test(granName)) {
+      return { interval: `1 ${granName}` };
+    }
+
     return cube && cube[dimName] && cube[dimName][gr] && cube[dimName][gr][granName];
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -575,7 +575,7 @@ export class CubeSymbols {
         }
         if (refProperty &&
           cube[refProperty].type === 'time' &&
-          ((cube[refProperty].granularities && cube[refProperty].granularities[propertyName]) ||
+          (self.resolveSubProperty([cubeName, refProperty, 'granularities', propertyName], cube) ||
            (typeof propertyName === 'string' && /^(second|minute|hour|day|week|month|quarter|year)$/i.test(propertyName))
           )) {
           return {
@@ -597,6 +597,21 @@ export class CubeSymbols {
         return undefined;
       }
     });
+  }
+
+  /**
+   * Tries to resolve subProperty object.
+   *
+   * For now, it only resolves custom granularities in time dimensions.
+   * In the future, it possibly will be extended to support globally defined granularities
+   * or even other subProperties.
+   * @param {string|string[]} path
+   * @param [refCube] Optional cube object to operate on
+   */
+  resolveSubProperty(path, refCube) {
+    const [cubeName, dimName, gr, granName] = Array.isArray(path) ? path : path.split('.');
+    const cube = refCube || this.symbols[cubeName];
+    return cube && cube[dimName] && cube[dimName][gr] && cube[dimName][gr][granName];
   }
 
   isCurrentCube(name) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -513,6 +513,11 @@ export class CubeSymbols {
         this.isCurrentCube(name) ? cubeName : name,
         collectJoinHints ? [] : undefined
       );
+    } else if (sqlResolveFn && this.symbols[cubeName] && this.symbols[cubeName][name]) {
+      cube = this.cubePropertyReferenceProxy(
+        cubeName,
+        name
+      );
     }
 
     return cube || (this.symbols[cubeName] && this.symbols[cubeName][name]);
@@ -526,6 +531,9 @@ export class CubeSymbols {
     const { sqlResolveFn, cubeAliasFn, query, cubeReferencesUsed } = self.resolveSymbolsCallContext || {};
     return new Proxy({}, {
       get: (v, propertyName) => {
+        if (propertyName === '_objectWithResolvedProperties') {
+          return true;
+        }
         if (propertyName === '__cubeName') {
           return cubeName;
         }
@@ -555,9 +563,6 @@ export class CubeSymbols {
         if (propertyName === 'sql') {
           return () => query.cubeSql(cube.cubeName());
         }
-        if (propertyName === '_objectWithResolvedProperties') {
-          return true;
-        }
         if (cube[propertyName]) {
           return {
             toString: () => this.withSymbolsCallContext(
@@ -571,6 +576,45 @@ export class CubeSymbols {
         }
         if (typeof propertyName === 'string') {
           throw new UserError(`${cubeName}.${propertyName} cannot be resolved. There's no such member or cube.`);
+        }
+        return undefined;
+      }
+    });
+  }
+
+  cubePropertyReferenceProxy(cubeName, refProperty) {
+    const self = this;
+    const { sqlResolveFn } = self.resolveSymbolsCallContext || {};
+    return new Proxy({}, {
+      get: (v, propertyName) => {
+        const cube = self.symbols[cubeName];
+        if (propertyName === '_objectWithResolvedProperties') {
+          return true;
+        }
+        if (propertyName === 'toString') {
+          return () => this.withSymbolsCallContext(
+            () => sqlResolveFn(cube[refProperty], cubeName, refProperty),
+            { ...this.resolveSymbolsCallContext }
+          );
+        }
+        if (cube[propertyName]) {
+          return {
+            toString: () => this.withSymbolsCallContext(
+              () => sqlResolveFn(cube[propertyName], cubeName, propertyName),
+              { ...this.resolveSymbolsCallContext },
+            ),
+          };
+        }
+        if (cube[refProperty].type === 'time' && cube[refProperty].granularities && cube[refProperty].granularities[propertyName]) {
+          return {
+            toString: () => this.withSymbolsCallContext(
+              () => sqlResolveFn(cube[refProperty], cubeName, refProperty, propertyName),
+              { ...this.resolveSymbolsCallContext },
+            ),
+          };
+        }
+        if (typeof propertyName === 'string') {
+          throw new UserError(`${cubeName}.${refProperty}.${propertyName} cannot be resolved. There's no such member or cube.`);
         }
         return undefined;
       }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -575,8 +575,9 @@ export class CubeSymbols {
         }
         if (refProperty &&
           cube[refProperty].type === 'time' &&
-          cube[refProperty].granularities &&
-          cube[refProperty].granularities[propertyName]) {
+          ((cube[refProperty].granularities && cube[refProperty].granularities[propertyName]) ||
+           (typeof propertyName === 'string' && /^(second|minute|hour|day|week|month|quarter|year)$/i.test(propertyName))
+          )) {
           return {
             toString: () => this.withSymbolsCallContext(
               () => sqlResolveFn(cube[refProperty], cubeName, refProperty, propertyName),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -507,6 +507,12 @@ export class CubeSymbols {
       return symbol;
     }
 
+    // In proxied subProperty flow `name` will be set to parent dimension|measure name,
+    // so there will be no cube = this.symbols[cubeName : name] found, but potentially
+    // during cube definition evaluation some other deeper subProperty may be requested.
+    // To distinguish such cases we pass the right now requested property name to
+    // cubeReferenceProxy, so later if subProperty is requested we'll have all the required
+    // information to construct the response.
     let cube = this.symbols[this.isCurrentCube(name) ? cubeName : name];
     if (sqlResolveFn) {
       if (cube) {

--- a/packages/cubejs-schema-compiler/test/integration/postgres/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/custom-granularities.test.ts
@@ -29,6 +29,10 @@ describe('Custom Granularities', () => {
           sql: status
           type: string
 
+        - name: createdAtHalfYear
+          sql: "{createdAt.half_year}"
+          type: string
+
         - name: createdAt
           sql: created_at
           type: time
@@ -72,6 +76,12 @@ describe('Custom Granularities', () => {
           type: count
           rolling_window:
             trailing: unbounded
+
+  views:
+    - name: orders_view
+      cubes:
+        - join_path: orders
+          includes: "*"
   `);
 
   it('works with half_year custom granularity w/o dimensions query', async () => dbRunner.runQueryTest(
@@ -106,6 +116,115 @@ describe('Custom Granularities', () => {
       {
         orders__count: '1',
         orders__created_at_half_year: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    { joinGraph, cubeEvaluator, compiler }
+  ));
+
+  it('works with proxied createdAtHalfYear custom granularity as dimension query', async () => dbRunner.runQueryTest(
+    {
+      measures: ['orders.count'],
+      timeDimensions: [{
+        dimension: 'orders.createdAt',
+        dateRange: ['2024-01-01', '2025-12-31']
+      }],
+      dimensions: ['orders.createdAtHalfYear'],
+      filters: [],
+      timezone: 'Europe/London'
+    },
+    [
+      {
+        orders__count: '13',
+        orders__created_at_half_year: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        orders__count: '13',
+        orders__created_at_half_year: '2024-07-01T00:00:00.000Z',
+      },
+      {
+        orders__count: '13',
+        orders__created_at_half_year: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        orders__count: '13',
+        orders__created_at_half_year: '2025-07-01T00:00:00.000Z',
+      },
+      {
+        orders__count: '1',
+        orders__created_at_half_year: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    { joinGraph, cubeEvaluator, compiler }
+  ));
+
+  it('works with half_year custom granularity w/o dimensions querying view', async () => dbRunner.runQueryTest(
+    {
+      measures: ['orders_view.count'],
+      timeDimensions: [{
+        dimension: 'orders_view.createdAt',
+        granularity: 'half_year',
+        dateRange: ['2024-01-01', '2025-12-31']
+      }],
+      dimensions: [],
+      filters: [],
+      timezone: 'Europe/London'
+    },
+    [
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2024-07-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2025-07-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '1',
+        orders_view__created_at_half_year: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    { joinGraph, cubeEvaluator, compiler }
+  ));
+
+  it('works with proxied createdAtHalfYear custom granularity as dimension querying view', async () => dbRunner.runQueryTest(
+    {
+      measures: ['orders_view.count'],
+      timeDimensions: [{
+        dimension: 'orders_view.createdAt',
+        dateRange: ['2024-01-01', '2025-12-31']
+      }],
+      dimensions: ['orders_view.createdAtHalfYear'],
+      filters: [],
+      timezone: 'Europe/London'
+    },
+    [
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2024-07-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '13',
+        orders_view__created_at_half_year: '2025-07-01T00:00:00.000Z',
+      },
+      {
+        orders_view__count: '1',
+        orders_view__created_at_half_year: '2026-01-01T00:00:00.000Z',
       },
     ],
     { joinGraph, cubeEvaluator, compiler }

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -433,6 +433,7 @@ describe('SQL Generation', () => {
           const queryAndParams = query.buildSqlAndParams();
           const queryString = queryAndParams[0];
 
+          expect(queryString.includes('undefined')).toBeFalsy();
           if (q.measures[0].includes('count')) {
             expect(queryString.includes('INTERVAL \'6 months\'')).toBeTruthy();
           } else if (q.measures[0].includes('rollingCountByTrailing2Day')) {
@@ -450,6 +451,7 @@ describe('SQL Generation', () => {
           const queryString = queryAndParams[0];
           console.log('Generated query: ', queryString);
 
+          expect(queryString.includes('undefined')).toBeFalsy();
           if (q.dimensions[0].includes('PredefinedYear')) {
             expect(queryString.includes('date_trunc(\'year\'')).toBeTruthy();
           } else if (q.dimensions[0].includes('PredefinedQuarter')) {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -351,6 +351,44 @@ describe('SQL Generation', () => {
         filters: [],
         timezone: 'Europe/Kyiv'
       },
+      {
+        measures: [
+          'orders_users.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders_users.proxyCreatedAtPredefinedYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders_users.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders_users.proxyCreatedAtHalfYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
     ];
 
     it('Test time series with different granularities', async () => {
@@ -418,7 +456,6 @@ describe('SQL Generation', () => {
             expect(queryString.includes('date_trunc(\'quarter\'')).toBeTruthy();
           } else {
             expect(queryString.includes('INTERVAL \'6 months\'')).toBeTruthy();
-            expect(queryString.includes('count("orders".id')).toBeTruthy();
           }
         });
       });

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -59,7 +59,7 @@ describe('SQL Generation', () => {
       createCubeSchemaWithCustomGranularities('orders')
     );
 
-    const queries = [
+    const granularityQueries = [
       {
         measures: [
           'orders.count'
@@ -254,10 +254,71 @@ describe('SQL Generation', () => {
       }
     ];
 
+    const proxiedGranularitiesQueries = [
+      {
+        measures: [
+          'orders.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders.createdAtHalfYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders.createdAtHalfYearBy1stJune'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            granularity: 'half_year_by_1st_june',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders.createdAtHalfYearBy1stMarch'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+    ];
+
     it('Test time series with different granularities', async () => {
       await compilers.compiler.compile();
 
-      const query = new BaseQuery(compilers, queries[0]);
+      const query = new BaseQuery(compilers, granularityQueries[0]);
 
       {
         const timeDimension = query.newTimeDimension({
@@ -290,7 +351,7 @@ describe('SQL Generation', () => {
         await compilers.compiler.compile();
       });
 
-      queries.forEach(q => {
+      granularityQueries.forEach(q => {
         it(`measure "${q.measures[0]}" + granularity "${q.timeDimensions[0].granularity}"`, () => {
           const query = new PostgresQuery(compilers, q);
           const queryAndParams = query.buildSqlAndParams();
@@ -303,6 +364,18 @@ describe('SQL Generation', () => {
           } else if (q.measures[0].includes('rollingCountByLeading2Day')) {
             expect(queryString.includes('+ interval \'3 day\'')).toBeTruthy();
           }
+        });
+      });
+
+      proxiedGranularitiesQueries.forEach(q => {
+        it(`proxy granularity reference "${q.dimensions[0]}"`, () => {
+          const query = new PostgresQuery(compilers, q);
+          const queryAndParams = query.buildSqlAndParams();
+          const queryString = queryAndParams[0];
+          console.log('Generated query: ', queryString);
+
+          expect(queryString.includes('INTERVAL \'6 months\'')).toBeTruthy();
+          expect(queryString.includes('count("orders".id')).toBeTruthy();
         });
       });
     });

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -251,7 +251,46 @@ describe('SQL Generation', () => {
         ],
         filters: [],
         timezone: 'Europe/Kyiv'
-      }
+      },
+      // requesting via view
+      {
+        measures: [
+          'orders_view.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders_view.createdAt',
+            granularity: 'half_year_by_1st_june',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders_view.rollingCountByUnbounded'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders_view.createdAt',
+            granularity: 'half_year',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders_view.status'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
     ];
 
     const proxiedGranularitiesQueries = [
@@ -377,6 +416,45 @@ describe('SQL Generation', () => {
         timeDimensions: [
           {
             dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders_users.proxyCreatedAtHalfYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      // requesting via views
+      {
+        measures: [
+          'orders_view.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders_view.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders_view.createdAtHalfYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders_view.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders_view.createdAt',
             dateRange: [
               '2020-01-01',
               '2021-12-31'

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -313,6 +313,44 @@ describe('SQL Generation', () => {
         filters: [],
         timezone: 'Europe/Kyiv'
       },
+      {
+        measures: [
+          'orders.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders.createdAtPredefinedYear'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
+      {
+        measures: [
+          'orders.count'
+        ],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            dateRange: [
+              '2020-01-01',
+              '2021-12-31'
+            ]
+          }
+        ],
+        dimensions: [
+          'orders.createdAtPredefinedQuarter'
+        ],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      },
     ];
 
     it('Test time series with different granularities', async () => {
@@ -374,8 +412,14 @@ describe('SQL Generation', () => {
           const queryString = queryAndParams[0];
           console.log('Generated query: ', queryString);
 
-          expect(queryString.includes('INTERVAL \'6 months\'')).toBeTruthy();
-          expect(queryString.includes('count("orders".id')).toBeTruthy();
+          if (q.dimensions[0].includes('PredefinedYear')) {
+            expect(queryString.includes('date_trunc(\'year\'')).toBeTruthy();
+          } else if (q.dimensions[0].includes('PredefinedQuarter')) {
+            expect(queryString.includes('date_trunc(\'quarter\'')).toBeTruthy();
+          } else {
+            expect(queryString.includes('INTERVAL \'6 months\'')).toBeTruthy();
+            expect(queryString.includes('count("orders".id')).toBeTruthy();
+          }
         });
       });
     });

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -468,7 +468,7 @@ describe('SQL Generation', () => {
         await compilers.compiler.compile();
       });
 
-      queries.forEach(q => {
+      granularityQueries.forEach(q => {
         it(`measure "${q.measures[0]}" + granularity "${q.timeDimensions[0].granularity}"`, () => {
           const query = new CubeStoreQuery(compilers, q);
           const queryAndParams = query.buildSqlAndParams();

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -205,6 +205,13 @@ export function createCubeSchemaWithCustomGranularities(name: string): string {
             type: 'count_distinct'
           }
         }
+      })
+
+      view(\`orders_view\`, {
+        cubes: [{
+          join_path: orders,
+          includes: '*'
+        }]
       })`;
 }
 

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -103,14 +103,34 @@ export function createCubeSchemaWithCustomGranularities(name: string): string {
               }
             }
           },
+          createdAtHalfYear: {
+            public: true,
+            sql: \`\${createdAt.half_year}\`,
+            type: 'string',
+          },
+          createdAtHalfYearBy1stJune: {
+            public: true,
+            sql: \`\${createdAt.half_year_by_1st_june}\`,
+            type: 'string',
+          },
+          createdAtHalfYearBy1stMarch: {
+            public: true,
+            sql: \`\${createdAt.half_year_by_1st_march}\`,
+            type: 'string',
+          },
           status: {
             type: 'string',
             sql: 'status',
+          },
+          id: {
+            type: 'number',
+            sql: 'id',
+            primaryKey: true,
+            public: true,
           }
         },
         measures: {
           count: {
-            sql: 'count',
             type: 'count'
           },
           rollingCountByTrailing2Day: {

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -103,6 +103,16 @@ export function createCubeSchemaWithCustomGranularities(name: string): string {
               }
             }
           },
+          createdAtPredefinedYear: {
+            public: true,
+            sql: \`\${createdAt.year}\`,
+            type: 'string',
+          },
+          createdAtPredefinedQuarter: {
+            public: true,
+            sql: \`\${createdAt.quarter}\`,
+            type: 'string',
+          },
           createdAtHalfYear: {
             public: true,
             sql: \`\${createdAt.half_year}\`,

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -161,6 +161,49 @@ export function createCubeSchemaWithCustomGranularities(name: string): string {
               trailing: 'unbounded'
             }
           }
+        },
+
+        joins: {
+          ${name}_users: {
+            sql: \`\${${name}_users}.id = \${${name}}.user_id\`,
+            relationship: \`one_to_many\`
+          }
+        }
+
+      })
+
+      cube(\`${name}_users\`, {
+        sql: \`SELECT * FROM users\`,
+
+        dimensions: {
+          id: {
+            type: 'number',
+            sql: 'id',
+            primaryKey: true,
+            public: true,
+          },
+          name: {
+            sql: 'name',
+            type: 'string',
+            public: true,
+          },
+          proxyCreatedAtPredefinedYear: {
+            sql: \`\${${name}.createdAt.year}\`,
+            type: \`string\`,
+            public: true,
+          },
+          proxyCreatedAtHalfYear: {
+            sql: \`\${${name}.createdAt.half_year}\`,
+            type: 'string',
+            public: true,
+          }
+        },
+
+        measures: {
+          count: {
+            sql: 'user_id',
+            type: 'count_distinct'
+          }
         }
       })`;
 }


### PR DESCRIPTION
This PR introduces the ability to reference the time dimension granularity in dimension definition like this:

```yaml
.....
    dimensions:
      - name: created_at_half_year
        sql: "{created_at.half_year}"
        type: string

      - name: created_at_fiscal_year_feb
        sql: "{created_at.fiscal_year_by_1st_feb}"
        type: string

      - name: created_at
        sql: created_at
        type: time
        granularities:
          - name: half_year
            interval: 6 months
          - name: half_year_by_1st_april
            interval: 6 months
            offset: 3 months
          - name: fiscal_year_by_1st_feb
            interval: 1 year
            offset: 1 month
          - name: fiscal_year_by_15th_march
            interval: 1 year
            origin: '2024-03-15'

      - name: created_at_predefined_year
         sql: "{createdAt.year}"                   # You can refer even predefined granularities
         type: string
```

Then you can request those dimensions like any other: add filters, order, or whatever.
Smth like this:
```json
{
  "measures": [
    "base_orders.count"
  ],
  "order": {
    "base_orders.count": "desc"
  },
  "timeDimensions": [
    {
      "dimension": "base_orders.created_at",
      "dateRange": [
        "2019-01-01",
        "2021-01-02"
      ]
    }
  ],
  "dimensions": [
    "base_orders.created_at_half_year"
  ]
}
```

The resulting query will automatically include the necessary code as if requesting the time dimension with specified granularity.

Depends on:
* #8537

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
