### PR TITLE
fix(cubesql): Use load meta with user change for SQL generation calls

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -465,12 +465,14 @@ impl CubeScanWrapperNode {
                                 node
                             )));
                         }
+                        let mut meta_with_user = load_request_meta.as_ref().clone();
+                        meta_with_user.set_change_user(node.options.change_user.clone());
                         let sql = transport
                             .sql(
                                 node.span_id.clone(),
                                 node.request.clone(),
                                 node.auth_context,
-                                load_request_meta.as_ref().clone(),
+                                meta_with_user,
                                 Some(
                                     node.member_fields
                                         .iter()
@@ -843,12 +845,16 @@ impl CubeScanWrapperNode {
                                 }
                                 // TODO time dimensions, filters, segments
 
+                                let mut meta_with_user = load_request_meta.as_ref().clone();
+                                meta_with_user.set_change_user(
+                                    ungrouped_scan_node.options.change_user.clone(),
+                                );
                                 let sql_response = transport
                                     .sql(
                                         ungrouped_scan_node.span_id.clone(),
                                         load_request.clone(),
                                         ungrouped_scan_node.auth_context.clone(),
-                                        load_request_meta.as_ref().clone(),
+                                        meta_with_user,
                                         // TODO use aliases or push everything through names?
                                         None,
                                         Some(sql.values.clone()),

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -289,68 +289,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_change_user_via_filter() {
-        init_testing_logger();
-
-        let query_plan = convert_select_to_query_plan(
-            "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher'"
-                .to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-        .await;
-
-        let cube_scan = query_plan.as_logical_plan().find_cube_scan();
-
-        assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
-
-        assert_eq!(
-            cube_scan.request,
-            V1LoadRequestQuery {
-                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
-                segments: Some(vec![]),
-                dimensions: Some(vec![]),
-                time_dimensions: None,
-                order: None,
-                limit: None,
-                offset: None,
-                filters: None,
-                ungrouped: None,
-            }
-        )
-    }
-
-    #[tokio::test]
-    async fn test_change_user_via_in_filter() {
-        init_testing_logger();
-
-        let query_plan = convert_select_to_query_plan(
-            "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user IN ('gopher')"
-                .to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-        .await;
-
-        let cube_scan = query_plan.as_logical_plan().find_cube_scan();
-
-        assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
-
-        assert_eq!(
-            cube_scan.request,
-            V1LoadRequestQuery {
-                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
-                segments: Some(vec![]),
-                dimensions: Some(vec![]),
-                time_dimensions: None,
-                order: None,
-                limit: None,
-                offset: None,
-                filters: None,
-                ungrouped: None,
-            }
-        )
-    }
-
-    #[tokio::test]
     async fn test_starts_with() {
         init_testing_logger();
 
@@ -479,92 +417,6 @@ mod tests {
             .sql;
 
         assert!(sql.contains("LOWER("));
-    }
-
-    #[tokio::test]
-    async fn test_change_user_via_in_filter_thoughtspot() {
-        init_testing_logger();
-
-        let query_plan = convert_select_to_query_plan(
-            r#"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce "ta_1" WHERE (LOWER("ta_1"."__user") IN ('gopher')) = TRUE"#.to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-            .await;
-
-        let expected_request = V1LoadRequestQuery {
-            measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
-            segments: Some(vec![]),
-            dimensions: Some(vec![]),
-            time_dimensions: None,
-            order: None,
-            limit: None,
-            offset: None,
-            filters: None,
-            ungrouped: None,
-        };
-
-        let cube_scan = query_plan.as_logical_plan().find_cube_scan();
-        assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
-        assert_eq!(cube_scan.request, expected_request);
-
-        let query_plan = convert_select_to_query_plan(
-            r#"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce "ta_1" WHERE ((LOWER("ta_1"."__user") IN ('gopher') = TRUE) = TRUE)"#.to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-            .await;
-
-        let cube_scan = query_plan.as_logical_plan().find_cube_scan();
-        assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
-        assert_eq!(cube_scan.request, expected_request);
-    }
-
-    #[tokio::test]
-    async fn test_change_user_via_filter_and() {
-        let query_plan = convert_select_to_query_plan(
-            "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher' AND customer_gender = 'male'".to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-            .await;
-
-        let cube_scan = query_plan.as_logical_plan().find_cube_scan();
-
-        assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
-
-        assert_eq!(
-            cube_scan.request,
-            V1LoadRequestQuery {
-                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
-                segments: Some(vec![]),
-                dimensions: Some(vec![]),
-                time_dimensions: None,
-                order: None,
-                limit: None,
-                offset: None,
-                filters: Some(vec![V1LoadRequestQueryFilterItem {
-                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
-                    operator: Some("equals".to_string()),
-                    values: Some(vec!["male".to_string()]),
-                    or: None,
-                    and: None,
-                }]),
-                ungrouped: None,
-            }
-        )
-    }
-
-    #[tokio::test]
-    async fn test_change_user_via_filter_or() {
-        // OR is not allowed for __user
-        let meta = get_test_tenant_ctx();
-        let query =
-            convert_sql_to_cube_query(
-                &"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher' OR customer_gender = 'male'".to_string(),
-                meta.clone(),
-                get_test_session(DatabaseProtocol::PostgreSQL, meta).await
-            ).await;
-
-        // TODO: We need to propagate error to result, to assert message
-        query.unwrap_err();
     }
 
     #[tokio::test]
@@ -8804,39 +8656,6 @@ ORDER BY "source"."str0" ASC
                 ungrouped: Some(true),
             }
         )
-    }
-
-    #[tokio::test]
-    async fn test_user_with_join() {
-        if !Rewriter::sql_push_down_enabled() {
-            return;
-        }
-        init_testing_logger();
-
-        let logical_plan = convert_select_to_query_plan(
-            "SELECT aliased.count as c, aliased.user_1 as u1, aliased.user_2 as u2 FROM (SELECT \"KibanaSampleDataEcommerce\".count as count, \"KibanaSampleDataEcommerce\".__user as user_1, Logs.__user as user_2 FROM \"KibanaSampleDataEcommerce\" CROSS JOIN Logs WHERE __user = 'foo') aliased".to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-            .await
-            .as_logical_plan();
-
-        let cube_scan = logical_plan.find_cube_scan();
-        assert_eq!(
-            cube_scan.request,
-            V1LoadRequestQuery {
-                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
-                dimensions: Some(vec![]),
-                segments: Some(vec![]),
-                time_dimensions: None,
-                order: Some(vec![]),
-                limit: None,
-                offset: None,
-                filters: None,
-                ungrouped: Some(true),
-            }
-        );
-
-        assert_eq!(cube_scan.options.change_user, Some("foo".to_string()))
     }
 
     #[tokio::test]

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -721,13 +721,17 @@ impl TransportService for TestConnectionTransport {
         _ctx: AuthContextRef,
         _meta_fields: LoadRequestMeta,
     ) -> Result<TransportLoadResponse, CubeError> {
-        if sql_query.is_some() {
-            unimplemented!("load with sql_query");
+        if let Some(sql_query) = sql_query {
+            return Err(CubeError::internal(format!(
+                "Test transport does not support load with SQL query: {sql_query:?}"
+            )));
         }
 
         let mocks = self.load_mocks.lock().await;
         let Some((_req, res)) = mocks.iter().find(|(req, _res)| req == &query) else {
-            panic!("Unexpected query: {:?}", query);
+            return Err(CubeError::internal(format!(
+                "Unexpected query in test transport: {query:?}"
+            )));
         };
         Ok(res.clone())
     }

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -36,6 +36,8 @@ pub mod test_df_execution;
 pub mod test_introspection;
 #[cfg(test)]
 pub mod test_udfs;
+#[cfg(test)]
+pub mod test_user_change;
 pub mod utils;
 pub use utils::*;
 

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -696,13 +696,17 @@ impl TransportService for TestConnectionTransport {
         _span_id: Option<Arc<SpanId>>,
         query: TransportLoadRequestQuery,
         _ctx: AuthContextRef,
-        _meta_fields: LoadRequestMeta,
+        meta: LoadRequestMeta,
         _member_to_alias: Option<HashMap<String, String>>,
         expression_params: Option<Vec<Option<String>>>,
     ) -> Result<SqlResponse, CubeError> {
+        let inputs = serde_json::json!({
+            "query": query,
+            "meta": meta,
+        });
         Ok(SqlResponse {
             sql: SqlQuery::new(
-                format!("SELECT * FROM {}", serde_json::to_string(&query).unwrap()),
+                format!("SELECT * FROM {}", serde_json::to_string(&inputs).unwrap()),
                 expression_params.unwrap_or(Vec::new()),
             ),
         })

--- a/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
@@ -7,7 +7,7 @@ use crate::compile::{
     convert_sql_to_cube_query,
     test::{
         convert_select_to_query_plan, get_test_session, get_test_tenant_ctx, init_testing_logger,
-        utils::LogicalPlanTestUtils,
+        utils::LogicalPlanTestUtils, TestContext,
     },
     DatabaseProtocol, Rewriter,
 };
@@ -190,4 +190,42 @@ async fn test_user_with_join() {
     );
 
     assert_eq!(cube_scan.options.change_user, Some("foo".to_string()))
+}
+
+/// This should test that query with CubeScanWrapper uses proper change_user for both SQL generation and execution calls
+#[tokio::test]
+async fn test_user_change_sql_generation() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let context = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+
+    context
+        .execute_query(
+            // language=PostgreSQL
+            r#"
+SELECT
+    COALESCE(customer_gender, 'N/A'),
+    AVG(avgPrice)
+FROM
+    KibanaSampleDataEcommerce
+WHERE
+    __user = 'gopher'
+GROUP BY 1
+;
+        "#
+            .to_string(),
+        )
+        .await
+        .expect_err("Test transport does not support load with SQL");
+
+    let load_calls = context.load_calls().await;
+    assert_eq!(load_calls.len(), 1);
+    let sql_query = load_calls[0].sql_query.as_ref().unwrap();
+    // This should be placed from load meta to query by TestConnectionTransport::sql
+    // It would mean that SQL generation used changed user
+    assert!(sql_query.sql.contains(r#""changeUser":"gopher""#));
+    assert_eq!(load_calls[0].meta.change_user(), Some("gopher".to_string()));
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
@@ -1,0 +1,193 @@
+//! Tests that check user change via __user virtual column
+
+use cubeclient::models::{V1LoadRequestQuery, V1LoadRequestQueryFilterItem};
+use pretty_assertions::assert_eq;
+
+use crate::compile::{
+    convert_sql_to_cube_query,
+    test::{
+        convert_select_to_query_plan, get_test_session, get_test_tenant_ctx, init_testing_logger,
+        utils::LogicalPlanTestUtils,
+    },
+    DatabaseProtocol, Rewriter,
+};
+
+#[tokio::test]
+async fn test_change_user_via_filter() {
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher'".to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let cube_scan = query_plan.as_logical_plan().find_cube_scan();
+
+    assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
+
+    assert_eq!(
+        cube_scan.request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
+            segments: Some(vec![]),
+            dimensions: Some(vec![]),
+            time_dimensions: None,
+            order: None,
+            limit: None,
+            offset: None,
+            filters: None,
+            ungrouped: None,
+        }
+    )
+}
+
+#[tokio::test]
+async fn test_change_user_via_in_filter() {
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user IN ('gopher')"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let cube_scan = query_plan.as_logical_plan().find_cube_scan();
+
+    assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
+
+    assert_eq!(
+        cube_scan.request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
+            segments: Some(vec![]),
+            dimensions: Some(vec![]),
+            time_dimensions: None,
+            order: None,
+            limit: None,
+            offset: None,
+            filters: None,
+            ungrouped: None,
+        }
+    )
+}
+
+#[tokio::test]
+async fn test_change_user_via_in_filter_thoughtspot() {
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce "ta_1" WHERE (LOWER("ta_1"."__user") IN ('gopher')) = TRUE"#.to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+        .await;
+
+    let expected_request = V1LoadRequestQuery {
+        measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
+        segments: Some(vec![]),
+        dimensions: Some(vec![]),
+        time_dimensions: None,
+        order: None,
+        limit: None,
+        offset: None,
+        filters: None,
+        ungrouped: None,
+    };
+
+    let cube_scan = query_plan.as_logical_plan().find_cube_scan();
+    assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
+    assert_eq!(cube_scan.request, expected_request);
+
+    let query_plan = convert_select_to_query_plan(
+        r#"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce "ta_1" WHERE ((LOWER("ta_1"."__user") IN ('gopher') = TRUE) = TRUE)"#.to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+        .await;
+
+    let cube_scan = query_plan.as_logical_plan().find_cube_scan();
+    assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
+    assert_eq!(cube_scan.request, expected_request);
+}
+
+#[tokio::test]
+async fn test_change_user_via_filter_and() {
+    let query_plan = convert_select_to_query_plan(
+        "SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher' AND customer_gender = 'male'".to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+        .await;
+
+    let cube_scan = query_plan.as_logical_plan().find_cube_scan();
+
+    assert_eq!(cube_scan.options.change_user, Some("gopher".to_string()));
+
+    assert_eq!(
+        cube_scan.request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
+            segments: Some(vec![]),
+            dimensions: Some(vec![]),
+            time_dimensions: None,
+            order: None,
+            limit: None,
+            offset: None,
+            filters: Some(vec![V1LoadRequestQueryFilterItem {
+                member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                operator: Some("equals".to_string()),
+                values: Some(vec!["male".to_string()]),
+                or: None,
+                and: None,
+            }]),
+            ungrouped: None,
+        }
+    )
+}
+
+#[tokio::test]
+async fn test_change_user_via_filter_or() {
+    // OR is not allowed for __user
+    let meta = get_test_tenant_ctx();
+    let query =
+        convert_sql_to_cube_query(
+            &"SELECT COUNT(*) as cnt FROM KibanaSampleDataEcommerce WHERE __user = 'gopher' OR customer_gender = 'male'".to_string(),
+            meta.clone(),
+            get_test_session(DatabaseProtocol::PostgreSQL, meta).await
+        ).await;
+
+    // TODO: We need to propagate error to result, to assert message
+    query.unwrap_err();
+}
+
+#[tokio::test]
+async fn test_user_with_join() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan(
+        "SELECT aliased.count as c, aliased.user_1 as u1, aliased.user_2 as u2 FROM (SELECT \"KibanaSampleDataEcommerce\".count as count, \"KibanaSampleDataEcommerce\".__user as user_1, Logs.__user as user_2 FROM \"KibanaSampleDataEcommerce\" CROSS JOIN Logs WHERE __user = 'foo') aliased".to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+        .await
+        .as_logical_plan();
+
+    let cube_scan = logical_plan.find_cube_scan();
+    assert_eq!(
+        cube_scan.request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
+            dimensions: Some(vec![]),
+            segments: Some(vec![]),
+            time_dimensions: None,
+            order: Some(vec![]),
+            limit: None,
+            offset: None,
+            filters: None,
+            ungrouped: Some(true),
+        }
+    );
+
+    assert_eq!(cube_scan.options.change_user, Some("foo".to_string()))
+}


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Use same meta for both SQL generation and execution calls
