### PR TITLE
feat(cubesql): Top-down extractor for rewrites

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hashbrown 0.14.3",
+ "indexmap 1.9.3",
  "itertools",
  "log",
  "lru",

--- a/rust/cubenativeutils/Cargo.lock
+++ b/rust/cubenativeutils/Cargo.lock
@@ -698,6 +698,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hashbrown 0.14.5",
+ "indexmap 1.9.3",
  "itertools",
  "log",
  "lru",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "flatbuffers",
  "half",
  "hex",
- "indexmap 1.8.1",
+ "indexmap 1.9.3",
  "lazy_static",
  "lexical-core",
  "multiversion",
@@ -473,7 +473,7 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
- "indexmap 1.8.1",
+ "indexmap 1.9.3",
  "textwrap",
 ]
 
@@ -773,6 +773,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hashbrown 0.14.3",
+ "indexmap 1.9.3",
  "insta",
  "itertools",
  "log",
@@ -995,7 +996,7 @@ dependencies = [
  "env_logger",
  "fxhash",
  "hashbrown 0.12.1",
- "indexmap 1.8.1",
+ "indexmap 1.9.3",
  "instant",
  "log",
  "num-bigint",
@@ -1278,12 +1279,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
@@ -1499,12 +1494,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -2762,7 +2757,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "indexmap 1.8.1",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -58,6 +58,7 @@ minijinja = { version = "1", features = ["json", "loader"] }
 lru = "0.12.1"
 sha2 = "0.10.8"
 bigdecimal = "0.4.2"
+indexmap = "1.9.3"
 
 
 [dev-dependencies]

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -190,7 +190,13 @@ pub trait QueryEngine {
         let mut rewriter = Rewriter::new(finalized_graph, cube_ctx.clone());
 
         let result = rewriter
-            .find_best_plan(root, state.auth_context().unwrap(), qtrace, span_id.clone())
+            .find_best_plan(
+                root,
+                state.auth_context().unwrap(),
+                qtrace,
+                span_id.clone(),
+                self.config_ref().top_down_extractor(),
+            )
             .await
             .map_err(|e| match e.cause {
                 CubeErrorCauseType::Internal(_) => CompilationError::Internal(

--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+
 use crate::{
     compile::rewrite::{
         rules::utils::granularity_str_to_int_order, CubeScanUngrouped, CubeScanWrapped,
@@ -6,9 +8,10 @@ use crate::{
     },
     transport::{MetaContext, V1CubeMetaDimensionExt},
 };
-use egg::{CostFunction, Id, Language};
-use std::sync::Arc;
+use egg::{Analysis, CostFunction, EGraph, Id, Language, RecExpr};
+use indexmap::IndexSet;
 
+#[derive(Debug)]
 pub struct BestCubePlan {
     meta_context: Arc<MetaContext>,
 }
@@ -17,245 +20,8 @@ impl BestCubePlan {
     pub fn new(meta_context: Arc<MetaContext>) -> Self {
         Self { meta_context }
     }
-}
 
-/// This cost struct maintains following structural relationships:
-/// - `replacers` > other nodes - having replacers in structure means not finished processing
-/// - `table_scans` > other nodes - having table scan means not detected cube scan
-/// - `empty_wrappers` > `non_detected_cube_scans` - we don't want empty wrapper to hide non detected cube scan errors
-/// - `non_detected_cube_scans` > other nodes - minimize cube scans without members
-/// - `filters` > `filter_members` - optimize for push down of filters
-/// - `filter_members` > `cube_members` - optimize for `inDateRange` filter push down to time dimension
-/// - `member_errors` > `cube_members` - extra cube members may be required (e.g. CASE)
-/// - `member_errors` > `wrapper_nodes` - use SQL push down where possible if cube scan can't be detected
-/// - `non_pushed_down_window` > `wrapper_nodes` - prefer to always push down window functions
-/// - `non_pushed_down_limit_sort` > `wrapper_nodes` - prefer to always push down limit-sort expressions
-/// - match errors by priority - optimize for more specific errors
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub struct CubePlanCost {
-    replacers: i64,
-    table_scans: i64,
-    empty_wrappers: i64,
-    non_detected_cube_scans: i64,
-    unwrapped_subqueries: usize,
-    member_errors: i64,
-    ungrouped_aggregates: usize,
-    // TODO if pre-aggregation can be used for window functions, then it'd be suboptimal
-    non_pushed_down_window: i64,
-    non_pushed_down_grouping_sets: i64,
-    non_pushed_down_limit_sort: i64,
-    wrapper_nodes: i64,
-    wrapped_select_ungrouped_scan: usize,
-    ast_size_outside_wrapper: usize,
-    filters: i64,
-    structure_points: i64,
-    filter_members: i64,
-    cube_members: i64,
-    errors: i64,
-    time_dimensions_used_as_dimensions: i64,
-    max_time_dimensions_granularity: i64,
-    cube_scan_nodes: i64,
-    ast_size_without_alias: usize,
-    ast_size: usize,
-    ast_size_inside_wrapper: usize,
-    ungrouped_nodes: usize,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum CubePlanState {
-    Wrapped,
-    Unwrapped(usize),
-    Wrapper,
-}
-
-impl CubePlanState {
-    pub fn add_child(&self, other: &Self) -> Self {
-        match (self, other) {
-            (CubePlanState::Wrapper, _) => CubePlanState::Wrapper,
-            (_, CubePlanState::Wrapped) => CubePlanState::Wrapped,
-            (CubePlanState::Wrapped, _) => CubePlanState::Wrapped,
-            (CubePlanState::Unwrapped(a), _) => CubePlanState::Unwrapped(*a),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum SortState {
-    None,
-    Current,
-    DirectChild,
-}
-
-impl SortState {
-    pub fn add_child(&self, other: &Self) -> Self {
-        match (self, other) {
-            (Self::Current, _) => Self::Current,
-            (_, Self::Current) | (Self::DirectChild, _) => Self::DirectChild,
-            _ => Self::None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct CubePlanCostAndState {
-    pub cost: CubePlanCost,
-    pub state: CubePlanState,
-    pub sort_state: SortState,
-}
-
-impl PartialOrd for CubePlanCostAndState {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cost.cmp(&other.cost))
-    }
-}
-
-impl Ord for CubePlanCostAndState {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.cost.cmp(&other.cost)
-    }
-}
-
-impl CubePlanCostAndState {
-    pub fn add_child(&self, other: &Self) -> Self {
-        Self {
-            cost: self.cost.add_child(&other.cost),
-            state: self.state.add_child(&other.state),
-            sort_state: self.sort_state.add_child(&other.sort_state),
-        }
-    }
-
-    pub fn finalize(&self, enode: &LogicalPlanLanguage) -> Self {
-        Self {
-            cost: self.cost.finalize(&self.state, &self.sort_state, enode),
-            state: self.state.clone(),
-            sort_state: self.sort_state.clone(),
-        }
-    }
-}
-
-impl CubePlanCost {
-    pub fn add_child(&self, other: &Self) -> Self {
-        Self {
-            replacers: self.replacers + other.replacers,
-            table_scans: self.table_scans + other.table_scans,
-            filters: self.filters + other.filters,
-            non_detected_cube_scans: (if other.cube_members == 0 {
-                self.non_detected_cube_scans
-            } else {
-                0
-            }) + other.non_detected_cube_scans,
-            filter_members: self.filter_members + other.filter_members,
-            non_pushed_down_window: self.non_pushed_down_window + other.non_pushed_down_window,
-            non_pushed_down_grouping_sets: self.non_pushed_down_grouping_sets
-                + other.non_pushed_down_grouping_sets,
-            non_pushed_down_limit_sort: self.non_pushed_down_limit_sort
-                + other.non_pushed_down_limit_sort,
-            member_errors: self.member_errors + other.member_errors,
-            cube_members: self.cube_members + other.cube_members,
-            errors: self.errors + other.errors,
-            structure_points: self.structure_points + other.structure_points,
-            empty_wrappers: self.empty_wrappers + other.empty_wrappers,
-            ast_size_outside_wrapper: self.ast_size_outside_wrapper
-                + other.ast_size_outside_wrapper,
-            ungrouped_aggregates: self.ungrouped_aggregates + other.ungrouped_aggregates,
-            wrapper_nodes: self.wrapper_nodes + other.wrapper_nodes,
-            wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan
-                + other.wrapped_select_ungrouped_scan,
-            cube_scan_nodes: self.cube_scan_nodes + other.cube_scan_nodes,
-            time_dimensions_used_as_dimensions: self.time_dimensions_used_as_dimensions
-                + other.time_dimensions_used_as_dimensions,
-            max_time_dimensions_granularity: self
-                .max_time_dimensions_granularity
-                .max(other.max_time_dimensions_granularity),
-            ast_size_without_alias: self.ast_size_without_alias + other.ast_size_without_alias,
-            ast_size: self.ast_size + other.ast_size,
-            ast_size_inside_wrapper: self.ast_size_inside_wrapper + other.ast_size_inside_wrapper,
-            ungrouped_nodes: self.ungrouped_nodes + other.ungrouped_nodes,
-            unwrapped_subqueries: self.unwrapped_subqueries + other.unwrapped_subqueries,
-        }
-    }
-
-    pub fn finalize(
-        &self,
-        state: &CubePlanState,
-        sort_state: &SortState,
-        enode: &LogicalPlanLanguage,
-    ) -> Self {
-        Self {
-            replacers: self.replacers,
-            table_scans: self.table_scans,
-            filters: self.filters,
-            non_detected_cube_scans: match state {
-                CubePlanState::Wrapped => 0,
-                CubePlanState::Unwrapped(_) => self.non_detected_cube_scans,
-                CubePlanState::Wrapper => 0,
-            },
-            filter_members: self.filter_members,
-            member_errors: self.member_errors,
-            non_pushed_down_window: self.non_pushed_down_window,
-            non_pushed_down_grouping_sets: match state {
-                CubePlanState::Wrapped => 0,
-                CubePlanState::Unwrapped(_) => self.non_pushed_down_grouping_sets,
-                CubePlanState::Wrapper => 0,
-            },
-            non_pushed_down_limit_sort: match sort_state {
-                SortState::DirectChild => self.non_pushed_down_limit_sort,
-                _ => 0,
-            },
-            cube_members: self.cube_members,
-            errors: self.errors,
-            structure_points: self.structure_points,
-            ast_size_outside_wrapper: match state {
-                CubePlanState::Wrapped => 0,
-                CubePlanState::Unwrapped(size) => *size,
-                CubePlanState::Wrapper => 0,
-            } + self.ast_size_outside_wrapper,
-            empty_wrappers: match state {
-                CubePlanState::Wrapped => 0,
-                CubePlanState::Unwrapped(_) => 0,
-                CubePlanState::Wrapper => {
-                    if self.ast_size_inside_wrapper == 0 {
-                        1
-                    } else {
-                        0
-                    }
-                }
-            } + self.empty_wrappers,
-            time_dimensions_used_as_dimensions: self.time_dimensions_used_as_dimensions,
-            max_time_dimensions_granularity: self.max_time_dimensions_granularity,
-            ungrouped_aggregates: match state {
-                CubePlanState::Wrapped => 0,
-                CubePlanState::Unwrapped(_) => {
-                    if let LogicalPlanLanguage::Aggregate(_) = enode {
-                        if self.ungrouped_nodes > 0 {
-                            1
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
-                    }
-                }
-                CubePlanState::Wrapper => 0,
-            } + self.ungrouped_aggregates,
-            unwrapped_subqueries: self.unwrapped_subqueries,
-            wrapper_nodes: self.wrapper_nodes,
-            wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan,
-            cube_scan_nodes: self.cube_scan_nodes,
-            ast_size_without_alias: self.ast_size_without_alias,
-            ast_size: self.ast_size,
-            ast_size_inside_wrapper: self.ast_size_inside_wrapper,
-            ungrouped_nodes: self.ungrouped_nodes,
-        }
-    }
-}
-
-impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
-    type Cost = CubePlanCostAndState;
-    fn cost<C>(&mut self, enode: &LogicalPlanLanguage, mut costs: C) -> Self::Cost
-    where
-        C: FnMut(Id) -> Self::Cost,
-    {
+    pub fn initial_cost(&self, enode: &LogicalPlanLanguage, top_down: bool) -> CubePlanCost {
         let table_scans = match enode {
             LogicalPlanLanguage::TableScan(_) => 1,
             _ => 0,
@@ -271,20 +37,6 @@ impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
             _ => 0,
         };
 
-        let ast_size_outside_wrapper = match enode {
-            LogicalPlanLanguage::Aggregate(_) => 1,
-            LogicalPlanLanguage::Projection(_) => 1,
-            LogicalPlanLanguage::Limit(_) => 1,
-            LogicalPlanLanguage::Sort(_) => 1,
-            LogicalPlanLanguage::Filter(_) => 1,
-            LogicalPlanLanguage::Join(_) => 1,
-            LogicalPlanLanguage::CrossJoin(_) => 1,
-            LogicalPlanLanguage::Union(_) => 1,
-            LogicalPlanLanguage::Window(_) => 1,
-            LogicalPlanLanguage::Subquery(_) => 1,
-            _ => 0,
-        };
-
         let non_pushed_down_window = match enode {
             LogicalPlanLanguage::Window(_) => 1,
             _ => 0,
@@ -296,7 +48,8 @@ impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
         };
 
         let non_pushed_down_limit_sort = match enode {
-            LogicalPlanLanguage::Limit(_) => 1,
+            LogicalPlanLanguage::Limit(_) if !top_down => 1,
+            LogicalPlanLanguage::Sort(_) if top_down => 1,
             _ => 0,
         };
 
@@ -433,34 +186,294 @@ impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
             _ => 0,
         };
 
-        let initial_cost = CubePlanCostAndState {
-            cost: CubePlanCost {
-                replacers: this_replacers,
-                table_scans,
-                filters,
-                filter_members,
-                non_detected_cube_scans,
-                member_errors,
-                non_pushed_down_window,
-                non_pushed_down_grouping_sets,
-                non_pushed_down_limit_sort,
-                cube_members,
-                errors: this_errors,
-                time_dimensions_used_as_dimensions,
-                max_time_dimensions_granularity,
-                structure_points,
-                ungrouped_aggregates: 0,
-                wrapper_nodes,
-                wrapped_select_ungrouped_scan,
-                empty_wrappers: 0,
-                ast_size_outside_wrapper: 0,
-                ast_size_inside_wrapper,
-                cube_scan_nodes,
-                ast_size_without_alias,
-                ast_size: 1,
-                ungrouped_nodes,
-                unwrapped_subqueries,
+        CubePlanCost {
+            replacers: this_replacers,
+            table_scans,
+            filters,
+            filter_members,
+            non_detected_cube_scans,
+            member_errors,
+            non_pushed_down_window,
+            non_pushed_down_grouping_sets,
+            non_pushed_down_limit_sort,
+            cube_members,
+            errors: this_errors,
+            time_dimensions_used_as_dimensions,
+            max_time_dimensions_granularity,
+            structure_points,
+            ungrouped_aggregates: 0,
+            wrapper_nodes,
+            wrapped_select_ungrouped_scan,
+            empty_wrappers: 0,
+            ast_size_outside_wrapper: 0,
+            ast_size_inside_wrapper,
+            cube_scan_nodes,
+            ast_size_without_alias,
+            ast_size: 1,
+            ungrouped_nodes,
+            unwrapped_subqueries,
+        }
+    }
+}
+
+/// This cost struct maintains following structural relationships:
+/// - `replacers` > other nodes - having replacers in structure means not finished processing
+/// - `table_scans` > other nodes - having table scan means not detected cube scan
+/// - `empty_wrappers` > `non_detected_cube_scans` - we don't want empty wrapper to hide non detected cube scan errors
+/// - `non_detected_cube_scans` > other nodes - minimize cube scans without members
+/// - `filters` > `filter_members` - optimize for push down of filters
+/// - `filter_members` > `cube_members` - optimize for `inDateRange` filter push down to time dimension
+/// - `member_errors` > `cube_members` - extra cube members may be required (e.g. CASE)
+/// - `member_errors` > `wrapper_nodes` - use SQL push down where possible if cube scan can't be detected
+/// - `non_pushed_down_window` > `wrapper_nodes` - prefer to always push down window functions
+/// - `non_pushed_down_limit_sort` > `wrapper_nodes` - prefer to always push down limit-sort expressions
+/// - match errors by priority - optimize for more specific errors
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CubePlanCost {
+    replacers: i64,
+    table_scans: i64,
+    empty_wrappers: i64,
+    non_detected_cube_scans: i64,
+    unwrapped_subqueries: usize,
+    member_errors: i64,
+    ungrouped_aggregates: usize,
+    // TODO if pre-aggregation can be used for window functions, then it'd be suboptimal
+    non_pushed_down_window: i64,
+    non_pushed_down_grouping_sets: i64,
+    non_pushed_down_limit_sort: i64,
+    wrapper_nodes: i64,
+    wrapped_select_ungrouped_scan: usize,
+    ast_size_outside_wrapper: usize,
+    filters: i64,
+    structure_points: i64,
+    filter_members: i64,
+    cube_members: i64,
+    errors: i64,
+    time_dimensions_used_as_dimensions: i64,
+    max_time_dimensions_granularity: i64,
+    cube_scan_nodes: i64,
+    ast_size_without_alias: usize,
+    ast_size: usize,
+    ast_size_inside_wrapper: usize,
+    ungrouped_nodes: usize,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum CubePlanState {
+    Wrapped,
+    Unwrapped(usize),
+    Wrapper,
+}
+
+impl CubePlanState {
+    pub fn add_child(&self, other: &Self) -> Self {
+        match (self, other) {
+            (CubePlanState::Wrapper, _) => CubePlanState::Wrapper,
+            (_, CubePlanState::Wrapped) => CubePlanState::Wrapped,
+            (CubePlanState::Wrapped, _) => CubePlanState::Wrapped,
+            (CubePlanState::Unwrapped(a), _) => CubePlanState::Unwrapped(*a),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum SortState {
+    None,
+    Current,
+    DirectChild,
+}
+
+impl SortState {
+    pub fn add_child(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Current, _) => Self::Current,
+            (_, Self::Current) | (Self::DirectChild, _) => Self::DirectChild,
+            _ => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CubePlanCostAndState {
+    pub cost: CubePlanCost,
+    pub state: CubePlanState,
+    pub sort_state: SortState,
+}
+
+impl PartialOrd for CubePlanCostAndState {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cost.cmp(&other.cost))
+    }
+}
+
+impl Ord for CubePlanCostAndState {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.cost.cmp(&other.cost)
+    }
+}
+
+impl CubePlanCostAndState {
+    pub fn add_child(&self, other: &Self) -> Self {
+        Self {
+            cost: self.cost.add_child(&other.cost),
+            state: self.state.add_child(&other.state),
+            sort_state: self.sort_state.add_child(&other.sort_state),
+        }
+    }
+
+    pub fn finalize(&self, enode: &LogicalPlanLanguage) -> Self {
+        Self {
+            cost: self
+                .cost
+                .finalize(&self.state, &self.sort_state, enode, false),
+            state: self.state.clone(),
+            sort_state: self.sort_state.clone(),
+        }
+    }
+}
+
+impl CubePlanCost {
+    pub fn add_child(&self, other: &Self) -> Self {
+        Self {
+            replacers: self.replacers + other.replacers,
+            table_scans: self.table_scans + other.table_scans,
+            filters: self.filters + other.filters,
+            non_detected_cube_scans: (if other.cube_members == 0 {
+                self.non_detected_cube_scans
+            } else {
+                0
+            }) + other.non_detected_cube_scans,
+            filter_members: self.filter_members + other.filter_members,
+            non_pushed_down_window: self.non_pushed_down_window + other.non_pushed_down_window,
+            non_pushed_down_grouping_sets: self.non_pushed_down_grouping_sets
+                + other.non_pushed_down_grouping_sets,
+            non_pushed_down_limit_sort: self.non_pushed_down_limit_sort
+                + other.non_pushed_down_limit_sort,
+            member_errors: self.member_errors + other.member_errors,
+            cube_members: self.cube_members + other.cube_members,
+            errors: self.errors + other.errors,
+            structure_points: self.structure_points + other.structure_points,
+            empty_wrappers: self.empty_wrappers + other.empty_wrappers,
+            ast_size_outside_wrapper: self.ast_size_outside_wrapper
+                + other.ast_size_outside_wrapper,
+            ungrouped_aggregates: self.ungrouped_aggregates + other.ungrouped_aggregates,
+            wrapper_nodes: self.wrapper_nodes + other.wrapper_nodes,
+            wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan
+                + other.wrapped_select_ungrouped_scan,
+            cube_scan_nodes: self.cube_scan_nodes + other.cube_scan_nodes,
+            time_dimensions_used_as_dimensions: self.time_dimensions_used_as_dimensions
+                + other.time_dimensions_used_as_dimensions,
+            max_time_dimensions_granularity: self
+                .max_time_dimensions_granularity
+                .max(other.max_time_dimensions_granularity),
+            ast_size_without_alias: self.ast_size_without_alias + other.ast_size_without_alias,
+            ast_size: self.ast_size + other.ast_size,
+            ast_size_inside_wrapper: self.ast_size_inside_wrapper + other.ast_size_inside_wrapper,
+            ungrouped_nodes: self.ungrouped_nodes + other.ungrouped_nodes,
+            unwrapped_subqueries: self.unwrapped_subqueries + other.unwrapped_subqueries,
+        }
+    }
+
+    pub fn finalize(
+        &self,
+        state: &CubePlanState,
+        sort_state: &SortState,
+        enode: &LogicalPlanLanguage,
+        top_down: bool,
+    ) -> Self {
+        Self {
+            replacers: self.replacers,
+            table_scans: self.table_scans,
+            filters: self.filters,
+            non_detected_cube_scans: match state {
+                CubePlanState::Wrapped => 0,
+                CubePlanState::Unwrapped(_) => self.non_detected_cube_scans,
+                CubePlanState::Wrapper => 0,
             },
+            filter_members: self.filter_members,
+            member_errors: self.member_errors,
+            non_pushed_down_window: self.non_pushed_down_window,
+            non_pushed_down_grouping_sets: match state {
+                CubePlanState::Wrapped => 0,
+                CubePlanState::Unwrapped(_) => self.non_pushed_down_grouping_sets,
+                CubePlanState::Wrapper => 0,
+            },
+            non_pushed_down_limit_sort: match sort_state {
+                SortState::DirectChild => self.non_pushed_down_limit_sort,
+                SortState::Current if top_down => self.non_pushed_down_limit_sort,
+                _ => 0,
+            },
+            cube_members: self.cube_members,
+            errors: self.errors,
+            structure_points: self.structure_points,
+            ast_size_outside_wrapper: match state {
+                CubePlanState::Wrapped => 0,
+                CubePlanState::Unwrapped(size) => *size,
+                CubePlanState::Wrapper => 0,
+            } + self.ast_size_outside_wrapper,
+            empty_wrappers: match state {
+                CubePlanState::Wrapped => 0,
+                CubePlanState::Unwrapped(_) => 0,
+                CubePlanState::Wrapper => {
+                    if self.ast_size_inside_wrapper == 0 {
+                        1
+                    } else {
+                        0
+                    }
+                }
+            } + self.empty_wrappers,
+            time_dimensions_used_as_dimensions: self.time_dimensions_used_as_dimensions,
+            max_time_dimensions_granularity: self.max_time_dimensions_granularity,
+            ungrouped_aggregates: match state {
+                CubePlanState::Wrapped => 0,
+                CubePlanState::Unwrapped(_) => {
+                    if let LogicalPlanLanguage::Aggregate(_) = enode {
+                        if self.ungrouped_nodes > 0 {
+                            1
+                        } else {
+                            0
+                        }
+                    } else {
+                        0
+                    }
+                }
+                CubePlanState::Wrapper => 0,
+            } + self.ungrouped_aggregates,
+            unwrapped_subqueries: self.unwrapped_subqueries,
+            wrapper_nodes: self.wrapper_nodes,
+            wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan,
+            cube_scan_nodes: self.cube_scan_nodes,
+            ast_size_without_alias: self.ast_size_without_alias,
+            ast_size: self.ast_size,
+            ast_size_inside_wrapper: self.ast_size_inside_wrapper,
+            ungrouped_nodes: self.ungrouped_nodes,
+        }
+    }
+}
+
+impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
+    type Cost = CubePlanCostAndState;
+    fn cost<C>(&mut self, enode: &LogicalPlanLanguage, mut costs: C) -> Self::Cost
+    where
+        C: FnMut(Id) -> Self::Cost,
+    {
+        let ast_size_outside_wrapper = match enode {
+            LogicalPlanLanguage::Aggregate(_) => 1,
+            LogicalPlanLanguage::Projection(_) => 1,
+            LogicalPlanLanguage::Limit(_) => 1,
+            LogicalPlanLanguage::Sort(_) => 1,
+            LogicalPlanLanguage::Filter(_) => 1,
+            LogicalPlanLanguage::Join(_) => 1,
+            LogicalPlanLanguage::CrossJoin(_) => 1,
+            LogicalPlanLanguage::Union(_) => 1,
+            LogicalPlanLanguage::Window(_) => 1,
+            LogicalPlanLanguage::Subquery(_) => 1,
+            _ => 0,
+        };
+
+        let cost = self.initial_cost(enode, false);
+        let initial_cost = CubePlanCostAndState {
+            cost,
             state: match enode {
                 LogicalPlanLanguage::CubeScanWrapped(CubeScanWrapped(true)) => {
                     CubePlanState::Wrapped
@@ -482,5 +495,346 @@ impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
             })
             .finalize(enode);
         res
+    }
+}
+
+pub trait TopDownCost: Clone + Debug + PartialOrd {
+    fn add(&self, other: &Self) -> Self;
+}
+
+pub trait TopDownState<L>: Clone + Debug + Eq + Hash
+where
+    L: Language,
+{
+    /// Transforms the current state based on node's contents.
+    fn transform<A>(&self, node: &L, egraph: &EGraph<L, A>) -> Self
+    where
+        A: Analysis<L>;
+}
+
+/// Simple implementation of TopDownState for lack of state.
+impl<L> TopDownState<L> for ()
+where
+    L: Language,
+{
+    fn transform<A>(&self, _: &L, _: &EGraph<L, A>) -> Self
+    where
+        A: Analysis<L>,
+    {
+        ()
+    }
+}
+
+pub trait TopDownCostFunction<L, S, C>: Debug
+where
+    L: Language,
+    S: TopDownState<L>,
+    C: TopDownCost,
+{
+    /// Returns the cost for the current node.
+    fn cost(&self, node: &L) -> C;
+
+    // Finalize the cost based on node and state.
+    fn finalize(&self, cost: C, node: &L, state: &S) -> C;
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct IdWithState<L, S>
+where
+    L: Language,
+    S: TopDownState<L>,
+{
+    id: Id,
+    state: Arc<S>,
+    phantom: PhantomData<L>,
+}
+
+impl<L, S> IdWithState<L, S>
+where
+    L: Language,
+    S: TopDownState<L>,
+{
+    pub fn new(id: Id, state: Arc<S>) -> Self {
+        Self {
+            id,
+            state,
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TopDownExtractor<'a, L, A, C, S, CF>
+where
+    L: Language,
+    A: Analysis<L>,
+    C: TopDownCost,
+    S: TopDownState<L>,
+    CF: TopDownCostFunction<L, S, C>,
+{
+    egraph: &'a EGraph<L, A>,
+    // Caches results. `None` for nodes in progress to prevent recursion
+    extract_map: HashMap<IdWithState<L, S>, Option<(usize, C)>>,
+    cost_fn: Arc<CF>,
+    root_state: Arc<S>,
+}
+
+impl<'a, L, A, C, S, CF> TopDownExtractor<'a, L, A, C, S, CF>
+where
+    L: Language,
+    A: Analysis<L>,
+    C: TopDownCost,
+    S: TopDownState<L>,
+    CF: TopDownCostFunction<L, S, C>,
+{
+    pub fn new(egraph: &'a EGraph<L, A>, cost_fn: CF, root_state: S) -> Self {
+        Self {
+            egraph,
+            extract_map: HashMap::new(),
+            cost_fn: Arc::new(cost_fn),
+            root_state: Arc::new(root_state),
+        }
+    }
+
+    /// Returns cost and path for best plan for provided root eclass.
+    ///
+    /// If all nodes happen to be recursive, returns `None`.
+    pub fn find_best(&mut self, root: Id) -> Option<(C, RecExpr<L>)> {
+        let cost = self.extract(root, Arc::clone(&self.root_state))?;
+        let root_id_with_state = IdWithState::new(root, Arc::clone(&self.root_state));
+        let root_node = self.choose_node(&root_id_with_state)?;
+        let recexpr =
+            self.build_recexpr(&root_node, root_id_with_state.state, |id_with_state| {
+                self.choose_node(id_with_state)
+            })?;
+        Some((cost, recexpr))
+    }
+
+    /// Recursively extracts the cost of each node in the eclass
+    /// and returns cost of the node with least cost based on the passed state,
+    /// caching the cost together with node index inside eclass in `extract_map`.
+    ///
+    /// Yields `None` if eclass is already in progress
+    /// or all its nodes happen to be recursive.
+    fn extract(&mut self, eclass: Id, state: Arc<S>) -> Option<C> {
+        let id_with_state = IdWithState::new(eclass, state);
+        if let Some(cached_index_and_cost) = self.extract_map.get(&id_with_state) {
+            // TODO: avoid cloning here?
+            return cached_index_and_cost.as_ref().map(|(_, cost)| cost.clone());
+        }
+
+        // Mark this eclass as in progress
+        self.extract_map.insert(id_with_state.clone(), None);
+
+        // Compute the cost of each node, take the minimum
+        let mut min_index = None;
+        let mut min_cost = None;
+        'nodes: for (index, node) in self.egraph[eclass].nodes.iter().enumerate() {
+            // Compute the cost of this node
+            let this_node_cost = self.cost_fn.cost(node);
+
+            // Get state for this node and its children
+            let new_state = Arc::new(id_with_state.state.transform(node, self.egraph));
+
+            // Recursively get children cost
+            let mut total_node_cost = this_node_cost;
+            for child in node.children() {
+                let Some(child_cost) = self.extract(*child, Arc::clone(&new_state)) else {
+                    // This path is inevitably recursive, try the next node
+                    continue 'nodes;
+                };
+                total_node_cost = total_node_cost.add(&child_cost);
+            }
+            total_node_cost = self.cost_fn.finalize(total_node_cost, node, &new_state);
+
+            // Now that we've finalized the cost, check if it's lower than the minimum
+            if let Some(min_cost) = &min_cost {
+                if &total_node_cost > min_cost {
+                    continue;
+                }
+            }
+
+            min_index = Some(index);
+            min_cost = Some(total_node_cost);
+        }
+
+        let (Some(min_index), Some(min_cost)) = (min_index, min_cost) else {
+            // All nodes were recursive
+            self.extract_map.remove(&id_with_state);
+            return None;
+        };
+
+        self.extract_map
+            .insert(id_with_state, Some((min_index, min_cost.clone())));
+        Some(min_cost)
+    }
+
+    /// A custom version of [`egg::Language::build_recexpr`], accepting state
+    /// in addition to [`egg::Id`].
+    fn build_recexpr<F>(&self, node: &L, start_state: Arc<S>, get_node: F) -> Option<RecExpr<L>>
+    where
+        F: Fn(&IdWithState<L, S>) -> Option<L>,
+    {
+        let state = Arc::new(start_state.transform(node, self.egraph));
+        let mut set = IndexSet::<L>::default();
+        let mut ids = HashMap::<IdWithState<L, S>, Id>::default();
+        let mut todo = node
+            .children()
+            .into_iter()
+            .map(|id| IdWithState::new(*id, Arc::clone(&state)))
+            .collect::<Vec<_>>();
+
+        while let Some(id_with_state) = todo.last().cloned() {
+            if ids.contains_key(&id_with_state) {
+                todo.pop();
+                continue;
+            }
+
+            let node = get_node(&id_with_state)?;
+            let node_state = Arc::new(id_with_state.state.transform(&node, self.egraph));
+
+            // Check to see if we can do this node yet
+            let mut ids_has_all_children = true;
+            for child in node.children() {
+                let child_id_with_state = IdWithState::new(*child, Arc::clone(&node_state));
+                if !ids.contains_key(&child_id_with_state) {
+                    ids_has_all_children = false;
+                    todo.push(child_id_with_state);
+                }
+            }
+
+            // All children are processed, so we can lookup this node safely
+            if ids_has_all_children {
+                let node = node.map_children(|id| {
+                    let id_with_state = IdWithState::new(id, Arc::clone(&node_state));
+                    ids[&id_with_state]
+                });
+                let (new_id, _) = set.insert_full(node);
+                ids.insert(id_with_state, Id::from(new_id));
+                todo.pop();
+            }
+        }
+
+        // Finally, add the root node and create the expression
+        let mut nodes = set.into_iter().collect::<Vec<_>>();
+        nodes.push(node.clone().map_children(|id| {
+            let id_with_state = IdWithState::new(id, Arc::clone(&state));
+            ids[&id_with_state]
+        }));
+        Some(RecExpr::from(nodes))
+    }
+
+    fn choose_node(&self, id_with_state: &IdWithState<L, S>) -> Option<L> {
+        let index = *self
+            .extract_map
+            .get(&id_with_state)?
+            .as_ref()
+            .map(|(index, _)| index)?;
+        Some(self.egraph[id_with_state.id].nodes[index].clone())
+    }
+}
+
+impl TopDownCost for CubePlanCost {
+    fn add(&self, other: &Self) -> Self {
+        self.add_child(other)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CubePlanTopDownState {
+    wrapped: CubePlanState,
+    limit: SortState,
+}
+
+impl CubePlanTopDownState {
+    pub fn new() -> Self {
+        Self {
+            wrapped: CubePlanState::Unwrapped(0),
+            limit: SortState::None,
+        }
+    }
+
+    pub fn is_wrapped<A>(
+        &self,
+        node: &LogicalPlanLanguage,
+        egraph: &EGraph<LogicalPlanLanguage, A>,
+    ) -> bool
+    where
+        A: Analysis<LogicalPlanLanguage>,
+    {
+        let LogicalPlanLanguage::CubeScan(cube_scan) = node else {
+            return false;
+        };
+        let wrapped_index = 8;
+        let wrapped_id = cube_scan[wrapped_index];
+        for node in &egraph[wrapped_id].nodes {
+            if !matches!(
+                node,
+                LogicalPlanLanguage::CubeScanWrapped(CubeScanWrapped(true))
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+impl TopDownState<LogicalPlanLanguage> for CubePlanTopDownState {
+    fn transform<A>(
+        &self,
+        node: &LogicalPlanLanguage,
+        egraph: &EGraph<LogicalPlanLanguage, A>,
+    ) -> Self
+    where
+        A: Analysis<LogicalPlanLanguage>,
+    {
+        let wrapped = match node {
+            LogicalPlanLanguage::CubeScanWrapper(_) => CubePlanState::Wrapper,
+            _ if self.wrapped == CubePlanState::Wrapped => CubePlanState::Wrapped,
+            LogicalPlanLanguage::CubeScan(_) if self.is_wrapped(node, egraph) => {
+                CubePlanState::Wrapped
+            }
+            _ => {
+                let ast_size_outside_wrapper = match node {
+                    LogicalPlanLanguage::Aggregate(_) => 1,
+                    LogicalPlanLanguage::Projection(_) => 1,
+                    LogicalPlanLanguage::Limit(_) => 1,
+                    LogicalPlanLanguage::Sort(_) => 1,
+                    LogicalPlanLanguage::Filter(_) => 1,
+                    LogicalPlanLanguage::Join(_) => 1,
+                    LogicalPlanLanguage::CrossJoin(_) => 1,
+                    LogicalPlanLanguage::Union(_) => 1,
+                    LogicalPlanLanguage::Window(_) => 1,
+                    LogicalPlanLanguage::Subquery(_) => 1,
+                    _ => 0,
+                };
+                CubePlanState::Unwrapped(ast_size_outside_wrapper)
+            }
+        };
+
+        let limit = match node {
+            LogicalPlanLanguage::Limit(_) => SortState::DirectChild,
+            LogicalPlanLanguage::Sort(_) if self.limit == SortState::DirectChild => {
+                SortState::Current
+            }
+            _ => SortState::None,
+        };
+
+        Self { wrapped, limit }
+    }
+}
+
+impl TopDownCostFunction<LogicalPlanLanguage, CubePlanTopDownState, CubePlanCost> for BestCubePlan {
+    fn cost(&self, node: &LogicalPlanLanguage) -> CubePlanCost {
+        self.initial_cost(node, true)
+    }
+
+    fn finalize(
+        &self,
+        cost: CubePlanCost,
+        node: &LogicalPlanLanguage,
+        state: &CubePlanTopDownState,
+    ) -> CubePlanCost {
+        CubePlanCost::finalize(&cost, &state.wrapped, &state.limit, node, true)
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -4,7 +4,7 @@ use crate::{
         rewrite::{
             analysis::LogicalPlanAnalysis,
             converter::LanguageToLogicalPlanConverter,
-            cost::BestCubePlan,
+            cost::{BestCubePlan, CubePlanTopDownState, TopDownExtractor},
             rules::{
                 case::CaseRules, common::CommonRules, dates::DateRules, filters::FilterRules,
                 flatten::FlattenRules, members::MemberRules, old_split::OldSplitRules,
@@ -314,6 +314,7 @@ impl Rewriter {
         auth_context: AuthContextRef,
         qtrace: &mut Option<Qtrace>,
         span_id: Option<Arc<SpanId>>,
+        top_down_extractor: bool,
     ) -> Result<LogicalPlan, CubeError> {
         let cube_context = self.cube_context.clone();
         let egraph = self.graph.clone();
@@ -337,9 +338,26 @@ impl Rewriter {
                 let (runner, qtrace_egraph_iterations) =
                     Self::run_rewrites(&cube_context, egraph, rules, "final")?;
 
-                let extractor =
-                    Extractor::new(&runner.egraph, BestCubePlan::new(cube_context.meta.clone()));
-                let (best_cost, best) = extractor.find_best(root);
+                let best = if top_down_extractor {
+                    let mut extractor = TopDownExtractor::new(
+                        &runner.egraph,
+                        BestCubePlan::new(cube_context.meta.clone()),
+                        CubePlanTopDownState::new(),
+                    );
+                    let Some((best_cost, best)) = extractor.find_best(root) else {
+                        return Err(CubeError::internal("Unable to find best plan".to_string()));
+                    };
+                    log::debug!("Best cost: {:?}", best_cost);
+                    best
+                } else {
+                    let extractor = Extractor::new(
+                        &runner.egraph,
+                        BestCubePlan::new(cube_context.meta.clone()),
+                    );
+                    let (best_cost, best) = extractor.find_best(root);
+                    log::debug!("Best cost: {:?}", best_cost);
+                    best
+                };
                 let qtrace_best_graph = if Qtrace::is_enabled() {
                     best.as_ref().iter().cloned().collect()
                 } else {
@@ -354,14 +372,13 @@ impl Rewriter {
                         .map(|(i, n)| format!("{}: {:?}", i, n))
                         .join(", ")
                 );
-                log::debug!("Best cost: {:?}", best_cost);
                 let converter = LanguageToLogicalPlanConverter::new(
                     best,
                     cube_context.clone(),
                     auth_context,
                     span_id.clone(),
                 );
-                Ok::<_, CubeError>((
+                Ok((
                     converter.to_logical_plan(new_root),
                     qtrace_egraph_iterations,
                     qtrace_best_graph,
@@ -498,6 +515,12 @@ impl Rewriter {
     pub fn sql_push_down_enabled() -> bool {
         env::var("CUBESQL_SQL_PUSH_DOWN")
             .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(true)
+    }
+
+    pub fn top_down_extractor_enabled() -> bool {
+        env::var("CUBESQL_TOP_DOWN_EXTRACTOR")
+            .map(|v| v.to_lowercase() != "false")
             .unwrap_or(true)
     }
 

--- a/rust/cubesql/cubesql/src/config/mod.rs
+++ b/rust/cubesql/cubesql/src/config/mod.rs
@@ -115,6 +115,8 @@ pub trait ConfigObj: DIService + Debug {
     fn max_sessions(&self) -> usize;
 
     fn no_implicit_order(&self) -> bool;
+
+    fn top_down_extractor(&self) -> bool;
 }
 
 #[derive(Debug, Clone)]
@@ -135,6 +137,7 @@ pub struct ConfigObjImpl {
     pub non_streaming_query_max_row_limit: i32,
     pub max_sessions: usize,
     pub no_implicit_order: bool,
+    pub top_down_extractor: bool,
 }
 
 impl ConfigObjImpl {
@@ -172,6 +175,7 @@ impl ConfigObjImpl {
             non_streaming_query_max_row_limit: env_parse("CUBEJS_DB_QUERY_LIMIT", 50000),
             max_sessions: env_parse("CUBEJS_MAX_SESSIONS", 1024),
             no_implicit_order: env_parse("CUBESQL_SQL_NO_IMPLICIT_ORDER", true),
+            top_down_extractor: env_parse("CUBESQL_TOP_DOWN_EXTRACTOR", true),
         }
     }
 }
@@ -238,6 +242,10 @@ impl ConfigObj for ConfigObjImpl {
     fn max_sessions(&self) -> usize {
         self.max_sessions
     }
+
+    fn top_down_extractor(&self) -> bool {
+        self.top_down_extractor
+    }
 }
 
 impl Config {
@@ -270,6 +278,7 @@ impl Config {
                 non_streaming_query_max_row_limit: 50000,
                 max_sessions: 1024,
                 no_implicit_order: true,
+                top_down_extractor: true,
             }),
         }
     }

--- a/rust/cubesqlplanner/Cargo.lock
+++ b/rust/cubesqlplanner/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hashbrown 0.14.5",
+ "indexmap 1.9.3",
  "itertools",
  "log",
  "lru",


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds a top-down extractor for e-graphs in addition to the previously used bottom-up extractor. This allows extracting nodes from e-classes with respect to their state. Use flag `CUBESQL_TOP_DOWN_EXTRACTOR=true` to enable.
