### PR TITLE
chore: tsconfig - target es2022 (Node.js 18)

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -1,4 +1,4 @@
-import { BaseFilter, BaseQuery, ParamAllocator } from '@cubejs-backend/schema-compiler';
+import { BaseFilter, BaseQuery } from '@cubejs-backend/schema-compiler';
 
 const GRANULARITY_TO_INTERVAL: Record<string, string> = {
   day: 'DAY',
@@ -22,8 +22,6 @@ class FireboltFilter extends BaseFilter {
 }
 
 export class FireboltQuery extends BaseQuery {
-  public paramAllocator!: ParamAllocator;
-
   public convertTz(field: string) {
     return `${field} AT TIME ZONE '${this.timezone}'`;
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/BaseQueueEventsBus.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/BaseQueueEventsBus.ts
@@ -1,14 +1,10 @@
 export class BaseQueueEventsBus {
-  protected readonly subscribers: Record<string, any>;
-
-  public constructor() {
-    this.subscribers = {};
-  }
+  protected readonly subscribers: Record<string, any> = {};
 
   public subscribe(id, callback) {
     this.subscribers[id] = { id, callback };
   }
-  
+
   public unsubscribe(id) {
     delete this.subscribers[id];
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueEventsBus.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueEventsBus.ts
@@ -1,8 +1,6 @@
 import { BaseQueueEventsBus } from './BaseQueueEventsBus';
 
 export class LocalQueueEventsBus extends BaseQueueEventsBus {
-  protected readonly subscribers: Record<string, any>;
-
   public emit(event) {
     Promise.all(Object.values(this.subscribers).map(({ callback }) => callback(event)))
       .catch(err => console.error(err));

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -17,17 +17,17 @@ import { CubejsServerCore } from '../../src/core/server';
 import { CreateOptions, SystemOptions } from '../../src/core/types';
 
 class CubejsServerCoreExposed extends CubejsServerCore {
-  public options: ServerCoreInitializedOptions;
+  public declare options: ServerCoreInitializedOptions;
 
-  public optsHandler: OptsHandler;
+  public declare optsHandler: OptsHandler;
 
-  public contextToDbType: DbTypeAsyncFn;
+  public declare contextToDbType: DbTypeAsyncFn;
 
-  public contextToExternalDbType: ExternalDbTypeFn;
+  public declare contextToExternalDbType: ExternalDbTypeFn;
 
-  public apiGateway = super.apiGateway;
+  public declare apiGateway;
 
-  public reloadEnvVariables = super.reloadEnvVariables;
+  public declare reloadEnvVariables;
 
   public constructor(
     opts: CreateOptions = {},
@@ -46,6 +46,7 @@ class CubejsServerCoreExposed extends CubejsServerCore {
 let message: string;
 
 const conf = {
+  apiSecret: 'testApiSecretToSuppressWarning',
   logger: (msg: string) => {
     message = msg;
   },
@@ -78,85 +79,91 @@ describe('OptsHandler class', () => {
   test('must handle vanila CreateOptions', async () => {
     process.env.CUBEJS_DB_TYPE = 'postgres';
 
-    let core;
-
     // Case 1
-    core = new CubejsServerCoreExposed({
-      ...conf,
-      dbType: undefined,
-      driverFactory: undefined,
-    });
+    {
+      const core = new CubejsServerCoreExposed({
+        ...conf,
+        dbType: undefined,
+        driverFactory: undefined,
+      });
 
-    expect(core.options.dbType).toBeDefined();
-    expect(typeof core.options.dbType).toEqual('function');
-    expect(await core.options.dbType({} as DriverContext))
-      .toEqual(process.env.CUBEJS_DB_TYPE);
+      expect(core.options.dbType).toBeDefined();
+      expect(typeof core.options.dbType).toEqual('function');
+      expect(await core.options.dbType({} as DriverContext))
+        .toEqual(process.env.CUBEJS_DB_TYPE);
 
-    expect(core.options.driverFactory).toBeDefined();
-    expect(typeof core.options.driverFactory).toEqual('function');
-    expect(await core.options.driverFactory({} as DriverContext)).toEqual({
-      type: process.env.CUBEJS_DB_TYPE,
-    });
+      expect(core.options.driverFactory).toBeDefined();
+      expect(typeof core.options.driverFactory).toEqual('function');
+      expect(await core.options.driverFactory({} as DriverContext)).toEqual({
+        type: process.env.CUBEJS_DB_TYPE,
+      });
+    }
 
     // Case 2
-    core = new CubejsServerCoreExposed({
-      ...conf,
-      dbType: 'postgres',
-      driverFactory: () => CubejsServerCore.createDriver('postgres'),
-    });
+    {
+      const core = new CubejsServerCoreExposed({
+        ...conf,
+        dbType: 'postgres',
+        driverFactory: () => CubejsServerCore.createDriver('postgres'),
+      });
 
-    expect(core.options.dbType).toBeDefined();
-    expect(typeof core.options.dbType).toEqual('function');
-    expect(await core.options.dbType({} as DriverContext))
-      .toEqual(process.env.CUBEJS_DB_TYPE);
+      expect(core.options.dbType).toBeDefined();
+      expect(typeof core.options.dbType).toEqual('function');
+      expect(await core.options.dbType({} as DriverContext))
+        .toEqual(process.env.CUBEJS_DB_TYPE);
 
-    expect(core.options.driverFactory).toBeDefined();
-    expect(typeof core.options.driverFactory).toEqual('function');
-    expect(
-      JSON.stringify(await core.options.driverFactory({} as DriverContext)),
-    ).toEqual(
-      JSON.stringify(CubejsServerCore.createDriver('postgres')),
-    );
+      expect(core.options.driverFactory).toBeDefined();
+      expect(typeof core.options.driverFactory).toEqual('function');
+      expect(
+        JSON.stringify(await core.options.driverFactory({} as DriverContext)),
+      ).toEqual(
+        JSON.stringify(CubejsServerCore.createDriver('postgres')),
+      );
+    }
 
     // Case 3
-    core = new CubejsServerCoreExposed({
-      ...conf,
-      dbType: () => 'postgres',
-      driverFactory: () => CubejsServerCore.createDriver('postgres'),
-    });
+    {
+      const core = new CubejsServerCoreExposed({
+        ...conf,
+        dbType: () => 'postgres',
+        driverFactory: () => CubejsServerCore.createDriver('postgres'),
+      });
 
-    expect(core.options.dbType).toBeDefined();
-    expect(typeof core.options.dbType).toEqual('function');
-    expect(await core.options.dbType({} as DriverContext))
-      .toEqual(process.env.CUBEJS_DB_TYPE);
+      expect(core.options.dbType).toBeDefined();
+      expect(typeof core.options.dbType).toEqual('function');
+      expect(await core.options.dbType({} as DriverContext))
+        .toEqual(process.env.CUBEJS_DB_TYPE);
 
-    expect(core.options.driverFactory).toBeDefined();
-    expect(typeof core.options.driverFactory).toEqual('function');
-    expect(
-      JSON.stringify(await core.options.driverFactory({} as DriverContext)),
-    ).toEqual(
-      JSON.stringify(CubejsServerCore.createDriver('postgres')),
-    );
+      expect(core.options.driverFactory).toBeDefined();
+      expect(typeof core.options.driverFactory).toEqual('function');
+      expect(
+        JSON.stringify(await core.options.driverFactory({} as DriverContext)),
+      ).toEqual(
+        JSON.stringify(CubejsServerCore.createDriver('postgres')),
+      );
+    }
 
     // Case 4
-    core = new CubejsServerCoreExposed({
-      ...conf,
-      dbType: () => 'postgres',
-      driverFactory: async () => CubejsServerCore.createDriver('postgres'),
-    });
+    {
+      const core = new CubejsServerCoreExposed({
+        ...conf,
+        dbType: () => 'postgres',
+        driverFactory: async () => CubejsServerCore.createDriver('postgres'),
+      });
 
-    expect(core.options.dbType).toBeDefined();
-    expect(typeof core.options.dbType).toEqual('function');
-    expect(await core.options.dbType({} as DriverContext))
-      .toEqual(process.env.CUBEJS_DB_TYPE);
+      expect(core.options.dbType).toBeDefined();
+      expect(typeof core.options.dbType).toEqual('function');
+      expect(await core.options.dbType({} as DriverContext))
+        .toEqual(process.env.CUBEJS_DB_TYPE);
 
-    expect(core.options.driverFactory).toBeDefined();
-    expect(typeof core.options.driverFactory).toEqual('function');
-    expect(
-      JSON.stringify(await core.options.driverFactory({} as DriverContext)),
-    ).toEqual(
-      JSON.stringify(CubejsServerCore.createDriver('postgres')),
-    );
+      expect(core.options.driverFactory).toBeDefined();
+      expect(typeof core.options.driverFactory).toEqual('function');
+      expect(
+        JSON.stringify(await core.options.driverFactory({} as DriverContext)),
+      ).toEqual(
+        JSON.stringify(CubejsServerCore.createDriver('postgres')),
+      );
+    }
   });
 
   test('must handle valid CreateOptions', async () => {
@@ -324,6 +331,7 @@ describe('OptsHandler class', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       core = new CubejsServerCoreExposed({
         ...conf,
+        apiSecret: undefined,
         dbType: undefined,
         driverFactory: undefined,
       });

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -14,9 +14,9 @@ import { OrchestratorApiOptions } from '../../src/core/OrchestratorApi';
 
 // It's just a mock to open protected methods
 class CubejsServerCoreOpen extends CubejsServerCore {
-  public readonly optsHandler: OptsHandler;
+  public declare optsHandler: OptsHandler;
 
-  public readonly options: ServerCoreInitializedOptions;
+  public declare options: ServerCoreInitializedOptions;
 
   public getRefreshScheduler = super.getRefreshScheduler;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,5 @@
 {
+  "_version": "18.2.0",
   "exclude": [
     "node_modules",
     "dist",
@@ -6,8 +7,8 @@
   "files": [],
   "compilerOptions": {
     "incremental": true,
-    "lib": ["es2021"],
-    "target": "es2021",
+    "lib": ["es2023"],
+    "target": "es2022",
     "module": "commonjs",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Starting from the v0.36 release, Node.js 18 is deprecated (we are using Node.js 20 for docker). This means that we are ready to use es2022 as a minimal version for our target in tsconfig.