### PR TITLE
fix(schema-compiler): Add missing “quarter” time unit to granularity definitions

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -140,6 +140,8 @@ const BaseDimensionWithoutSubQuery = {
               month: () => 12 % v === 0,
               // Only quarters divisible by a year with no remainder are valid
               quarter: () => 4 % v === 0,
+              // Only 1 week is valid
+              week: () => v === 1,
               // Only 1 day is valid
               day: () => v === 1,
               // Only hours divisible by a day with no remainder are valid

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -82,9 +82,9 @@ const everyCronTimeZone = Joi.string().custom((value, helper) => {
   }
 });
 
-const GranularityInterval = Joi.string().pattern(/^\d+\s+(second|minute|hour|day|week|month|year)s?(\s\d+\s+(second|minute|hour|day|week|month|year)s?){0,7}$/, 'granularity interval');
+const GranularityInterval = Joi.string().pattern(/^\d+\s+(second|minute|hour|day|week|month|quarter|year)s?(\s\d+\s+(second|minute|hour|day|week|month|quarter|year)s?){0,7}$/, 'granularity interval');
 // Do not allow negative intervals for granularities, while offsets could be negative
-const GranularityOffset = Joi.string().pattern(/^-?(\d+\s+)(second|minute|hour|day|week|month|year)s?(\s-?\d+\s+(second|minute|hour|day|week|month|year)s?){0,7}$/, 'granularity offset');
+const GranularityOffset = Joi.string().pattern(/^-?(\d+\s+)(second|minute|hour|day|week|month|quarter|year)s?(\s-?\d+\s+(second|minute|hour|day|week|month|quarter|year)s?){0,7}$/, 'granularity offset');
 
 const BaseDimensionWithoutSubQuery = {
   aliases: Joi.array().items(Joi.string()),

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -770,6 +770,24 @@ describe('Cube Validation', () => {
         expect(validationResult.error).toBeTruthy();
       }
 
+      {
+        const cube = newCube({
+          half_year: {
+            interval: '3 weeks',
+          }
+        });
+
+        const validationResult = cubeValidator.validate(cube, {
+          error: (message: any, _e: any) => {
+            console.log(message);
+            expect(message).toContain('"dimensions.createdAt" does not match any of the allowed types');
+            expect(message).toContain('Arbitrary intervals cannot be used without origin point specified');
+          }
+        } as any);
+
+        expect(validationResult.error).toBeTruthy();
+      }
+
       // Offset doesn't matter in this case
       {
         const cube = newCube({

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -745,6 +745,25 @@ describe('Cube Validation', () => {
           error: (message: any, _e: any) => {
             console.log(message);
             expect(message).toContain('"dimensions.createdAt" does not match any of the allowed types');
+            expect(message).toContain('Arbitrary intervals cannot be used without origin point specified');
+          }
+        } as any);
+
+        expect(validationResult.error).toBeTruthy();
+      }
+
+      {
+        const cube = newCube({
+          half_year: {
+            interval: '3 quarters',
+          }
+        });
+
+        const validationResult = cubeValidator.validate(cube, {
+          error: (message: any, _e: any) => {
+            console.log(message);
+            expect(message).toContain('"dimensions.createdAt" does not match any of the allowed types');
+            expect(message).toContain('Arbitrary intervals cannot be used without origin point specified');
           }
         } as any);
 
@@ -846,6 +865,18 @@ describe('Cube Validation', () => {
         const cube = newCube({
           half_year: {
             interval: '10 months',
+            origin: '2024-04',
+          }
+        });
+
+        const validationResult = cubeValidator.validate(cube, new ConsoleErrorReporter());
+        expect(validationResult.error).toBeFalsy();
+      }
+
+      {
+        const cube = newCube({
+          half_year: {
+            interval: '2 quarters',
             origin: '2024-04',
           }
         });


### PR DESCRIPTION
- **fix(schema-compiler): Add missing “quarter” time unit to granularity definitions**
- **add tests for quarters in granularities**
- **fix(schema-compiler): allow custom granularities with 1 week interval definition**
- **more tests**
