### PR TITLE
refactor(cubesql): Make Postgres authentication extensible

### DIFF
--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -16,9 +16,9 @@ use crate::{
     },
     config::{ConfigObj, ConfigObjImpl},
     sql::{
-        compiler_cache::CompilerCacheImpl, dataframe::batches_to_dataframe, AuthContextRef,
-        AuthenticateResponse, HttpAuthContext, ServerManager, Session, SessionManager,
-        SqlAuthService,
+        compiler_cache::CompilerCacheImpl, dataframe::batches_to_dataframe,
+        pg_auth_service::PostgresAuthServiceDefaultImpl, AuthContextRef, AuthenticateResponse,
+        HttpAuthContext, ServerManager, Session, SessionManager, SqlAuthService,
     },
     transport::{
         CubeStreamReceiver, LoadRequestMeta, SpanId, SqlGenerator, SqlResponse, SqlTemplates,
@@ -607,6 +607,7 @@ async fn get_test_session_with_config_and_transport(
     let server = Arc::new(ServerManager::new(
         get_test_auth(),
         test_transport.clone(),
+        Arc::new(PostgresAuthServiceDefaultImpl::new()),
         Arc::new(CompilerCacheImpl::new(config_obj.clone(), test_transport)),
         None,
         config_obj,

--- a/rust/cubesql/cubesql/src/sql/postgres/mod.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod extended;
+pub mod pg_auth_service;
 pub(crate) mod pg_type;
 pub(crate) mod service;
 pub(crate) mod shim;

--- a/rust/cubesql/cubesql/src/sql/postgres/pg_auth_service.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/pg_auth_service.rs
@@ -1,0 +1,110 @@
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+
+use crate::{
+    sql::{AuthContextRef, SqlAuthService},
+    CubeError,
+};
+
+pub use pg_srv::{
+    buffer as pg_srv_buffer,
+    protocol::{
+        AuthenticationRequest, AuthenticationRequestExtension, FrontendMessage,
+        FrontendMessageExtension,
+    },
+    MessageTagParser, MessageTagParserDefaultImpl, ProtocolError,
+};
+
+#[derive(Debug)]
+pub enum AuthenticationStatus {
+    UnexpectedFrontendMessage,
+    Failed(String),
+    // User name + auth context
+    Success(String, AuthContextRef),
+}
+
+#[async_trait]
+pub trait PostgresAuthService: Sync + Send + Debug {
+    fn get_auth_method(&self, parameters: &HashMap<String, String>) -> AuthenticationRequest;
+
+    async fn authenticate(
+        &self,
+        service: Arc<dyn SqlAuthService>,
+        request: AuthenticationRequest,
+        secret: FrontendMessage,
+        parameters: &HashMap<String, String>,
+    ) -> AuthenticationStatus;
+
+    fn get_pg_message_tag_parser(&self) -> Arc<dyn MessageTagParser>;
+}
+
+#[derive(Debug)]
+pub struct PostgresAuthServiceDefaultImpl {
+    pg_message_tag_parser: Arc<dyn MessageTagParser>,
+}
+
+impl PostgresAuthServiceDefaultImpl {
+    pub fn new() -> Self {
+        Self {
+            pg_message_tag_parser: Arc::new(MessageTagParserDefaultImpl::default()),
+        }
+    }
+}
+
+#[async_trait]
+impl PostgresAuthService for PostgresAuthServiceDefaultImpl {
+    fn get_auth_method(&self, _: &HashMap<String, String>) -> AuthenticationRequest {
+        AuthenticationRequest::CleartextPassword
+    }
+
+    async fn authenticate(
+        &self,
+        service: Arc<dyn SqlAuthService>,
+        request: AuthenticationRequest,
+        secret: FrontendMessage,
+        parameters: &HashMap<String, String>,
+    ) -> AuthenticationStatus {
+        let FrontendMessage::PasswordMessage(password_message) = secret else {
+            return AuthenticationStatus::UnexpectedFrontendMessage;
+        };
+
+        if !matches!(request, AuthenticationRequest::CleartextPassword) {
+            return AuthenticationStatus::UnexpectedFrontendMessage;
+        }
+
+        let user = parameters.get("user").unwrap().clone();
+        let authenticate_response = service
+            .authenticate(Some(user.clone()), Some(password_message.password.clone()))
+            .await;
+
+        let auth_fail = || {
+            AuthenticationStatus::Failed(format!(
+                "password authentication failed for user \"{}\"",
+                user
+            ))
+        };
+
+        let Ok(authenticate_response) = authenticate_response else {
+            return auth_fail();
+        };
+
+        if !authenticate_response.skip_password_check {
+            let is_password_correct = match authenticate_response.password {
+                None => false,
+                Some(password) => password == password_message.password,
+            };
+            if !is_password_correct {
+                return auth_fail();
+            }
+        }
+
+        AuthenticationStatus::Success(user, authenticate_response.context)
+    }
+
+    fn get_pg_message_tag_parser(&self) -> Arc<dyn MessageTagParser> {
+        Arc::clone(&self.pg_message_tag_parser)
+    }
+}
+
+crate::di_service!(PostgresAuthServiceDefaultImpl, [PostgresAuthService]);

--- a/rust/cubesql/cubesql/src/sql/server_manager.rs
+++ b/rust/cubesql/cubesql/src/sql/server_manager.rs
@@ -4,6 +4,7 @@ use crate::{
     sql::{
         compiler_cache::CompilerCache,
         database_variables::{mysql_default_global_variables, postgres_default_global_variables},
+        pg_auth_service::PostgresAuthService,
         SqlAuthService,
     },
     transport::TransportService,
@@ -37,6 +38,7 @@ pub struct ServerManager {
     // References to shared things
     pub auth: Arc<dyn SqlAuthService>,
     pub transport: Arc<dyn TransportService>,
+    pub pg_auth: Arc<dyn PostgresAuthService>,
     // Non references
     pub configuration: ServerConfiguration,
     pub nonce: Option<Vec<u8>>,
@@ -52,6 +54,7 @@ impl ServerManager {
     pub fn new(
         auth: Arc<dyn SqlAuthService>,
         transport: Arc<dyn TransportService>,
+        pg_auth: Arc<dyn PostgresAuthService>,
         compiler_cache: Arc<dyn CompilerCache>,
         nonce: Option<Vec<u8>>,
         config_obj: Arc<dyn ConfigObj>,
@@ -59,6 +62,7 @@ impl ServerManager {
         Self {
             auth,
             transport,
+            pg_auth,
             compiler_cache,
             nonce,
             config_obj,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR refactors pg-srv, making authentication request methods and message tag parsing to be extendable. It also adds `PostgresAuthService` to be able to extend the auth process.
