### PR TITLE
fix(schema-compiler): correct origin timestamp initialization in Granularity instance

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -25,7 +25,7 @@ export class Granularity {
   ) {
     this.granularity = timeDimension.granularity;
     this.predefinedGranularity = isPredefinedGranularity(this.granularity);
-    this.origin = moment().startOf('year'); // Defaults to current year start
+    this.origin = moment.tz('UTC').startOf('year'); // Defaults to current year start
 
     if (this.predefinedGranularity) {
       this.granularityInterval = `1 ${this.granularity}`;
@@ -60,17 +60,17 @@ export class Granularity {
       return this.granularity;
     }
 
-    if (this.origin) {
-      return this.query.minGranularity(
-        this.granularityFromInterval(),
-        this.query.granularityFor(this.origin.utc())
-      );
-    }
-
     if (this.granularityOffset) {
       return this.query.minGranularity(
         this.granularityFromInterval(),
         this.granularityFromOffset()
+      );
+    }
+
+    if (this.origin) {
+      return this.query.minGranularity(
+        this.granularityFromInterval(),
+        this.query.granularityFor(this.origin.utc())
       );
     }
 

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
@@ -314,7 +314,7 @@ export class PreAggregations {
         dateRange: td.dateRange,
         granularity: td.granularity,
       });
-    }).map(d => query.newTimeDimension(d));
+    });
 
     let sortedAllCubeNames;
     let sortedUsedCubePrimaryKeys;


### PR DESCRIPTION
- **remove doubled query.newTimeDimension() call in transformQueryToCanUseForm**
- **fix(schema-compiler): correct origin timestamp initialization in Granularity instance**
- **tests for custom preagg matches**

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

