### PR TITLE
Metadata cache factory result

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -1324,7 +1324,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#faf7acb5a3f3d4976711f6faf76c7750b22b0eda"
+source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#7e935118e556a31c35f5e5bb4ecb465cefb19ebb"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubestore/cubestore/src/sql/table_creator.rs
+++ b/rust/cubestore/cubestore/src/sql/table_creator.rs
@@ -24,7 +24,7 @@ use std::mem::take;
 #[async_trait]
 
 pub trait TableExtensionService: DIService + Send + Sync {
-    async fn get_extension(&self) -> Option<serde_json::Value>;
+    async fn get_extension(&self) -> Result<Option<serde_json::Value>, CubeError>;
 }
 
 pub struct TableExtensionServiceImpl;
@@ -37,8 +37,8 @@ impl TableExtensionServiceImpl {
 
 #[async_trait]
 impl TableExtensionService for TableExtensionServiceImpl {
-    async fn get_extension(&self) -> Option<serde_json::Value> {
-        None
+    async fn get_extension(&self) -> Result<Option<serde_json::Value>, CubeError> {
+        Ok(None)
     }
 }
 
@@ -99,7 +99,7 @@ impl TableCreator {
         trace_obj: &Option<String>,
     ) -> Result<IdRow<Table>, CubeError> {
         let extension: Option<serde_json::Value> =
-            self.table_extension_service.get_extension().await;
+            self.table_extension_service.get_extension().await?;
         if !if_not_exists {
             return self
                 .create_table_loop(

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -1188,11 +1188,12 @@ async fn write_to_files_impl(
     mut pick_writer: impl FnMut(&RecordBatch) -> WriteBatchTo,
 ) -> Result<(), CubeError> {
     let schema = Arc::new(store.arrow_schema());
+    let writer_props = store.writer_props()?;
     let mut writers = files.into_iter().map(move |f| -> Result<_, CubeError> {
         Ok(ArrowWriter::try_new(
             File::create(f)?,
             schema.clone(),
-            Some(store.writer_props()),
+            Some(writer_props.clone()),
         )?)
     });
 

--- a/rust/cubestore/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/cubestore/src/table/parquet.rs
@@ -114,11 +114,13 @@ impl ParquetTableStore {
     }
 
     pub fn writer_props(&self) -> Result<WriterProperties, CubeError> {
-        self.metadata_cache_factory.build_writer_props(
-            WriterProperties::builder()
-                .set_max_row_group_size(self.row_group_size)
-                .set_writer_version(WriterVersion::PARQUET_2_0),
-        ).map_err(CubeError::from)
+        self.metadata_cache_factory
+            .build_writer_props(
+                WriterProperties::builder()
+                    .set_max_row_group_size(self.row_group_size)
+                    .set_writer_version(WriterVersion::PARQUET_2_0),
+            )
+            .map_err(CubeError::from)
     }
 
     pub fn write_data(&self, dest_file: &str, columns: Vec<ArrayRef>) -> Result<(), CubeError> {

--- a/rust/cubestore/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/cubestore/src/table/parquet.rs
@@ -113,21 +113,20 @@ impl ParquetTableStore {
         arrow_schema(&self.table)
     }
 
-    pub fn writer_props(&self) -> WriterProperties {
+    pub fn writer_props(&self) -> Result<WriterProperties, CubeError> {
         self.metadata_cache_factory.build_writer_props(
             WriterProperties::builder()
                 .set_max_row_group_size(self.row_group_size)
                 .set_writer_version(WriterVersion::PARQUET_2_0),
-        )
+        ).map_err(CubeError::from)
     }
 
     pub fn write_data(&self, dest_file: &str, columns: Vec<ArrayRef>) -> Result<(), CubeError> {
         let schema = Arc::new(arrow_schema(&self.table));
         let batch = RecordBatch::try_new(schema.clone(), columns.to_vec())?;
 
-        // TODO: Just look for every place SerializedFileWriter is constructed and see if we missed one.
         let mut w =
-            ArrowWriter::try_new(File::create(dest_file)?, schema, Some(self.writer_props()))?;
+            ArrowWriter::try_new(File::create(dest_file)?, schema, Some(self.writer_props()?))?;
         w.write(&batch)?;
         w.close()?;
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Makes TableExtensionService::get_extension return a Result.

This PR will still need its Cargo.lock pointer to be updated with the commit of https://github.com/cube-js/arrow-datafusion/pull/169 after it has been merged.