### PR TITLE
feat(client-core): timeseries for custom intervals

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -1303,4 +1303,10 @@ declare module '@cubejs-client/core' {
     stage: string;
     timeElapsed: number;
   };
+
+  export function granularityFor(dateStr: string): string;
+
+  export function minGranularityForIntervals(i1: string, i2: string): string;
+
+  export function isPredefinedGranularity(granularity: TimeDimensionGranularity): boolean;
 }

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -271,22 +271,22 @@ class CubeApi {
             if (v.type === 'number') {
               return k;
             }
-            
+
             return undefined;
           }).filter(Boolean);
-          
+
           result.data = result.data.map((row) => {
             numericMembers.forEach((key) => {
               if (row[key] != null) {
                 row[key] = Number(row[key]);
               }
             });
-            
+
             return row;
           });
         });
       }
-      
+
       if (response.results[0].query.responseFormat &&
         response.results[0].query.responseFormat === ResultType.COMPACT) {
         response.results.forEach((result, j) => {
@@ -302,7 +302,7 @@ class CubeApi {
         });
       }
     }
-    
+
     return new ResultSet(response, {
       parseDateMeasures: this.parseDateMeasures
     });
@@ -388,3 +388,4 @@ export default (apiToken, options) => new CubeApi(apiToken, options);
 
 export { CubeApi, HttpTransport, ResultSet, RequestError, Meta };
 export * from './utils';
+export * from './time';

--- a/packages/cubejs-client-core/src/tests/ResultSet.test.js
+++ b/packages/cubejs-client-core/src/tests/ResultSet.test.js
@@ -102,6 +102,303 @@ describe('ResultSet', () => {
       ];
       expect(resultSet.timeSeries(timeDimension)).toEqual(output);
     });
+
+    test('it generates array of dates - custom interval - 1 year, origin - 2020-01-01', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2023-12-31'],
+        granularity: 'one_year',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2021-01-01T00:00:00.000',
+        '2022-01-01T00:00:00.000',
+        '2023-01-01T00:00:00.000'
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.one_year': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '1 year',
+            title: '1 year',
+            interval: '1 year',
+            origin: '2020-01-01',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 1 year, origin - 2025-03-01', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2022-12-31'],
+        granularity: 'one_year',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2020-03-01T00:00:00.000',
+        '2021-03-01T00:00:00.000',
+        '2022-03-01T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.one_year': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '1 year',
+            title: '1 year',
+            interval: '1 year',
+            origin: '2025-03-01',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 1 year, offset - 2 months', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2022-12-31'],
+        granularity: 'one_year',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2020-03-01T00:00:00.000',
+        '2021-03-01T00:00:00.000',
+        '2022-03-01T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.one_year': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '1 year',
+            title: '1 year',
+            interval: '1 year',
+            offset: '2 months',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 2 months, origin - 2019-01-01', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-12-31'],
+        granularity: 'two_months',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2021-01-01T00:00:00.000',
+        '2021-03-01T00:00:00.000',
+        '2021-05-01T00:00:00.000',
+        '2021-07-01T00:00:00.000',
+        '2021-09-01T00:00:00.000',
+        '2021-11-01T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.two_months': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '2 months',
+            title: '2 months',
+            interval: '2 months',
+            origin: '2019-01-01',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 2 months, no offset', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-12-31'],
+        granularity: 'two_months',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2021-01-01T00:00:00.000',
+        '2021-03-01T00:00:00.000',
+        '2021-05-01T00:00:00.000',
+        '2021-07-01T00:00:00.000',
+        '2021-09-01T00:00:00.000',
+        '2021-11-01T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.two_months': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '2 months',
+            title: '2 months',
+            interval: '2 months',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 2 months, origin - 2019-03-15', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-12-31'],
+        granularity: 'two_months',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2020-11-15T00:00:00.000',
+        '2021-01-15T00:00:00.000',
+        '2021-03-15T00:00:00.000',
+        '2021-05-15T00:00:00.000',
+        '2021-07-15T00:00:00.000',
+        '2021-09-15T00:00:00.000',
+        '2021-11-15T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.two_months': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '2 months',
+            title: '2 months',
+            interval: '2 months',
+            origin: '2019-03-15',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 1 months 2 weeks 3 days, origin - 2021-01-25', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-12-31'],
+        granularity: 'one_mo_two_we_three_d',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2020-12-08T00:00:00.000',
+        '2021-01-25T00:00:00.000',
+        '2021-03-14T00:00:00.000',
+        '2021-05-01T00:00:00.000',
+        '2021-06-18T00:00:00.000',
+        '2021-08-04T00:00:00.000',
+        '2021-09-21T00:00:00.000',
+        '2021-11-07T00:00:00.000',
+        '2021-12-24T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.one_mo_two_we_three_d': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '1 months 2 weeks 3 days',
+            title: '1 months 2 weeks 3 days',
+            interval: '1 months 2 weeks 3 days',
+            origin: '2021-01-25',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 3 weeks, origin - 2020-12-15', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-03-01'],
+        granularity: 'three_weeks',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2020-12-15T00:00:00.000',
+        '2021-01-05T00:00:00.000',
+        '2021-01-26T00:00:00.000',
+        '2021-02-16T00:00:00.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.three_weeks': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '3 weeks',
+            title: '3 weeks',
+            interval: '3 weeks',
+            origin: '2020-12-15',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds, origin - 2021-01-01', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-01-01', '2021-12-31'],
+        granularity: 'two_mo_3w_4d_5h_6m_7s',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2021-01-01T00:00:00.000',
+        '2021-03-26T05:06:07.000',
+        '2021-06-20T10:12:14.000',
+        '2021-09-14T15:18:21.000',
+        '2021-12-09T20:24:28.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.two_mo_3w_4d_5h_6m_7s': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: 'two_mo_3w_4d_5h_6m_7s',
+            title: 'two_mo_3w_4d_5h_6m_7s',
+            interval: '2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds',
+            origin: '2021-01-01',
+          },
+        },
+      })).toEqual(output);
+    });
+
+    test('it generates array of dates - custom interval - 10 minutes 15 seconds, origin - 2021-02-01 09:59:45', () => {
+      const resultSet = new ResultSet({});
+      const timeDimension = {
+        dateRange: ['2021-02-01 10:00:00', '2021-02-01 12:00:00'],
+        granularity: 'ten_min_fifteen_sec',
+        dimension: 'Events.time'
+      };
+      const output = [
+        '2021-02-01T09:59:45.000',
+        '2021-02-01T10:10:00.000',
+        '2021-02-01T10:20:15.000',
+        '2021-02-01T10:30:30.000',
+        '2021-02-01T10:40:45.000',
+        '2021-02-01T10:51:00.000',
+        '2021-02-01T11:01:15.000',
+        '2021-02-01T11:11:30.000',
+        '2021-02-01T11:21:45.000',
+        '2021-02-01T11:32:00.000',
+        '2021-02-01T11:42:15.000',
+        '2021-02-01T11:52:30.000',
+      ];
+      expect(resultSet.timeSeries(timeDimension, 1, {
+        'Events.time.ten_min_fifteen_sec': {
+          title: 'Time Dimension',
+          shortTitle: 'TD',
+          type: 'time',
+          granularity: {
+            name: '10 minutes 15 seconds',
+            title: '10 minutes 15 seconds',
+            interval: '10 minutes 15 seconds',
+            origin: '2021-02-01 09:59:45',
+          },
+        },
+      })).toEqual(output);
+    });
   });
 
   describe('chartPivot', () => {
@@ -145,7 +442,7 @@ describe('ResultSet', () => {
       expect(resultSet.chartPivot()).toEqual([
         {
           x: 'Name 1',
-          
+
           'Foo.count': 'Some string',
           xValues: [
             'Name 1'
@@ -194,7 +491,7 @@ describe('ResultSet', () => {
       expect(resultSet.chartPivot()).toEqual([
         {
           x: 'Name 1',
-          
+
           'Foo.count': 0,
           xValues: [
             'Name 1'
@@ -291,7 +588,7 @@ describe('ResultSet', () => {
       expect(resultSet.chartPivot()).toEqual([
         {
           x: 'Name 1',
-          
+
           'Foo.count': 10,
           xValues: [
             'Name 1'
@@ -343,7 +640,7 @@ describe('ResultSet', () => {
       expect(resultSet.chartPivot()).toEqual([
         {
           x: 'Name 1',
-          
+
           'Foo.latestRun': new Date('2020-03-11T18:06:09.403Z'),
           xValues: [
             'Name 1'

--- a/packages/cubejs-client-core/src/tests/granularity.test.js
+++ b/packages/cubejs-client-core/src/tests/granularity.test.js
@@ -1,3 +1,5 @@
+/* globals describe,test,expect */
+
 import 'jest';
 import dayjs from 'dayjs';
 import ko from 'dayjs/locale/ko';

--- a/packages/cubejs-client-core/src/tests/utils.test.js
+++ b/packages/cubejs-client-core/src/tests/utils.test.js
@@ -1,7 +1,7 @@
 import 'jest';
 
-import { TIME_SERIES, dayRange } from '../ResultSet';
 import { defaultOrder } from '../utils';
+import { dayRange, TIME_SERIES } from '../time';
 
 describe('utils', () => {
   test('default order', () => {

--- a/packages/cubejs-client-core/src/time.js
+++ b/packages/cubejs-client-core/src/time.js
@@ -1,0 +1,296 @@
+import dayjs from 'dayjs';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+import duration from 'dayjs/plugin/duration';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import en from 'dayjs/locale/en';
+
+dayjs.extend(quarterOfYear);
+dayjs.extend(duration);
+dayjs.extend(isoWeek);
+
+export const GRANULARITIES = [
+  { name: undefined, title: 'w/o grouping' },
+  { name: 'second', title: 'Second' },
+  { name: 'minute', title: 'Minute' },
+  { name: 'hour', title: 'Hour' },
+  { name: 'day', title: 'Day' },
+  { name: 'week', title: 'Week' },
+  { name: 'month', title: 'Month' },
+  { name: 'quarter', title: 'Quarter' },
+  { name: 'year', title: 'Year' },
+];
+
+export const DEFAULT_GRANULARITY = 'day';
+
+// When granularity is week, weekStart Value must be 1. However, since the client can change it globally
+// (https://day.js.org/docs/en/i18n/changing-locale) So the function below has been added.
+export const internalDayjs = (...args) => dayjs(...args).locale({ ...en, weekStart: 1 });
+
+export const TIME_SERIES = {
+  day: (range) => range.by('d').map(d => d.format('YYYY-MM-DDT00:00:00.000')),
+  month: (range) => range.snapTo('month').by('M').map(d => d.format('YYYY-MM-01T00:00:00.000')),
+  year: (range) => range.snapTo('year').by('y').map(d => d.format('YYYY-01-01T00:00:00.000')),
+  hour: (range) => range.by('h').map(d => d.format('YYYY-MM-DDTHH:00:00.000')),
+  minute: (range) => range.by('m').map(d => d.format('YYYY-MM-DDTHH:mm:00.000')),
+  second: (range) => range.by('s').map(d => d.format('YYYY-MM-DDTHH:mm:ss.000')),
+  week: (range) => range.snapTo('week').by('w').map(d => d.startOf('week').format('YYYY-MM-DDT00:00:00.000')),
+  quarter: (range) => range.snapTo('quarter').by('quarter').map(d => d.startOf('quarter').format(
+    'YYYY-MM-DDT00:00:00.000'
+  )),
+};
+
+export const isPredefinedGranularity = (granularity) => !!TIME_SERIES[granularity];
+
+export const DateRegex = /^\d\d\d\d-\d\d-\d\d$/;
+export const LocalDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z?$/;
+
+export const dayRange = (from, to) => ({
+  by: (value) => {
+    const results = [];
+
+    let start = internalDayjs(from);
+    const end = internalDayjs(to);
+
+    while (start.isBefore(end) || start.isSame(end)) {
+      results.push(start);
+      start = start.add(1, value);
+    }
+
+    return results;
+  },
+  snapTo: (value) => dayRange(internalDayjs(from).startOf(value), internalDayjs(to).endOf(value)),
+  start: internalDayjs(from),
+  end: internalDayjs(to),
+});
+
+/**
+ * Parse PostgreSQL-like interval string into object
+ * E.g. '2 years 15 months 100 weeks 99 hours 15 seconds'
+ * Negative units are also supported
+ * E.g. '-2 months 5 days -10 hours'
+ *
+ * TODO: It's copy/paste of parseSqlInterval from @cubejs-backend/shared [time.ts]
+ * It's not referenced to omit imports of moment.js staff.
+ * Probably one day we should choose one implementation and reuse it in other places.
+ */
+export function parseSqlInterval(intervalStr) {
+  const interval = {};
+  const parts = intervalStr.split(/\s+/);
+
+  for (let i = 0; i < parts.length; i += 2) {
+    const value = parseInt(parts[i], 10);
+    const unit = parts[i + 1];
+
+    // Remove ending 's' (e.g., 'days' -> 'day')
+    const singularUnit = unit.endsWith('s') ? unit.slice(0, -1) : unit;
+    interval[singularUnit] = value;
+  }
+
+  return interval;
+}
+
+/**
+ * Adds interval to provided date.
+ * TODO: It's copy/paste of addInterval from @cubejs-backend/shared [time.ts]
+ * but operates with dayjs instead of moment.js
+ * @param {dayjs} date
+ * @param interval
+ * @returns {dayjs}
+ */
+export function addInterval(date, interval) {
+  let res = date.clone();
+
+  Object.entries(interval).forEach(([key, value]) => {
+    res = res.add(value, key);
+  });
+
+  return res;
+}
+
+/**
+ * Adds interval to provided date.
+ * TODO: It's copy/paste of subtractInterval from @cubejs-backend/shared [time.ts]
+ * but operates with dayjs instead of moment.js
+ * @param {dayjs} date
+ * @param interval
+ * @returns {dayjs}
+ */
+export function subtractInterval(date, interval) {
+  let res = date.clone();
+
+  Object.entries(interval).forEach(([key, value]) => {
+    res = res.subtract(value, key);
+  });
+
+  return res;
+}
+
+/**
+ * Returns the closest date prior to date parameter aligned with the origin point
+ * TODO: It's copy/paste of alignToOrigin from @cubejs-backend/shared [time.ts]
+ * but operates with dayjs instead of moment.js
+ */
+function alignToOrigin(startDate, interval, origin) {
+  let alignedDate = startDate.clone();
+  let intervalOp;
+  let isIntervalNegative = false;
+
+  let offsetDate = addInterval(origin, interval);
+
+  // The easiest way to check the interval sign
+  if (offsetDate.isBefore(origin)) {
+    isIntervalNegative = true;
+  }
+
+  offsetDate = origin.clone();
+
+  if (startDate.isBefore(origin)) {
+    intervalOp = isIntervalNegative ? addInterval : subtractInterval;
+
+    while (offsetDate.isAfter(startDate)) {
+      offsetDate = intervalOp(offsetDate, interval);
+    }
+    alignedDate = offsetDate;
+  } else {
+    intervalOp = isIntervalNegative ? subtractInterval : addInterval;
+
+    while (offsetDate.isBefore(startDate)) {
+      alignedDate = offsetDate.clone();
+      offsetDate = intervalOp(offsetDate, interval);
+    }
+
+    if (offsetDate.isSame(startDate)) {
+      alignedDate = offsetDate;
+    }
+  }
+
+  return alignedDate;
+}
+
+/**
+ * Returns the time series points for the custom interval
+ * TODO: It's almost a copy/paste of timeSeriesFromCustomInterval from
+ * @cubejs-backend/shared [time.ts] but operates with dayjs instead of moment.js
+ */
+export const timeSeriesFromCustomInterval = (from, to, granularity) => {
+  const intervalParsed = parseSqlInterval(granularity.interval);
+  const start = internalDayjs(from);
+  const end = internalDayjs(to);
+  let origin = granularity.origin ? internalDayjs(granularity.origin) : internalDayjs().startOf('year');
+  if (granularity.offset) {
+    origin = addInterval(origin, parseSqlInterval(granularity.offset));
+  }
+  let alignedStart = alignToOrigin(start, intervalParsed, origin);
+
+  const dates = [];
+
+  while (alignedStart.isBefore(end) || alignedStart.isSame(end)) {
+    dates.push(alignedStart.format('YYYY-MM-DDTHH:mm:ss.000'));
+    alignedStart = addInterval(alignedStart, intervalParsed);
+  }
+
+  return dates;
+};
+
+/**
+ * Returns the lowest time unit for the interval
+ * @protected
+ * @param {string} interval
+ * @returns {string}
+ */
+export const diffTimeUnitForInterval = (interval) => {
+  if (/second/i.test(interval)) {
+    return 'second';
+  } else if (/minute/i.test(interval)) {
+    return 'minute';
+  } else if (/hour/i.test(interval)) {
+    return 'hour';
+  } else if (/day/i.test(interval)) {
+    return 'day';
+  } else if (/week/i.test(interval)) {
+    return 'day';
+  } else if (/month/i.test(interval)) {
+    return 'month';
+  } else if (/quarter/i.test(interval)) {
+    return 'month';
+  } else /* if (/year/i.test(interval)) */ {
+    return 'year';
+  }
+};
+
+const granularityOrder = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'];
+
+export const minGranularityForIntervals = (i1, i2) => {
+  const g1 = diffTimeUnitForInterval(i1);
+  const g2 = diffTimeUnitForInterval(i2);
+  const g1pos = granularityOrder.indexOf(g1);
+  const g2pos = granularityOrder.indexOf(g2);
+
+  if (g1pos > g2pos) {
+    return g1;
+  }
+
+  return g2;
+};
+
+export const granularityFor = (dateStr) => {
+  const dayjsDate = internalDayjs(dateStr);
+  const month = dayjsDate.month();
+  const date = dayjsDate.date();
+  const hours = dayjsDate.hour();
+  const minutes = dayjsDate.minute();
+  const seconds = dayjsDate.second();
+  const milliseconds = dayjsDate.millisecond();
+  const weekDay = dayjsDate.isoWeekday();
+
+  if (
+    month === 0 &&
+    date === 1 &&
+    hours === 0 &&
+    minutes === 0 &&
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'year';
+  } else if (
+    date === 1 &&
+    hours === 0 &&
+    minutes === 0 &&
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'month';
+  } else if (
+    weekDay === 1 &&
+    hours === 0 &&
+    minutes === 0 &&
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'week';
+  } else if (
+    hours === 0 &&
+    minutes === 0 &&
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'day';
+  } else if (
+    minutes === 0 &&
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'hour';
+  } else if (
+    seconds === 0 &&
+    milliseconds === 0
+  ) {
+    return 'minute';
+  } else if (
+    milliseconds === 0
+  ) {
+    return 'second';
+  }
+
+  return 'second'; // TODO return 'millisecond';
+};

--- a/packages/cubejs-client-core/src/utils.js
+++ b/packages/cubejs-client-core/src/utils.js
@@ -1,22 +1,9 @@
-import { indexBy, prop, clone, equals, fromPairs, toPairs } from 'ramda';
-
-export const DEFAULT_GRANULARITY = 'day';
-
-export const GRANULARITIES = [
-  { name: undefined, title: 'w/o grouping' },
-  { name: 'second', title: 'Second' },
-  { name: 'minute', title: 'Minute' },
-  { name: 'hour', title: 'Hour' },
-  { name: 'day', title: 'Day' },
-  { name: 'week', title: 'Week' },
-  { name: 'month', title: 'Month' },
-  { name: 'quarter', title: 'Quarter' },
-  { name: 'year', title: 'Year' },
-];
+import { clone, equals, fromPairs, indexBy, prop, toPairs } from 'ramda';
+import { DEFAULT_GRANULARITY } from './time';
 
 export function removeEmptyQueryFields(_query) {
   const query = _query || {};
-  
+
   return fromPairs(
     toPairs(query)
       .map(([key, value]) => {
@@ -27,7 +14,7 @@ export function removeEmptyQueryFields(_query) {
             return null;
           }
         }
-        
+
         if (key === 'order' && value) {
           if (Array.isArray(value) && !value.length) {
             return null;
@@ -44,7 +31,7 @@ export function removeEmptyQueryFields(_query) {
 
 export function validateQuery(_query) {
   const query = _query || {};
-  
+
   return removeEmptyQueryFields({
     ...query,
     filters: (query.filters || []).filter((f) => f.operator),


### PR DESCRIPTION
This PR brings custom granularity time-series generation. This allows to build charts not only for predefined granularities like `month` or `day` but for any interval defined in custom granularity for time dimension.

This depends on:
* https://github.com/cube-js/cube/pull/8740

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
