### PR TITLE
feat(playground): custom granularities support

### DIFF
--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@ant-design/compatible": "^1.0.1",
     "@ant-design/icons": "^5.3.5",
-    "@cube-dev/ui-kit": "0.37.3",
+    "@cube-dev/ui-kit": "0.37.4",
     "@cubejs-client/core": "^0.36.4",
     "@cubejs-client/react": "^0.36.4",
     "@types/flexsearch": "^0.7.3",

--- a/packages/cubejs-playground/src/QueryBuilderV2/QueryBuilderExtras.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/QueryBuilderExtras.tsx
@@ -53,7 +53,7 @@ const LIMIT_OPTIONS: { key: number; label: string }[] = [
   { key: 1000, label: '1,000' },
   { key: 5000, label: '5,000 (Default)' },
   { key: 50000, label: '50,000 (Max)' },
-] as const;
+];
 const LIMIT_OPTION_VALUES = LIMIT_OPTIONS.map((option) => option.key) as number[];
 
 function timezoneByName(name: string) {

--- a/packages/cubejs-playground/src/QueryBuilderV2/QueryBuilderExtras.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/QueryBuilderExtras.tsx
@@ -53,7 +53,7 @@ const LIMIT_OPTIONS: { key: number; label: string }[] = [
   { key: 1000, label: '1,000' },
   { key: 5000, label: '5,000 (Default)' },
   { key: 50000, label: '50,000 (Max)' },
-];
+] as const;
 const LIMIT_OPTION_VALUES = LIMIT_OPTIONS.map((option) => option.key) as number[];
 
 function timezoneByName(name: string) {

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
@@ -1,4 +1,10 @@
-import { ChartType, TimeDimensionGranularity } from '@cubejs-client/core';
+import {
+  ChartType,
+  TimeDimensionGranularity,
+  granularityFor,
+  minGranularityForIntervals,
+  isPredefinedGranularity
+} from '@cubejs-client/core';
 import { UseCubeQueryResult } from '@cubejs-client/react';
 import { Skeleton, Tag, tasty } from '@cube-dev/ui-kit';
 import formatDate from 'date-fns/format';
@@ -113,7 +119,12 @@ function CartesianChart({
       return (key as string).split('.').length === 3;
     }
   ) as string;
-  const granularity = granularityField?.split('.')[2];
+  let granularity = granularityField?.split('.')[2];
+
+  if (!isPredefinedGranularity(granularity)) {
+    const granularityInfo = resultSet?.loadResponse.results[0].annotation.timeDimensions[granularityField]?.granularity;
+    granularity = minGranularityForIntervals(granularityInfo.interval, granularityInfo.offset || granularityFor(granularityInfo.origin));
+  }
 
   const formatDate = useMemo(() => {
     if (dateFormat) {

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
@@ -3,7 +3,7 @@ import {
   TimeDimensionGranularity,
   granularityFor,
   minGranularityForIntervals,
-  isPredefinedGranularity
+  isPredefinedGranularity,
 } from '@cubejs-client/core';
 import { UseCubeQueryResult } from '@cubejs-client/react';
 import { Skeleton, Tag, tasty } from '@cube-dev/ui-kit';
@@ -122,8 +122,14 @@ function CartesianChart({
   let granularity = granularityField?.split('.')[2];
 
   if (!isPredefinedGranularity(granularity)) {
-    const granularityInfo = resultSet?.loadResponse.results[0].annotation.timeDimensions[granularityField]?.granularity;
-    granularity = minGranularityForIntervals(granularityInfo.interval, granularityInfo.offset || granularityFor(granularityInfo.origin));
+    const granularityInfo =
+      resultSet?.loadResponse.results[0]?.annotation.timeDimensions[granularityField]?.granularity;
+    if (granularityInfo) {
+      granularity = minGranularityForIntervals(
+        granularityInfo.interval,
+        granularityInfo.offset || granularityFor(granularityInfo.origin)
+      );
+    }
   }
 
   const formatDate = useMemo(() => {

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/ChartRenderer.tsx
@@ -7,7 +7,6 @@ import {
 } from '@cubejs-client/core';
 import { UseCubeQueryResult } from '@cubejs-client/react';
 import { Skeleton, Tag, tasty } from '@cube-dev/ui-kit';
-import formatDate from 'date-fns/format';
 import { ComponentType, memo, useCallback, useMemo } from 'react';
 import { Col, Row, Statistic, Table } from 'antd';
 import {
@@ -34,27 +33,9 @@ import {
   getChartColorByIndex,
   getChartSolidColorByIndex,
 } from '../utils/chart-colors';
+import { formatDateByGranularity, formatDateByPattern } from '../utils/index';
 
 import { LocalError } from './LocalError';
-
-const FORMAT_MAP = {
-  second: 'HH:mm:ss, yyyy-LL-dd',
-  minute: 'HH:mm, yyyy-LL-dd',
-  hour: 'HH:00, yyyy-LL-dd',
-  day: 'yyyy-LL-dd',
-  week: "'W'w yyyy-LL-dd",
-  month: 'LLL yyyy',
-  quarter: 'QQQ yyyy',
-  year: 'yyyy',
-};
-
-export function formatDateByGranularity(timestamp: Date, granularity?: TimeDimensionGranularity) {
-  return formatDate(timestamp, FORMAT_MAP[granularity ?? 'second']);
-}
-
-export function formatDateByPattern(timestamp: Date, format?: string) {
-  return formatDate(timestamp, format ?? FORMAT_MAP['second']);
-}
 
 function CustomDot(props: any) {
   const { cx, cy, fill } = props;

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/GranularityListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/GranularityListMember.tsx
@@ -1,0 +1,56 @@
+import { CalendarEditIcon, CalendarIcon, Text, TooltipProvider } from '@cube-dev/ui-kit';
+import { useRef } from 'react';
+
+import { useHasOverflow } from '../hooks/index';
+import { titleize } from '../utils/index';
+
+import { ListMemberButton } from './ListMemberButton';
+
+export interface GranularityListMemberProps {
+  name: string;
+  title?: string;
+  isCustom?: boolean;
+  isSelected: boolean;
+  onToggle: () => void;
+}
+
+export function GranularityListMember(props: GranularityListMemberProps) {
+  const { name, title, isCustom, isSelected, onToggle } = props;
+  const textRef = useRef<HTMLDivElement>(null);
+
+  const hasOverflow = useHasOverflow(textRef);
+  const isAutoTitle = titleize(name) === title;
+
+  const button = (
+    <ListMemberButton
+      icon={isCustom ? <CalendarEditIcon /> : <CalendarIcon />}
+      data-member="timeDimension"
+      isSelected={isSelected}
+      onPress={onToggle}
+    >
+      <Text ref={textRef} ellipsis>
+        {name}
+      </Text>
+    </ListMemberButton>
+  );
+
+  if (hasOverflow || (!isAutoTitle && isCustom)) {
+    return (
+      <TooltipProvider
+        title={
+          <>
+            <Text preset="t4">{name}</Text>
+            <br />
+            <Text preset="t3">{title}</Text>
+          </>
+        }
+        delay={1000}
+        placement="right"
+      >
+        {button}
+      </TooltipProvider>
+    );
+  } else {
+    return button;
+  }
+}

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/ListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/ListMember.tsx
@@ -11,7 +11,7 @@ import {
 import { TCubeMeasure, TCubeDimension, TCubeSegment, Cube, MemberType } from '@cubejs-client/core';
 import { PlusOutlined } from '@ant-design/icons';
 
-import { getTypeIcon } from '../utils';
+import { getTypeIcon, titleize } from '../utils';
 import { PrimaryKeyIcon } from '../icons/PrimaryKeyIcon';
 import { NonPublicIcon } from '../icons/NonPublicIcon';
 import { ItemInfoIcon } from '../icons/ItemInfoIcon';
@@ -60,6 +60,8 @@ export function ListMember(props: ListMemberProps) {
   const description = member.description;
 
   const hasOverflow = useHasOverflow(textRef);
+  const isAutoTitle = titleize(member.name) === title;
+
   const button = (
     <ListMemberWrapper>
       <ListMemberButton
@@ -122,11 +124,15 @@ export function ListMember(props: ListMemberProps) {
     </ListMemberWrapper>
   );
 
-  return hasOverflow ? (
+  return hasOverflow || !isAutoTitle ? (
     <TooltipProvider
       title={
         <>
-          <b>{name}</b>
+          <Text preset="t4">
+            <b>{name}</b>
+          </Text>
+          <br />
+          <Text preset="t4">{title}</Text>
         </>
       }
       delay={1000}

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/SidePanelCubeItem.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/SidePanelCubeItem.tsx
@@ -16,6 +16,7 @@ import { ArrowIcon } from '../icons/ArrowIcon';
 import { NonPublicIcon } from '../icons/NonPublicIcon';
 import { ItemInfoIcon } from '../icons/ItemInfoIcon';
 import { useHasOverflow, useFilteredMembers } from '../hooks';
+import { titleize } from '../utils/index';
 
 import { ListMember } from './ListMember';
 import { TimeListMember } from './TimeListMember';
@@ -366,6 +367,7 @@ export function SidePanelCubeItem({
   }, [segments.join(','), query?.segments?.join(','), showMembers, mode, meta]);
 
   const hasOverflow = useHasOverflow(textRef);
+  const isAutoTitle = titleize(name) === title;
 
   const noVisibleMembers = !dimensions.length && !measures.length && !segments.length;
 
@@ -468,12 +470,16 @@ export function SidePanelCubeItem({
   return (
     <Space flow="column" gap="0">
       <CubeWrapper>
-        {hasOverflow ? (
+        {hasOverflow || !isAutoTitle ? (
           <TooltipProvider
             delay={1000}
             title={
               <>
-                <b>{name}</b>
+                <Text preset="t4">
+                  <b>{name}</b>
+                </Text>
+                <br />
+                <Text preset="t4">{title}</Text>
               </>
             }
             placement="right"

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -66,8 +66,12 @@ export function TimeListMember(props: ListMemberProps) {
   // @ts-ignore
   const description = member.description;
   const isTimestampSelected = isSelected();
-  const isGranularitySelectedList = GRANULARITIES.map((granularity) => isSelected(granularity));
-  const selectedGranularity = GRANULARITIES.find((granularity) => isSelected(granularity));
+
+  const memberGranularities = (member.type === 'time' && member.granularities) ?
+    member.granularities.map(g => g.name).concat(GRANULARITIES) :
+    GRANULARITIES;
+  const isGranularitySelectedList = memberGranularities.map((granularity) => isSelected(granularity));
+  const selectedGranularity = memberGranularities.find((granularity) => isSelected(granularity));
   // const isGranularitySelected = !!isGranularitySelectedList.find((gran) => gran);
 
   open = isCompact ? false : open;
@@ -162,7 +166,7 @@ export function TimeListMember(props: ListMemberProps) {
               <Text ellipsis>value</Text>
             </ListMemberButton>
           ) : null}
-          {GRANULARITIES.map((granularity, i) => {
+          {memberGranularities.map((granularity, i) => {
             return open && !isCompact ? (
               <ListMemberButton
                 key={`${name}.${granularity}`}

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -7,6 +7,7 @@ import {
   TimeIcon,
   CalendarIcon,
   TooltipProvider,
+  CubeIcon,
 } from '@cube-dev/ui-kit';
 import { Cube, TCubeDimension, TimeDimensionGranularity } from '@cubejs-client/core';
 
@@ -32,7 +33,7 @@ interface ListMemberProps {
   onToggleDataRange?: (name: string) => void;
 }
 
-const GRANULARITIES: TimeDimensionGranularity[] = [
+const PREDEFINED_GRANULARITIES: TimeDimensionGranularity[] = [
   'second',
   'minute',
   'hour',
@@ -67,12 +68,16 @@ export function TimeListMember(props: ListMemberProps) {
   const description = member.description;
   const isTimestampSelected = isSelected();
 
+  const customGranularities = (member.type === 'time' && member.granularities) ?
+    member.granularities.map(g => g.name) : [];
   const memberGranularities = (member.type === 'time' && member.granularities) ?
-    member.granularities.map(g => g.name).concat(GRANULARITIES) :
-    GRANULARITIES;
-  const isGranularitySelectedList = memberGranularities.map((granularity) => isSelected(granularity));
+    member.granularities.map(g => g.name).concat(PREDEFINED_GRANULARITIES) :
+    PREDEFINED_GRANULARITIES;
+  const isGranularitySelectedMap = {};
+  memberGranularities.forEach((granularity) => {
+    isGranularitySelectedMap[granularity] = isSelected(granularity)
+  });
   const selectedGranularity = memberGranularities.find((granularity) => isSelected(granularity));
-  // const isGranularitySelected = !!isGranularitySelectedList.find((gran) => gran);
 
   open = isCompact ? false : open;
 
@@ -134,6 +139,26 @@ export function TimeListMember(props: ListMemberProps) {
     </ListMemberButton>
   );
 
+  const granularityItems = (items, icon) => {
+    if (!open || isCompact) {
+      return null;
+    }
+
+    return items.map((granularity, i) => (<ListMemberButton
+        key={`${name}.${granularity}`}
+        icon={icon}
+        data-member="timeDimension"
+        isSelected={isGranularitySelectedMap[granularity]}
+        onPress={() => {
+          onGranularityToggle(member.name, granularity);
+          setOpen(false);
+        }}
+      >
+        <Text ellipsis>{granularity}</Text>
+      </ListMemberButton>
+    ));
+  }
+
   return (
     <>
       {hasOverflow ? (
@@ -166,22 +191,9 @@ export function TimeListMember(props: ListMemberProps) {
               <Text ellipsis>value</Text>
             </ListMemberButton>
           ) : null}
-          {memberGranularities.map((granularity, i) => {
-            return open && !isCompact ? (
-              <ListMemberButton
-                key={`${name}.${granularity}`}
-                icon={<CalendarIcon />}
-                data-member="timeDimension"
-                isSelected={isGranularitySelectedList[i]}
-                onPress={() => {
-                  onGranularityToggle(member.name, granularity);
-                  setOpen(false);
-                }}
-              >
-                <Text ellipsis>{granularity}</Text>
-              </ListMemberButton>
-            ) : null;
-          })}
+          {/* TODO: Add special icon for custom granularities and use it here */}
+          {granularityItems(customGranularities, <CubeIcon />)}
+          {granularityItems(PREDEFINED_GRANULARITIES, <CalendarIcon />)}
         </Flex>
       ) : null}
     </>

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -2,14 +2,13 @@ import { useMemo, useRef, useState } from 'react';
 import { Flex, Space, Text, TimeIcon, TooltipProvider } from '@cube-dev/ui-kit';
 import { Cube, TCubeDimension, TimeDimensionGranularity } from '@cubejs-client/core';
 
-import { GranularityListMember } from './GranularityListMember';
-
 import { ArrowIcon } from '../icons/ArrowIcon';
 import { NonPublicIcon } from '../icons/NonPublicIcon';
 import { ItemInfoIcon } from '../icons/ItemInfoIcon';
 import { useHasOverflow } from '../hooks/has-overflow';
 import { titleize } from '../utils/index';
 
+import { GranularityListMember } from './GranularityListMember';
 import { ListMemberButton } from './ListMemberButton';
 import { FilterByMemberButton } from './FilterByMemberButton';
 import { FilteredLabel } from './FilteredLabel';

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { Flex, Space, Text, TimeIcon, TooltipProvider } from '@cube-dev/ui-kit';
 import { Cube, TCubeDimension, TimeDimensionGranularity } from '@cubejs-client/core';
 
-import { GranularityListMember } from '@/modules/playground/components/QueryBuilder/components/GranularityListMember';
+import { GranularityListMember } from './GranularityListMember';
 
 import { ArrowIcon } from '../icons/ArrowIcon';
 import { NonPublicIcon } from '../icons/NonPublicIcon';

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -6,8 +6,8 @@ import {
   Text,
   TimeIcon,
   CalendarIcon,
+  CalendarEditIcon,
   TooltipProvider,
-  CubeIcon,
 } from '@cube-dev/ui-kit';
 import { Cube, TCubeDimension, TimeDimensionGranularity } from '@cubejs-client/core';
 
@@ -191,8 +191,7 @@ export function TimeListMember(props: ListMemberProps) {
               <Text ellipsis>value</Text>
             </ListMemberButton>
           ) : null}
-          {/* TODO: Add special icon for custom granularities and use it here */}
-          {granularityItems(customGranularities, <CubeIcon />)}
+          {granularityItems(customGranularities, <CalendarEditIcon />)}
           {granularityItems(PREDEFINED_GRANULARITIES, <CalendarIcon />)}
         </Flex>
       ) : null}

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -1,24 +1,17 @@
-import { useRef, useState } from 'react';
-import {
-  Action,
-  Flex,
-  Space,
-  Text,
-  TimeIcon,
-  CalendarIcon,
-  CalendarEditIcon,
-  TooltipProvider,
-} from '@cube-dev/ui-kit';
+import { useMemo, useRef, useState } from 'react';
+import { Flex, Space, Text, TimeIcon, TooltipProvider } from '@cube-dev/ui-kit';
 import { Cube, TCubeDimension, TimeDimensionGranularity } from '@cubejs-client/core';
+
+import { GranularityListMember } from '@/modules/playground/components/QueryBuilder/components/GranularityListMember';
 
 import { ArrowIcon } from '../icons/ArrowIcon';
 import { NonPublicIcon } from '../icons/NonPublicIcon';
 import { ItemInfoIcon } from '../icons/ItemInfoIcon';
 import { useHasOverflow } from '../hooks/has-overflow';
+import { titleize } from '../utils/index';
 
 import { ListMemberButton } from './ListMemberButton';
 import { FilterByMemberButton } from './FilterByMemberButton';
-import { MemberBadge } from './Badge';
 import { FilteredLabel } from './FilteredLabel';
 
 interface ListMemberProps {
@@ -70,8 +63,21 @@ export function TimeListMember(props: ListMemberProps) {
 
   const customGranularities =
     member.type === 'time' && member.granularities ? member.granularities.map((g) => g.name) : [];
+  const customGranularitiesTitleMap = useMemo(() => {
+    return (
+      member.type === 'time' &&
+      member.granularities?.reduce(
+        (map, granularity) => {
+          map[granularity.name] = granularity.title;
+
+          return map;
+        },
+        {} as Record<string, string>
+      )
+    );
+  }, [member.type === 'time' ? member.granularities : null]);
   const memberGranularities = customGranularities.concat(PREDEFINED_GRANULARITIES);
-  const isGranularitySelectedMap = {};
+  const isGranularitySelectedMap: Record<string, boolean> = {};
   memberGranularities.forEach((granularity) => {
     isGranularitySelectedMap[granularity] = isSelected(granularity);
   });
@@ -80,6 +86,8 @@ export function TimeListMember(props: ListMemberProps) {
   open = isCompact ? false : open;
 
   const hasOverflow = useHasOverflow(textRef);
+  const isAutoTitle = titleize(member.name) === title;
+
   const button = (
     <ListMemberButton
       icon={
@@ -106,22 +114,7 @@ export function TimeListMember(props: ListMemberProps) {
       <Text ref={textRef} ellipsis>
         {filterString ? <FilteredLabel text={name} filter={filterString} /> : name}
       </Text>
-      {(isCompact || !open) && selectedGranularity ? (
-        <TooltipProvider
-          delay={1000}
-          title="Click the granularity label to remove it from the query"
-        >
-          <Action
-            onPress={() => {
-              onGranularityToggle(member.name, selectedGranularity);
-            }}
-          >
-            <MemberBadge isSpecial type="timeDimension">
-              {selectedGranularity}
-            </MemberBadge>
-          </Action>
-        </TooltipProvider>
-      ) : null}
+
       <Space gap=".5x">
         <Space gap="1x">
           {description ? <ItemInfoIcon title={title} description={description} /> : undefined}
@@ -137,30 +130,34 @@ export function TimeListMember(props: ListMemberProps) {
     </ListMemberButton>
   );
 
-  const granularityItems = (items, icon) => {
-    if (!open || isCompact) {
-      return null;
-    }
+  const granularityItems = (items: string[], isCustom?: boolean) => {
+    return items.map((granularity: string) => {
+      if (
+        ((!open || isCompact) && !isGranularitySelectedMap[granularity]) ||
+        !customGranularitiesTitleMap
+      ) {
+        return null;
+      }
 
-    return items.map((granularity, i) => (
-      <ListMemberButton
-        key={`${name}.${granularity}`}
-        icon={icon}
-        data-member="timeDimension"
-        isSelected={isGranularitySelectedMap[granularity]}
-        onPress={() => {
-          onGranularityToggle(member.name, granularity);
-          setOpen(false);
-        }}
-      >
-        <Text ellipsis>{granularity}</Text>
-      </ListMemberButton>
-    ));
+      return (
+        <GranularityListMember
+          key={`${name}.${granularity}`}
+          name={granularity}
+          title={customGranularitiesTitleMap[granularity]}
+          isCustom={isCustom}
+          isSelected={isGranularitySelectedMap[granularity]}
+          onToggle={() => {
+            onGranularityToggle(member.name, granularity);
+            setOpen(false);
+          }}
+        />
+      );
+    });
   };
 
   return (
     <>
-      {hasOverflow ? (
+      {hasOverflow || !isAutoTitle ? (
         <TooltipProvider
           title={
             <>
@@ -175,7 +172,7 @@ export function TimeListMember(props: ListMemberProps) {
       ) : (
         button
       )}
-      {open || isCompact ? (
+      {open || isCompact || selectedGranularity ? (
         <Flex flow="column" gap="1bw" padding="4.5x left">
           {open && !isCompact ? (
             <ListMemberButton
@@ -190,8 +187,8 @@ export function TimeListMember(props: ListMemberProps) {
               <Text ellipsis>value</Text>
             </ListMemberButton>
           ) : null}
-          {granularityItems(customGranularities, <CalendarEditIcon />)}
-          {granularityItems(PREDEFINED_GRANULARITIES, <CalendarIcon />)}
+          {granularityItems(customGranularities, true)}
+          {granularityItems(PREDEFINED_GRANULARITIES)}
         </Flex>
       ) : null}
     </>

--- a/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/components/TimeListMember.tsx
@@ -68,14 +68,12 @@ export function TimeListMember(props: ListMemberProps) {
   const description = member.description;
   const isTimestampSelected = isSelected();
 
-  const customGranularities = (member.type === 'time' && member.granularities) ?
-    member.granularities.map(g => g.name) : [];
-  const memberGranularities = (member.type === 'time' && member.granularities) ?
-    member.granularities.map(g => g.name).concat(PREDEFINED_GRANULARITIES) :
-    PREDEFINED_GRANULARITIES;
+  const customGranularities =
+    member.type === 'time' && member.granularities ? member.granularities.map((g) => g.name) : [];
+  const memberGranularities = customGranularities.concat(PREDEFINED_GRANULARITIES);
   const isGranularitySelectedMap = {};
   memberGranularities.forEach((granularity) => {
-    isGranularitySelectedMap[granularity] = isSelected(granularity)
+    isGranularitySelectedMap[granularity] = isSelected(granularity);
   });
   const selectedGranularity = memberGranularities.find((granularity) => isSelected(granularity));
 
@@ -144,7 +142,8 @@ export function TimeListMember(props: ListMemberProps) {
       return null;
     }
 
-    return items.map((granularity, i) => (<ListMemberButton
+    return items.map((granularity, i) => (
+      <ListMemberButton
         key={`${name}.${granularity}`}
         icon={icon}
         data-member="timeDimension"
@@ -157,7 +156,7 @@ export function TimeListMember(props: ListMemberProps) {
         <Text ellipsis>{granularity}</Text>
       </ListMemberButton>
     ));
-  }
+  };
 
   return (
     <>

--- a/packages/cubejs-playground/src/QueryBuilderV2/utils/format-date-by-granularity.tsx
+++ b/packages/cubejs-playground/src/QueryBuilderV2/utils/format-date-by-granularity.tsx
@@ -13,7 +13,11 @@ const FORMAT_MAP = {
 };
 
 export function formatDateByGranularity(timestamp: Date, granularity?: TimeDimensionGranularity) {
-  return formatDate(timestamp, FORMAT_MAP[granularity ?? 'second']);
+  return formatDate(
+    timestamp,
+    FORMAT_MAP[(granularity as Exclude<TimeDimensionGranularity, string>) ?? 'second'] ??
+      FORMAT_MAP['second']
+  );
 }
 
 export function formatDateByPattern(timestamp: Date, format?: string) {

--- a/packages/cubejs-playground/src/QueryBuilderV2/utils/index.ts
+++ b/packages/cubejs-playground/src/QueryBuilderV2/utils/index.ts
@@ -11,3 +11,4 @@ export * from './use-commit-press';
 export * from './uncapitalize';
 export * from './uniq-array';
 export * from './graphql-converters';
+export * from './titleize';

--- a/packages/cubejs-playground/src/QueryBuilderV2/utils/titleize.ts
+++ b/packages/cubejs-playground/src/QueryBuilderV2/utils/titleize.ts
@@ -1,0 +1,57 @@
+const underbar = new RegExp('_', 'g');
+const dot = new RegExp('\\.', 'g');
+const nonTitlecasedWords = [
+  'and',
+  'or',
+  'nor',
+  'a',
+  'an',
+  'the',
+  'so',
+  'but',
+  'to',
+  'of',
+  'at',
+  'by',
+  'from',
+  'into',
+  'on',
+  'onto',
+  'off',
+  'out',
+  'in',
+  'over',
+  'with',
+  'for',
+];
+
+function capitalize(str: string) {
+  str = str.toLowerCase();
+
+  return str.substring(0, 1).toUpperCase() + str.substring(1);
+}
+
+export function titleize(str: string) {
+  str = str.toLowerCase().replace(underbar, ' ').replace(dot, ' ');
+  const strArr = str.split(' ');
+  const j = strArr.length;
+  let d: string[], l: number;
+
+  for (let i = 0; i < j; i++) {
+    d = strArr[i].split('-');
+    l = d.length;
+
+    for (let k = 0; k < l; k++) {
+      if (nonTitlecasedWords.indexOf(d[k].toLowerCase()) < 0) {
+        d[k] = capitalize(d[k]);
+      }
+    }
+
+    strArr[i] = d.join('-');
+  }
+
+  str = strArr.join(' ');
+  str = str.substring(0, 1).toUpperCase() + str.substring(1);
+
+  return str;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
 
-"@cube-dev/ui-kit@0.37.3":
-  version "0.37.3"
-  resolved "https://registry.yarnpkg.com/@cube-dev/ui-kit/-/ui-kit-0.37.3.tgz#cb0bbba199fe63e692ee1b163f7473e6dd0eb9e9"
-  integrity sha512-7VJXTm+Z9MYdCErzssb2LkkyF3xzAtrfiD1JkJVX+M/Pc6is3JHLp0MQWBOe859ue4bj6AobHaTZcGB4mpxesg==
+"@cube-dev/ui-kit@0.37.4":
+  version "0.37.4"
+  resolved "https://registry.yarnpkg.com/@cube-dev/ui-kit/-/ui-kit-0.37.4.tgz#5e79a6875cd20ce24db401aecb594c9278f71313"
+  integrity sha512-F7P+XAL5ZO1pKauRkeaVxQc0iBx05urKHfZbSvq5Pubavif8HWMBce22rGQ/N7N9+GnTFt0Wt1zq+FEdJsvBUA==
   dependencies:
     "@ant-design/icons" "^5.3.4"
     "@internationalized/date" "^3.5.2"


### PR DESCRIPTION
This PR brings support for custom granularities in our playground V2! Now you can choose custom granularities in Query Builder, get the results and even see the charts with custom intervals!

This depends on:
* https://github.com/cube-js/cube/pull/8742
* https://github.com/cube-js/cube-ui-kit/pull/500

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
