### PR TITLE
feat: new style RBAC framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ testings/
 rust/cubesql/profile.json
 .cubestore
 .env
-
+.vimspector.json

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -234,7 +234,7 @@ class ApiGateway {
       const { query, variables } = req.body;
       const compilerApi = await this.getCompilerApi(req.context);
 
-      const metaConfig = await compilerApi.metaConfig({
+      const metaConfig = await compilerApi.metaConfig(req.context, {
         requestId: req.context.requestId,
       });
 
@@ -267,7 +267,7 @@ class ApiGateway {
         const compilerApi = await this.getCompilerApi(req.context);
         let schema = compilerApi.getGraphQLSchema();
         if (!schema) {
-          let metaConfig = await compilerApi.metaConfig({
+          let metaConfig = await compilerApi.metaConfig(req.context, {
             requestId: req.context.requestId,
           });
           metaConfig = this.filterVisibleItemsInMeta(req.context, metaConfig);
@@ -551,7 +551,7 @@ class ApiGateway {
     try {
       await this.assertApiScope('meta', context.securityContext);
       const compilerApi = await this.getCompilerApi(context);
-      const metaConfig = await compilerApi.metaConfig({
+      const metaConfig = await compilerApi.metaConfig(context, {
         requestId: context.requestId,
         includeCompilerId: includeCompilerId || onlyCompilerId
       });
@@ -587,7 +587,7 @@ class ApiGateway {
     try {
       await this.assertApiScope('meta', context.securityContext);
       const compilerApi = await this.getCompilerApi(context);
-      const metaConfigExtended = await compilerApi.metaConfigExtended({
+      const metaConfigExtended = await compilerApi.metaConfigExtended(context, {
         requestId: context.requestId,
       });
       const { metaConfig, cubeDefinitions } = metaConfigExtended;
@@ -1010,7 +1010,7 @@ class ApiGateway {
           } else {
             const metaCacheKey = JSON.stringify(ctx);
             if (!metaCache.has(metaCacheKey)) {
-              metaCache.set(metaCacheKey, await compiler.metaConfigExtended(ctx));
+              metaCache.set(metaCacheKey, await compiler.metaConfigExtended(context, ctx));
             }
 
             // checking and fetching result status
@@ -1180,6 +1180,7 @@ class ApiGateway {
     }, context);
 
     const startTime = new Date().getTime();
+    const compilerApi = await this.getCompilerApi(context);
 
     let normalizedQueries: NormalizedQuery[] = await Promise.all(
       queries.map(
@@ -1195,8 +1196,14 @@ class ApiGateway {
           }
 
           const normalizedQuery = normalizeQuery(currentQuery, persistent);
-          let rewrittenQuery = await this.queryRewrite(
+          // First apply cube/view level security policies
+          const queryWithRlsFilters = await compilerApi.applyRowLevelSecurity(
             normalizedQuery,
+            context
+          );
+          // Then apply user-supplied queryRewrite
+          let rewrittenQuery = await this.queryRewrite(
+            queryWithRlsFilters,
             context,
           );
 
@@ -1693,7 +1700,7 @@ class ApiGateway {
         await this.getNormalizedQueries(query, context);
 
       let metaConfigResult = await (await this
-        .getCompilerApi(context)).metaConfig({
+        .getCompilerApi(context)).metaConfig(request.context, {
         requestId: context.requestId
       });
 
@@ -1803,7 +1810,7 @@ class ApiGateway {
         await this.getNormalizedQueries(query, context, request.streaming, request.memberExpressions);
 
       const compilerApi = await this.getCompilerApi(context);
-      let metaConfigResult = await compilerApi.metaConfig({
+      let metaConfigResult = await compilerApi.metaConfig(request.context, {
         requestId: context.requestId
       });
 

--- a/packages/cubejs-api-gateway/src/helpers/prepareAnnotation.ts
+++ b/packages/cubejs-api-gateway/src/helpers/prepareAnnotation.ts
@@ -48,7 +48,8 @@ const annotation = (
 ) => (member: string | MemberExpression): undefined | [string, ConfigItem] => {
   const [cubeName, fieldName] = (<MemberExpression>member).expression ? [(<MemberExpression>member).cubeName, (<MemberExpression>member).name] : (<string>member).split('.');
   const memberWithoutGranularity = [cubeName, fieldName].join('.');
-  const config: ConfigItem = configMap[cubeName][memberType]
+  const cubeConfig = configMap[cubeName];
+  const config: ConfigItem = cubeConfig && cubeConfig[memberType]
     .find(m => m.name === memberWithoutGranularity);
 
   if (!config) {

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -471,7 +471,7 @@ describe('API Gateway', () => {
         queryRewrite: async (query, _context) => {
           query.limit = 2;
           return query;
-        }
+        },
       }
     );
 

--- a/packages/cubejs-api-gateway/test/mocks.ts
+++ b/packages/cubejs-api-gateway/test/mocks.ts
@@ -75,6 +75,10 @@ export const compilerApi = jest.fn().mockImplementation(async () => ({
     return 'postgres';
   },
 
+  async applyRowLevelSecurity(query: any) {
+    return query;
+  },
+
   async metaConfig() {
     return [
       {

--- a/packages/cubejs-schema-compiler/src/compiler/CompilerCache.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CompilerCache.ts
@@ -4,6 +4,8 @@ import { QueryCache } from '../adapter/QueryCache';
 export class CompilerCache extends QueryCache {
   protected readonly queryCache: LRUCache<string, QueryCache>;
 
+  protected readonly rbacCache: LRUCache<string, any>;
+
   public constructor({ maxQueryCacheSize, maxQueryCacheAge }) {
     super();
 
@@ -12,6 +14,15 @@ export class CompilerCache extends QueryCache {
       maxAge: (maxQueryCacheAge * 1000) || 1000 * 60 * 10,
       updateAgeOnGet: true
     });
+
+    this.rbacCache = new LRUCache({
+      max: 10000,
+      maxAge: 1000 * 60 * 5, // 5 minutes
+    });
+  }
+
+  public getRbacCacheInstance(): LRUCache<string, any> {
+    return this.rbacCache;
   }
 
   public getQueryCache(key: unknown): QueryCache {

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
@@ -25,6 +25,9 @@ export const transpiledFieldsPatterns: Array<RegExp> = [
   /^excludes$/,
   /^hierarchies\.[0-9]+\.levels$/,
   /^cubes\.[0-9]+\.(joinPath|join_path)$/,
+  /^(accessPolicy|access_policy)\.[0-9]+\.(rowLevel|row_level)\.filters\.[0-9]+.*\.member$/,
+  /^(accessPolicy|access_policy)\.[0-9]+\.(rowLevel|row_level)\.filters\.[0-9]+.*\.values$/,
+  /^(accessPolicy|access_policy)\.[0-9]+\.conditions.[0-9]+\.if$/,
 ];
 
 export const transpiledFields: Set<String> = new Set<String>();

--- a/packages/cubejs-schema-compiler/src/compiler/utils.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/utils.ts
@@ -48,6 +48,7 @@ export function camelizeCube(cube: any): unknown {
   camelizeObjectPart(cube.dimensions, false);
   camelizeObjectPart(cube.preAggregations, false);
   camelizeObjectPart(cube.cubes, false);
+  camelizeObjectPart(cube.accessPolicy, false);
 
   return cube;
 }

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -1,5 +1,5 @@
 import { prepareCompiler } from './PrepareCompiler';
-import { createCubeSchema, createCubeSchemaWithCustomGranularities } from './utils';
+import { createCubeSchema, createCubeSchemaWithCustomGranularities, createCubeSchemaWithAccessPolicy } from './utils';
 
 describe('Schema Testing', () => {
   const schemaCompile = async () => {
@@ -366,5 +366,13 @@ describe('Schema Testing', () => {
       CubeC: { relationship: 'hasMany' },
       CubeD: { relationship: 'belongsTo' }
     });
+  });
+
+  it('valid schema with accessPolicy', async () => {
+    const { compiler } = prepareCompiler([
+      createCubeSchemaWithAccessPolicy('ProtectedCube'),
+    ]);
+    await compiler.compile();
+    compiler.throwIfAnyErrors();
   });
 });

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -72,6 +72,7 @@ const schemaOptions = Joi.object().keys({
   //
   cacheAndQueueDriver: Joi.string().valid('cubestore', 'memory'),
   contextToAppId: Joi.func(),
+  contextToRoles: Joi.func(),
   contextToOrchestratorId: Joi.func(),
   contextToDataSourceId: Joi.func(),
   contextToApiScopes: Joi.func(),

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -506,6 +506,7 @@ export class CubejsServerCore {
           ),
           externalDialectClass: this.options.externalDialectFactory && this.options.externalDialectFactory(context),
           schemaVersion: currentSchemaVersion,
+          contextToRoles: this.options.contextToRoles,
           preAggregationsSchema: await this.preAggregationsSchema(context),
           context,
           allowJsDuplicatePropsInSchema: this.options.allowJsDuplicatePropsInSchema,
@@ -667,6 +668,7 @@ export class CubejsServerCore {
       options.dbType || this.options.dbType,
       {
         schemaVersion: options.schemaVersion || this.options.schemaVersion,
+        contextToRoles: this.options.contextToRoles,
         devServer: this.options.devServer,
         logger: this.logger,
         externalDbType: options.externalDbType,

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -120,6 +120,7 @@ export type DatabaseType =
   | 'materialize';
 
 export type ContextToAppIdFn = (context: RequestContext) => string | Promise<string>;
+export type ContextToRolesFn = (context: RequestContext) => string[] | Promise<string[]>;
 export type ContextToOrchestratorIdFn = (context: RequestContext) => string | Promise<string>;
 
 export type OrchestratorOptionsFn = (context: RequestContext) => OrchestratorOptions | Promise<OrchestratorOptions>;
@@ -176,6 +177,7 @@ export interface CreateOptions {
   externalDialectFactory?: ExternalDialectFactoryFn;
   cacheAndQueueDriver?: CacheAndQueryDriverType;
   contextToAppId?: ContextToAppIdFn;
+  contextToRoles?: ContextToRolesFn;
   contextToOrchestratorId?: ContextToOrchestratorIdFn;
   contextToApiScopes?: ContextToApiScopesFn;
   repositoryFactory?: (context: RequestContext) => SchemaFileRepository;

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -349,7 +349,7 @@ describe('index.test', () => {
     const metaConfigExtendedSpy = jest.spyOn(compilerApi, 'metaConfigExtended');
 
     test('CompilerApi metaConfig', async () => {
-      const metaConfig = await compilerApi.metaConfig({ requestId: 'XXX' });
+      const metaConfig = await compilerApi.metaConfig({ securityContext: {} }, { requestId: 'XXX' });
       expect((<any[]>metaConfig)?.length).toBeGreaterThan(0);
       expect(metaConfig[0]).toHaveProperty('config');
       expect(metaConfig[0].config.hasOwnProperty('sql')).toBe(false);
@@ -358,7 +358,7 @@ describe('index.test', () => {
     });
 
     test('CompilerApi metaConfigExtended', async () => {
-      const metaConfigExtended = await compilerApi.metaConfigExtended({ requestId: 'XXX' });
+      const metaConfigExtended = await compilerApi.metaConfigExtended({ securityContext: {} }, { requestId: 'XXX' });
       expect(metaConfigExtended).toHaveProperty('metaConfig');
       expect(metaConfigExtended.metaConfig.length).toBeGreaterThan(0);
       expect(metaConfigExtended).toHaveProperty('cubeDefinitions');
@@ -378,14 +378,14 @@ describe('index.test', () => {
     const metaConfigExtendedSpy = jest.spyOn(compilerApi, 'metaConfigExtended');
 
     test('CompilerApi metaConfig', async () => {
-      const metaConfig = await compilerApi.metaConfig({ requestId: 'XXX' });
+      const metaConfig = await compilerApi.metaConfig({ securityContext: {} }, { requestId: 'XXX' });
       expect(metaConfig).toEqual([]);
       expect(metaConfigSpy).toHaveBeenCalled();
       metaConfigSpy.mockClear();
     });
 
     test('CompilerApi metaConfigExtended', async () => {
-      const metaConfigExtended = await compilerApi.metaConfigExtended({ requestId: 'XXX' });
+      const metaConfigExtended = await compilerApi.metaConfigExtended({ securityContext: {} }, { requestId: 'XXX' });
       expect(metaConfigExtended).toHaveProperty('metaConfig');
       expect(metaConfigExtended.metaConfig).toEqual([]);
       expect(metaConfigExtended).toHaveProperty('cubeDefinitions');

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
@@ -1,0 +1,27 @@
+module.exports = {
+  contextToRoles: async (context) => context.securityContext.auth?.roles || [],
+  checkSqlAuth: async (req, user, password) => {
+    if (user === 'admin') {
+      if (password && password !== 'admin_password') {
+        throw new Error(`Password doesn't match for ${user}`);
+      }
+      return {
+        password,
+        superuser: true,
+        securityContext: {
+          auth: {
+            username: 'admin',
+            userAttributes: {
+              region: 'CA',
+              city: 'Fresno',
+              canHaveAdmin: true,
+              minDefaultId: 10000,
+            },
+            roles: ['admin', 'ownder', 'hr'],
+          },
+        },
+      };
+    }
+    throw new Error(`User "${user}" doesn't exist`);
+  }
+};

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/line_items.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/line_items.js
@@ -1,0 +1,76 @@
+cube('line_items', {
+  sql_table: 'public.line_items',
+
+  data_source: 'default',
+
+  joins: {
+    orders: {
+      relationship: 'many_to_one',
+      sql: `${orders}.id = ${line_items}.order_id`,
+    },
+
+  },
+
+  dimensions: {
+    id: {
+      sql: 'id',
+      type: 'number',
+      primary_key: true,
+    },
+
+    created_at: {
+      sql: 'created_at',
+      type: 'time',
+    },
+
+    price_dim: {
+      sql: 'price',
+      type: 'number',
+    },
+  },
+
+  measures: {
+    count: {
+      type: 'count',
+    },
+
+    price: {
+      sql: 'price',
+      type: 'sum',
+    },
+
+    quantity: {
+      sql: 'quantity',
+      type: 'sum',
+    },
+  },
+
+  accessPolicy: [
+    {
+      role: '*',
+      rowLevel: {
+        filters: [{
+          member: 'id',
+          operator: 'gt',
+          // This is to test dynamic values based on security context
+          values: [`${security_context.auth?.userAttributes?.minDefaultId || 20000}`],
+        }]
+      }
+    },
+    {
+      role: 'admin',
+      conditions: [
+        {
+          if: security_context.auth?.userAttributes?.region === 'CA',
+        },
+      ],
+      rowLevel: {
+        // The "allowAll" flag should negate the default `id` filter
+        allowAll: true,
+      },
+      memberLevel: {
+        excludes: ['created_at'],
+      },
+    },
+  ],
+});

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders.js
@@ -1,0 +1,76 @@
+cube('orders', {
+  sql_table: 'public.orders',
+
+  data_source: 'default',
+
+  joins: {
+    line_items: {
+      relationship: 'one_to_many',
+      sql: `${orders}.id = ${line_items}.order_id`,
+    },
+  },
+
+  dimensions: {
+    id: {
+      sql: 'id',
+      type: 'number',
+      primary_key: true,
+    },
+
+    created_at: {
+      sql: 'created_at',
+      type: 'time',
+    },
+  },
+
+  measures: {
+    count: {
+      type: 'count',
+    },
+  },
+
+  accessPolicy: [
+    {
+      role: '*',
+      memberLevel: {
+        // This cube is "private" by default and only accessible via views
+        includes: [],
+      },
+      rowLevel: {
+        filters: [
+          {
+            member: 'id',
+            operator: 'equals',
+            values: [1],
+          },
+        ],
+      },
+    },
+    {
+      role: 'admin',
+      memberLevel: {
+        // This cube is "private" by default and only accessible via views
+        includes: [],
+      },
+      rowLevel: {
+        filters: [
+          {
+            or: [
+              {
+                member: `${CUBE}.id`,
+                operator: 'equals',
+                values: [10],
+              },
+              {
+                // Testing different ways of referencing cube members
+                member: 'id',
+                operator: 'equals',
+                values: ['11'],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+});

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders_open.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders_open.yaml
@@ -1,0 +1,19 @@
+cubes:
+  # An open cube with no access policy
+  - name: orders_open
+    sql_table: orders
+
+    dimensions:
+      - name: id
+        sql: id
+        type: string
+        primary_key: true
+
+      - name: created_at
+        sql: created_at
+        type: time
+
+    measures:
+      - name: count
+        sql: id
+        type: count

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/users.yaml
@@ -1,0 +1,49 @@
+cubes:
+  - name: users
+    sql_table: users
+
+    measures:
+      - name: count
+        sql: id
+        type: count
+
+    dimensions:
+      - name: city
+        sql: city
+        type: string
+
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+    access_policy:
+      - role: "*"
+      - role: admin
+        conditions:
+          # This thing will fail if there's no auth info in the context
+          # Unfortunately, as of now, there's no way to write more complex expressions
+          # that would allow us to check for the existence of the auth object
+          - if: "{ security_context.auth.userAttributes.canHaveAdmin }"
+        row_level:
+          filters:
+            - or:
+              - and:
+                - member: "{CUBE}.city"
+                  operator: notStartsWith
+                  values:
+                    - London
+                    - "{ security_context.auth.userAttributes.city }"
+                    # mixing string, dynamic values, integers and bools should not
+                    # cause any compilation issues
+                    - 4
+                    - true
+                - member: "city"
+                  operator: notEquals
+                  values:
+                    - 'San Francisco'
+              - member: "{CUBE}.city"
+                operator: equals
+                values:
+                  - "New York"
+

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/views.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/views.yaml
@@ -1,0 +1,37 @@
+views:
+  - name: line_items_view_price_gt_200
+    cubes:
+      - join_path: line_items
+        includes: "*"
+    access_policy:
+      - role: "*"
+        row_level:
+          filters:
+            - member: "${CUBE}.price_dim"
+              operator: gt
+              values:
+                - 200
+
+  - name: line_items_view_joined_orders
+    cubes:
+      - join_path: line_items
+        includes: "*"
+      - join_path: line_items.orders
+        prefix: true
+        includes: "*"
+
+  - name: line_items_view_no_policy
+    cubes:
+      - join_path: line_items
+        includes: "*"
+
+  - name: orders_view
+    cubes:
+      - join_path: orders
+        includes: "*"
+    access_policy:
+      - role: admin
+        member_level:
+          includes: "*"
+        row_level:
+          allow_all: true

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -73,6 +73,7 @@
     "smoke:postgres": "jest --verbose -i dist/test/smoke-postgres.test.js",
     "smoke:redshift": "jest --verbose -i dist/test/smoke-redshift.test.js",
     "smoke:redshift:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-redshift.test.js",
+    "smoke:rbac": "TZ=UTC jest --verbose --forceExit -i dist/test/smoke-rbac.test.js",
     "smoke:cubesql": "TZ=UTC jest --verbose --forceExit -i dist/test/smoke-cubesql.test.js",
     "smoke:cubesql:snapshot": "TZ=UTC jest --verbose --forceExit --updateSnapshot -i dist/test/smoke-cubesql.test.js",
     "smoke:prestodb": "jest --verbose -i dist/test/smoke-prestodb.test.js",

--- a/packages/cubejs-testing/test/__snapshots__/smoke-rbac.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-rbac.test.ts.snap
@@ -1,0 +1,1083 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from line_items: line_items 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 180,
+    "price_dim": 180,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 169,
+    "price_dim": 169,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 156,
+    "price_dim": 156,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 36,
+    "price_dim": 36,
+    "quantity": 5,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 63,
+    "price_dim": 63,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from line_items_view_joined_orders: orders_view 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "orders_count": "1",
+    "orders_created_at": 2018-10-23T07:54:39.000Z,
+    "orders_id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+    "orders_count": "1",
+    "orders_created_at": 2019-12-16T08:09:36.000Z,
+    "orders_id": 10,
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+    "id": 11,
+    "orders_count": "1",
+    "orders_created_at": 2019-04-22T15:52:17.000Z,
+    "orders_id": 11,
+    "price": 170,
+    "price_dim": 170,
+    "quantity": 1,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from line_items_view_no_policy: line_items_view_no_policy 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+    "id": 2,
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-05-13T21:23:08.000Z,
+    "id": 3,
+    "price": 180,
+    "price_dim": 180,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-04-10T22:51:15.000Z,
+    "id": 4,
+    "price": 169,
+    "price_dim": 169,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-16T15:00:34.000Z,
+    "id": 5,
+    "price": 156,
+    "price_dim": 156,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-05-23T04:25:27.000Z,
+    "id": 6,
+    "price": 36,
+    "price_dim": 36,
+    "quantity": 5,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+    "id": 7,
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+    "id": 8,
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-11-15T18:22:17.000Z,
+    "id": 9,
+    "price": 63,
+    "price_dim": 63,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from line_items_view_price_gt_200: line_items_view_price_gt_200 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+    "id": 2,
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+    "id": 7,
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+    "id": 8,
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-12-04T06:39:17.000Z,
+    "id": 12,
+    "price": 266,
+    "price_dim": 266,
+    "quantity": 9,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-01-28T20:03:53.000Z,
+    "id": 13,
+    "price": 286,
+    "price_dim": 286,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-08-04T21:41:23.000Z,
+    "id": 15,
+    "price": 237,
+    "price_dim": 237,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-14T05:31:34.000Z,
+    "id": 25,
+    "price": 262,
+    "price_dim": 262,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2016-01-01T23:00:21.000Z,
+    "id": 29,
+    "price": 241,
+    "price_dim": 241,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-05T18:07:39.000Z,
+    "id": 34,
+    "price": 249,
+    "price_dim": 249,
+    "quantity": 8,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from orders: orders_open 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-05-13T21:23:08.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-04-10T22:51:15.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-16T15:00:34.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-11-15T18:22:17.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-12-04T06:39:17.000Z,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from orders_view: orders_view 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+    "id": 11,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC through SQL API SELECT * from users: users 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via REST API line_items hidden created_at: line_items_view_no_policy_rest 1`] = `
+Array [
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-01-01T23:00:21.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-02-27T06:09:59.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-02-27T11:38:04.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-03-06T17:41:43.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-03-07T19:41:43.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-03-13T22:34:22.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-03-21T21:13:47.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-05-01T07:26:55.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-05-13T07:03:15.000",
+  },
+  Object {
+    "line_items_view_no_policy.count": "1",
+    "line_items_view_no_policy.created_at": "2016-05-15T22:44:26.000",
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via REST API orders_view and cube with default policy: orders_open_rest 1`] = `
+Array [
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-01T16:45:36.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-01T17:23:48.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-01T17:41:57.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-01T23:00:21.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-02T14:06:50.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-02T21:56:15.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-02T22:47:22.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-04T09:34:08.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-04T22:18:52.000",
+  },
+  Object {
+    "orders_open.count": "1",
+    "orders_open.created_at": "2016-01-05T01:39:46.000",
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via REST API orders_view and cube with default policy: orders_view_rest 1`] = `Array []`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from line_items: line_items 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 180,
+    "price_dim": 180,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 169,
+    "price_dim": 169,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 156,
+    "price_dim": 156,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 36,
+    "price_dim": 36,
+    "quantity": 5,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 63,
+    "price_dim": 63,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from line_items_view_joined_orders: orders_view 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "orders_count": "1",
+    "orders_created_at": 2018-10-23T07:54:39.000Z,
+    "orders_id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+    "orders_count": "1",
+    "orders_created_at": 2019-12-16T08:09:36.000Z,
+    "orders_id": 10,
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+    "id": 11,
+    "orders_count": "1",
+    "orders_created_at": 2019-04-22T15:52:17.000Z,
+    "orders_id": 11,
+    "price": 170,
+    "price_dim": 170,
+    "quantity": 1,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from line_items_view_no_policy: line_items_view_no_policy 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+    "id": 2,
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-05-13T21:23:08.000Z,
+    "id": 3,
+    "price": 180,
+    "price_dim": 180,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-04-10T22:51:15.000Z,
+    "id": 4,
+    "price": 169,
+    "price_dim": 169,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-16T15:00:34.000Z,
+    "id": 5,
+    "price": 156,
+    "price_dim": 156,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-05-23T04:25:27.000Z,
+    "id": 6,
+    "price": 36,
+    "price_dim": 36,
+    "quantity": 5,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+    "id": 7,
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+    "id": 8,
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-11-15T18:22:17.000Z,
+    "id": 9,
+    "price": 63,
+    "price_dim": 63,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+    "price": 68,
+    "price_dim": 68,
+    "quantity": 6,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from line_items_view_price_gt_200: line_items_view_price_gt_200 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+    "price": 267,
+    "price_dim": 267,
+    "quantity": 2,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+    "id": 2,
+    "price": 263,
+    "price_dim": 263,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+    "id": 7,
+    "price": 245,
+    "price_dim": 245,
+    "quantity": 4,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+    "id": 8,
+    "price": 232,
+    "price_dim": 232,
+    "quantity": 8,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-12-04T06:39:17.000Z,
+    "id": 12,
+    "price": 266,
+    "price_dim": 266,
+    "quantity": 9,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-01-28T20:03:53.000Z,
+    "id": 13,
+    "price": 286,
+    "price_dim": 286,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-08-04T21:41:23.000Z,
+    "id": 15,
+    "price": 237,
+    "price_dim": 237,
+    "quantity": 6,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-14T05:31:34.000Z,
+    "id": 25,
+    "price": 262,
+    "price_dim": 262,
+    "quantity": 1,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2016-01-01T23:00:21.000Z,
+    "id": 29,
+    "price": 241,
+    "price_dim": 241,
+    "quantity": 7,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-05T18:07:39.000Z,
+    "id": 34,
+    "price": 249,
+    "price_dim": 249,
+    "quantity": 8,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from orders: orders_open 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-01-01T13:50:20.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-05-13T21:23:08.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-04-10T22:51:15.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-07-16T15:00:34.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-09-29T20:29:30.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-17T03:32:54.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-11-15T18:22:17.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2017-12-04T06:39:17.000Z,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from orders_view: orders_view 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-12-16T08:09:36.000Z,
+    "id": 10,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2019-04-22T15:52:17.000Z,
+    "id": 11,
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "count": "1",
+    "created_at": 2018-10-23T07:54:39.000Z,
+    "id": 1,
+  },
+]
+`;
+
+exports[`Cube RBAC Engine RBAC via SQL API SELECT * from users: users 1`] = `
+Array [
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+  Object {
+    "__cubeJoinField": null,
+    "__user": null,
+    "city": "Austin",
+    "count": "1",
+  },
+]
+`;

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -33,7 +33,7 @@ describe('SQL API', () => {
     const conn = new PgClient({
       database: 'db',
       port: pgPort,
-      host: 'localhost',
+      host: '127.0.0.1',
       user,
       password,
       ssl: false,

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -1,0 +1,249 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { afterAll, beforeAll, jest, expect } from '@jest/globals';
+import { sign } from 'jsonwebtoken';
+import { Client as PgClient } from 'pg';
+import cubejs, { CubeApi, Query } from '@cubejs-client/core';
+import { PostgresDBRunner } from '@cubejs-backend/testing-shared';
+import type { StartedTestContainer } from 'testcontainers';
+
+import { BirdBox, getBirdbox } from '../src';
+import {
+  DEFAULT_CONFIG,
+  JEST_AFTER_ALL_DEFAULT_TIMEOUT,
+  JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+} from './smoke-tests';
+
+describe('Cube RBAC Engine', () => {
+  jest.setTimeout(60 * 5 * 1000);
+
+  let birdbox: BirdBox;
+  let db: StartedTestContainer;
+
+  const pgPort = 5656;
+  let connectionId = 0;
+
+  async function createPostgresClient(user: string, password: string) {
+    connectionId++;
+    const currentConnId = connectionId;
+
+    console.debug(`[pg] new connection ${currentConnId}`);
+
+    const conn = new PgClient({
+      database: 'db',
+      port: pgPort,
+      host: '127.0.0.1',
+      user,
+      password,
+      ssl: false,
+    });
+    conn.on('error', (err) => {
+      console.log(err);
+    });
+    conn.on('end', () => {
+      console.debug(`[pg] end ${currentConnId}`);
+    });
+
+    await conn.connect();
+
+    return conn;
+  }
+
+  beforeAll(async () => {
+    db = await PostgresDBRunner.startContainer({});
+    await PostgresDBRunner.loadEcom(db);
+    birdbox = await getBirdbox(
+      'postgres',
+      {
+        ...DEFAULT_CONFIG,
+        //
+        CUBESQL_LOG_LEVEL: 'trace',
+        //
+        CUBEJS_DB_TYPE: 'postgres',
+        CUBEJS_DB_HOST: db.getHost(),
+        CUBEJS_DB_PORT: `${db.getMappedPort(5432)}`,
+        CUBEJS_DB_NAME: 'test',
+        CUBEJS_DB_USER: 'test',
+        CUBEJS_DB_PASS: 'test',
+        //
+        CUBEJS_PG_SQL_PORT: `${pgPort}`,
+        CUBESQL_SQL_PUSH_DOWN: 'true',
+        CUBESQL_STREAM_MODE: 'true',
+      },
+      {
+        schemaDir: 'rbac/model',
+        cubejsConfig: 'rbac/cube.js',
+      }
+    );
+  }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
+
+  afterAll(async () => {
+    await birdbox.stop();
+    await db.stop();
+  }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+  describe('RBAC via SQL API', () => {
+    let connection: PgClient;
+
+    beforeAll(async () => {
+      connection = await createPostgresClient('admin', 'admin_password');
+    });
+
+    afterAll(async () => {
+      await connection.end();
+    }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+    test('SELECT * from line_items', async () => {
+      const res = await connection.query('SELECT * FROM line_items limit 10');
+      // This query should return all rows because of the `allow_all` statement
+      // It should also exclude the `created_at` dimension as per memberLevel policy
+      expect(res.rows).toMatchSnapshot('line_items');
+    });
+
+    // ???
+    test('SELECT * from line_items_view_no_policy', async () => {
+      const res = await connection.query('SELECT * FROM line_items_view_no_policy limit 10');
+      // This should query the line_items cube through the view that should
+      // allow for the ommitted `created_at` dimension to be included
+      expect(res.rows).toMatchSnapshot('line_items_view_no_policy');
+    });
+
+    test('SELECT * from line_items_view_price_gt_200', async () => {
+      const res = await connection.query('SELECT * FROM line_items_view_price_gt_200 limit 10');
+      // This query should add an extra filter by `price_dim` defined at the view level
+      expect(res.rows).toMatchSnapshot('line_items_view_price_gt_200');
+    });
+
+    test('SELECT * from orders', async () => {
+      let failed = false;
+      try {
+        // Orders cube does not expose any members so, the query should fail
+        await connection.query('SELECT * FROM orders');
+      } catch (e) {
+        failed = true;
+      }
+      expect(failed).toBe(true);
+
+      const res = await connection.query('SELECT * FROM orders_open limit 10');
+      // Open version of the orders cube should return everything
+      expect(res.rows).toMatchSnapshot('orders_open');
+    });
+
+    test('SELECT * from orders_view', async () => {
+      const res = await connection.query('SELECT * FROM orders_view limit 10');
+      // Orders cube should be visible via the view
+      expect(res.rows).toMatchSnapshot('orders_view');
+    });
+
+    test('SELECT * from line_items_view_joined_orders', async () => {
+      const res = await connection.query('SELECT * FROM line_items_view_joined_orders limit 10');
+      // Querying the line_items cube with joined orders should take into account
+      // orders row level policy and return only a few rows with select ids
+      expect(res.rows).toMatchSnapshot('orders_view');
+    });
+
+    test('SELECT * from users', async () => {
+      const res = await connection.query('SELECT * FROM users limit 10');
+      // Querying a cube with nested filters and mixed values should not cause any issues
+      expect(res.rows).toMatchSnapshot('users');
+    });
+  });
+
+  describe('RBAC via REST API', () => {
+    let client: CubeApi;
+    let defaultClient: CubeApi;
+
+    const ADMIN_API_TOKEN = sign({
+      auth: {
+        username: 'admin',
+        userAttributes: {
+          region: 'CA',
+          city: 'Fresno',
+          canHaveAdmin: true,
+          minDefaultId: 10000,
+        },
+        roles: ['admin', 'ownder', 'hr'],
+      },
+    }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
+      expiresIn: '2 days'
+    });
+
+    const DEFAULT_API_TOKEN = sign({
+      auth: {
+        username: 'nobody',
+        userAttributes: {},
+        roles: [],
+      },
+    }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
+      expiresIn: '2 days'
+    });
+
+    beforeAll(async () => {
+      client = cubejs(async () => ADMIN_API_TOKEN, {
+        apiUrl: birdbox.configuration.apiUrl,
+      });
+      defaultClient = cubejs(async () => DEFAULT_API_TOKEN, {
+        apiUrl: birdbox.configuration.apiUrl,
+      });
+    });
+
+    test('line_items hidden created_at', async () => {
+      let query: Query = {
+        measures: ['line_items.count'],
+        dimensions: ['line_items.created_at'],
+        order: {
+          'line_items.created_at': 'asc',
+        },
+      };
+      let error = '';
+      try {
+        await client.load(query, {});
+      } catch (e: any) {
+        error = e.toString();
+      }
+      expect(error).toContain('You requested hidden member');
+      query = {
+        measures: ['line_items_view_no_policy.count'],
+        dimensions: ['line_items_view_no_policy.created_at'],
+        order: {
+          'line_items_view_no_policy.created_at': 'asc',
+        },
+        limit: 10,
+      };
+      const result = await client.load(query, {});
+      expect(result.rawData()).toMatchSnapshot('line_items_view_no_policy_rest');
+    });
+
+    test('orders_view and cube with default policy', async () => {
+      let error = '';
+      try {
+        await defaultClient.load({
+          measures: ['orders.count'],
+        });
+      } catch (e: any) {
+        error = e.toString();
+      }
+      expect(error).toContain('You requested hidden member');
+
+      let result = await defaultClient.load({
+        measures: ['orders_view.count'],
+        dimensions: ['orders_view.created_at'],
+        order: {
+          'orders_view.created_at': 'asc',
+        },
+      });
+      // It should only return one value allowed by the default policy
+      expect(result.rawData()).toMatchSnapshot('orders_view_rest');
+
+      result = await defaultClient.load({
+        measures: ['orders_open.count'],
+        dimensions: ['orders_open.created_at'],
+        order: {
+          'orders_open.created_at': 'asc',
+        },
+        limit: 10
+      });
+      // order_open should return all values since it has no access policy
+      expect(result.rawData()).toMatchSnapshot('orders_open_rest');
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a new style Role Based Access Control framework
for cubes. User can now define `accessPolicies` on Cubes and Views which
will be evaluated into `queryRewrite` and visibility rules.

This commit introduces a new config: `contextToRoles(context):
string[]`. It should return a list of user role names based on the
request context. Access Policies are defined per Cube x Role name like

```
access_policy:
  - role: "manager"
    conditions:
      - if "{ security_context.isNotSuspended }"
    row_level:
      filters:
        - member: `access_level`
          operator: lt
          values: [2]
    member_level:
      includes: "*"
      excludes: [`top_secret_field`]
```

Each policy can define a `row_level` and `member_level` rules.
Row level rules can be defined as a list of filters or `allow_all: true`
Member level rules should specify a list of "included" members that the
user with a given role is allowed to see.

When evaluating Cube and View level policies:
- row level filters are joined via AND (least permissive policy wins)
- member level policy at the view always wins (you can expose a hidden
  member of a Cube on a View)

Policies can reference `security_context` (lowercase) when evaluating
policy conditions and filter values.