### PR TITLE
chore(cubestore): add await on a check_bools call in test

### DIFF
--- a/rust/cubestore/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/cubestore/src/table/parquet.rs
@@ -516,7 +516,7 @@ mod tests {
                 bools.push(false);
             }
         }
-        check_bools(bools);
+        check_bools(bools).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
The local closure `check_bools` in this test function was made async, but this caller hadn't been updated.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


