### PR TITLE
fix: Render LIMIT 0 and OFFSET 0 properly in SQL templates

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3217,8 +3217,8 @@ export class BaseQuery {
           '{% if filter %}\nWHERE {{ filter }}{% endif %}' +
           '{% if group_by %}\nGROUP BY {{ group_by }}{% endif %}' +
           '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}{% endif %}' +
-          '{% if limit %}\nLIMIT {{ limit }}{% endif %}' +
-          '{% if offset %}\nOFFSET {{ offset }}{% endif %}',
+          '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}' +
+          '{% if offset is not none %}\nOFFSET {{ offset }}{% endif %}',
         group_by_exprs: '{{ group_by | map(attribute=\'index\') | join(\', \') }}',
       },
       expressions: {

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -116,8 +116,8 @@ export class PrestodbQuery extends BaseQuery {
       'FROM (\n  {{ from }}\n) AS {{ from_alias }} \n' +
       '{% if group_by %} GROUP BY {{ group_by }}{% endif %}' +
       '{% if order_by %} ORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}{% endif %}' +
-      '{% if offset %}\nOFFSET {{ offset }}{% endif %}' +
-      '{% if limit %}\nLIMIT {{ limit }}{% endif %}';
+      '{% if offset is not none %}\nOFFSET {{ offset }}{% endif %}' +
+      '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.expressions.interval_single_date_part = 'INTERVAL \'{{ num }}\' {{ date_part }}';
     templates.expressions.timestamp_literal = 'from_iso8601_timestamp(\'{{ value }}\')';

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -390,6 +390,13 @@ describe('SQL API', () => {
       expect(res.rows).toEqual([]);
     });
 
+    test('zero limited dimension aggregated queries through wrapper', async () => {
+      // Attempts to trigger query generation from SQL templates, not from Cube
+      const query = 'SELECT MIN(t.maxval) FROM (SELECT MAX(createdAt) as maxval FROM Orders LIMIT 10) t LIMIT 0';
+      const res = await connection.query(query);
+      expect(res.rows).toEqual([]);
+    });
+
     test('select dimension agg where false', async () => {
       const query =
           'SELECT MAX("createdAt") AS "max" FROM "BigOrders" WHERE 1 = 0';

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -15455,8 +15455,8 @@ ORDER BY "source"."str0" ASC
                     r#"SELECT {{ select_concat | map(attribute='aliased') | join(', ') }}
 FROM ({{ from }}) AS {{ from_alias }}
 {% if group_by %} GROUP BY {{ group_by | map(attribute='index') | join(', ') }}{% endif %}
-{% if order_by %} ORDER BY {{ order_by | map(attribute='expr') | join(', ') }}{% endif %}{% if offset %}
-OFFSET {{ offset }}{% endif %}{% if limit %}
+{% if order_by %} ORDER BY {{ order_by | map(attribute='expr') | join(', ') }}{% endif %}{% if offset is not none %}
+OFFSET {{ offset }}{% endif %}{% if limit is not none %}
 LIMIT {{ limit }}{% endif %}"#.to_string(),
                 ),
             ]

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -506,8 +506,8 @@ FROM (
 ) AS {{ from_alias }} {% endif %} {% if filter %}
 WHERE {{ filter }}{% endif %}{% if group_by %}
 GROUP BY {{ group_by }}{% endif %}{% if order_by %}
-ORDER BY {{ order_by | map(attribute='expr') | join(', ') }}{% endif %}{% if limit %}
-LIMIT {{ limit }}{% endif %}{% if offset %}
+ORDER BY {{ order_by | map(attribute='expr') | join(', ') }}{% endif %}{% if limit is not none %}
+LIMIT {{ limit }}{% endif %}{% if offset is not none %}
 OFFSET {{ offset }}{% endif %}"#.to_string(),
                     ),
                     (


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`if limit` condition in Jinja will fail for both `None` and `Some(0)`
This is more or less fine for offset, but completely wrong for limit. For consistency both are changed.
