### PR TITLE
feat(cubesql): SQL push down multiple window expressions with different sort keys

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -18588,4 +18588,41 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_double_window_aggr_sql_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            SELECT
+                customer_gender AS customer_gender,
+                notes AS notes,
+                SUM(SUM(taxful_total_price)) OVER (PARTITION BY customer_gender ORDER BY customer_gender) AS sum,
+                AVG(SUM(taxful_total_price)) OVER (PARTITION BY notes ORDER BY notes) AS avg
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1, 2
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan
+            .find_cube_scan_wrapper()
+            .wrapped_sql
+            .unwrap()
+            .sql;
+        assert!(sql.contains("OVER (PARTITION BY"));
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/window.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/window.rs
@@ -1,116 +1,228 @@
-use crate::compile::rewrite::{
-    analysis::LogicalPlanAnalysis, cube_scan_wrapper, rewrite, rules::wrapper::WrapperRules,
-    window, wrapped_select, wrapped_select_window_expr_empty_tail, wrapper_pullup_replacer,
-    wrapper_pushdown_replacer, ListType, LogicalPlanLanguage,
+use crate::{
+    compile::rewrite::{
+        analysis::LogicalPlanAnalysis, cube_scan_wrapper, rewrite, rules::wrapper::WrapperRules,
+        transforming_rewrite, window, wrapped_select, wrapped_select_window_expr_empty_tail,
+        wrapper_pullup_replacer, wrapper_pushdown_replacer, ListType, LogicalPlanLanguage,
+    },
+    var,
 };
-use egg::Rewrite;
+use egg::{EGraph, Rewrite, Subst};
 
 impl WrapperRules {
     pub fn window_rules(&self, rules: &mut Vec<Rewrite<LogicalPlanLanguage, LogicalPlanAnalysis>>) {
-        rules.extend(vec![rewrite(
-            "wrapper-push-down-window-to-cube-scan",
-            window(
-                cube_scan_wrapper(
-                    wrapper_pullup_replacer(
-                        wrapped_select(
-                            "?select_type",
-                            "?projection_expr",
-                            "?subqueries",
-                            "?group_expr",
-                            "?aggr_expr",
-                            wrapped_select_window_expr_empty_tail(),
-                            "?cube_scan_input",
-                            "?joins",
-                            "?filter_expr",
-                            "?having_expr",
-                            "?limit",
-                            "?offset",
-                            "?order_expr",
-                            "?select_alias",
-                            "?select_distinct",
-                            "?select_ungrouped",
-                            "?select_ungrouped_scan",
+        rules.extend(vec![
+            rewrite(
+                "wrapper-push-down-window-to-cube-scan",
+                window(
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            wrapped_select(
+                                "?select_type",
+                                "?projection_expr",
+                                "?subqueries",
+                                "?group_expr",
+                                "?aggr_expr",
+                                wrapped_select_window_expr_empty_tail(),
+                                "?cube_scan_input",
+                                "?joins",
+                                "?filter_expr",
+                                "?having_expr",
+                                "?limit",
+                                "?offset",
+                                "?order_expr",
+                                "?select_alias",
+                                "?select_distinct",
+                                "?select_ungrouped",
+                                "?select_ungrouped_scan",
+                            ),
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
                         ),
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    "?window_expr",
+                ),
+                cube_scan_wrapper(
+                    wrapped_select(
+                        "?select_type",
+                        wrapper_pullup_replacer(
+                            "?projection_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?subqueries",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?group_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?aggr_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pushdown_replacer(
+                            "?window_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?cube_scan_input",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?joins",
+                        wrapper_pullup_replacer(
+                            "?filter_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?having_expr",
+                        "?limit",
+                        "?offset",
+                        wrapper_pullup_replacer(
+                            "?order_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?select_alias",
+                        "?select_distinct",
+                        "?select_ungrouped",
+                        "?select_ungrouped_scan",
                     ),
                     "CubeScanWrapperFinalized:false",
                 ),
-                "?window_expr",
             ),
-            cube_scan_wrapper(
-                wrapped_select(
-                    "?select_type",
-                    wrapper_pullup_replacer(
-                        "?projection_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
+            transforming_rewrite(
+                "wrapper-push-down-window-combined-to-cube-scan",
+                window(
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            wrapped_select(
+                                "?select_type",
+                                "?projection_expr",
+                                "?subqueries",
+                                "?group_expr",
+                                "?aggr_expr",
+                                "?wrapped_window_expr",
+                                "?cube_scan_input",
+                                "?joins",
+                                "?filter_expr",
+                                "?having_expr",
+                                "?limit",
+                                "?offset",
+                                "?order_expr",
+                                "?select_alias",
+                                "?select_distinct",
+                                "?select_ungrouped",
+                                "?select_ungrouped_scan",
+                            ),
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "CubeScanWrapperFinalized:false",
                     ),
-                    wrapper_pullup_replacer(
-                        "?subqueries",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    wrapper_pullup_replacer(
-                        "?group_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    wrapper_pullup_replacer(
-                        "?aggr_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    wrapper_pushdown_replacer(
-                        "?window_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    wrapper_pullup_replacer(
-                        "?cube_scan_input",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    "?joins",
-                    wrapper_pullup_replacer(
-                        "?filter_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    "?having_expr",
-                    "?limit",
-                    "?offset",
-                    wrapper_pullup_replacer(
-                        "?order_expr",
-                        "?alias_to_cube",
-                        "?ungrouped",
-                        "?in_projection",
-                        "?cube_members",
-                    ),
-                    "?select_alias",
-                    "?select_distinct",
-                    "?select_ungrouped",
-                    "?select_ungrouped_scan",
+                    "?window_expr",
                 ),
-                "CubeScanWrapperFinalized:false",
+                cube_scan_wrapper(
+                    wrapped_select(
+                        "?select_type",
+                        wrapper_pullup_replacer(
+                            "?projection_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?subqueries",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?group_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        wrapper_pullup_replacer(
+                            "?aggr_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?new_window_expr",
+                        wrapper_pullup_replacer(
+                            "?cube_scan_input",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?joins",
+                        wrapper_pullup_replacer(
+                            "?filter_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?having_expr",
+                        "?limit",
+                        "?offset",
+                        wrapper_pullup_replacer(
+                            "?order_expr",
+                            "?alias_to_cube",
+                            "?ungrouped",
+                            "?in_projection",
+                            "?cube_members",
+                        ),
+                        "?select_alias",
+                        "?select_distinct",
+                        "?select_ungrouped",
+                        "?select_ungrouped_scan",
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+                self.transform_window_combined(
+                    "?wrapped_window_expr",
+                    "?alias_to_cube",
+                    "?ungrouped",
+                    "?in_projection",
+                    "?cube_members",
+                    "?window_expr",
+                    "?new_window_expr",
+                ),
             ),
-        )]);
+        ]);
 
         if self.config_obj.push_down_pull_up_split() {
             Self::flat_list_pushdown_pullup_rules(
@@ -126,6 +238,98 @@ impl WrapperRules {
                 "WindowWindowExpr",
                 "WrappedSelectWindowExpr",
             );
+        }
+    }
+
+    fn transform_window_combined(
+        &self,
+        wrapped_window_expr_var: &'static str,
+        alias_to_cube_var: &'static str,
+        ungrouped_var: &'static str,
+        in_projection_var: &'static str,
+        cube_members_var: &'static str,
+        window_expr_var: &'static str,
+        new_window_expr_var: &'static str,
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool {
+        let wrapped_window_expr_var = var!(wrapped_window_expr_var);
+        let alias_to_cube_var = var!(alias_to_cube_var);
+        let ungrouped_var = var!(ungrouped_var);
+        let in_projection_var = var!(in_projection_var);
+        let cube_members_var = var!(cube_members_var);
+        let window_expr_var = var!(window_expr_var);
+        let new_window_expr_var = var!(new_window_expr_var);
+        let push_down_pull_up_split = self.config_obj.push_down_pull_up_split();
+        move |egraph, subst| {
+            for wrapped_node in &egraph[subst[wrapped_window_expr_var]].nodes {
+                let LogicalPlanLanguage::WrappedSelectWindowExpr(wrapped_ids) = wrapped_node else {
+                    continue;
+                };
+                if wrapped_ids.is_empty() {
+                    continue;
+                }
+                for window_node in &egraph[subst[window_expr_var]].nodes {
+                    let LogicalPlanLanguage::WindowWindowExpr(window_ids) = window_node else {
+                        continue;
+                    };
+
+                    if !push_down_pull_up_split {
+                        let left = egraph.add(LogicalPlanLanguage::WrapperPullupReplacer([
+                            subst[wrapped_window_expr_var],
+                            subst[alias_to_cube_var],
+                            subst[ungrouped_var],
+                            subst[in_projection_var],
+                            subst[cube_members_var],
+                        ]));
+                        let right = egraph.add(LogicalPlanLanguage::WrapperPushdownReplacer([
+                            subst[window_expr_var],
+                            subst[alias_to_cube_var],
+                            subst[ungrouped_var],
+                            subst[in_projection_var],
+                            subst[cube_members_var],
+                        ]));
+
+                        subst.insert(
+                            new_window_expr_var,
+                            egraph.add(LogicalPlanLanguage::WindowWindowExpr(vec![left, right])),
+                        );
+                        return true;
+                    }
+
+                    let wrapped_ids = wrapped_ids.clone();
+                    let window_ids = window_ids.clone();
+
+                    let mut new_window_expr_ids = Vec::new();
+                    for id in wrapped_ids {
+                        new_window_expr_ids.push(egraph.add(
+                            LogicalPlanLanguage::WrapperPullupReplacer([
+                                id,
+                                subst[alias_to_cube_var],
+                                subst[ungrouped_var],
+                                subst[in_projection_var],
+                                subst[cube_members_var],
+                            ]),
+                        ));
+                    }
+                    for id in window_ids {
+                        new_window_expr_ids.push(egraph.add(
+                            LogicalPlanLanguage::WrapperPushdownReplacer([
+                                id,
+                                subst[alias_to_cube_var],
+                                subst[ungrouped_var],
+                                subst[in_projection_var],
+                                subst[cube_members_var],
+                            ]),
+                        ));
+                    }
+
+                    subst.insert(
+                        new_window_expr_var,
+                        egraph.add(LogicalPlanLanguage::WindowWindowExpr(new_window_expr_ids)),
+                    );
+                    return true;
+                }
+            }
+            false
         }
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds SQL push down support for multiple window expressions with different sort keys. In cases where there are several window function expressions in a `SELECT` and they `ORDER BY` different keys, DataFusion generates several `WindowAggr` nodes on top of each other, with window expressions grouped by sort keys. Joining them together is invalid in terms of DataFusion logical plan, but having them together in a wrapped select is fine. Related test is added.
