### PR TITLE
chore(cubesql): Do not call async Node functions while planning

### DIFF
--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -1,5 +1,8 @@
 use crate::compile::engine::df::planner::CubeQueryPlanner;
-use std::{backtrace::Backtrace, collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use std::{
+    backtrace::Backtrace, collections::HashMap, future::Future, pin::Pin, sync::Arc,
+    time::SystemTime,
+};
 
 use crate::{
     compile::{
@@ -21,8 +24,9 @@ use crate::{
     },
     config::ConfigObj,
     sql::{
-        compiler_cache::CompilerCache, statement::SensitiveDataSanitizer, SessionManager,
-        SessionState,
+        compiler_cache::{CompilerCache, CompilerCacheEntry},
+        statement::SensitiveDataSanitizer,
+        SessionManager, SessionState,
     },
     transport::{LoadRequestMeta, MetaContext, SpanId, TransportService},
     CubeErrorCauseType,
@@ -78,6 +82,11 @@ pub trait QueryEngine {
 
     fn sanitize_statement(&self, stmt: &Self::AstStatementType) -> Self::AstStatementType;
 
+    async fn get_cache_entry(
+        &self,
+        state: Arc<SessionState>,
+    ) -> Result<Arc<CompilerCacheEntry>, CompilationError>;
+
     async fn plan(
         &self,
         stmt: Self::AstStatementType,
@@ -86,6 +95,26 @@ pub trait QueryEngine {
         meta: Arc<MetaContext>,
         state: Arc<SessionState>,
     ) -> CompilationResult<(QueryPlan, Self::PlanMetadataType)> {
+        let cache_entry = self.get_cache_entry(state.clone()).await?;
+
+        let planning_start = SystemTime::now();
+        if let Some(span_id) = span_id.as_ref() {
+            if let Some(auth_context) = state.auth_context() {
+                self.transport_ref()
+                    .log_load_state(
+                        Some(span_id.clone()),
+                        auth_context,
+                        state.get_load_request_meta(),
+                        "SQL API Query Planning".to_string(),
+                        serde_json::json!({
+                            "query": span_id.query_key.clone(),
+                        }),
+                    )
+                    .await
+                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+            }
+        }
+
         let ctx = self.create_session_ctx(state.clone())?;
         let cube_ctx = self.create_cube_ctx(state.clone(), meta.clone(), ctx.clone())?;
 
@@ -144,7 +173,7 @@ pub trait QueryEngine {
         let mut finalized_graph = self
             .compiler_cache_ref()
             .rewrite(
-                state.auth_context().unwrap(),
+                Arc::clone(&cache_entry),
                 cube_ctx.clone(),
                 converter.take_egraph(),
                 &query_params.unwrap(),
@@ -192,6 +221,7 @@ pub trait QueryEngine {
         let result = rewriter
             .find_best_plan(
                 root,
+                cache_entry,
                 state.auth_context().unwrap(),
                 qtrace,
                 span_id.clone(),
@@ -243,12 +273,31 @@ pub trait QueryEngine {
                 // TODO: We should find what optimizers will be safety to use for OLAP queries
                 guard.optimizer.rules = vec![];
             }
-            if let Some(span_id) = span_id {
+            if let Some(span_id) = &span_id {
                 span_id.set_is_data_query(true).await;
             }
         };
 
         log::debug!("Rewrite: {:#?}", rewrite_plan);
+
+        if let Some(span_id) = span_id.as_ref() {
+            if let Some(auth_context) = state.auth_context() {
+                self.transport_ref()
+                    .log_load_state(
+                        Some(span_id.clone()),
+                        auth_context,
+                        state.get_load_request_meta(),
+                        "SQL API Query Planning Success".to_string(),
+                        serde_json::json!({
+                            "query": span_id.query_key.clone(),
+                            "duration": planning_start.elapsed().unwrap().as_millis() as u64,
+                        }),
+                    )
+                    .await
+                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+            }
+        }
+
         let rewrite_plan = Self::evaluate_wrapped_sql(
             self.transport_ref().clone(),
             Arc::new(state.get_load_request_meta()),
@@ -500,6 +549,21 @@ impl QueryEngine for SqlQueryEngine {
 
     fn sanitize_statement(&self, stmt: &Self::AstStatementType) -> Self::AstStatementType {
         SensitiveDataSanitizer::new().replace(stmt.clone())
+    }
+
+    async fn get_cache_entry(
+        &self,
+        state: Arc<SessionState>,
+    ) -> Result<Arc<CompilerCacheEntry>, CompilationError> {
+        self.compiler_cache_ref()
+            .get_cache_entry(
+                state.auth_context().ok_or_else(|| {
+                    CompilationError::internal("Unable to get auth context".to_string())
+                })?,
+                state.protocol.clone(),
+            )
+            .await
+            .map_err(|e| CompilationError::internal(e.to_string()))
     }
 }
 

--- a/rust/cubesql/cubesql/src/compile/router.rs
+++ b/rust/cubesql/cubesql/src/compile/router.rs
@@ -3,7 +3,7 @@ use crate::compile::{
     StatusFlags,
 };
 use sqlparser::ast;
-use std::{collections::HashMap, sync::Arc, time::SystemTime};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     compile::{
@@ -61,50 +61,8 @@ impl QueryRouter {
         qtrace: &mut Option<Qtrace>,
         span_id: Option<Arc<SpanId>>,
     ) -> CompilationResult<QueryPlan> {
-        let planning_start = SystemTime::now();
-        if let Some(span_id) = span_id.as_ref() {
-            if let Some(auth_context) = self.state.auth_context() {
-                self.session_manager
-                    .server
-                    .transport
-                    .log_load_state(
-                        Some(span_id.clone()),
-                        auth_context,
-                        self.state.get_load_request_meta(),
-                        "SQL API Query Planning".to_string(),
-                        serde_json::json!({
-                            "query": span_id.query_key.clone(),
-                        }),
-                    )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
-            }
-        }
-        let result = self
-            .create_df_logical_plan(stmt.clone(), qtrace, span_id.clone())
-            .await?;
-
-        if let Some(span_id) = span_id.as_ref() {
-            if let Some(auth_context) = self.state.auth_context() {
-                self.session_manager
-                    .server
-                    .transport
-                    .log_load_state(
-                        Some(span_id.clone()),
-                        auth_context,
-                        self.state.get_load_request_meta(),
-                        "SQL API Query Planning Success".to_string(),
-                        serde_json::json!({
-                            "query": span_id.query_key.clone(),
-                            "duration": planning_start.elapsed().unwrap().as_millis() as u64,
-                        }),
-                    )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
-            }
-        }
-
-        return Ok(result);
+        self.create_df_logical_plan(stmt.clone(), qtrace, span_id.clone())
+            .await
     }
 
     pub async fn plan(

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -12,6 +12,7 @@ use crate::{
         CommandCompletion, CompilationError, DatabaseProtocol, QueryPlan, StatusFlags,
     },
     sql::{
+        compiler_cache::CompilerCacheEntry,
         df_type_to_pg_tid,
         extended::{Cursor, Portal, PortalBatch, PortalFrom},
         statement::{PostgresStatementParamsFinder, StatementPlaceholderReplacer},
@@ -238,6 +239,15 @@ impl AsyncPostgresShim {
         shim.partial_write_buf = bytes::BytesMut::new();
         shim.write_admin_shutdown_fatal_message().await?;
         return Ok(());
+    }
+
+    async fn get_cache_entry(&self) -> Result<Arc<CompilerCacheEntry>, CubeError> {
+        self.session
+            .session_manager
+            .server
+            .compiler_cache
+            .get_cache_entry(self.auth_context()?, self.session.state.protocol.clone())
+            .await
     }
 
     pub async fn run_on(
@@ -1058,12 +1068,8 @@ impl AsyncPostgresShim {
                     source_statement.bind(body.to_bind_values(&parameters)?)?;
                 drop(statements_guard);
 
-                let meta = self
-                    .session
-                    .server
-                    .compiler_cache
-                    .meta(self.auth_context()?, self.session.state.protocol.clone())
-                    .await?;
+                let cache_entry = self.get_cache_entry().await?;
+                let meta = self.session.server.compiler_cache.meta(cache_entry).await?;
 
                 let plan = convert_statement_to_cube_query(
                     prepared_statement,
@@ -1171,12 +1177,8 @@ impl AsyncPostgresShim {
                     .map(|param| param.coltype.to_pg_tid())
                     .collect();
 
-                let meta = self
-                    .session
-                    .server
-                    .compiler_cache
-                    .meta(self.auth_context()?, self.session.state.protocol.clone())
-                    .await?;
+                let cache_entry = self.get_cache_entry().await?;
+                let meta = self.session.server.compiler_cache.meta(cache_entry).await?;
 
                 let stmt_replacer = StatementPlaceholderReplacer::new();
                 let hacked_query = stmt_replacer.replace(query.clone())?;
@@ -1794,12 +1796,8 @@ impl AsyncPostgresShim {
         qtrace: &mut Option<Qtrace>,
         span_id: Option<Arc<SpanId>>,
     ) -> Result<(), ConnectionError> {
-        let meta = self
-            .session
-            .server
-            .compiler_cache
-            .meta(self.auth_context()?, self.session.state.protocol.clone())
-            .await?;
+        let cache_entry = self.get_cache_entry().await?;
+        let meta = self.session.server.compiler_cache.meta(cache_entry).await?;
 
         let statements =
             parse_sql_to_statements(&query.to_string(), DatabaseProtocol::PostgreSQL, qtrace)?;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR restructures the way compiler cache works, removing the need to call async Node functions while planning, at the cost of passing around `compiler_id`.
