### PR TITLE
fix(cubesql): Fix `TRUNC` SQL push down for Databricks

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -194,6 +194,7 @@ export class DatabricksQuery extends BaseQuery {
     templates.functions.DATEDIFF = 'DATEDIFF({{ date_part }}, DATE_TRUNC(\'{{ date_part }}\', {{ args[1] }}), DATE_TRUNC(\'{{ date_part }}\', {{ args[2] }}))';
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
+    templates.functions.TRUNC = 'CASE WHEN ({{ args[0] }}) >= 0 THEN FLOOR({{ args_concat }}) ELSE CEIL({{ args_concat }}) END';
     templates.expressions.timestamp_literal = 'from_utc_timestamp(\'{{ value }}\', \'UTC\')';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.quotes.identifiers = '`';


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR changes `TRUNC` SQL push down definition for Databricks, as in Databricks `TRUNC` has an entirely different meaning, working with dates instead of numbers. There's no alternative, so `CASE` is required to emulate behavior.
