### PR TITLE
fix(cubestore): Metastore - increase parallelism to 2 (align with max background jobs)

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/rocks_store.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_store.rs
@@ -772,7 +772,7 @@ impl RocksStoreConfig {
             // Default: 1 (i.e. no subcompactions)
             max_subcompactions: 1,
             // Default: 1
-            parallelism: 1,
+            parallelism: 2,
         }
     }
 


### PR DESCRIPTION
The number of threads RocksDB will use for all background operations. Even if you increase the max_background_jobs but keep parallelism as 1, it won’t lead to a lot of performance increase. Ideally, this option should be kept equal to the number of cores in your machine.

max_background_jobs is 2, but parallelism was 1. Must be aligned.