### PR TITLE
feat: Enable `CUBESQL_SQL_PUSH_DOWN` by default

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1633,7 +1633,7 @@ const variables: Record<string, (...args: any) => any> = {
     .asInt(),
 
   allowUngroupedWithoutPrimaryKey: () => get('CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY')
-    .default(get('CUBESQL_SQL_PUSH_DOWN').default('false').asString())
+    .default(get('CUBESQL_SQL_PUSH_DOWN').default('true').asString())
     .asBoolStrict(),
   nodeEnv: () => get('NODE_ENV')
     .asString(),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -498,7 +498,7 @@ impl Rewriter {
     pub fn sql_push_down_enabled() -> bool {
         env::var("CUBESQL_SQL_PUSH_DOWN")
             .map(|v| v.to_lowercase() == "true")
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     pub fn rewrite_rules(

--- a/rust/cubesql/cubesql/src/config/mod.rs
+++ b/rust/cubesql/cubesql/src/config/mod.rs
@@ -143,7 +143,7 @@ impl ConfigObjImpl {
             .ok()
             .map(|v| v.parse::<u64>().unwrap())
             .unwrap_or(120);
-        let sql_push_down = env_parse("CUBESQL_SQL_PUSH_DOWN", false);
+        let sql_push_down = env_parse("CUBESQL_SQL_PUSH_DOWN", true);
         Self {
             bind_address: env::var("CUBESQL_BIND_ADDR").ok().or_else(|| {
                 env::var("CUBESQL_PORT")


### PR DESCRIPTION
BREAKING CHANGE: Enabling `CUBESQL_SQL_PUSH_DOWN` is backward incompatible to many default behaviors of SQL API

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

