### PR TITLE
feat(Firebolt): Use driver's own test connection method

### DIFF
--- a/packages/cubejs-firebolt-driver/package.json
+++ b/packages/cubejs-firebolt-driver/package.json
@@ -31,7 +31,7 @@
     "@cubejs-backend/base-driver": "^1.0.0",
     "@cubejs-backend/schema-compiler": "^1.0.0",
     "@cubejs-backend/shared": "^1.0.0",
-    "firebolt-sdk": "^1.2.0"
+    "firebolt-sdk": "^1.8.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
@@ -170,7 +170,8 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
 
   public async testConnection(): Promise<void> {
     try {
-      await this.query('select 1');
+      const connection = await this.getConnection();
+      await connection.testConnection();
     } catch (error) {
       console.log(error);
       throw new Error('Unable to connect');

--- a/yarn.lock
+++ b/yarn.lock
@@ -16501,10 +16501,10 @@ find-yarn-workspace-root@^2.0.0:
   dependencies:
     micromatch "^4.0.2"
 
-firebolt-sdk@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/firebolt-sdk/-/firebolt-sdk-1.4.0.tgz#13a2b54a3b4265179c484e3bb8a37e15880aee1b"
-  integrity sha512-ZAFDtlpyoR4BJZPgem3aZEzpssVe39lAWCzsMDMw7KKFUJzqeMA7ARL99puB5bDcMzLBteGDR1S8iyPkwLTJsA==
+firebolt-sdk@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/firebolt-sdk/-/firebolt-sdk-1.8.0.tgz#f2366f28608b40db688f30505a20fba393f10aae"
+  integrity sha512-jQBh6a8xxkRQyjwliJ7l/1jHG3pn5367mhDP2UrMKqDmkWQl4qKngcQB7RMT3I9bsUJmwvHMe4ym5pOo8ZIPyA==
   dependencies:
     "@types/json-bigint" "^1.0.1"
     abort-controller "^3.0.0"


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code

**Description of Changes Made (if issue reference is not provided)**

Delegating connection verification to the Firebolt SDK driver. This allows more flexibility and more importantly avoids unnecessary charges to Firebolt's customers: Firebolt engines have auto-stop functionality that allows them to spin down when not in use. However, healthcheck queries can keep them up, despite not having any useful load. Firebolt's SDK provides a way to check if the connection is working without resetting the auto-stop timer. If the engine is down or there are connectivity errors `testConnection` will still error out, as before.
