### PR TITLE
feat(drivers): add an option to skip connection test probes in bigquery, aurora, postgres(redshift), snowflake

### DIFF
--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -93,13 +93,14 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
       testConnectionTimeout?: number,
     } = {}
   ) {
-    super({
-      testConnectionTimeout: config.testConnectionTimeout,
-    });
-
     const dataSource =
       config.dataSource ||
       assertDataSource('default');
+
+    super({
+      testConnectionTimeout: config.testConnectionTimeout,
+      isTestConnectionDisabled: getEnv('dbDisableTestConnection', { dataSource }),
+    });
 
     this.options = {
       scopes: [
@@ -155,6 +156,10 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
   }
 
   public async testConnection() {
+    if (this.isTestConnectionDisabled()) {
+      return;
+    }
+
     await this.bigquery.query({
       query: 'SELECT ? AS number',
       params: ['1'],

--- a/packages/cubejs-mysql-aurora-serverless-driver/driver/AuroraServerlessMySqlDriver.js
+++ b/packages/cubejs-mysql-aurora-serverless-driver/driver/AuroraServerlessMySqlDriver.js
@@ -33,14 +33,15 @@ class AuroraServerlessMySqlDriver extends BaseDriver {
    * Class constructor.
    */
   constructor(config = {}) {
-    super({
-      testConnectionTimeout: config.testConnectionTimeout,
-    });
-    
     const dataSource =
       config.dataSource ||
       assertDataSource('default');
-    
+
+    super({
+      testConnectionTimeout: config.testConnectionTimeout,
+      isTestConnectionDisabled: getEnv('dbDisableTestConnection', { dataSource }),
+    });
+
     this.config = {
       secretArn:
         config.secretArn ||
@@ -66,7 +67,11 @@ class AuroraServerlessMySqlDriver extends BaseDriver {
   }
 
   async testConnection() {
-    return this.dataApi.query('SELECT 1');
+    if (this.isTestConnectionDisabled()) {
+      return;
+    }
+
+    await this.dataApi.query('SELECT 1');
   }
 
   positionBindings(sql) {

--- a/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
+++ b/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
@@ -241,13 +241,14 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
       testConnectionTimeout?: number,
     } = {}
   ) {
-    super({
-      testConnectionTimeout: config.testConnectionTimeout,
-    });
-
     const dataSource =
       config.dataSource ||
       assertDataSource('default');
+
+    super({
+      testConnectionTimeout: config.testConnectionTimeout,
+      isTestConnectionDisabled: getEnv('dbDisableTestConnection', { dataSource }),
+    });
 
     let privateKey = getEnv('snowflakePrivateKey', { dataSource });
     if (privateKey && !privateKey.endsWith('\n')) {
@@ -420,6 +421,10 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
    * Test driver's connection.
    */
   public async testConnection() {
+    if (this.isTestConnectionDisabled()) {
+      return;
+    }
+
     const connection = await this.createConnection();
 
     await new Promise(


### PR DESCRIPTION
 * feat(bigquery-driver): add an option to skip connection test probes
* feat(aurora-serverless-driver): add an option to skip connection test probes
* feat(postgres-driver): add an option to skip connection test probes
* feat(snowflake-driver): add an option to skip connection test probes

This is the followup for #8833

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
