### PR TITLE
feat(redshift-driver): optimize testConnection() with just establishing connection without real query

### DIFF
--- a/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
+++ b/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
@@ -107,6 +107,16 @@ export class RedshiftDriver extends PostgresDriver<RedshiftDriverConfiguration> 
     }
   }
 
+  /**
+   * AWS Redshift doesn't have any special connection check.
+   * And querying even system tables is billed.
+   * @override
+   */
+  public async testConnection() {
+    const conn = await this.pool.connect();
+    conn.release();
+  }
+
   public override async stream(
     query: string,
     values: unknown[],
@@ -287,8 +297,7 @@ export class RedshiftDriver extends PostgresDriver<RedshiftDriverConfiguration> 
       };
     } finally {
       conn.removeAllListeners('notice');
-
-      await conn.release();
+      conn.release();
     }
   }
 


### PR DESCRIPTION
Optimize testConnection() with just establishing a db connection without performing the `SELECT 1` query which makes serverless instances to keep running...

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
