### PR TITLE
refactor(cubesql): Improve EGraph debugger, part 1: initial state, JSON for data, eslint, prettier, hooks deps, 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.rs]
 indent_size = 4
+
+[rust/cubesql/cubesql/egraph-debug-template/**/*.{js,jsx,ts,tsx}]
+indent_size = 4

--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -19,6 +19,11 @@
     "prettier": "3.3.3",
     "react-scripts": "5.0.1"
   },
+  "eslintConfig": {
+    "extends": [
+      "react-app"
+    ]
+  },
   "prettier": {
     "singleQuote": true,
     "tabWidth": 4

--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -11,11 +11,17 @@
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false && react-scripts start",
     "build": "react-scripts build",
+    "reformat": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "prettier": "3.3.3",
     "react-scripts": "5.0.1"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4
   },
   "browserslist": {
     "production": [

--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -15,7 +15,7 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
-    "react-scripts": "latest"
+    "react-scripts": "5.0.1"
   },
   "browserslist": {
     "production": [

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -338,12 +338,15 @@ const LayoutFlow = () => {
         setPreNodesEdges({ preNodes: newNodes, preEdges: newEdges });
     };
 
-    const navigate = (id) => {
-        zoomTo(fitView, [id]);
-        if (!navHistory.includes(id)) {
-            setNavHistory(navHistory.concat(id));
-        }
-    };
+    const navigate = useCallback(
+        (id) => {
+            zoomTo(fitView, [id]);
+            if (!navHistory.includes(id)) {
+                setNavHistory(navHistory.concat(id));
+            }
+        },
+        [fitView, navHistory],
+    );
 
     const nodeTypes = useMemo(
         () => ({

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -212,7 +212,7 @@ const splitLabel = (label) => {
 };
 
 const ChildrenNode =
-    ({ navigate, nodes }) =>
+    ({ navigate /*, nodes*/ }) =>
     ({ data: { label } }) => {
         return (
             <div>
@@ -224,10 +224,12 @@ const ChildrenNode =
                                 style={{ color: 'blue', cursor: 'pointer' }}
                                 onClick={() => navigate(s)}
                                 key={i}
-                                title={nodes
-                                    .filter((n) => n.id.indexOf(`${s}-`) === 0)
-                                    .map((n) => n.label)
-                                    .join(', ')}
+                                // title is broken due to circular deps, see nodeTypes comment
+                                // TODO fix it
+                                // title={nodes
+                                //     .filter((n) => n.id.indexOf(`${s}-`) === 0)
+                                //     .map((n) => n.label)
+                                //     .join(', ')}
                             >
                                 {s}
                             </span>
@@ -350,9 +352,12 @@ const LayoutFlow = () => {
 
     const nodeTypes = useMemo(
         () => ({
-            default: ChildrenNode({ navigate, nodes }),
+            // `nodeTypes` can't depend on `nodes`, because `nodes` will be changed by ReactFlow
+            // There will be a dep cycle nodeTypes -> ReactFlow instance -> onNodesChange -> nodes -> nodeTypes
+            default: ChildrenNode({ navigate /*, nodes*/ }),
         }),
-        [navHistory],
+        // TODO dependency on navigate will cause nodeTypes rebuild after each navigation history change
+        [navigate],
     );
 
     useEffect(() => {

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -220,7 +220,7 @@ const ChildrenNode =
                 {splitLabel(label).map((s, i) => {
                     if (s.match(/\d+/)) {
                         return (
-                            <a
+                            <span
                                 style={{ color: 'blue', cursor: 'pointer' }}
                                 onClick={() => navigate(s)}
                                 key={i}
@@ -230,7 +230,7 @@ const ChildrenNode =
                                     .join(', ')}
                             >
                                 {s}
-                            </a>
+                            </span>
                         );
                     } else {
                         return <span key={i}>{s}</span>;

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -1,4 +1,4 @@
-import { states } from './states';
+import states from './states.json';
 import { createRoot } from 'react-dom/client';
 import ELK from 'elkjs/lib/elk.bundled.js';
 import React, { useCallback, useState, useEffect, useMemo } from 'react';

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -366,7 +366,16 @@ const LayoutFlow = () => {
             navHistory,
             showOnlySelected,
         );
-    }, [preNodes, setNodes, setEdges, stateIdx, showOnlySelected, navHistory]);
+    }, [
+        preNodes,
+        setNodes,
+        setEdges,
+        stateIdx,
+        showOnlySelected,
+        navHistory,
+        fitView,
+        preEdges,
+    ]);
 
     const stateLabel =
         stateIdx === 0

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -2,12 +2,14 @@ use crate::{
     compile::{
         rewrite::{
             converter::{is_expr_node, node_to_expr, LogicalPlanToLanguageConverter},
-            expr_column_name, AggregateUDFExprFun, AliasExprAlias, AllMembersAlias, AllMembersCube,
-            ChangeUserCube, ColumnExprColumn, DimensionName, FilterMemberMember, FilterMemberOp,
-            LiteralExprValue, LiteralMemberRelation, LiteralMemberValue, LogicalPlanLanguage,
-            MeasureName, ScalarFunctionExprFun, SegmentMemberMember, SegmentName,
-            TableScanSourceTableName, TimeDimensionDateRange, TimeDimensionGranularity,
-            TimeDimensionName, VirtualFieldCube, VirtualFieldName,
+            expr_column_name,
+            rewriter::{CubeEGraph, DebugData},
+            AggregateUDFExprFun, AliasExprAlias, AllMembersAlias, AllMembersCube, ChangeUserCube,
+            ColumnExprColumn, DimensionName, FilterMemberMember, FilterMemberOp, LiteralExprValue,
+            LiteralMemberRelation, LiteralMemberValue, LogicalPlanLanguage, MeasureName,
+            ScalarFunctionExprFun, SegmentMemberMember, SegmentName, TableScanSourceTableName,
+            TimeDimensionDateRange, TimeDimensionGranularity, TimeDimensionName, VirtualFieldCube,
+            VirtualFieldName,
         },
         CubeContext,
     },
@@ -233,11 +235,16 @@ impl Member {
     }
 }
 
+type EgraphDebugState = DebugData;
+
 #[derive(Clone)]
 pub struct LogicalPlanAnalysis {
     /* This is 0, when creating the EGraph.  It's set to 1 before iteration 0,
     2 before the iteration 1, etc. */
     pub iteration_timestamp: usize,
+    /// Debug info, used with egraph-debug
+    /// Will be filled by special hook in Runner
+    pub debug_states: Vec<EgraphDebugState>,
     cube_context: Arc<CubeContext>,
     planner: Arc<DefaultPhysicalPlanner>,
 }
@@ -270,9 +277,23 @@ impl LogicalPlanAnalysis {
     pub fn new(cube_context: Arc<CubeContext>, planner: Arc<DefaultPhysicalPlanner>) -> Self {
         Self {
             iteration_timestamp: 0,
+            debug_states: vec![],
             cube_context,
             planner,
         }
+    }
+
+    fn prepare_egraph_debug_state(egraph: &CubeEGraph) -> EgraphDebugState {
+        DebugData::prepare(egraph)
+    }
+
+    pub fn store_egraph_debug_state(egraph: &mut CubeEGraph) {
+        debug_assert_eq!(
+            egraph.analysis.iteration_timestamp,
+            egraph.analysis.debug_states.len()
+        );
+        let state = Self::prepare_egraph_debug_state(egraph);
+        egraph.analysis.debug_states.push(state);
     }
 
     fn make_original_expr(

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -261,11 +261,8 @@ fn write_debug_states(
         last_debug_data = Some(debug_data_clone);
     }
     fs::write(
-        format!("{}/src/states.js", dir),
-        &format!(
-            "export const states = {};",
-            serde_json::to_string_pretty(&states)?
-        ),
+        format!("{}/src/states.json", dir),
+        serde_json::to_string_pretty(&states)?,
     )?;
 
     Ok(())


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Various improvements to EGraph debugger:
* Used JSON instead of JS to store debug data
* Move data collection from `IterationData` to analysis, to store and access initial EGraph state
* Fixed some hooks dependencies
* Enabled prettier
* Enabled eslint
