### PR TITLE
refactor(cubesql): Improve EGraph debugger, part 2: TypeScript, ELK in worker, simplify ReactFlow <-> ELK interop

### DIFF
--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -11,11 +11,13 @@
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false && react-scripts start",
     "build": "react-scripts build",
+    "check": "tsc",
     "reformat": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "@tsconfig/strictest": "2.0.5",
     "@types/node": "20.16.12",
     "@types/react": "18.0.38",
     "@types/react-dom": "18.0.11",

--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -23,7 +23,8 @@
     "@types/react-dom": "18.0.11",
     "prettier": "3.3.3",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "web-worker": "1.3.0"
   },
   "eslintConfig": {
     "extends": [

--- a/rust/cubesql/cubesql/egraph-debug-template/package.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/package.json
@@ -16,8 +16,12 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "@types/node": "20.16.12",
+    "@types/react": "18.0.38",
+    "@types/react-dom": "18.0.11",
     "prettier": "3.3.3",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "typescript": "4.9.5"
   },
   "eslintConfig": {
     "extends": [

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -106,7 +106,7 @@ function layout(
 
     const graph = {
         id: 'root',
-        layoutOptions: layoutOptions,
+        layoutOptions,
         children: Object.keys(groupNodes).map((key) => groupNodes[key]),
         edges: elkEdges,
     };

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -162,23 +162,14 @@ async function layout(
     if (abortSignal.aborted) {
         return;
     }
-    window.requestAnimationFrame(() => {
+    // TODO investigate why setTimeout is necessary, something related to ReactFlow state and setNodes/setEdges probably
+    setTimeout(() => {
         if (abortSignal.aborted) {
             return;
         }
 
-        if (navHistory?.length) {
-            setTimeout(() => {
-                if (abortSignal.aborted) {
-                    return;
-                }
-
-                zoomTo(fitView, navHistory);
-            }, 500);
-        } else {
-            fitView();
-        }
-    });
+        zoomTo(fitView, navHistory);
+    }, 500);
     return flatChildren;
 }
 

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -97,11 +97,18 @@ function layout(
                 }),
         );
 
+    // Primitive edges are deprecated in ELK, so we should use ElkExtendedEdge, that use arrays, essentially hyperedges
+    const elkEdges = edges.map((edge) => ({
+        id: edge.id,
+        sources: [edge.source],
+        targets: [edge.target],
+    }));
+
     const graph = {
         id: 'root',
         layoutOptions: layoutOptions,
         children: Object.keys(groupNodes).map((key) => groupNodes[key]),
-        edges: edges,
+        edges: elkEdges,
     };
 
     const elk = new ELK();

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -470,5 +470,8 @@ function rootComponent() {
 }
 
 const rootElement = document.getElementById('ui');
+if (rootElement === null) {
+    throw new Error('Root element not found');
+}
 const root = createRoot(rootElement);
 root.render(rootComponent());

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -66,8 +66,8 @@ function layout(
 ) {
     const defaultOptions = {
         'elk.algorithm': 'layered',
-        'elk.layered.spacing.nodeNodeBetweenLayers': 100,
-        'elk.spacing.nodeNode': 80,
+        'elk.layered.spacing.nodeNodeBetweenLayers': '100',
+        'elk.spacing.nodeNode': '80',
         'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
         'elk.direction': 'DOWN',
     };

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -111,19 +111,16 @@ function layout(
         edges: elkEdges,
     };
 
-    function elk2flow(node, flattenChildren, withStyle) {
+    function elk2flow(node, flattenChildren) {
         node.position = { x: node.x, y: node.y };
-        if (withStyle) {
-            node.style = {
-                ...node.style,
-                width: node.width,
-                height: node.height,
-            };
-        }
+        node.style = {
+            ...node.style,
+            width: node.width,
+            height: node.height,
+        };
         flattenChildren.push(node);
         (node.children ?? []).forEach((child) => {
-            // only depth 0 get styles
-            elk2flow(child, flattenChildren, false);
+            elk2flow(child, flattenChildren);
         });
         delete node.children;
     }
@@ -135,7 +132,7 @@ function layout(
         const flattenChildren = [];
 
         children.forEach((node) => {
-            elk2flow(node, flattenChildren, true);
+            elk2flow(node, flattenChildren);
         });
 
         setNodes(flattenChildren);

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -250,16 +250,20 @@ const ChildrenNode =
         );
     };
 
+function jsonClone(t) {
+    return JSON.parse(JSON.stringify(t));
+}
+
 const LayoutFlow = () => {
     const [{ preNodes, preEdges }, setPreNodesEdges] = useState({
         preNodes: initialNodes,
         preEdges: initialEdges,
     });
     const [nodes, setNodes, onNodesChange] = useNodesState(
-        JSON.parse(JSON.stringify(initialNodes)),
+        jsonClone(initialNodes),
     );
     const [edges, setEdges, onEdgesChange] = useEdgesState(
-        JSON.parse(JSON.stringify(initialEdges)),
+        jsonClone(initialEdges),
     );
     const [stateIdx, setStateIdx] = useState(0);
     const { fitView } = useReactFlow();
@@ -370,8 +374,8 @@ const LayoutFlow = () => {
     useEffect(() => {
         layout(
             {},
-            JSON.parse(JSON.stringify(preNodes)),
-            JSON.parse(JSON.stringify(preEdges)),
+            jsonClone(preNodes),
+            jsonClone(preEdges),
             setNodes,
             setEdges,
             fitView,

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -111,6 +111,23 @@ function layout(
         edges: elkEdges,
     };
 
+    function elk2flow(node, flattenChildren, withStyle) {
+        node.position = { x: node.x, y: node.y };
+        if (withStyle) {
+            node.style = {
+                ...node.style,
+                width: node.width,
+                height: node.height,
+            };
+        }
+        flattenChildren.push(node);
+        (node.children ?? []).forEach((child) => {
+            // only depth 0 get styles
+            elk2flow(child, flattenChildren, false);
+        });
+        delete node.children;
+    }
+
     const elk = new ELK();
     return elk.layout(graph).then(({ children }) => {
         // By mutating the children in-place we saves ourselves from creating a
@@ -118,18 +135,7 @@ function layout(
         const flattenChildren = [];
 
         children.forEach((node) => {
-            node.position = { x: node.x, y: node.y };
-            node.style = {
-                ...node.style,
-                width: node.width,
-                height: node.height,
-            };
-            flattenChildren.push(node);
-            node.children.forEach((child) => {
-                child.position = { x: child.x, y: child.y };
-                flattenChildren.push(child);
-            });
-            delete node.children;
+            elk2flow(node, flattenChildren, true);
         });
 
         setNodes(flattenChildren);

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -47,7 +47,7 @@ const toEdge = (n) => ({
     style:
         n.source.indexOf(`${n.target}-`) === 0
             ? { stroke: '#f00', strokeWidth: 10 }
-            : undefined,
+            : {},
 });
 const initialNodes = data.combos
     .map(toGroupNode)

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -46,7 +46,7 @@ const toEdge = (n) => ({
     id: `${n.source}->${n.target}`,
     style:
         n.source.indexOf(`${n.target}-`) === 0
-            ? { stroke: '#f00', 'stroke-width': 10 }
+            ? { stroke: '#f00', strokeWidth: 10 }
             : undefined,
 });
 const initialNodes = data.combos

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.js
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.js
@@ -54,7 +54,7 @@ const initialNodes = data.combos
     .concat(data.nodes.map(toRegularNode));
 const initialEdges = data.edges.map(toEdge);
 
-function layout(
+async function layout(
     options,
     nodes,
     edges,
@@ -126,28 +126,28 @@ function layout(
     }
 
     const elk = new ELK();
-    return elk.layout(graph).then(({ children }) => {
-        // By mutating the children in-place we saves ourselves from creating a
-        // needless copy of the nodes array.
-        const flattenChildren = [];
+    const { children } = await elk.layout(graph);
 
-        children.forEach((node) => {
-            elk2flow(node, flattenChildren);
-        });
+    // By mutating the children in-place we saves ourselves from creating a
+    // needless copy of the nodes array.
+    const flattenChildren = [];
 
-        setNodes(flattenChildren);
-        setEdges(edges);
-        window.requestAnimationFrame(() => {
-            if (navHistory?.length) {
-                setTimeout(() => {
-                    zoomTo(fitView, navHistory);
-                }, 500);
-            } else {
-                fitView();
-            }
-        });
-        return flattenChildren;
+    children.forEach((node) => {
+        elk2flow(node, flattenChildren);
     });
+
+    setNodes(flattenChildren);
+    setEdges(edges);
+    window.requestAnimationFrame(() => {
+        if (navHistory?.length) {
+            setTimeout(() => {
+                zoomTo(fitView, navHistory);
+            }, 500);
+        } else {
+            fitView();
+        }
+    });
+    return flattenChildren;
 }
 
 const highlightColor = 'rgba(170,255,170,0.71)';

--- a/rust/cubesql/cubesql/egraph-debug-template/src/index.tsx
+++ b/rust/cubesql/cubesql/egraph-debug-template/src/index.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import ELK from 'elkjs/lib/elk.bundled.js';
+import ELK from 'elkjs';
 import type { ElkNode, LayoutOptions } from 'elkjs';
 import { useCallback, useState, useEffect, useMemo } from 'react';
 import ReactFlow, {
@@ -96,6 +96,18 @@ const initialNodes = data.combos
     .map(toGroupNode)
     .concat(data.nodes.map(toRegularNode));
 const initialEdges = data.edges.map(toEdge);
+
+const elk = new ELK({
+    workerFactory: function (_url) {
+        // TODO something is broken with bundling and web-worker
+        return new Worker(
+            new URL(
+                '../node_modules/elkjs/lib/elk-worker.min.js',
+                import.meta.url,
+            ),
+        );
+    },
+});
 
 async function layout(
     options: LayoutOptions,
@@ -200,7 +212,8 @@ async function layout(
         });
     }
 
-    const elk = new ELK();
+    // TODO add throbber while waiting for layout
+    // TODO add queue to be able to cancel request before sending it to worker
     const { children } = await elk.layout(graph);
 
     if (abortSignal.aborted) {

--- a/rust/cubesql/cubesql/egraph-debug-template/tsconfig.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/rust/cubesql/cubesql/egraph-debug-template/tsconfig.json
+++ b/rust/cubesql/cubesql/egraph-debug-template/tsconfig.json
@@ -1,24 +1,31 @@
 {
+  // multiple base configs is supported in TS 5.0+
+  // See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#supporting-multiple-configuration-files-in-extends
+  // But CRA supports only TS 4
+  // To add insult to injury, is does not fail with proper error, it prints "No issues found." instead
+
+  // @tsconfig/create-react-app is a bit broken, it uses moduleResolution=bundler with resolveJsonModule=true, which is incompatible
+  // TODO make it ["@tsconfig/create-react-app", "@tsconfig/strictest"] after TS bump
+  "extends": "@tsconfig/strictest",
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
+    "allowJs": false,
+    "checkJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+
+    // Those are from create-react-app
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "moduleResolution": "NodeNext",
+    "target": "es2015",
+
+    // Those are from create-react-app
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
     "noEmit": true,
-    "jsx": "react-jsx"
+    "resolveJsonModule": true,
+
+    // This adds too much noise when iterating over arrays
+    "noUncheckedIndexedAccess": false,
   },
   "include": [
     "src"

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -186,8 +186,8 @@ fn write_debug_states(runner: &CubeRunner, stage: &str) -> Result<(), CubeError>
         format!("{}/tsconfig.json", dir),
     )?;
     fs::copy(
-        "egraph-debug-template/src/index.js",
-        format!("{}/src/index.js", dir),
+        "egraph-debug-template/src/index.tsx",
+        format!("{}/src/index.tsx", dir),
     )?;
 
     let mut states = Vec::new();

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -182,6 +182,10 @@ fn write_debug_states(runner: &CubeRunner, stage: &str) -> Result<(), CubeError>
         format!("{}/package.json", dir),
     )?;
     fs::copy(
+        "egraph-debug-template/tsconfig.json",
+        format!("{}/tsconfig.json", dir),
+    )?;
+    fs::copy(
         "egraph-debug-template/src/index.js",
         format!("{}/src/index.js", dir),
     )?;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Various improvements to EGraph debugger:
* Port to TypeScript
* Lots of small changed for proper typing
* Moved ELK to worker. Now UI stays responsive while ELK is working on layout
* Add simple cleanup for layout effect. Now user don't have to wait for ALL animations triggered for layouts, only for last one.