### PR TITLE
fix(schema-compiler): return granularity-truncated queries in client time zone

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -114,7 +114,7 @@ export class BaseTimeDimension extends BaseFilter {
       return this.convertedToTz();
     }
 
-    return this.query.dimensionTimeGroupedColumn(this.convertedToTz(), <Granularity>granularity);
+    return this.query.convertTz(this.query.dimensionTimeGroupedColumn(this.query.dimensionSql(this), <Granularity>granularity));
   }
 
   public dimensionDefinition(): DimensionDefinition | SegmentDefinition {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -121,7 +121,7 @@ describe('SQL Generation', () => {
 
       const queryAndParams = query.buildSqlAndParams();
 
-      expect(queryAndParams[0]).toContain('"cards".type "cards__type", date_trunc(\'day\', ("cards".created_at::timestamptz AT TIME ZONE \'America/Los_Angeles\')) "cards__created_at_day"');
+      expect(queryAndParams[0]).toContain('"cards".type "cards__type", (date_trunc(\'day\', "cards".created_at)::timestamptz AT TIME ZONE \'America/Los_Angeles\') "cards__created_at_day"');
       expect(queryAndParams[0]).toContain('GROUP BY 1, 2');
       expect(queryAndParams[0]).toContain('ORDER BY 2');
     });


### PR DESCRIPTION
Time dimensions with granularities were returned always in UTC. This fixes it and now dimensions are returned in client time zones.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
