### PR TITLE
chore: Release script - push tag and commit manually

### DIFF
--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -11,4 +11,11 @@ BUMP=$1
 if [ "x$BUMP" == "x" ]; then
   BUMP=patch
 fi
-yarn lerna version --create-release=github --conventional-commits --exact $BUMP
+
+# In publish workflow we need to detect branch for tags from github.event.base_ref
+# It's possible only when GitHub receives information of tag from separate push
+# Lerna uses single push for commit & tag, that's why --no-push is passed and pushed manually
+yarn lerna version --create-release=github --conventional-commits --exact --no-push $BUMP
+git push -u origin HEAD
+# commitdate doesn't work with lerna tags :( version:refname is not an option, because we have LTS branches
+git push origin v$(cat lerna.json | jq -r '.version')


### PR DESCRIPTION
Lerna uses single push for tag & commit, which breaks GitHub logic for detection of `github.event.base_ref`.