### PR TITLE
fix(schema-compiler): Support member alias for TD with granularity

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -70,9 +70,13 @@ export class BaseTimeDimension extends BaseFilter {
     return super.aliasName();
   }
 
-  // @ts-ignore
-  public unescapedAliasName(granularity: string) {
+  public unescapedAliasName(granularity?: string) {
     const actualGranularity = granularity || this.granularityObj?.granularity || 'day';
+
+    const fullName = `${this.dimension}.${actualGranularity}`;
+    if (this.query.options.memberToAlias && this.query.options.memberToAlias[fullName]) {
+      return this.query.options.memberToAlias[fullName];
+    }
 
     return `${this.query.aliasName(this.dimension)}_${actualGranularity}`; // TODO date here for rollups
   }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

There's no way for SQL API to specify time dimension in load query during SQL generation for CubeScan: only "dimension" part is supported by Cube ATM, and either SQL API should trim granularity from member path, and replicate alias logic from schema compiler, or schema compiler should support granularity in aliases
