### PR TITLE
fix(schema-compiler): fix FILTER_PARAMS to populate set and notSet filters in cube's SQL query

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3809,21 +3809,20 @@ export class BaseQuery {
     if (!filterParamArg) {
       throw new Error(`FILTER_PARAMS arg not found for ${filter.measure || filter.dimension}`);
     }
-    if (
-      filterParams && filterParams.length
-    ) {
-      if (typeof filterParamArg.__column() === 'function') {
-        // eslint-disable-next-line prefer-spread
-        return filterParamArg.__column().apply(
-          null,
-          filterParams.map(allocateParam),
-        );
-      } else {
-        return filter.conditionSql(filterParamArg.__column());
-      }
-    } else {
+
+    if (typeof filterParamArg.__column() !== 'function') {
+      return filter.conditionSql(filterParamArg.__column());
+    }
+
+    if (!filterParams || !filterParams.length) {
       return '1 = 1';
     }
+
+    // eslint-disable-next-line prefer-spread
+    return filterParamArg.__column().apply(
+      null,
+      filterParams.map(allocateParam),
+    );
   }
 
   filterGroupFunction() {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1762,6 +1762,84 @@ describe('SQL Generation', () => {
       expect(cubeSQL).toMatch(/\(\s*\(.*type\s*=\s*\$\d\$.*OR.*type\s*=\s*\$\d\$.*\)\s*AND\s*\(.*type\s*=\s*\$\d\$.*OR.*type\s*=\s*\$\d\$.*\)\s*\)/);
     });
 
+    it('equals NULL filter', async () => {
+      await compilers.compiler.compile();
+      const query = new BaseQuery(compilers, {
+        measures: ['Order.count'],
+        filters: [
+          {
+            and: [
+              {
+                member: 'Order.type',
+                operator: 'equals',
+                values: [null],
+              },
+            ]
+          }
+        ],
+      });
+      const cubeSQL = query.cubeSql('Order');
+      expect(cubeSQL).toContain('where (((type IS NULL)))');
+    });
+
+    it('notSet(IS NULL) filter', async () => {
+      await compilers.compiler.compile();
+      const query = new BaseQuery(compilers, {
+        measures: ['Order.count'],
+        filters: [
+          {
+            and: [
+              {
+                member: 'Order.type',
+                operator: 'notSet',
+              },
+            ]
+          }
+        ],
+      });
+      const cubeSQL = query.cubeSql('Order');
+      expect(cubeSQL).toContain('where (((type IS NULL)))');
+    });
+
+    it('notEquals NULL filter', async () => {
+      await compilers.compiler.compile();
+      const query = new BaseQuery(compilers, {
+        measures: ['Order.count'],
+        filters: [
+          {
+            and: [
+              {
+                member: 'Order.type',
+                operator: 'notEquals',
+                values: [null],
+              },
+            ]
+          }
+        ],
+      });
+      const cubeSQL = query.cubeSql('Order');
+      expect(cubeSQL).toContain('where (((type IS NOT NULL)))');
+    });
+
+    it('set(IS NOT NULL) filter', async () => {
+      await compilers.compiler.compile();
+      const query = new BaseQuery(compilers, {
+        measures: ['Order.count'],
+        filters: [
+          {
+            and: [
+              {
+                member: 'Order.type',
+                operator: 'set',
+              },
+            ]
+          }
+        ],
+      });
+      const cubeSQL = query.cubeSql('Order');
+      expect(cubeSQL).toContain('where (((type IS NOT NULL)))');
+    });
+
     it('propagate filter params from view into cube\'s query', async () => {
       await compilers.compiler.compile();
       const query = new BaseQuery(compilers, {


### PR DESCRIPTION
The presence of the following filters in a cube query: `set`, `notSet`, `eq NULL` or `NOT eq NULL` renders the corresponding FILTER_PARAMS as `1 = 1` irrespective of the cube or filter.

This is because the `renderFilterParams` method skips invoking `filter.conditionSql` when converting a `filter` to its corresponding SQL due to an empty `filterParams` array. 

For `set` and `notSet`, the filter cannot have value(s). 
For `eq NULL` or `NOT eq NULL` the `null` value is filtered by: https://github.com/cube-js/cube/blob/349597a4a1b10f6e76ef3bf18c37986cdd0962f8/packages/cubejs-schema-compiler/src/adapter/BaseFilter.ts#L115

This leads to an empty `filterParams` array, thus, skipping the filter SQL, thereby returning `1 = 1`.

This PR aims to fix the bug by restructuring the nested if-else block, thereby also improving the readability of the same.

**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required