### PR TITLE
fix(playground): fix version check for yaml model generation

### DIFF
--- a/packages/cubejs-playground/src/pages/Schema/SchemaPage.tsx
+++ b/packages/cubejs-playground/src/pages/Schema/SchemaPage.tsx
@@ -187,10 +187,10 @@ export class SchemaPage extends Component<SchemaPageProps, any> {
 
     const { playgroundContext } = this.context;
 
-    const [, minor] = playgroundContext.coreServerVersion
+    const [major, minor] = playgroundContext.coreServerVersion
       ? playgroundContext.coreServerVersion.split('.')
       : [];
-    const isYamlFormatSupported: boolean = !minor || Number(minor) >= 31;
+    const isYamlFormatSupported: boolean = (Number(major) > 0) || (!minor || Number(minor) >= 31);
 
     const renderTreeNodes = (data) =>
       data.map((item) => {


### PR DESCRIPTION
This fixes incorrect version checking for yaml data model generation in PG (as v1.0 was treated < 0.31)

This fixes #8943
