### PR TITLE
Add aarch64-apple-darwin build target to cubestore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -666,6 +666,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
         include:
           - target: x86_64-pc-windows-msvc
             os: windows-2019
@@ -673,10 +674,18 @@ jobs:
             strip: true
             # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
-            # Please use minimal possible version of macOS, because it produces constraint on libstdc++
             tar_executable: tar
+            # Please use minimal possible version of macOS, because it produces constraint on libstdc++
           - target: x86_64-apple-darwin
             os: macos-12
+            executable_name: cubestored
+            # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
+            strip: false
+            compress: false
+            # bsd tar has a different format with Sparse files which breaks download script
+            tar_executable: gtar
+          - os: macos-14
+            target: aarch64-apple-darwin
             executable_name: cubestored
             # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
             strip: false

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -187,6 +187,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
         include:
           - os: windows-2019
             target: x86_64-pc-windows-msvc
@@ -197,6 +198,12 @@ jobs:
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
           - os: macos-12
             target: x86_64-apple-darwin
+            executable_name: cubestored
+            # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
+            strip: false
+            compress: false
+          - os: macos-14
+            target: aarch64-apple-darwin
             executable_name: cubestored
             # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
             strip: false

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -118,6 +118,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
         include:
           - os: windows-2019
             target: x86_64-pc-windows-msvc
@@ -128,6 +129,12 @@ jobs:
             # Please use minimal possible version of macOS, because it produces constraint on libstdc++
           - os: macos-12
             target: x86_64-apple-darwin
+            executable_name: cubestored
+            # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
+            strip: false
+            compress: false
+          - os: macos-14
+            target: aarch64-apple-darwin
             executable_name: cubestored
             # upx has been disabled because it is crashing for macOS Ventura or above! It was disabled on 2024-09-05.
             strip: false

--- a/rust/cubestore/js-wrapper/src/utils.ts
+++ b/rust/cubestore/js-wrapper/src/utils.ts
@@ -29,8 +29,7 @@ export function getTarget(): string {
             );
         }
       case 'darwin':
-        // Rosetta 2 is required
-        return 'x86_64-apple-darwin';
+        return 'aarch64-apple-darwin';
       default:
         throw new Error(
           `You are using ${process.env} platform on arm64 which is not supported by Cube Store`,


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #8949 

**Description of Changes Made**

Add `aarch64-apple-darwin` as a build target to the `cubestore` matrix and update `getTarget()` to return `aarch64-apple-darwin` to darwin on arm64 instead of returning `x86_64-apple-darwin` and requiring Rosetta 2.

A previous attempt appears to have been made by @ovr on #2658 but seems to have been abandoned (perhaps because at the time GitHub actions did not have a ARM64 macOS runner? It was [made available on Jan 2024](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)).

I ran the workflow `rust-cubestore-master.yml`, downloaded the artifact resulting from the new job `cubestore (aarch64-apple-darwin)` to a macbook w/ arm64 and confirmed that #8949 is solved.

I am not familiar with the build/release infrastructure of Cube. Please review and let me know if any changes should be made. Thanks!