### PR TITLE
fix(cubesql): fix unhandled timestamp unwrapping in df/transform_response

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -1135,10 +1135,16 @@ pub fn transform_response<V: ValueObject>(
                                     ))
                                 })?;
                             // TODO switch parsing to microseconds
-                            if timestamp.timestamp_millis() > (((1 as i64) << 62) / 1_000_000) {
+                            if timestamp.timestamp_millis() > (((1i64) << 62) / 1_000_000) {
                                 builder.append_null()?;
+                            } else if let Some(nanos) = timestamp.timestamp_nanos_opt() {
+                                builder.append_value(nanos)?;
                             } else {
-                                builder.append_value(timestamp.timestamp_nanos_opt().unwrap())?;
+                                log::error!(
+                                    "Unable to cast timestamp value to nanoseconds: {}",
+                                    timestamp.to_string()
+                                );
+                                builder.append_null()?;
                             }
                         },
                     },


### PR DESCRIPTION
This PR fixes timestamp parsing handling unwrapping that may lead to panic:
```
thread 'tokio-runtime-worker' panicked at cube/rust/cubesql/cubesql/src/compile/engine/df/scan.rs:1133:86:
called `Option::unwrap()` on a `None` value
```

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
