### PR TITLE
chore(cubestore): Remove dependency on feature(cursor_remaining) in c…

### DIFF
--- a/rust/cubestore/cubehll/src/instance.rs
+++ b/rust/cubestore/cubehll/src/instance.rs
@@ -201,7 +201,7 @@ impl HllInstance {
                 let mut values = Vec::with_capacity(num_hashes);
                 let mut data = Cursor::new(data);
                 let maxval = (1 << reg_width) as u32 - 1;
-                while !data.is_empty() {
+                while data.position() < data.get_ref().len() as u64 {
                     let hash = data.read_u64::<BigEndian>().unwrap();
                     let ind = hash & mask;
                     let val = hash >> log_num_buckets;

--- a/rust/cubestore/cubehll/src/lib.rs
+++ b/rust/cubestore/cubehll/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(cursor_remaining)]
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
…ubehll

This got removed in more recent versions of Rust, or it got replaced with another unstable API, `data.split() -> (&[u8], &[u8])`, gated by `feature(cursor_split)`.

So this uses stable API functions.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required
