### PR TITLE
chore(cubesql): E2E - check that env variables are not empty

### DIFF
--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -25,17 +25,32 @@ pub struct PostgresIntegrationTestSuite {
     // connection: tokio_postgres::Connection<Socket, NoTlsStream>,
 }
 
+fn get_env_var(env_name: &'static str) -> Option<String> {
+    if let Ok(value) = env::var(env_name) {
+        // Variable can be defined, but be empty on the CI
+        if value.is_empty() {
+            log::warn!("Environment variable {} is declared, but empty", env_name);
+
+            None
+        } else {
+            Some(value)
+        }
+    } else {
+        None
+    }
+}
+
 impl PostgresIntegrationTestSuite {
     pub(crate) async fn before_all() -> AsyncTestConstructorResult {
         let mut env_defined = false;
 
-        if let Ok(testing_cube_token) = env::var("CUBESQL_TESTING_CUBE_TOKEN".to_string()) {
+        if let Some(testing_cube_token) = get_env_var("CUBESQL_TESTING_CUBE_TOKEN") {
             env::set_var("CUBESQL_CUBE_TOKEN", testing_cube_token);
 
             env_defined = true;
         };
 
-        if let Ok(testing_cube_url) = env::var("CUBESQL_TESTING_CUBE_URL".to_string()) {
+        if let Some(testing_cube_url) = get_env_var("CUBESQL_TESTING_CUBE_URL") {
             env::set_var("CUBESQL_CUBE_URL", testing_cube_url);
         } else {
             env_defined = false;


### PR DESCRIPTION
I figured out that CI is broken for contributors. I am not totally sure, but I belive it's related to that env variables are defined, while being empty.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/9c698187-c1bf-4e4b-80ad-9f2b6814b31d">

https://github.com/cube-js/cube/pull/8947