### PR TITLE
perf(cubestore): Arrow Cargo.lock pointers for GroupsAccumulator changes

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -160,7 +160,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube#1963799bd9fd1de3948eba3fce11ddb9c1392d7c"
+source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube#b6c25a93744951fb2c73019e57084132788b0a09"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -1329,7 +1329,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#c29478ed9678ad1dcae7508dc0195fb94a689e6c"
+source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#8d4663ba60e4370a953b62a302221c46eca39e5c"
 dependencies = [
  "ahash",
  "arrow",
@@ -3429,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube#1963799bd9fd1de3948eba3fce11ddb9c1392d7c"
+source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube#b6c25a93744951fb2c73019e57084132788b0a09"
 dependencies = [
  "aes-gcm",
  "arrow",

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -3144,14 +3144,14 @@ async fn planning_inplace_aggregate2(service: Box<dyn SqlClient>) {
         pp_phys_plan_ext(p.router.as_ref(), &verbose),
         "Projection, [url, SUM(Data.hits)@1:hits]\
            \n  AggregateTopK, limit: 10, sortBy: [2 desc null last]\
-           \n    ClusterSend, partitions: [[1, 2]]"
+           \n    ClusterSend, partitions: [[1, 2]], sort_order: [1]"
     );
     assert_eq!(
         pp_phys_plan_ext(p.worker.as_ref(), &verbose),
         "Projection, [url, SUM(Data.hits)@1:hits]\
            \n  AggregateTopK, limit: 10, sortBy: [2 desc null last]\
-           \n    Worker\
-           \n      Sort, by: [SUM(hits)@1 desc nulls last]\
+           \n    Worker, sort_order: [1]\
+           \n      Sort, by: [SUM(hits)@1 desc nulls last], sort_order: [1]\
            \n        FullInplaceAggregate, sort_order: [0]\
            \n          MergeSort, single_vals: [0, 1], sort_order: [0, 1, 2]\
            \n            Union, single_vals: [0, 1], sort_order: [0, 1, 2]\

--- a/rust/cubestore/cubestore/src/metastore/table.rs
+++ b/rust/cubestore/cubestore/src/metastore/table.rs
@@ -11,7 +11,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 use chrono::DateTime;
 use chrono::Utc;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
-use datafusion::physical_plan::expressions::{Column as FusionColumn, Max, Min, Sum};
+use datafusion::physical_plan::expressions::{sum_return_type, Column as FusionColumn, Max, Min, Sum};
 use datafusion::physical_plan::{udaf, AggregateExpr, PhysicalExpr};
 use itertools::Itertools;
 
@@ -76,7 +76,8 @@ impl AggregateColumn {
         )?);
         let res: Arc<dyn AggregateExpr> = match self.function {
             AggregateFunction::SUM => {
-                Arc::new(Sum::new(col.clone(), col.name(), col.data_type(schema)?))
+                let input_data_type = col.data_type(schema)?;
+                Arc::new(Sum::new(col.clone(), col.name(), sum_return_type(&input_data_type)?, &input_data_type))
             }
             AggregateFunction::MAX => {
                 Arc::new(Max::new(col.clone(), col.name(), col.data_type(schema)?))

--- a/rust/cubestore/cubestore/src/metastore/table.rs
+++ b/rust/cubestore/cubestore/src/metastore/table.rs
@@ -11,7 +11,9 @@ use byteorder::{BigEndian, WriteBytesExt};
 use chrono::DateTime;
 use chrono::Utc;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
-use datafusion::physical_plan::expressions::{sum_return_type, Column as FusionColumn, Max, Min, Sum};
+use datafusion::physical_plan::expressions::{
+    sum_return_type, Column as FusionColumn, Max, Min, Sum,
+};
 use datafusion::physical_plan::{udaf, AggregateExpr, PhysicalExpr};
 use itertools::Itertools;
 
@@ -77,7 +79,12 @@ impl AggregateColumn {
         let res: Arc<dyn AggregateExpr> = match self.function {
             AggregateFunction::SUM => {
                 let input_data_type = col.data_type(schema)?;
-                Arc::new(Sum::new(col.clone(), col.name(), sum_return_type(&input_data_type)?, &input_data_type))
+                Arc::new(Sum::new(
+                    col.clone(),
+                    col.name(),
+                    sum_return_type(&input_data_type)?,
+                    &input_data_type,
+                ))
             }
             AggregateFunction::MAX => {
                 Arc::new(Max::new(col.clone(), col.name(), col.data_type(schema)?))


### PR DESCRIPTION
This includes test changes adding new sort_order information to expected pretty-print values, because of this (performance-related) bug fix: https://github.com/cube-js/arrow-datafusion/commit/b3acc9fd434cec56c2ba7b18f592a56e051ba616

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

