### PR TITLE
chore(cubestore): Use fourth input parameter for Sum::new

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/table.rs
+++ b/rust/cubestore/cubestore/src/metastore/table.rs
@@ -11,7 +11,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 use chrono::DateTime;
 use chrono::Utc;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
-use datafusion::physical_plan::expressions::{Column as FusionColumn, Max, Min, Sum};
+use datafusion::physical_plan::expressions::{sum_return_type, Column as FusionColumn, Max, Min, Sum};
 use datafusion::physical_plan::{udaf, AggregateExpr, PhysicalExpr};
 use itertools::Itertools;
 
@@ -76,7 +76,8 @@ impl AggregateColumn {
         )?);
         let res: Arc<dyn AggregateExpr> = match self.function {
             AggregateFunction::SUM => {
-                Arc::new(Sum::new(col.clone(), col.name(), col.data_type(schema)?))
+                let input_data_type = col.data_type(schema)?;
+                Arc::new(Sum::new(col.clone(), col.name(), sum_return_type(&input_data_type)?, &input_data_type))
             }
             AggregateFunction::MAX => {
                 Arc::new(Max::new(col.clone(), col.name(), col.data_type(schema)?))


### PR DESCRIPTION
This is waiting on https://github.com/cube-js/arrow-datafusion/pull/177 (now merged) and https://github.com/cube-js/arrow-datafusion/pull/178 and will need to come with a Cargo.lock pointer update once that PR is merged.