### PR TITLE
fix: Install python3 executable for node-gyp

### DIFF
--- a/packages/cubejs-docker/dev.Dockerfile
+++ b/packages/cubejs-docker/dev.Dockerfile
@@ -8,8 +8,9 @@ ENV CI=0
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
+    # python3 package is necessary to install `python3` executable for node-gyp
     && apt-get install -y --no-install-recommends libssl3 curl \
-       cmake python3.11 libpython3.11-dev gcc g++ make cmake openjdk-17-jdk-headless \
+       cmake python3 python3.11 libpython3.11-dev gcc g++ make cmake openjdk-17-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
 
 ENV RUSTUP_HOME=/usr/local/rustup

--- a/packages/cubejs-docker/latest-debian-jdk.Dockerfile
+++ b/packages/cubejs-docker/latest-debian-jdk.Dockerfile
@@ -10,8 +10,9 @@ RUN yarn config set network-timeout 120000 -g
 
 # Required for node-oracledb to buld on ARM64
 RUN apt-get update \
+    # python3 package is necessary to install `python3` executable for node-gyp
     # libpython3-dev is needed to trigger post-installer to download native with python
-    && apt-get install -y python3.11 libpython3.11-dev gcc g++ make cmake openjdk-17-jdk-headless \
+    && apt-get install -y python3 python3.11 libpython3.11-dev gcc g++ make cmake openjdk-17-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
 
 # We are copying root yarn.lock file to the context folder during the Publish GH

--- a/packages/cubejs-docker/latest.Dockerfile
+++ b/packages/cubejs-docker/latest.Dockerfile
@@ -9,8 +9,9 @@ RUN yarn config set network-timeout 120000 -g
 
 # Required for node-oracledb to buld on ARM64
 RUN apt-get update \
+    # python3 package is necessary to install `python3` executable for node-gyp
     # libpython3-dev is needed to trigger post-installer to download native with python
-    && apt-get install -y python3.11 libpython3.11-dev gcc g++ make cmake \
+    && apt-get install -y python3 python3.11 libpython3.11-dev gcc g++ make cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # We are copying root yarn.lock file to the context folder during the Publish GH

--- a/packages/cubejs-docker/local.Dockerfile
+++ b/packages/cubejs-docker/local.Dockerfile
@@ -10,7 +10,8 @@ ENV CUBEJS_DOCKER_IMAGE_TAG=latest
 
 RUN DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get install -y --no-install-recommends libssl3 python3.11 libpython3.11-dev \
+    # python3 package is necessary to install `python3` executable for node-gyp
+    && apt-get install -y --no-install-recommends libssl3 python3 python3.11 libpython3.11-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production
@@ -30,7 +31,7 @@ RUN yarn config set network-timeout 120000 -g
 
 # Required for node-oracledb to buld on ARM64
 RUN apt-get update \
-    && apt-get install -y python3 gcc g++ make cmake \
+    && apt-get install -y gcc g++ make cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # We are copying root yarn.lock file to the context folder during the Publish GH


### PR DESCRIPTION
**Description of Changes Made (if issue reference is not provided)**

By default node-gyp looks only for `python` and `python3` executables, and python3.11 package installs only `python3.11` That leads to failure during installation optional dependency `java` from NPM even in `-jdk` image

Without `python3` executable `java` fails during installation, and because it is marked optional, installation is successful.
But later, at runtime any JDBC driver would fail with `Cannot find module 'java'`, even in image with JDK installed.

This PR installs `python3` executable, as expected by node-gyp, but there are alternative aproaches:
* Use `PYTHON` environment variable
* Use `npm/yarn config set python`, but that is not supported in NPM 9 and newer (See https://github.com/nodejs/node-gyp/issues/2798)

`local.Dockerfile` and `testing-drivers.Dockerfile` were not affected because they both had `python3` package installed before running `yarn install`.