### PR TITLE
feat(firebolt): Automatically start the engine after connection (#9001)

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
@@ -77,7 +77,8 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
       testConnectionTimeout?: number,
     } = {},
   ) {
-    super(config);
+    // Set connection timeout to 2 minutes to allow the engine to start if it's stopped
+    super({ testConnectionTimeout: 120000, ...config });
 
     const dataSource =
       config.dataSource ||
@@ -122,6 +123,7 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
   private async initConnection() {
     try {
       const connection = await this.firebolt.connect(this.config.connection);
+      await this.ensureEngineRunning();
       return connection;
     } catch (e) {
       this.connection = null;
@@ -174,7 +176,7 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
       await connection.testConnection();
     } catch (error) {
       console.log(error);
-      throw new Error('Unable to connect');
+      throw error;
     }
   }
 

--- a/packages/cubejs-firebolt-driver/test/autostart.test.ts
+++ b/packages/cubejs-firebolt-driver/test/autostart.test.ts
@@ -1,6 +1,9 @@
+import {assertDataSource, getEnv} from '@cubejs-backend/shared';
 import { DriverTests } from '@cubejs-backend/testing-shared';
 
 import { FireboltDriver } from '../src';
+import { Firebolt } from 'firebolt-sdk';
+import { version } from 'firebolt-sdk/package.json';
 
 describe('FireboltDriver autostart', () => {
   let tests: DriverTests;
@@ -28,6 +31,40 @@ describe('FireboltDriver autostart', () => {
       await tests.testQuery();
     } catch (error) {
       expect(driver.ensureEngineRunning).toHaveBeenCalled();
+    }
+  });
+  test('starts the engine after connection', async () => {
+    const dataSource = assertDataSource('default');
+
+    const username = getEnv('dbUser', { dataSource });
+    const auth = username.includes('@')
+      ? { username, password: getEnv('dbPass', { dataSource }) }
+      : { client_id: username, client_secret: getEnv('dbPass', { dataSource }) };
+    const engineName = getEnv('fireboltEngineName', { dataSource });
+    const firebolt = Firebolt({
+      apiEndpoint: getEnv('fireboltApiEndpoint', { dataSource }) || 'api.app.firebolt.io',
+    })
+    await firebolt.connect({
+      auth,
+      database: getEnv('dbName', { dataSource }),
+      account: getEnv('fireboltAccount', { dataSource }),
+      engineEndpoint: getEnv('fireboltEngineEndpoint', { dataSource }),
+      additionalParameters: {
+        userClients: [{
+          name: 'CubeDev+Cube',
+          version
+        }]
+      },
+    });
+
+    const engine = await firebolt.resourceManager.engine.getByName(engineName);
+    try {
+      await engine.stop();
+
+      driver = new FireboltDriver({});
+      await driver.testConnection();
+    } finally {
+      await engine.start();
     }
   });
 });


### PR DESCRIPTION
Backporting https://github.com/cube-js/cube/pull/9001 to stable