### PR TITLE
fix(backend-native): Pass req.securityContext to Python config

### DIFF
--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -352,6 +352,7 @@ export interface PyConfiguration {
   repositoryFactory?: (ctx: unknown) => Promise<unknown>,
   logger?: (msg: string, params: Record<string, any>) => void,
   checkAuth?: (req: unknown, authorization: string) => Promise<{ 'security_context'?: unknown }>
+  extendContext?: (req: unknown) => Promise<unknown>
   queryRewrite?: (query: unknown, ctx: unknown) => Promise<unknown>
   contextToApiScopes?: () => Promise<string[]>
   contextToRoles?: (ctx: unknown) => Promise<string[]>
@@ -365,6 +366,11 @@ function simplifyExpressRequest(req: ExpressRequest) {
     method: req.method,
     headers: req.headers,
     ip: req.ip,
+
+    // req.securityContext is an extension of request done by api-gateway
+    // But its typings currently live in api-gateway package, which has native-backend (this package) as it's dependency
+    // TODO extract typings to separate package and drop as any
+    ...(Object.hasOwn(req, 'securityContext') ? { securityContext: (req as any).securityContext } : {}),
   };
 }
 

--- a/packages/cubejs-backend-native/test/config.py
+++ b/packages/cubejs-backend-native/test/config.py
@@ -20,6 +20,23 @@ async def check_auth(req, authorization):
     }
 
 
+@config('extend_context')
+def extend_context(req):
+  print("[python] extend_context req=", req)
+  if "securityContext" not in req:
+    return {
+      "security_context": {
+        "error": "missing",
+      }
+    }
+
+  req["securityContext"]["extended_by_config"] = True
+
+  return {
+    "security_context": req["securityContext"],
+  }
+
+
 @config
 async def repository_factory(ctx):
     print("[python] repository_factory ctx=", ctx)

--- a/packages/cubejs-backend-native/test/python.test.ts
+++ b/packages/cubejs-backend-native/test/python.test.ts
@@ -43,6 +43,7 @@ suite('Python Config', () => {
       pgSqlPort: 5555,
       preAggregationsSchema: expect.any(Function),
       checkAuth: expect.any(Function),
+      extendContext: expect.any(Function),
       queryRewrite: expect.any(Function),
       repositoryFactory: expect.any(Function),
       schemaVersion: expect.any(Function),
@@ -81,6 +82,31 @@ suite('Python Config', () => {
     }
 
     expect(await config.contextToApiScopes()).toEqual(['meta', 'data', 'jobs']);
+  });
+
+  test('extend_context', async () => {
+    if (!config.extendContext) {
+      throw new Error('extendContext was not defined in config.py');
+    }
+
+    // Without security context
+    expect(await config.extendContext({})).toEqual({
+      security_context: {
+        error: 'missing',
+      },
+    });
+
+    // With security context
+    expect(await config.extendContext({
+      securityContext: { sub: '1234567890', iat: 1516239022, user_id: 42 }
+    })).toEqual({
+      security_context: {
+        extended_by_config: true,
+        sub: '1234567890',
+        iat: 1516239022,
+        user_id: 42
+      },
+    });
   });
 
   test('repository factory', async () => {


### PR DESCRIPTION
This is necessary for `extend_context`. By the time `extendContext` is called, `req` in JS-land is already extended with `securityContext` after `checkAuth`, and JS config receives it with extensions.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#8753

**Description of Changes Made (if issue reference is not provided)**

This is necessary for `extend_context`. By the time `extendContext` is called, `req` in JS-land is already extended with `securityContext` after `checkAuth`, and JS config receives it with extensions.
