### PR TITLE
fix(schema-compiler): fix time dimension granularity origin formatting in local timezone

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 **Check List**
-- [ ] Tests has been run in packages where changes made if available
+- [ ] Tests have been run in packages where changes made if available
 - [ ] Linter has been run for changed code
 - [ ] Tests for the changes have been added if not covered yet
 - [ ] Docs have been added / updated if required

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -13,6 +13,8 @@ export class Granularity {
 
   public readonly granularityInterval: string;
 
+  public readonly queryTimezone: string;
+
   public readonly granularityOffset: string | undefined;
 
   public readonly origin: moment.Moment;
@@ -25,6 +27,7 @@ export class Granularity {
   ) {
     this.granularity = timeDimension.granularity;
     this.predefinedGranularity = isPredefinedGranularity(this.granularity);
+    this.queryTimezone = query.timezone;
     this.origin = moment.tz(query.timezone).startOf('year'); // Defaults to current year start
 
     if (this.predefinedGranularity) {
@@ -59,7 +62,7 @@ export class Granularity {
    * @returns origin date string in Query timezone
    */
   public originLocalFormatted(): string {
-    return this.origin.format('YYYY-MM-DDTHH:mm:ss.SSS');
+    return this.origin.tz(this.queryTimezone).format('YYYY-MM-DDTHH:mm:ss.SSS');
   }
 
   /**

--- a/packages/cubejs-schema-compiler/test/integration/clickhouse/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/clickhouse/custom-granularities.test.ts
@@ -41,9 +41,11 @@ describe('Custom Granularities', () => {
           granularities:
             - name: half_year
               interval: 6 months
+              origin: '2024-01-01' # to keep tests stable across time (year change, etc)
             - name: half_year_by_1st_april
               interval: 6 months
-              offset: 3 months
+              #offset: 3 months
+              origin: '2024-04-01' # to keep tests stable across time (year change, etc)
             - name: two_weeks_by_friday
               interval: 2 weeks
               origin: '2024-08-23'

--- a/packages/cubejs-schema-compiler/test/integration/mssql/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/mssql/custom-granularities.test.ts
@@ -37,9 +37,11 @@ describe('Custom Granularities', () => {
           granularities:
             - name: half_year
               interval: 6 months
+              origin: '2024-01-01' # to keep tests stable across time (year change, etc)
             - name: half_year_by_1st_april
               interval: 6 months
-              offset: 3 months
+              #offset: 3 months
+              origin: '2024-04-01' # to keep tests stable across time (year change, etc)
             - name: two_weeks_by_friday
               interval: 2 weeks
               origin: '2024-08-23'

--- a/packages/cubejs-schema-compiler/test/integration/mysql/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/mysql/custom-granularities.test.ts
@@ -37,9 +37,11 @@ describe('Custom Granularities', () => {
           granularities:
             - name: half_year
               interval: 6 months
+              origin: '2024-01-01' # to keep tests stable across time (year change, etc)
             - name: half_year_by_1st_april
               interval: 6 months
-              offset: 3 months
+              #offset: 3 months
+              origin: '2024-04-01' # to keep tests stable across time (year change, etc)
             - name: two_weeks_by_friday
               interval: 2 weeks
               origin: '2024-08-23'

--- a/packages/cubejs-schema-compiler/test/integration/postgres/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/custom-granularities.test.ts
@@ -39,9 +39,11 @@ describe('Custom Granularities', () => {
           granularities:
             - name: half_year
               interval: 6 months
+              origin: '2024-01-01' # to keep tests stable across time (year change, etc)
             - name: half_year_by_1st_april
               interval: 6 months
-              offset: 3 months
+              #offset: 3 months
+              origin: '2024-04-01' # to keep tests stable across time (year change, etc)
             - name: two_weeks_by_friday
               interval: 2 weeks
               origin: '2024-08-23'

--- a/packages/cubejs-testing-drivers/fixtures/_schemas.json
+++ b/packages/cubejs-testing-drivers/fixtures/_schemas.json
@@ -93,12 +93,13 @@
           "granularities": [
             {
               "name": "half_year",
-              "interval": "6 months"
+              "interval": "6 months",
+              "origin": "2024-01-01"
             },
             {
               "name": "half_year_by_1st_april",
               "interval": "6 months",
-              "offset": "3 months"
+              "origin": "2024-04-01"
             },
             {
               "name": "two_mo_by_feb",
@@ -119,12 +120,13 @@
           "granularities": [
             {
               "name": "half_year",
-              "interval": "6 months"
+              "interval": "6 months",
+              "origin": "2024-01-01"
             },
             {
               "name": "half_year_by_1st_april",
               "interval": "6 months",
-              "offset": "3 months"
+              "origin": "2024-04-01"
             },
             {
               "name": "two_mo_by_feb",


### PR DESCRIPTION
This PR fixes incorrect TD granularity formatting in the query timezone.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
