### PR TITLE
fix(dremio-driver): Fix stale version of testing-shared dependency

### DIFF
--- a/packages/cubejs-dremio-driver/package.json
+++ b/packages/cubejs-dremio-driver/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@cubejs-backend/linter": "^1.0.0",
-    "@cubejs-backend/testing-shared": "1.1.9",
+    "@cubejs-backend/testing-shared": "1.1.11",
     "jest": "^27"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`dremio-driver` has old version of intra-repo dependency, and is stuck to it: lerna won't upgrade it, thinking that's intended. Also this is the reason of unnecessary diff in `yarn.lock`.
Strangely, we are using `yarn install --frozen-lockfile` in CI, but it finish successfully, and does not change lockfile.