### PR TITLE
fix(clickhouse-driver): Support overriding Username & Password from Driver Config

### DIFF
--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -145,8 +145,8 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     const protocol = config.protocol ?? getEnv('dbSsl', { dataSource }) ? 'https:' : 'http:';
     const url = `${protocol}//${host}:${port}`;
 
-    const username = getEnv('dbUser', { dataSource });
-    const password = getEnv('dbPass', { dataSource });
+    const username = config.username ?? getEnv('dbUser', { dataSource });
+    const password = config.password ?? getEnv('dbPass', { dataSource });
     const database = config.database ?? (getEnv('dbName', { dataSource }) as string) ?? 'default';
 
     // TODO this is a bit inconsistent with readOnly


### PR DESCRIPTION
Add the ability to override the username and password from the driver configuration. Currently, when using multiple data sources for different tenants ([Multitenancy vs Multiple Data Sources](https://cube.dev/docs/product/configuration/advanced/multitenancy#multitenancy-vs-multiple-data-sources)) it is not possible to use the username and password defined in the `ClickHouseDriver` config instead of the default ENV variables CUBEJS_DB_USER, CUBEJS_DB_PASS

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

