### PR TITLE
fix(cubesql): Pass proper in_projection flag in non-trivial wrapper pull up rule

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
@@ -285,7 +285,7 @@ impl WrapperRules {
                         // This is fixed to false for any LHS because we should only allow to push to Cube when from is ungrouped CubeSCan
                         // And after pulling replacer over this node it will be WrappedSelect(from=WrappedSelect), so it should not allow to push for whatever LP is on top of it
                         "WrapperPullupReplacerPushToCube:false",
-                        "?inner_projection_expr",
+                        "?in_projection",
                         "?cube_members",
                         "?grouped_subqueries",
                     ),


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

