### PR TITLE
fix(client-ws-transport): Flush send queue in close() to avoid race

### DIFF
--- a/packages/cubejs-client-ws-transport/src/index.ts
+++ b/packages/cubejs-client-ws-transport/src/index.ts
@@ -91,6 +91,9 @@ class WebSocketTransport implements ITransport<WebSocketTransportResult> {
 
   public async close(): Promise<void> {
     if (this.ws) {
+      // Flush send queue before sending close frame
+      this.ws.sendQueue();
+
       this.ws.close();
     }
   }


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Before this there were a race between `setTimeout` in `sendMessage` and `close`. Even for a good citizen, that calls `unsubscribe()` and awaits result there were no synchronization between unsubscribe adding message to `messageQueue` and restarting timer, and actually sending this message to WebSocket. When `close()` is called close frame is sent immediately to WebSocket. If at that moment messageQueue is not empty, and timer is armed it can wake up, and discover socket in CLOSING state: send side closed, recv side open.

For now - just flush everything queued, and send close frame after, so it would look like close was queued after. More complete solution is to add synchronization between unsubscribe call and sending message, or even receiving ack for it.