### PR TITLE
fix(schema-compiler): Fix queries with time dimensions without granularities don't hit pre-aggregations with allow_non_strict_date_range_match=true

### DIFF
--- a/packages/cubejs-backend-shared/src/time.ts
+++ b/packages/cubejs-backend-shared/src/time.ts
@@ -76,7 +76,7 @@ export function subtractInterval(date: moment.Moment, interval: ParsedInterval):
 /**
  * Returns the closest date prior to date parameter aligned with the origin point
  */
-function alignToOrigin(startDate: moment.Moment, interval: ParsedInterval, origin: moment.Moment): moment.Moment {
+export const alignToOrigin = (startDate: moment.Moment, interval: ParsedInterval, origin: moment.Moment): moment.Moment => {
   let alignedDate = startDate.clone();
   let intervalOp;
   let isIntervalNegative = false;
@@ -111,9 +111,9 @@ function alignToOrigin(startDate: moment.Moment, interval: ParsedInterval, origi
   }
 
   return alignedDate;
-}
+};
 
-function parsedSqlIntervalToDuration(parsedInterval: ParsedInterval): moment.Duration {
+export const parsedSqlIntervalToDuration = (parsedInterval: ParsedInterval): moment.Duration => {
   const duration = moment.duration();
 
   Object.entries(parsedInterval).forEach(([key, value]) => {
@@ -121,7 +121,7 @@ function parsedSqlIntervalToDuration(parsedInterval: ParsedInterval): moment.Dur
   });
 
   return duration;
-}
+};
 
 function checkSeriesForDateRange(intervalStr: string, [startStr, endStr]: QueryDateRange): void {
   const intervalParsed = parseSqlInterval(intervalStr);

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -26,6 +26,7 @@ import { BaseTimeDimension } from './BaseTimeDimension';
 import { ParamAllocator } from './ParamAllocator';
 import { PreAggregations } from './PreAggregations';
 import { SqlParser } from '../parser/SqlParser';
+import { Granularity } from './Granularity';
 
 const DEFAULT_PREAGGREGATIONS_SCHEMA = 'stb_pre_aggregations';
 
@@ -1379,7 +1380,47 @@ export class BaseQuery {
   }
 
   granularityHierarchies() {
-    return R.fromPairs(Object.keys(standardGranularitiesParents).map(k => [k, this.granularityParentHierarchy(k)]));
+    return this.cacheValue(
+      // If time dimension custom granularity in data model is defined without
+      // timezone information they are treated in query timezone.
+      // Because of that it's not possible to correctly precalculate
+      // granularities hierarchies on startup as they are specific for each timezone.
+      ['granularityHierarchies', this.timezone],
+      () => R.reduce(
+        (hierarchies, cube) => R.reduce(
+          (acc, [tdName, td]) => {
+            const dimensionKey = `${cube}.${tdName}`;
+
+            // constructing standard granularities for time dimension
+            const standardEntries = R.fromPairs(
+              R.keys(standardGranularitiesParents).map(gr => [
+                `${dimensionKey}.${gr}`,
+                standardGranularitiesParents[gr],
+              ]),
+            );
+
+            // If we have custom granularities in time dimension
+            const customEntries = td.granularities
+              ? R.fromPairs(
+                R.keys(td.granularities).map(granularityName => {
+                  const grObj = new Granularity(this, { dimension: dimensionKey, granularity: granularityName });
+                  return [
+                    `${dimensionKey}.${granularityName}`,
+                    [granularityName, ...standardGranularitiesParents[grObj.minGranularity()]],
+                  ];
+                }),
+              )
+              : {};
+
+            return { ...acc, ...standardEntries, ...customEntries };
+          },
+          hierarchies,
+          R.toPairs(this.cubeEvaluator.timeDimensionsForCube(cube)),
+        ),
+        {},
+        R.keys(this.cubeEvaluator.evaluatedCubes),
+      ),
+    );
   }
 
   granularityParentHierarchy(granularity) {
@@ -1646,7 +1687,8 @@ export class BaseQuery {
 
   /**
    *
-   * @param {{sql: string, on: {cubeName: string, expression: Function}, joinType: 'LEFT' | 'INNER', alias: string}} customJoin
+   * @param {{sql: string, on: {cubeName: string, expression: Function}, joinType: 'LEFT' | 'INNER', alias: string}}
+   *   customJoin
    * @returns {JoinItem}
    */
   customSubQueryJoin(customJoin) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -39,7 +39,7 @@ export class BaseTimeDimension extends BaseFilter {
   }
 
   // TODO: find and fix all hidden references to granularity to rely on granularityObj instead?
-  public get granularity(): string | undefined {
+  public get granularity(): string | null | undefined {
     return this.granularityObj?.granularity;
   }
 
@@ -217,7 +217,7 @@ export class BaseTimeDimension extends BaseFilter {
     return this.query.dateTimeCast(this.query.paramAllocator.allocateParam(this.dateRange ? this.dateToFormatted() : BUILD_RANGE_END_LOCAL));
   }
 
-  public dateRangeGranularity() {
+  public dateRangeGranularity(): string | null {
     if (!this.dateRange) {
       return null;
     }
@@ -262,7 +262,7 @@ export class BaseTimeDimension extends BaseFilter {
   }
 
   public resolvedGranularity() {
-    return this.granularityObj?.resolvedGranularity();
+    return this.granularityObj ? this.granularityObj.resolvedGranularity() : this.dateRangeGranularity();
   }
 
   public isPredefinedGranularity(): boolean {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -241,6 +241,10 @@ export class BaseTimeDimension extends BaseFilter {
               return this.dateRangeGranularity();
             }
 
+            if (!this.dateRange) {
+              return this.granularityObj.minGranularity();
+            }
+
             // If we have granularity and date range, we need to check
             // that the interval and the granularity offset are stacked/fits with date range
             if (this.granularityObj.isPredefined() ||

--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -229,9 +229,9 @@ export class BaseTimeDimension extends BaseFilter {
     );
   }
 
-  protected rollupGranularityValue: any | null = null;
+  protected rollupGranularityValue: string | null = null;
 
-  public rollupGranularity() {
+  public rollupGranularity(): string | null {
     if (!this.rollupGranularityValue) {
       this.rollupGranularityValue =
         this.query.cacheValue(

--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -241,7 +241,14 @@ export class BaseTimeDimension extends BaseFilter {
               return this.dateRangeGranularity();
             }
 
-            return this.query.minGranularity(this.granularityObj.minGranularity(), this.dateRangeGranularity());
+            // If we have granularity and date range, we need to check
+            // that the interval and the granularity offset are stacked/fits with date range
+            if (this.granularityObj.isPredefined() ||
+              !this.granularityObj.isAlignedWithDateRange([this.dateFromFormatted(), this.dateToFormatted()])) {
+              return this.query.minGranularity(this.granularityObj.minGranularity(), this.dateRangeGranularity());
+            }
+
+            return this.granularityObj.granularity;
           }
         );
     }
@@ -263,10 +270,6 @@ export class BaseTimeDimension extends BaseFilter {
 
   public resolvedGranularity() {
     return this.granularityObj ? this.granularityObj.resolvedGranularity() : this.dateRangeGranularity();
-  }
-
-  public isPredefinedGranularity(): boolean {
-    return this.granularityObj?.isPredefined() || false;
   }
 
   public wildcardRange() {

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -109,14 +109,6 @@ export class Granularity {
     return timeSeriesFromCustomInterval(this.granularityInterval, dateRange, moment(this.originLocalFormatted()), options);
   }
 
-  public resolvedGranularity(): string {
-    if (this.predefinedGranularity) {
-      return this.granularity;
-    }
-
-    return this.granularityFromInterval();
-  }
-
   /**
    * Returns the smallest granularity for the granularityInterval
    */

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -109,6 +109,14 @@ export class Granularity {
     return timeSeriesFromCustomInterval(this.granularityInterval, dateRange, moment(this.originLocalFormatted()), options);
   }
 
+  public resolvedGranularity(): string {
+    if (this.predefinedGranularity) {
+      return this.granularity;
+    }
+
+    return this.granularityFromInterval();
+  }
+
   /**
    * Returns the smallest granularity for the granularityInterval
    */

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -168,9 +168,13 @@ export class Granularity {
     const grIntervalDuration = parsedSqlIntervalToDuration(intervalParsed);
     const msFrom = moment.tz(startStr, this.queryTimezone);
     const msTo = moment.tz(endStr, this.queryTimezone).add(1, 'ms');
-    const dateRangeDuration = moment.duration(msTo.diff(msFrom));
 
-    if (dateRangeDuration.asMilliseconds() % grIntervalDuration.asMilliseconds() !== 0) {
+    // We can't simply compare interval milliseconds because of DSTs.
+    const testDate = msFrom.clone();
+    while (testDate.isBefore(msTo)) {
+      testDate.add(grIntervalDuration);
+    }
+    if (!testDate.isSame(msTo)) {
       return false;
     }
 

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
@@ -501,26 +501,6 @@ export class PreAggregations {
     );
   }
 
-  canUsePreAggregationAndCheckIfRefValid(query) {
-    const transformedQuery = PreAggregations.transformQueryToCanUseForm(query);
-    return (refs) => PreAggregations.canUsePreAggregationForTransformedQueryFn(
-      transformedQuery, refs
-    );
-  }
-
-  checkAutoRollupPreAggregationValid(refs) {
-    try {
-      this.autoRollupPreAggregationQuery(null, refs); // TODO null
-      return true;
-    } catch (e) {
-      if (e instanceof UserError || e.toString().indexOf('ReferenceError') !== -1) {
-        return false;
-      } else {
-        throw e;
-      }
-    }
-  }
-
   /**
    * Returns function to determine whether pre-aggregation can be used or not
    * for specified query, or its value for `refs` if specified.

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -448,8 +448,8 @@ export class CubeEvaluator extends CubeSymbols {
 
   public timeDimensionPathsForCube(cube: any) {
     return R.compose(
-      R.map(nameToDefinition => `${cube}.${nameToDefinition[0]}`),
-      R.toPairs,
+      R.map(dimName => `${cube}.${dimName}`),
+      R.keys,
       // @ts-ignore
       R.filter((d: any) => d.type === 'time')
       // @ts-ignore
@@ -460,12 +460,19 @@ export class CubeEvaluator extends CubeSymbols {
     return this.cubeFromPath(cube).measures || {};
   }
 
+  public timeDimensionsForCube(cube) {
+    return R.filter(
+      (d: any) => d.type === 'time',
+      this.cubeFromPath(cube).dimensions || {}
+    );
+  }
+
   public preAggregationsForCube(path: string) {
     return this.cubeFromPath(path).preAggregations || {};
   }
 
   /**
-   * Returns pre-aggregations filtered by the spcified selector.
+   * Returns pre-aggregations filtered by the specified selector.
    * @param {{
    *  scheduled: boolean,
    *  dataSource: Array<string>,

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-agg-allow-non-strict.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-agg-allow-non-strict.test.ts
@@ -205,7 +205,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(true, false, false));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -266,7 +266,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(false, true, false));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -294,7 +294,7 @@ describe(
         expect(query.indexOf('cube__hourly_data')).toEqual(-1);
       });
 
-      it('hour query with the `week` granularity match `HourlyData`', async () => {
+      it('hour query with the `week` granularity match `DailyData`', async () => {
         await compiler.compile();
         const [,,, request] = getQueries(compiler, joinGraph, cubeEvaluator);
         const [query] = request.buildSqlAndParams();
@@ -327,7 +327,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(false, false, true));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -388,7 +388,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(true, true, false));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -449,7 +449,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(true, false, true));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -510,7 +510,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(false, true, true));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);
@@ -571,7 +571,7 @@ describe(
 
       const { compiler, joinGraph, cubeEvaluator } =
         prepareCompiler(getCube(true, true, true));
-      
+
       it('month query with the `month` granularity match `MonthlyData`', async () => {
         await compiler.compile();
         const [request] = getQueries(compiler, joinGraph, cubeEvaluator);

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -94,7 +94,13 @@ describe('PreAggregations', () => {
         },
         createdAt: {
           type: 'time',
-          sql: 'created_at'
+          sql: 'created_at',
+          granularities: {
+            hourTenMinOffset: {
+              interval: '1 hour',
+              offset: '10 minutes'
+            }
+          }
         },
         signedUpAt: {
           type: 'time',
@@ -223,6 +229,11 @@ describe('PreAggregations', () => {
           timeDimensionReference: createdAt,
           granularity: 'hour',
           partitionGranularity: 'month'
+        },
+        countCustomGranularity: {
+          measures: [count],
+          timeDimension: createdAt,
+          granularity: 'hourTenMinOffset'
         },
         sourceAndIdRollup: {
           measures: [count],
@@ -584,6 +595,49 @@ describe('PreAggregations', () => {
           {
             visitors__count: '2',
             visitors__created_at_hour: '2017-01-06T16:00:00.000Z',
+          },
+        ]
+      );
+    });
+  }));
+
+  it('simple pre-aggregation with custom granularity (exact match)', () => compiler.compile().then(() => {
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'visitors.count'
+      ],
+      timeDimensions: [{
+        dimension: 'visitors.createdAt',
+        dateRange: ['2017-01-01 00:10:00.000', '2017-01-29 22:09:59.999'],
+        granularity: 'hourTenMinOffset',
+      }],
+      timezone: 'America/Los_Angeles',
+      preAggregationsSchema: ''
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    console.log(queryAndParams);
+    expect(query.preAggregations?.preAggregationForQuery?.canUsePreAggregation).toEqual(true);
+    expect(queryAndParams[0]).toMatch(/visitors_count_custom_granularity/);
+
+    return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
+      expect(res).toEqual(
+        [
+          {
+            visitors__count: '1',
+            visitors__created_at_hourTenMinOffset: '2017-01-02T15:10:00.000Z',
+          },
+          {
+            visitors__count: '1',
+            visitors__created_at_hourTenMinOffset: '2017-01-04T15:10:00.000Z',
+          },
+          {
+            visitors__count: '1',
+            visitors__created_at_hourTenMinOffset: '2017-01-05T15:10:00.000Z',
+          },
+          {
+            visitors__count: '2',
+            visitors__created_at_hourTenMinOffset: '2017-01-06T15:10:00.000Z',
           },
         ]
       );

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -547,14 +547,15 @@ describe('PreAggregations', () => {
     });
   }));
 
-  it('simple pre-aggregation (with no granularity in query)', () => compiler.compile().then(() => {
+  it('simple pre-aggregation (allowNonStrictDateRangeMatch: true)', () => compiler.compile().then(() => {
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
       ],
       timeDimensions: [{
         dimension: 'visitors.createdAt',
-        dateRange: ['2017-01-01 00:00:00.000', '2017-01-29 22:59:59.999']
+        dateRange: ['2017-01-01 00:10:00.000', '2017-01-29 22:59:59.999'],
+        granularity: 'hour',
       }],
       timezone: 'America/Los_Angeles',
       preAggregationsSchema: ''
@@ -567,9 +568,24 @@ describe('PreAggregations', () => {
 
     return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
       expect(res).toEqual(
-        [{
-          visitors__count: '5'
-        }]
+        [
+          {
+            visitors__count: '1',
+            visitors__created_at_hour: '2017-01-02T16:00:00.000Z',
+          },
+          {
+            visitors__count: '1',
+            visitors__created_at_hour: '2017-01-04T16:00:00.000Z',
+          },
+          {
+            visitors__count: '1',
+            visitors__created_at_hour: '2017-01-05T16:00:00.000Z',
+          },
+          {
+            visitors__count: '2',
+            visitors__created_at_hour: '2017-01-06T16:00:00.000Z',
+          },
+        ]
       );
     });
   }));

--- a/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
@@ -16,7 +16,8 @@ describe('Pre Aggregation by filter match tests', () => {
         },
         one_week_by_sunday: {
           interval: '1 week',
-          offset: '-1 day'
+          // offset: '-1 day' // offsets might lead to flaky tests through years
+          origin: '2025-01-05 00:00:00'
         },
         two_weeks_by_1st_feb_00am: {
           interval: '2 weeks',
@@ -38,6 +39,8 @@ describe('Pre Aggregation by filter match tests', () => {
     preAggTimeGranularity: string,
     queryAggTimeGranularity: string,
     queryTimeZone: string = 'America/Los_Angeles',
+    dateRange: [ string, string ] = ['2017-01-01', '2017-03-31'],
+    allowNonStrictDateRangeMatch: boolean = false
   ) {
     const aaa: any = {
       type: 'rollup',
@@ -46,8 +49,7 @@ describe('Pre Aggregation by filter match tests', () => {
       timeDimension: 'cube.created',
       granularity: preAggTimeGranularity,
       partitionGranularity: 'year',
-      // Enabling only for custom granularities
-      allowNonStrictDateRangeMatch: !/^(minute|hour|day|week|month|quarter|year)$/.test(preAggTimeGranularity)
+      allowNonStrictDateRangeMatch
     };
 
     const cube: any = {
@@ -65,7 +67,7 @@ describe('Pre Aggregation by filter match tests', () => {
 
     // aaa.sortedDimensions = aaa.dimensions;
     // aaa.sortedDimensions.sort();
-    aaa.sortedTimeDimensions = [[aaa.timeDimension, aaa.granularity]];
+    aaa.sortedTimeDimensions = [[aaa.timeDimension, aaa.granularity, 'day']];
 
     return compiler.compile().then(() => {
       const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
@@ -73,7 +75,7 @@ describe('Pre Aggregation by filter match tests', () => {
         timeDimensions: [{
           dimension: 'cube.created',
           granularity: queryAggTimeGranularity,
-          dateRange: { from: '2017-01-01', to: '2017-03-31' }
+          dateRange,
         }],
         timezone: queryTimeZone,
       });
@@ -92,15 +94,43 @@ describe('Pre Aggregation by filter match tests', () => {
   ));
 
   it('1 count measure, one_week_by_sunday, one_week_by_sunday', () => testPreAggregationMatch(
-    true, ['count'], 'one_week_by_sunday', 'one_week_by_sunday'
+    true,
+    ['count'],
+    'one_week_by_sunday',
+    'one_week_by_sunday',
+    'UTC',
+    ['2024-02-11', '2024-03-02']
   ));
 
-  it('1 count measure, two_weeks_by_1st_feb_00am, two_weeks_by_1st_feb_00am', () => testPreAggregationMatch(
-    true, ['count'], 'two_weeks_by_1st_feb_00am', 'two_weeks_by_1st_feb_00am'
+  it('1 count measure, one_week_by_sunday, one_week_by_sunday (dst)', () => testPreAggregationMatch(
+    true,
+    ['count'],
+    'one_week_by_sunday',
+    'one_week_by_sunday',
+    'UTC',
+    ['2024-02-25', '2024-03-30'], // DST Switch happens here, but still must work!
+  ));
+
+  it('1 count measure, two_weeks_by_1st_feb_00am, two_weeks_by_1st_feb_00am (match)', () => testPreAggregationMatch(
+    true,
+    ['count'],
+    'two_weeks_by_1st_feb_00am',
+    'two_weeks_by_1st_feb_00am',
+    'UTC',
+    ['2024-01-18', '2024-02-28']
+  ));
+
+  it('1 count measure, two_weeks_by_1st_feb_00am, two_weeks_by_1st_feb_00am (miss)', () => testPreAggregationMatch(
+    false,
+    ['count'],
+    'two_weeks_by_1st_feb_00am',
+    'two_weeks_by_1st_feb_00am',
+    'UTC',
+    ['2024-01-18', '2024-02-07'], // Interval not aligned
   ));
 
   it('1 count measure, day, one_week_by_sunday', () => testPreAggregationMatch(
-    true, ['count'], 'day', 'one_week_by_sunday'
+    true, ['count'], 'day', 'one_week_by_sunday', 'UTC'
   ));
 
   it('1 count measure, day, two_weeks_by_1st_feb_00am', () => testPreAggregationMatch(

--- a/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
@@ -107,7 +107,7 @@ describe('Pre Aggregation by filter match tests', () => {
     ['count'],
     'one_week_by_sunday',
     'one_week_by_sunday',
-    'UTC',
+    'America/Los_Angeles',
     ['2024-02-25', '2024-03-30'], // DST Switch happens here, but still must work!
   ));
 


### PR DESCRIPTION
This fixes queries with time dimensions but without granularities that don't hit pre-aggregations having set allow_non_strict_date_range_match=true.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

