### PR TITLE
fix(schema-compiler): move create table name check to underlying driver for Postgres, MySQL, Oracle

### DIFF
--- a/packages/cubejs-mysql-driver/src/MySqlDriver.ts
+++ b/packages/cubejs-mysql-driver/src/MySqlDriver.ts
@@ -22,6 +22,7 @@ import {
   IndexesSQL,
   DownloadTableMemoryData,
   DriverCapabilities,
+  TableColumn,
 } from '@cubejs-backend/base-driver';
 
 const GenericTypeToMySql: Record<GenericDataBaseType, string> = {
@@ -180,7 +181,7 @@ export class MySqlDriver extends BaseDriver implements DriverInterface {
 
   protected primaryKeysQuery(conditionString?: string): string | null {
     return `SELECT
-      TABLE_SCHEMA as ${this.quoteIdentifier('table_schema')}, 
+      TABLE_SCHEMA as ${this.quoteIdentifier('table_schema')},
       TABLE_NAME as ${this.quoteIdentifier('table_name')},
       COLUMN_NAME as ${this.quoteIdentifier('column_name')}
   FROM
@@ -260,6 +261,14 @@ export class MySqlDriver extends BaseDriver implements DriverInterface {
       // eslint-disable-next-line no-underscore-dangle
       await (<any> this.pool)._factory.destroy(conn);
     }
+  }
+
+  public async createTable(quotedTableName: string, columns: TableColumn[]): Promise<void> {
+    if (quotedTableName.length > 64) {
+      throw new Error('MySQL can not work with table names longer than 64 symbols. ' +
+        `Consider using the 'sqlAlias' attribute in your cube definition for ${quotedTableName}.`);
+    }
+    return super.createTable(quotedTableName, columns);
   }
 
   public async query(query: string, values: unknown[]) {

--- a/packages/cubejs-mysql-driver/test/MySqlDriver.test.ts
+++ b/packages/cubejs-mysql-driver/test/MySqlDriver.test.ts
@@ -116,4 +116,18 @@ describe('MySqlDriver', () => {
       await tableData.release();
     }
   });
+
+  test('table name check', async () => {
+    const tblName = 'really-really-really-looooooooooooooooooooooooooooooooooooooooooooooooooooong-table-name';
+    try {
+      await mySqlDriver.createTable(tblName, [{ name: 'id', type: 'bigint' }]);
+
+      throw new Error('createTable must throw an exception');
+    } catch (e: any) {
+      expect(e.message).toEqual(
+        'MySQL can not work with table names longer than 64 symbols. ' +
+        `Consider using the 'sqlAlias' attribute in your cube definition for ${tblName}.`
+      );
+    }
+  });
 });

--- a/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
+++ b/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
@@ -142,6 +142,20 @@ describe('PostgresDriver', () => {
     }
   });
 
+  test('table name check', async () => {
+    const tblName = 'really-really-really-looooooooooooooooooooooooooooooooooooooooooooooooooooong-table-name';
+    try {
+      await driver.createTable(tblName, [{ name: 'id', type: 'bigint' }]);
+
+      throw new Error('createTable must throw an exception');
+    } catch (e: any) {
+      expect(e.message).toEqual(
+        'PostgreSQL can not work with table names longer than 63 symbols. ' +
+        `Consider using the 'sqlAlias' attribute in your cube definition for ${tblName}.`
+      );
+    }
+  });
+
   // Note: This test MUST be the last in the list.
   test('release', async () => {
     expect(async () => {


### PR DESCRIPTION
The check for the table name length is been moved to the driver from query class, thus it is enforced
ony for specific datasources.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

