### PR TITLE
fix(cubesql): Fix SELECT DISTINCT on pushdown

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -15700,7 +15700,10 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                     "KibanaSampleDataEcommerce.customer_gender".to_string(),
                 ]),
                 segments: Some(vec![]),
-                order: Some(vec![]),
+                order: Some(vec![vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "asc".to_string()
+                ],]),
                 ..Default::default()
             }
         )

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -8346,7 +8346,7 @@ ORDER BY "source"."str0" ASC
                 ..Default::default()
             }
         );
-        
+
         let logical_plan = convert_select_to_query_plan(
             "SELECT DISTINCT * FROM KibanaSampleDataEcommerce".to_string(),
             DatabaseProtocol::PostgreSQL,

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -8345,6 +8345,41 @@ ORDER BY "source"."str0" ASC
                 order: Some(vec![]),
                 ..Default::default()
             }
+        );
+        
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT * FROM KibanaSampleDataEcommerce".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![
+                    "KibanaSampleDataEcommerce.count".to_string(),
+                    "KibanaSampleDataEcommerce.maxPrice".to_string(),
+                    "KibanaSampleDataEcommerce.sumPrice".to_string(),
+                    "KibanaSampleDataEcommerce.minPrice".to_string(),
+                    "KibanaSampleDataEcommerce.avgPrice".to_string(),
+                    "KibanaSampleDataEcommerce.countDistinct".to_string(),
+                ]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.order_date".to_string(),
+                    "KibanaSampleDataEcommerce.last_mod".to_string(),
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "KibanaSampleDataEcommerce.notes".to_string(),
+                    "KibanaSampleDataEcommerce.taxful_total_price".to_string(),
+                    "KibanaSampleDataEcommerce.has_subscription".to_string(),
+                ]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ungrouped: Some(true),
+                ..Default::default()
+            }
         )
     }
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -8235,7 +8235,6 @@ ORDER BY "source"."str0" ASC
                 ]),
                 segments: Some(vec![]),
                 order: Some(vec![]),
-                ungrouped: Some(false),
                 ..Default::default()
             }
         )
@@ -15702,7 +15701,6 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                 ]),
                 segments: Some(vec![]),
                 order: Some(vec![]),
-                ungrouped: Some(true),
                 ..Default::default()
             }
         )

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -8213,7 +8213,7 @@ ORDER BY "source"."str0" ASC
         init_testing_logger();
 
         let logical_plan = convert_select_to_query_plan(
-            "SELECT DISTINCT customer_gender FROM \"KibanaSampleDataEcommerce\"".to_string(),
+            "SELECT DISTINCT customer_gender FROM KibanaSampleDataEcommerce".to_string(),
             DatabaseProtocol::PostgreSQL,
         )
         .await
@@ -8226,12 +8226,120 @@ ORDER BY "source"."str0" ASC
             V1LoadRequestQuery {
                 measures: Some(vec![]),
                 dimensions: Some(vec![
-                    // "KibanaSampleDataEcommerce.order_date".to_string(),
-                    // "KibanaSampleDataEcommerce.last_mod".to_string(),
                     "KibanaSampleDataEcommerce.customer_gender".to_string(),
-                    // "KibanaSampleDataEcommerce.notes".to_string(),
-                    // "KibanaSampleDataEcommerce.taxful_total_price".to_string(),
-                    // "KibanaSampleDataEcommerce.has_subscription".to_string(),
+                ]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ..Default::default()
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT customer_gender FROM KibanaSampleDataEcommerce LIMIT 100".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                ]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                limit: Some(100),
+                ..Default::default()
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT * FROM (SELECT customer_gender FROM KibanaSampleDataEcommerce LIMIT 100) q_0".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                ]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                limit: Some(100),
+                ungrouped: Some(true),
+                ..Default::default()
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT customer_gender, order_date FROM KibanaSampleDataEcommerce"
+                .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "KibanaSampleDataEcommerce.order_date".to_string(),
+                ]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ..Default::default()
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT MAX(maxPrice) FROM KibanaSampleDataEcommerce".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.maxPrice".to_string(),]),
+                dimensions: Some(vec![]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ..Default::default()
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            "SELECT DISTINCT * FROM (SELECT customer_gender, MAX(maxPrice) FROM KibanaSampleDataEcommerce GROUP BY 1) q_0".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        println!("logical_plan: {:?}", logical_plan);
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.maxPrice".to_string(),]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
                 ]),
                 segments: Some(vec![]),
                 order: Some(vec![]),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -269,8 +269,8 @@ impl RewriteRules for MemberRules {
                     "?members",
                     "?filters",
                     "?orders",
-                    "?limit",
-                    "?offset",
+                    "CubeScanLimit:None",
+                    "CubeScanOffset:None",
                     "?split",
                     "?can_pushdown_join",
                     "CubeScanWrapped:false",
@@ -281,14 +281,14 @@ impl RewriteRules for MemberRules {
                     "?members",
                     "?filters",
                     "?orders",
-                    "?limit",
-                    "?offset",
+                    "CubeScanLimit:None",
+                    "CubeScanOffset:None",
                     "?split",
                     "?can_pushdown_join",
                     "CubeScanWrapped:false",
                     "CubeScanUngrouped:false",
                 ),
-                self.select_distinct_dimensions(/*"?members",*/ "?limit"),
+                self.select_distinct_dimensions(/*"?members"*/),
             ),
             // MOD function to binary expr
             transforming_rewrite_with_root(
@@ -1509,20 +1509,10 @@ impl MemberRules {
     fn select_distinct_dimensions(
         &self,
         // members_var: &'static str,
-        limit_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         // let members_var = var!(members_var);
-        let limit_var = var!(limit_var);
 
-        move |egraph, subst| {
-            let cube_limit = var_iter!(egraph[subst[limit_var]], CubeScanLimit)
-                .next()
-                .unwrap();
-
-            if cube_limit.is_some() {
-                return false;
-            }
-
+        move |_egraph, _subst| {
             // for members in var_list_iter!(egraph[subst[members_var]], CubeScanMembers) {
             //     // TODO: check if all members in request are dimensions
             //     // If no - return false

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1524,7 +1524,12 @@ impl MemberRules {
                         // we should allow transform only for queries with dimensions only,
                         // as it doesn't make sense for measures
                         meta_context
-                            .find_measure_with_name(member.name().unwrap().to_string())
+                            .find_measure_with_name(
+                                member
+                                    .name()
+                                    .expect("Measure should have a name")
+                                    .to_string(),
+                            )
                             .is_some()
                     })
                 })

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1520,17 +1520,17 @@ impl MemberRules {
                 .member_name_to_expr
                 .as_ref()
                 .map_or(true, |member_names_to_expr| {
-                    !member_names_to_expr.list.iter().any(|(_, member, _)| {
-                        // we should allow transform only for queries with dimensions only,
+                    !member_names_to_expr.list.iter().all(|(_, member, _)| {
+                        // we should allow transform for queries with dimensions only,
                         // as it doesn't make sense for measures
-                        meta_context
-                            .find_measure_with_name(
-                                member
-                                    .name()
-                                    .expect("Measure should have a name")
-                                    .to_string(),
-                            )
-                            .is_some()
+                        if let Some(name) = member.name() {
+                            meta_context
+                                .find_dimension_with_name(name.to_string())
+                                .is_some()
+                                || meta_context.is_synthetic_field(name.to_string())
+                        } else {
+                            true
+                        }
                     })
                 })
         }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -288,7 +288,7 @@ impl RewriteRules for MemberRules {
                     "CubeScanWrapped:false",
                     "CubeScanUngrouped:false",
                 ),
-                self.select_distinct_dimensions("?members", "?limit"),
+                self.select_distinct_dimensions(/*"?members",*/ "?limit"),
             ),
             // MOD function to binary expr
             transforming_rewrite_with_root(
@@ -1508,10 +1508,10 @@ impl MemberRules {
 
     fn select_distinct_dimensions(
         &self,
-        members_var: &'static str,
+        // members_var: &'static str,
         limit_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
-        let members_var = var!(members_var);
+        // let members_var = var!(members_var);
         let limit_var = var!(limit_var);
 
         move |egraph, subst| {
@@ -1523,7 +1523,13 @@ impl MemberRules {
                 return false;
             }
 
-            for members in var_list_iter!(egraph[subst[members_var]], CubeScanMembers) {}
+            // for members in var_list_iter!(egraph[subst[members_var]], CubeScanMembers) {
+            //     // TODO: check if all members in request are dimensions
+            //     // If no - return false
+            //     for member in members.iter() {
+            //         println!("member: {:?}", egraph[*member]);
+            //     }
+            // }
 
             true
         }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1,7 +1,7 @@
 use crate::{
     compile::rewrite::{
         agg_fun_expr, aggregate, alias_expr, all_members,
-        analysis::{ConstantFolding, LogicalPlanData, MemberNamesToExpr, OriginalExpr},
+        analysis::{ConstantFolding, LogicalPlanData, Member, MemberNamesToExpr, OriginalExpr},
         binary_expr, cast_expr, change_user_expr, column_expr, cross_join, cube_scan,
         cube_scan_filters_empty_tail, cube_scan_members, cube_scan_members_empty_tail,
         cube_scan_order_empty_tail, dimension_expr, distinct, expr_column_name, fun_expr, join,
@@ -1548,13 +1548,11 @@ impl MemberRules {
                     names_to_expr.list.iter().all(|(_, member, _)| {
                         // we should allow transform for queries with dimensions only,
                         // as it doesn't make sense for measures
-                        if let Some(name) = member.name() {
-                            meta_context
-                                .find_dimension_with_name(name.to_string())
-                                .is_some()
-                                || meta_context.is_synthetic_field(name.to_string())
-                        } else {
-                            true
+                        match member {
+                            Member::Dimension { .. } => true,
+                            Member::VirtualField { .. } => true,
+                            Member::LiteralMember { .. } => true,
+                            _ => false,
                         }
                     })
                 }


### PR DESCRIPTION
This PR fixes correct Cube query generation for `SELECT DISTINCT xxxx` queries via SQL API.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

