### PR TITLE
fix(cubesql): Break cost symmetry for (non)-push-to-Cube WrappedSelect

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -4,7 +4,7 @@ use crate::{
     compile::rewrite::{
         rules::utils::granularity_str_to_int_order, CubeScanUngrouped, CubeScanWrapped,
         DimensionName, LogicalPlanLanguage, MemberErrorPriority, ScalarUDFExprFun,
-        TimeDimensionGranularity, WrappedSelectUngroupedScan,
+        TimeDimensionGranularity, WrappedSelectPushToCube, WrappedSelectUngroupedScan,
     },
     transport::{MetaContext, V1CubeMetaDimensionExt},
 };
@@ -189,6 +189,11 @@ impl BestCubePlan {
             _ => 0,
         };
 
+        let wrapped_select_non_push_to_cube = match enode {
+            LogicalPlanLanguage::WrappedSelectPushToCube(WrappedSelectPushToCube(false)) => 1,
+            _ => 0,
+        };
+
         let wrapped_select_ungrouped_scan = match enode {
             LogicalPlanLanguage::WrappedSelectUngroupedScan(WrappedSelectUngroupedScan(true)) => 1,
             _ => 0,
@@ -218,6 +223,7 @@ impl BestCubePlan {
             ungrouped_aggregates: 0,
             wrapper_nodes,
             joins,
+            wrapped_select_non_push_to_cube,
             wrapped_select_ungrouped_scan,
             empty_wrappers: 0,
             ast_size_outside_wrapper: 0,
@@ -243,6 +249,7 @@ impl BestCubePlan {
 /// - `member_errors` > `wrapper_nodes` - use SQL push down where possible if cube scan can't be detected
 /// - `non_pushed_down_window` > `wrapper_nodes` - prefer to always push down window functions
 /// - `non_pushed_down_limit_sort` > `wrapper_nodes` - prefer to always push down limit-sort expressions
+/// - `wrapped_select_non_push_to_cube` > `wrapped_select_ungrouped_scan` - otherwise cost would prefer any aggregation, even non-push-to-Cube
 /// - match errors by priority - optimize for more specific errors
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CubePlanCost {
@@ -260,6 +267,7 @@ pub struct CubePlanCost {
     joins: usize,
     wrapper_nodes: i64,
     ast_size_outside_wrapper: usize,
+    wrapped_select_non_push_to_cube: usize,
     wrapped_select_ungrouped_scan: usize,
     filters: i64,
     structure_points: i64,
@@ -386,6 +394,8 @@ impl CubePlanCost {
                 + other.ast_size_outside_wrapper,
             ungrouped_aggregates: self.ungrouped_aggregates + other.ungrouped_aggregates,
             wrapper_nodes: self.wrapper_nodes + other.wrapper_nodes,
+            wrapped_select_non_push_to_cube: self.wrapped_select_non_push_to_cube
+                + other.wrapped_select_non_push_to_cube,
             wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan
                 + other.wrapped_select_ungrouped_scan,
             cube_scan_nodes: self.cube_scan_nodes + other.cube_scan_nodes,
@@ -472,6 +482,7 @@ impl CubePlanCost {
             } + self.ungrouped_aggregates,
             unwrapped_subqueries: self.unwrapped_subqueries,
             wrapper_nodes: self.wrapper_nodes,
+            wrapped_select_non_push_to_cube: self.wrapped_select_non_push_to_cube,
             wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan,
             cube_scan_nodes: self.cube_scan_nodes,
             ast_size_without_alias: self.ast_size_without_alias,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Break symmetry for pust-to-Cube vs non-push-to-Cube plans, and test pushed members count on simple query.

Consider this query:

```
SELECT
    CAST(dim_date0 AS DATE) AS "dim_date0"
FROM
    MultiTypeCube
LIMIT 10
;
```

It can be represented with these two wrapper plans: 

![image](https://github.com/user-attachments/assets/bbd56259-63b9-4bd0-b44b-cb3f41904600)

Without changes in cost both of those would have the same cost:

```
CubePlanCost {
    replacers: 0,
    table_scans: 0,
    empty_wrappers: 0,
    non_detected_cube_scans: 0,
    unwrapped_subqueries: 0,
    member_errors: 0,
    ungrouped_aggregates: 0,
    non_pushed_down_window: 0,
    non_pushed_down_grouping_sets: 0,
    non_pushed_down_limit_sort: 0,
    joins: 0,
    wrapper_nodes: 1,
    ast_size_outside_wrapper: 0,
    wrapped_select_ungrouped_scan: 1,
    filters: 0,
    structure_points: 0,
    filter_members: 0,
    zero_members_wrapper: 1,
    cube_members: 0,
    errors: 0,
    time_dimensions_used_as_dimensions: 0,
    max_time_dimensions_granularity: 0,
    cube_scan_nodes: 1,
    ast_size_without_alias: 38,
    ast_size: 40,
    ast_size_inside_wrapper: 1,
    ungrouped_nodes: 1,
}
```

Which one of those will get executed is implementation defined, and right now top-down and bottom-up cost choose different plans.