### PR TITLE
feat(cubesql): Add projection flattening rule

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -60,6 +60,7 @@ impl RewriteRules for WrapperRules {
         self.aggregate_merge_rules(&mut rules);
         self.projection_rules(&mut rules);
         self.projection_rules_subquery(&mut rules);
+        self.projection_merge_rules(&mut rules);
         self.limit_rules(&mut rules);
         self.filter_rules(&mut rules);
         self.filter_rules_subquery(&mut rules);


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Allow to flatten projection node into internal WrappedSelect. This should allow to execute plans like Projection(Filter(...)) as a single ungrouped wrapper with push-to-Cube
