### PR TITLE
chore!: Remove `running_total` measure type

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -57,7 +57,7 @@ features:
 | Removed    | [Node.js 14](#nodejs-14)                                                                                                          | v0.32.0    | v0.35.0   |
 | Removed    | [Using Redis for in-memory cache and queue](#using-redis-for-in-memory-cache-and-queue)                                           | v0.32.0    | v0.36.0   |
 | Deprecated | [`SECURITY_CONTEXT`](#security_context)                                                                                           | v0.33.0    |           |
-| Deprecated | [`running_total` measure type](#running_total-measure-type)                                                                       | v0.33.39   |           |
+| Removed    | [`running_total` measure type](#running_total-measure-type)                                                                       | v0.33.39   | v1.2.0    |
 | Deprecated | [Top-level `includes` parameter in views](#top-level-includes-parameter-in-views)                                                 | v0.34.34   |           |
 | Removed    | [Node.js 16](#nodejs-16)                                                                                                          | v0.35.0    | v0.36.0   |
 | Removed    | [MySQL-based SQL API](#mysql-based-sql-api)                                                                                       | v0.35.0    | v0.35.0   |
@@ -341,11 +341,11 @@ instead.
 
 ### `running_total` measure type
 
-**Deprecated in Release: v0.33.39**
+**Removed in release: v1.2.0**
 
-The `running_total` measure type is now deprecated, and we recommend using
+The `running_total` measure type has been removed. Instead, we recommend using the
 [`rolling_window`](https://cube.dev/docs/product/data-modeling/reference/measures#rolling_window)
-to calculate running totals instead.
+parameter to calculate running totals.
 
 ### Top-level `includes` parameter in views
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
@@ -126,13 +126,10 @@ export class BaseMeasure {
   }
 
   public static isCumulative(definition) {
-    return definition.type === 'runningTotal' || !!definition.rollingWindow;
+    return !!definition.rollingWindow;
   }
 
   public rollingWindowDefinition() {
-    if (this.measureDefinition().type === 'runningTotal') {
-      throw new UserError('runningTotal rollups aren\'t supported. Please consider replacing runningTotal measure with rollingWindow.');
-    }
     const { type } = this.measureDefinition().rollingWindow;
     if (type && type !== 'fixed') {
       throw new UserError(`Only fixed rolling windows are supported by Cube Store but got '${type}' rolling window`);
@@ -142,9 +139,6 @@ export class BaseMeasure {
 
   public dateJoinCondition() {
     const definition = this.measureDefinition();
-    if (definition.type === 'runningTotal') {
-      return this.query.runningTotalDateJoinCondition();
-    }
     const { rollingWindow } = definition;
     if (rollingWindow.type === 'to_date') {
       return this.query.rollingWindowToDateJoinCondition(rollingWindow.granularity);

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -731,16 +731,6 @@ export class BaseQuery {
     });
   }
 
-  runningTotalDateJoinCondition() {
-    return this.timeDimensions.map(
-      d => [
-        d,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (dateFrom, dateTo, dateField, dimensionDateFrom, dimensionDateTo) => `${dateField} >= ${dimensionDateFrom} AND ${dateField} <= ${dateTo}`
-      ]
-    );
-  }
-
   rollingWindowToDateJoinCondition(granularity) {
     return this.timeDimensions.map(
       d => [
@@ -2675,8 +2665,6 @@ export class BaseQuery {
         this.countDistinctApprox(evaluateSql);
     } else if (symbol.type === 'countDistinct' || symbol.type === 'count' && !symbol.sql && multiplied) {
       return `count(distinct ${evaluateSql})`;
-    } else if (symbol.type === 'runningTotal') {
-      return `sum(${evaluateSql})`; // TODO
     }
     if (multiplied) {
       if (symbol.type === 'number' && evaluateSql === 'count(*)') {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -549,15 +549,15 @@ const CubeRefreshKeySchema = condition(
 );
 
 const measureType = Joi.string().valid(
-  'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox'
+  'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'countDistinctApprox'
 );
 
 const measureTypeWithCount = Joi.string().valid(
-  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox'
+  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'countDistinctApprox'
 );
 
 const multiStageMeasureType = Joi.string().valid(
-  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox',
+  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'countDistinctApprox',
   'rank'
 );
 

--- a/packages/cubejs-schema-compiler/test/integration/mssql/mssql-ungrouped.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/mssql/mssql-ungrouped.test.ts
@@ -50,10 +50,6 @@ describe('MSSqlUngrouped', () => {
           }]
         },
         per_visitor_revenue: perVisitorRevenueMeasure,
-        revenueRunning: {
-          type: 'runningTotal',
-          sql: 'amount'
-        },
         revenueRolling: {
           type: 'sum',
           sql: 'amount',
@@ -84,14 +80,6 @@ describe('MSSqlUngrouped', () => {
             trailing: '2 day',
             offset: 'start'
           }
-        },
-        runningCount: {
-          type: 'runningTotal',
-          sql: '1'
-        },
-        runningRevenuePerCount: {
-          type: 'number',
-          sql: \`round(\${revenueRunning} / \${runningCount})\`
         },
         averageCheckins: {
           type: 'avg',

--- a/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation-logic.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation-logic.test.ts
@@ -45,10 +45,6 @@ describe('SQL Generation', () => {
           }]
         },
         per_visitor_revenue: perVisitorRevenueMeasure,
-        revenueRunning: {
-          type: 'runningTotal',
-          sql: 'amount'
-        },
         revenueRolling: {
           type: 'sum',
           sql: 'amount',
@@ -79,14 +75,6 @@ describe('SQL Generation', () => {
             trailing: '2 day',
             offset: 'start'
           }
-        },
-        runningCount: {
-          type: 'runningTotal',
-          sql: '1'
-        },
-        runningRevenuePerCount: {
-          type: 'number',
-          sql: \`round(\${revenueRunning} / \${runningCount})\`
         },
         averageCheckins: {
           type: 'avg',


### PR DESCRIPTION
BREAKING CHANGE: `running_total` measure type has long been deprecated. Use the `rolling_window` parameter instead.