### PR TITLE
fix(cubejs-client-ngx): Configure package-level Lerna publish directory for Angular

### DIFF
--- a/packages/cubejs-client-ngx/.gitignore
+++ b/packages/cubejs-client-ngx/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .yalc/
 yalc.lock
+.angular/

--- a/packages/cubejs-client-ngx/README.md
+++ b/packages/cubejs-client-ngx/README.md
@@ -2,7 +2,7 @@
 
 [Website](https://cube.dev) • [Docs](https://cube.dev/docs) • [Blog](https://cube.dev/blog) • [Slack](https://slack.cube.dev) • [Twitter](https://twitter.com/the_cube_dev)
 
-[![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
+[![npm version](https://badge.fury.io/js/%40cubejs-client%2Fngx.svg)](https://badge.fury.io/js/%40cubejs-client%2Fngx)
 [![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
 
 # Cube.js Angular Client

--- a/packages/cubejs-client-ngx/package.json
+++ b/packages/cubejs-client-ngx/package.json
@@ -9,9 +9,16 @@
     "directory": "packages/cubejs-client-ngx"
   },
   "description": "Cube.js client for Angular",
-  "files": [
-    "dist"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "lerna": {
+    "command": {
+      "publish": {
+        "directory": "dist"
+      }
+    }
+  },
   "license": "MIT",
   "scripts": {
     "build": "ng build",


### PR DESCRIPTION
This pull request updates the `@cubejs-client/ngx` package to explicitly define its Lerna publish directory at the package level. Previously, Lerna was publishing the entire dist folder instead of its contents, leading to module resolution issues when linking the package in Angular projects.

Key changes include adding the `lerna.command.publish.directory` configuration inside the package’s package.json, ensuring that Lerna correctly publishes from the intended dist location.

Reference: [Lerna directory documentation](https://lerna.js.org/docs/concepts/configuring-published-files#--directory)

