### PR TITLE
feat: PatchMeasure member expression

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -30,6 +30,7 @@
     "@cubejs-backend/native": "1.2.30",
     "@cubejs-backend/shared": "1.2.30",
     "@ungap/structured-clone": "^0.3.4",
+    "assert-never": "^1.4.0",
     "body-parser": "^1.19.0",
     "chrono-node": "^2.6.2",
     "express": "^4.21.1",

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1395,17 +1395,17 @@ class ApiGateway {
   private parseMemberExpression(memberExpression: string): string | ParsedMemberExpression {
     if (memberExpression.startsWith('{')) {
       const obj = parseInputMemberExpression(JSON.parse(memberExpression));
-      const args = obj.cube_params;
+      const args = obj.cubeParams;
       args.push(`return \`${obj.expr}\``);
 
-      const groupingSet = obj.grouping_set ? {
-        groupType: obj.grouping_set.group_type,
-        id: obj.grouping_set.id,
-        subId: obj.grouping_set.sub_id ? obj.grouping_set.sub_id : undefined
+      const groupingSet = obj.groupingSet ? {
+        groupType: obj.groupingSet.groupType,
+        id: obj.groupingSet.id,
+        subId: obj.groupingSet.subId ? obj.groupingSet.subId : undefined
       } : undefined;
 
       return {
-        cubeName: obj.cube_name,
+        cubeName: obj.cubeName,
         name: obj.alias,
         expressionName: obj.alias,
         expression: args,

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -83,6 +83,7 @@ import {
   normalizeQueryCancelPreAggregations,
   normalizeQueryPreAggregationPreview,
   normalizeQueryPreAggregations,
+  parseInputMemberExpression,
   preAggsJobsRequestSchema,
   remapToQueryAdapterFormat,
 } from './query';
@@ -1392,30 +1393,26 @@ class ApiGateway {
   }
 
   private parseMemberExpression(memberExpression: string): string | ParsedMemberExpression {
-    try {
-      if (memberExpression.startsWith('{')) {
-        const obj = JSON.parse(memberExpression);
-        const args = obj.cube_params;
-        args.push(`return \`${obj.expr}\``);
+    if (memberExpression.startsWith('{')) {
+      const obj = parseInputMemberExpression(JSON.parse(memberExpression));
+      const args = obj.cube_params;
+      args.push(`return \`${obj.expr}\``);
 
-        const groupingSet = obj.grouping_set ? {
-          groupType: obj.grouping_set.group_type,
-          id: obj.grouping_set.id,
-          subId: obj.grouping_set.sub_id ? obj.grouping_set.sub_id : undefined
-        } : undefined;
+      const groupingSet = obj.grouping_set ? {
+        groupType: obj.grouping_set.group_type,
+        id: obj.grouping_set.id,
+        subId: obj.grouping_set.sub_id ? obj.grouping_set.sub_id : undefined
+      } : undefined;
 
-        return {
-          cubeName: obj.cube_name,
-          name: obj.alias,
-          expressionName: obj.alias,
-          expression: args,
-          definition: memberExpression,
-          groupingSet,
-        };
-      } else {
-        return memberExpression;
-      }
-    } catch {
+      return {
+        cubeName: obj.cube_name,
+        name: obj.alias,
+        expressionName: obj.alias,
+        expression: args,
+        definition: memberExpression,
+        groupingSet,
+      };
+    } else {
       return memberExpression;
     }
   }

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -59,11 +59,17 @@ const memberExpression = parsedMemberExpression.keys({
 });
 
 // This should be aligned with cubesql side
+const inputMemberExpressionSqlFunction = Joi.object().keys({
+  type: Joi.valid('SqlFunction').required(),
+  cubeParams: Joi.array().items(Joi.string()).required(),
+  sql: Joi.string().required(),
+});
+
+// This should be aligned with cubesql side
 const inputMemberExpression = Joi.object().keys({
   cubeName: Joi.string().required(),
   alias: Joi.string().required(),
-  cubeParams: Joi.array().items(Joi.string()).required(),
-  expr: Joi.string().required(),
+  expr: Joi.alternatives(inputMemberExpressionSqlFunction),
   groupingSet: Joi.object().keys({
     groupType: Joi.valid('Rollup', 'Cube').required(),
     id: Joi.number().required(),

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -60,19 +60,14 @@ const memberExpression = parsedMemberExpression.keys({
 
 // This should be aligned with cubesql side
 const inputMemberExpression = Joi.object().keys({
-  // eslint-disable-next-line camelcase
-  cube_name: Joi.string().required(),
+  cubeName: Joi.string().required(),
   alias: Joi.string().required(),
-  // eslint-disable-next-line camelcase
-  cube_params: Joi.array().items(Joi.string()).required(),
+  cubeParams: Joi.array().items(Joi.string()).required(),
   expr: Joi.string().required(),
-  // eslint-disable-next-line camelcase
-  grouping_set: Joi.object().keys({
-    // eslint-disable-next-line camelcase
-    group_type: Joi.valid('Rollup', 'Cube').required(),
+  groupingSet: Joi.object().keys({
+    groupType: Joi.valid('Rollup', 'Cube').required(),
     id: Joi.number().required(),
-    // eslint-disable-next-line camelcase
-    sub_id: Joi.number().allow(null),
+    subId: Joi.number().allow(null),
   }).allow(null)
 });
 

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -58,6 +58,24 @@ const memberExpression = parsedMemberExpression.keys({
   expression: Joi.func().required(),
 });
 
+// This should be aligned with cubesql side
+const inputMemberExpression = Joi.object().keys({
+  // eslint-disable-next-line camelcase
+  cube_name: Joi.string().required(),
+  alias: Joi.string().required(),
+  // eslint-disable-next-line camelcase
+  cube_params: Joi.array().items(Joi.string()).required(),
+  expr: Joi.string().required(),
+  // eslint-disable-next-line camelcase
+  grouping_set: Joi.object().keys({
+    // eslint-disable-next-line camelcase
+    group_type: Joi.valid('Rollup', 'Cube').required(),
+    id: Joi.number().required(),
+    // eslint-disable-next-line camelcase
+    sub_id: Joi.number().allow(null),
+  }).allow(null)
+});
+
 const operators = [
   'equals',
   'notEquals',
@@ -214,6 +232,20 @@ const normalizeQueryFilters = (filter) => (
     return res;
   })
 );
+
+/**
+ * Parse incoming member expression
+ * @param {unknown} expression
+ * @throws {import('./UserError').UserError}
+ * @returns {import('./types/query').InputMemberExpression}
+ */
+function parseInputMemberExpression(expression) {
+  const { error } = inputMemberExpression.validate(expression);
+  if (error) {
+    throw new UserError(`Invalid member expression format: ${error.message || error.toString()}`);
+  }
+  return expression;
+}
 
 /**
  * Normalize incoming network query.
@@ -384,5 +416,6 @@ export {
   normalizeQueryPreAggregations,
   normalizeQueryPreAggregationPreview,
   normalizeQueryCancelPreAggregations,
+  parseInputMemberExpression,
   remapToQueryAdapterFormat,
 };

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -46,8 +46,26 @@ type GroupingSet = {
     subId?: null | number
 };
 
+export type EvalPatchMeasureFilterExpression = {
+  sql: Function,
+};
+
+export type PatchMeasureExpression = {
+  type: 'PatchMeasure',
+  sourceMeasure: string,
+  replaceAggregationType: string | null,
+  addFilters: Array<Array<string>>,
+};
+
+export type EvalPatchMeasureExpression = {
+  type: 'PatchMeasure',
+  sourceMeasure: string,
+  replaceAggregationType: string | null,
+  addFilters: Array<EvalPatchMeasureFilterExpression>,
+};
+
 type ParsedMemberExpression = {
-  expression: string[];
+  expression: string[] | PatchMeasureExpression;
   cubeName: string;
   name: string;
   expressionName: string;
@@ -56,20 +74,32 @@ type ParsedMemberExpression = {
 };
 
 type MemberExpression = Omit<ParsedMemberExpression, 'expression'> & {
-  expression: Function;
+  expression: Function | EvalPatchMeasureExpression;
+};
+
+type InputSqlFunction = {
+  cubeParams: Array<string>,
+  sql: string,
 };
 
 export type InputMemberExpressionSqlFunction = {
   type: 'SqlFunction'
-  cubeParams: Array<string>,
-  sql: string,
+} & InputSqlFunction;
+
+export type InputMemberExpressionPatchMeasure = {
+  type: 'PatchMeasure',
+  sourceMeasure: string,
+  replaceAggregationType: string | null,
+  addFilters: Array<InputSqlFunction>,
 };
+
+export type InputMemberExpressionExpr = InputMemberExpressionSqlFunction | InputMemberExpressionPatchMeasure;
 
 // This should be aligned with cubesql side
 export type InputMemberExpression = {
   cubeName: string,
   alias: string,
-  expr: InputMemberExpressionSqlFunction,
+  expr: InputMemberExpressionExpr,
   groupingSet: GroupingSet | null,
 };
 

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -38,8 +38,10 @@ type LogicalOrFilter = {
   or: (QueryFilter | LogicalAndFilter)[]
 };
 
+export type GroupingSetType = 'Rollup' | 'Cube';
+
 type GroupingSet = {
-    groupType: string,
+    groupType: GroupingSetType,
     id: number,
     subId?: null | number
 };
@@ -55,6 +57,26 @@ type ParsedMemberExpression = {
 
 type MemberExpression = Omit<ParsedMemberExpression, 'expression'> & {
   expression: Function;
+};
+
+export type InputGroupingSetDesc = {
+  // eslint-disable-next-line camelcase
+  group_type: GroupingSetType,
+  id: number,
+  // eslint-disable-next-line camelcase
+  sub_id: number | null,
+};
+
+// This should be aligned with cubesql side
+export type InputMemberExpression = {
+  // eslint-disable-next-line camelcase
+  cube_name: string,
+  alias: string,
+  // eslint-disable-next-line camelcase
+  cube_params: Array<string>,
+  expr: string,
+  // eslint-disable-next-line camelcase
+  grouping_set: InputGroupingSetDesc | null,
 };
 
 /**

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -59,24 +59,13 @@ type MemberExpression = Omit<ParsedMemberExpression, 'expression'> & {
   expression: Function;
 };
 
-export type InputGroupingSetDesc = {
-  // eslint-disable-next-line camelcase
-  group_type: GroupingSetType,
-  id: number,
-  // eslint-disable-next-line camelcase
-  sub_id: number | null,
-};
-
 // This should be aligned with cubesql side
 export type InputMemberExpression = {
-  // eslint-disable-next-line camelcase
-  cube_name: string,
+  cubeName: string,
   alias: string,
-  // eslint-disable-next-line camelcase
-  cube_params: Array<string>,
+  cubeParams: Array<string>,
   expr: string,
-  // eslint-disable-next-line camelcase
-  grouping_set: InputGroupingSetDesc | null,
+  groupingSet: GroupingSet | null,
 };
 
 /**

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -59,12 +59,17 @@ type MemberExpression = Omit<ParsedMemberExpression, 'expression'> & {
   expression: Function;
 };
 
+export type InputMemberExpressionSqlFunction = {
+  type: 'SqlFunction'
+  cubeParams: Array<string>,
+  sql: string,
+};
+
 // This should be aligned with cubesql side
 export type InputMemberExpression = {
   cubeName: string,
   alias: string,
-  cubeParams: Array<string>,
-  expr: string,
+  expr: InputMemberExpressionSqlFunction,
   groupingSet: GroupingSet | null,
 };
 

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -774,13 +774,13 @@ describe('API Gateway', () => {
     const query = {
       measures: [
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cubeName":"sales","alias":"sum_sales_line_i","cubeParams":["sales"],"expr":"SUM(${sales.line_items_price})","groupingSet":null}'
+        '{"cubeName":"sales","alias":"sum_sales_line_i","expr":{"type":"SqlFunction","cubeParams":["sales"],"sql":"SUM(${sales.line_items_price})"},"groupingSet":null}'
       ],
       dimensions: [
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cubeName":"sales","alias":"users_age","cubeParams":["sales"],"expr":"${sales.users_age}","groupingSet":null}',
+        '{"cubeName":"sales","alias":"users_age","expr":{"type":"SqlFunction","cubeParams":["sales"],"sql":"${sales.users_age}"},"groupingSet":null}',
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cubeName":"sales","alias":"cast_sales_users","cubeParams":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","groupingSet":null}'
+        '{"cubeName":"sales","alias":"cast_sales_users","expr":{"type":"SqlFunction","cubeParams":["sales"],"sql":"CAST(${sales.users_first_name} AS TEXT)"},"groupingSet":null}'
       ],
       segments: [],
       order: []

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -771,6 +771,21 @@ describe('API Gateway', () => {
   });
 
   describe('sql api member expressions evaluations', () => {
+    const query = {
+      measures: [
+        // eslint-disable-next-line no-template-curly-in-string
+        '{"cube_name":"sales","alias":"sum_sales_line_i","cube_params":["sales"],"expr":"SUM(${sales.line_items_price})","grouping_set":null}'
+      ],
+      dimensions: [
+        // eslint-disable-next-line no-template-curly-in-string
+        '{"cube_name":"sales","alias":"users_age","cube_params":["sales"],"expr":"${sales.users_age}","grouping_set":null}',
+        // eslint-disable-next-line no-template-curly-in-string
+        '{"cube_name":"sales","alias":"cast_sales_users","cube_params":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","grouping_set":null}'
+      ],
+      segments: [],
+      order: []
+    };
+
     test('throw error if expressions are not allowed', async () => {
       const { apiGateway } = await createApiGateway();
       const request: QueryRequest = {
@@ -779,20 +794,7 @@ describe('API Gateway', () => {
           const errorMessage = message as { error: string };
           expect(errorMessage.error).toEqual('Error: Expressions are not allowed in this context');
         },
-        query: {
-          measures: [
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"sum_sales_line_i","cube_params":["sales"],"expr":"SUM(${sales.line_items_price})","grouping_set":null}'
-          ],
-          dimensions: [
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"users_age","cube_params":["sales"],"expr":"${sales.users_age}","grouping_set":null}',
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"cast_sales_users","cube_params":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","grouping_set":null}'
-          ],
-          segments: [],
-          order: []
-        },
+        query,
         expressionParams: [],
         exportAnnotatedSql: true,
         memberExpressions: false,
@@ -820,20 +822,7 @@ describe('API Gateway', () => {
         res(message) {
           expect(message.hasOwnProperty('sql')).toBe(true);
         },
-        query: {
-          measures: [
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"sum_sales_line_i","cube_params":["sales"],"expr":"SUM(${sales.line_items_price})","grouping_set":null}'
-          ],
-          dimensions: [
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"users_age","cube_params":["sales"],"expr":"${sales.users_age}","grouping_set":null}',
-            // eslint-disable-next-line no-template-curly-in-string
-            '{"cube_name":"sales","alias":"cast_sales_users","cube_params":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","grouping_set":null}'
-          ],
-          segments: [],
-          order: []
-        },
+        query,
         expressionParams: [],
         exportAnnotatedSql: true,
         memberExpressions: true,

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -774,13 +774,13 @@ describe('API Gateway', () => {
     const query = {
       measures: [
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cube_name":"sales","alias":"sum_sales_line_i","cube_params":["sales"],"expr":"SUM(${sales.line_items_price})","grouping_set":null}'
+        '{"cubeName":"sales","alias":"sum_sales_line_i","cubeParams":["sales"],"expr":"SUM(${sales.line_items_price})","groupingSet":null}'
       ],
       dimensions: [
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cube_name":"sales","alias":"users_age","cube_params":["sales"],"expr":"${sales.users_age}","grouping_set":null}',
+        '{"cubeName":"sales","alias":"users_age","cubeParams":["sales"],"expr":"${sales.users_age}","groupingSet":null}',
         // eslint-disable-next-line no-template-curly-in-string
-        '{"cube_name":"sales","alias":"cast_sales_users","cube_params":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","grouping_set":null}'
+        '{"cubeName":"sales","alias":"cast_sales_users","cubeParams":["sales"],"expr":"CAST(${sales.users_first_name} AS TEXT)","groupingSet":null}'
       ],
       segments: [],
       order: []

--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
@@ -1,5 +1,6 @@
 import { UserError } from '../compiler/UserError';
 import type { BaseQuery } from './BaseQuery';
+import { MeasureDefinition } from "../compiler/CubeEvaluator";
 
 export class BaseMeasure {
   public readonly expression: any;
@@ -9,6 +10,100 @@ export class BaseMeasure {
   public readonly expressionName: any;
 
   public readonly isMemberExpression: boolean = false;
+
+  protected readonly patchedMeasure: MeasureDefinition | null = null;
+
+  protected preparePatchedMeasure(sourceMeasure: string, newMeasureType: string | null, addFilters: Array<{sql: Function}>): MeasureDefinition {
+    const source = this.query.cubeEvaluator.measureByPath(sourceMeasure);
+
+    let resultMeasureType = source.type;
+    if (newMeasureType !== null) {
+      switch (source.type) {
+        case 'sum':
+        case 'avg':
+        case 'min':
+        case 'max':
+          switch (newMeasureType) {
+            case 'sum':
+            case 'avg':
+            case 'min':
+            case 'max':
+            case 'count_distinct':
+            case 'count_distinct_approx':
+              // Can change from avg/... to count_distinct
+              // Latter does not care what input value is
+              // ok, do nothing
+              break;
+            default:
+              throw new UserError(
+                `Unsupported measure type replacement for ${sourceMeasure}: ${source.type} => ${newMeasureType}`
+              );
+          }
+          break;
+        case 'count_distinct':
+        case 'count_distinct_approx':
+          switch (newMeasureType) {
+            case 'count_distinct':
+            case 'count_distinct_approx':
+              // ok, do nothing
+              break;
+            default:
+              // Can not change from count_distinct to avg/...
+              // Latter do care what input value is, and original measure can be defined on strings
+              throw new UserError(
+                `Unsupported measure type replacement for ${sourceMeasure}: ${source.type} => ${newMeasureType}`
+              );
+          }
+          break;
+        default:
+          // Can not change from string, time, boolean, number
+          // Aggregation is already included in SQL, it's hard to patch that
+          // Can not change from count
+          // There's no SQL at all
+          throw new UserError(
+            `Unsupported measure type replacement for ${sourceMeasure}: ${source.type} => ${newMeasureType}`
+          );
+      }
+
+      resultMeasureType = newMeasureType;
+    }
+
+    const resultFilters = source.filters ?? [];
+
+    if (addFilters.length > 0) {
+      switch (resultMeasureType) {
+        case 'sum':
+        case 'avg':
+        case 'min':
+        case 'max':
+        case 'count':
+        case 'count_distinct':
+        case 'count_distinct_approx':
+          // ok, do nothing
+          break;
+        default:
+          // Can not add filters to string, time, boolean, number
+          // Aggregation is already included in SQL, it's hard to patch that
+          throw new UserError(
+            `Unsupported additional filters for measure ${sourceMeasure} type ${source.type}`
+          );
+      }
+
+      resultFilters.push(...addFilters);
+    }
+
+    const patchedFrom = this.query.cubeEvaluator.parsePath('measures', sourceMeasure);
+
+    return {
+      ...source,
+      type: resultMeasureType,
+      filters: resultFilters,
+      patchedFrom: {
+        cubeName: patchedFrom[0],
+        name: patchedFrom[1],
+      },
+    };
+  }
 
   public constructor(
     protected readonly query: BaseQuery,
@@ -20,6 +115,14 @@ export class BaseMeasure {
       // In case of SQL push down expressionName doesn't contain cube name. It's just a column name.
       this.expressionName = measure.expressionName || `${measure.cubeName}.${measure.name}`;
       this.isMemberExpression = !!measure.definition;
+
+      if (measure.expression.type === 'PatchMeasure') {
+        this.patchedMeasure = this.preparePatchedMeasure(
+          measure.expression.sourceMeasure,
+          measure.expression.replaceAggregationType,
+          measure.expression.addFilters,
+        );
+      }
     }
   }
 
@@ -74,10 +177,16 @@ export class BaseMeasure {
   }
 
   public measureDefinition() {
+    if (this.patchedMeasure) {
+      return this.patchedMeasure;
+    }
     return this.query.cubeEvaluator.measureByPath(this.measure);
   }
 
   public definition(): any {
+    if (this.patchedMeasure) {
+      return this.patchedMeasure;
+    }
     if (this.expression) {
       return {
         sql: this.expression,

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -56,6 +56,7 @@ export type MeasureDefinition = {
   reduceByReferences?: string[],
   addGroupByReferences?: string[],
   timeShiftReferences?: TimeShiftDefinitionReference[],
+  patchedFrom?: { cubeName: string, name: string },
 };
 
 export type PreAggregationFilters = {

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -546,6 +546,40 @@ Array [
 ]
 `;
 
+exports[`SQL API Postgres (Data) measure with ad-hoc filter and original measure: measure-with-ad-hoc-filters-and-original-measure 1`] = `
+Array [
+  Object {
+    "new_amount": 300,
+    "total_amount": 1700,
+  },
+]
+`;
+
+exports[`SQL API Postgres (Data) measure with ad-hoc filter: measure-with-ad-hoc-filters 1`] = `
+Array [
+  Object {
+    "new_amount": 300,
+  },
+]
+`;
+
+exports[`SQL API Postgres (Data) measure with replaced aggregation and original measure: measure-with-replaced-aggregation-and-original-measure 1`] = `
+Array [
+  Object {
+    "min_amount": 100,
+    "sum_amount": 1700,
+  },
+]
+`;
+
+exports[`SQL API Postgres (Data) measure with replaced aggregation: measure-with-replaced-aggregation 1`] = `
+Array [
+  Object {
+    "min_amount": 100,
+  },
+]
+`;
+
 exports[`SQL API Postgres (Data) metabase max number: metabase max number 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -796,5 +796,67 @@ filter_subq AS (
       const res = await connection.query(query);
       expect(res.rows).toMatchSnapshot('wrapper-duplicated-members');
     });
+
+    test('measure with replaced aggregation', async () => {
+      const query = `
+        SELECT
+          MIN(totalAmount) AS min_amount
+        FROM
+          Orders
+      `;
+
+      const res = await connection.query(query);
+      expect(res.rows).toMatchSnapshot('measure-with-replaced-aggregation');
+    });
+
+    test('measure with replaced aggregation and original measure', async () => {
+      const query = `
+        SELECT
+          SUM(totalAmount) AS sum_amount,
+          MIN(totalAmount) AS min_amount
+        FROM
+          Orders
+      `;
+
+      const res = await connection.query(query);
+      expect(res.rows).toMatchSnapshot('measure-with-replaced-aggregation-and-original-measure');
+    });
+
+    test('measure with ad-hoc filter', async () => {
+      const query = `
+      SELECT
+        SUM(
+          CASE status = 'new'
+          WHEN TRUE
+          THEN totalAmount
+          ELSE NULL
+          END
+        ) AS new_amount
+      FROM
+        Orders
+      `;
+
+      const res = await connection.query(query);
+      expect(res.rows).toMatchSnapshot('measure-with-ad-hoc-filters');
+    });
+
+    test('measure with ad-hoc filter and original measure', async () => {
+      const query = `
+      SELECT
+        SUM(totalAmount) AS total_amount,
+        SUM(
+          CASE status = 'new'
+          WHEN TRUE
+          THEN totalAmount
+          ELSE NULL
+          END
+        ) AS new_amount
+      FROM
+        Orders
+      `;
+
+      const res = await connection.query(query);
+      expect(res.rows).toMatchSnapshot('measure-with-ad-hoc-filters-and-original-measure');
+    });
   });
 });

--- a/rust/cubesql/cubesql/src/compile/engine/df/snapshots/cubesql__compile__engine__df__wrapper__tests__member_expression_patch_measure.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/snapshots/cubesql__compile__engine__df__wrapper__tests__member_expression_patch_measure.snap
@@ -1,0 +1,22 @@
+---
+source: cubesql/src/compile/engine/df/wrapper.rs
+expression: "UngroupedMemberDef\n{\n    cube_name: \"cube\".to_string(), alias: \"alias\".to_string(), expr:\n    UngroupedMemberExpr::PatchMeasure(PatchMeasureDef\n    {\n        source_measure: \"cube.measure\".to_string(), replace_aggregation_type:\n        None, add_filters:\n        vec![SqlFunctionExpr\n        {\n            cube_params: vec![\"cube\".to_string()], sql:\n            \"1 + 2 = 3\".to_string(),\n        }],\n    }), grouping_set: None,\n}"
+---
+{
+  "cubeName": "cube",
+  "alias": "alias",
+  "expr": {
+    "type": "PatchMeasure",
+    "sourceMeasure": "cube.measure",
+    "replaceAggregationType": null,
+    "addFilters": [
+      {
+        "cubeParams": [
+          "cube"
+        ],
+        "sql": "1 + 2 = 3"
+      }
+    ]
+  },
+  "groupingSet": null
+}

--- a/rust/cubesql/cubesql/src/compile/engine/df/snapshots/cubesql__compile__engine__df__wrapper__tests__member_expression_sql.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/snapshots/cubesql__compile__engine__df__wrapper__tests__member_expression_sql.snap
@@ -1,0 +1,17 @@
+---
+source: cubesql/src/compile/engine/df/wrapper.rs
+expression: "UngroupedMemberDef\n{\n    cube_name: \"cube\".to_string(), alias: \"alias\".to_string(), expr:\n    UngroupedMemberExpr::SqlFunction(SqlFunctionExpr\n    {\n        cube_params: vec![\"cube\".to_string(), \"other\".to_string()], sql:\n        \"1 + 2\".to_string(),\n    }), grouping_set: None,\n}"
+---
+{
+  "cubeName": "cube",
+  "alias": "alias",
+  "expr": {
+    "type": "SqlFunction",
+    "cubeParams": [
+      "cube",
+      "other"
+    ],
+    "sql": "1 + 2"
+  },
+  "groupingSet": null
+}

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2,7 +2,7 @@ use crate::{
     compile::{
         engine::{
             df::scan::{CubeScanNode, DataType, MemberField, WrappedSelectNode},
-            udf::MEASURE_UDAF_NAME,
+            udf::{MEASURE_UDAF_NAME, PATCH_MEASURE_UDAF_NAME},
         },
         rewrite::{
             extract_exprlist_from_groupping_set,
@@ -76,9 +76,20 @@ struct SqlFunctionExpr {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct PatchMeasureDef {
+    #[serde(rename = "sourceMeasure")]
+    source_measure: String,
+    #[serde(rename = "replaceAggregationType")]
+    replace_aggregation_type: Option<String>,
+    #[serde(rename = "addFilters")]
+    add_filters: Vec<SqlFunctionExpr>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 enum UngroupedMemberExpr {
     SqlFunction(SqlFunctionExpr),
+    PatchMeasure(PatchMeasureDef),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1197,6 +1208,20 @@ impl CubeScanWrapperNode {
                             )
                             .await?;
                             let group_descs = extract_group_type_from_groupping_set(&group_expr)?;
+
+                            let (patch_measures, aggr_expr, sql) = Self::extract_patch_measures(
+                                schema.as_ref(),
+                                aggr_expr,
+                                sql,
+                                generator.clone(),
+                                column_remapping,
+                                &mut next_remapper,
+                                can_rename_columns,
+                                push_to_cube_context,
+                                subqueries_sql.clone(),
+                            )
+                            .await?;
+
                             let (aggregate, sql) = Self::generate_column_expr(
                                 schema.clone(),
                                 aggr_expr.clone(),
@@ -1356,6 +1381,11 @@ impl CubeScanWrapperNode {
                                                     &ungrouped_scan_node.used_cubes,
                                                 )
                                             }))
+                                            .chain(patch_measures.into_iter().map(
+                                                |(def, cube, alias)| {
+                                                    Self::patch_measure_expr(def, cube, alias)
+                                                },
+                                            ))
                                             .collect::<Result<_>>()?,
                                     ),
                                     dimensions: Some(
@@ -1411,6 +1441,7 @@ impl CubeScanWrapperNode {
                                                                 .map(|(_e, c)| c.0.clone())
                                                         };
 
+                                                        // TODO handle patch measures collection here
                                                         let aliased_column = find_column(&aggr_expr, &aggregate)
                                                             .or_else(|| find_column(&projection_expr, &projection))
                                                             .or_else(|| find_column(&flat_group_expr, &group_by))
@@ -1491,6 +1522,12 @@ impl CubeScanWrapperNode {
                                     request: load_request.clone(),
                                 })
                             } else {
+                                if !patch_measures.is_empty() {
+                                    return Err(CubeError::internal(format!(
+                                        "Unexpected patch measures for non-push-to-Cube wrapped select: {patch_measures:?}",
+                                    )));
+                                }
+
                                 let resulting_sql = generator
                                     .get_sql_templates()
                                     .select(
@@ -1563,6 +1600,179 @@ impl CubeScanWrapperNode {
         })
     }
 
+    fn get_patch_measure<'l>(
+        sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: &'l Expr,
+        push_to_cube_context: Option<&'l PushToCubeContext<'_>>,
+        subqueries: Arc<HashMap<String, String>>,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = result::Result<
+                        (Option<(PatchMeasureDef, String)>, SqlQuery),
+                        CubeError,
+                    >,
+                > + Send
+                + 'l,
+        >,
+    > {
+        Box::pin(async move {
+            match expr {
+                Expr::Alias(inner, _alias) => {
+                    Self::get_patch_measure(
+                        sql_query,
+                        sql_generator,
+                        inner,
+                        push_to_cube_context,
+                        subqueries,
+                    )
+                    .await
+                }
+                Expr::AggregateUDF { fun, args } => {
+                    if fun.name != PATCH_MEASURE_UDAF_NAME {
+                        return Ok((None, sql_query));
+                    }
+
+                    let Some(PushToCubeContext {
+                        ungrouped_scan_node,
+                        ..
+                    }) = push_to_cube_context
+                    else {
+                        return Err(CubeError::internal(format!(
+                            "Unexpected UDAF expression without push-to-Cube context: {}",
+                            fun.name
+                        )));
+                    };
+
+                    let (measure, aggregation, filter) = match args.as_slice() {
+                        [measure, aggregation, filter] => (measure, aggregation, filter),
+                        _ => {
+                            return Err(CubeError::internal(format!(
+                                "Unexpected number arguments for UDAF: {}, {args:?}",
+                                fun.name
+                            )))
+                        }
+                    };
+
+                    let Expr::Column(measure_column) = measure else {
+                        return Err(CubeError::internal(format!(
+                            "First argument should be column expression: {}",
+                            fun.name
+                        )));
+                    };
+
+                    let aggregation = match aggregation {
+                        Expr::Literal(ScalarValue::Utf8(Some(aggregation))) => Some(aggregation),
+                        Expr::Literal(ScalarValue::Null) => None,
+                        _ => {
+                            return Err(CubeError::internal(format!(
+                                "Second argument should be Utf8 literal expression: {}",
+                                fun.name
+                            )));
+                        }
+                    };
+
+                    let (filters, sql_query) = match filter {
+                        Expr::Literal(ScalarValue::Null) => (vec![], sql_query),
+                        _ => {
+                            let mut used_members = HashSet::new();
+                            let (filter, sql_query) = Self::generate_sql_for_expr(
+                                sql_query,
+                                sql_generator.clone(),
+                                filter.clone(),
+                                push_to_cube_context,
+                                subqueries.clone(),
+                                Some(&mut used_members),
+                            )
+                            .await?;
+
+                            let used_cubes = Self::prepare_used_cubes(&used_members);
+
+                            (
+                                vec![SqlFunctionExpr {
+                                    cube_params: used_cubes,
+                                    sql: filter,
+                                }],
+                                sql_query,
+                            )
+                        }
+                    };
+
+                    let member =
+                        Self::find_member_in_ungrouped_scan(ungrouped_scan_node, measure_column)?;
+
+                    let MemberField::Member(member) = member else {
+                        return Err(CubeError::internal(format!(
+                            "First argument should reference member, not literal: {}",
+                            fun.name
+                        )));
+                    };
+
+                    let (cube, _member) = member.split_once('.').ok_or_else(|| {
+                        CubeError::internal(format!("Can't parse cube name from member {member}",))
+                    })?;
+
+                    Ok((
+                        Some((
+                            PatchMeasureDef {
+                                source_measure: member.clone(),
+                                replace_aggregation_type: aggregation.cloned(),
+                                add_filters: filters,
+                            },
+                            cube.to_string(),
+                        )),
+                        sql_query,
+                    ))
+                }
+                _ => Ok((None, sql_query)),
+            }
+        })
+    }
+
+    async fn extract_patch_measures(
+        schema: &DFSchema,
+        exprs: impl IntoIterator<Item = Expr>,
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        column_remapping: Option<&ColumnRemapping>,
+        next_remapper: &mut Remapper,
+        can_rename_columns: bool,
+        push_to_cube_context: Option<&PushToCubeContext<'_>>,
+        subqueries: Arc<HashMap<String, String>>,
+    ) -> result::Result<(Vec<(PatchMeasureDef, String, String)>, Vec<Expr>, SqlQuery), CubeError>
+    {
+        let mut patches = vec![];
+        let mut other = vec![];
+
+        for original_expr in exprs {
+            let (patch_def, sql_query_next) = Self::get_patch_measure(
+                sql_query,
+                sql_generator.clone(),
+                &original_expr,
+                push_to_cube_context,
+                subqueries.clone(),
+            )
+            .await?;
+            sql_query = sql_query_next;
+            if let Some((patch_def, cube)) = patch_def {
+                let (_expr, alias) = Self::remap_column_expression(
+                    schema,
+                    &original_expr,
+                    column_remapping,
+                    next_remapper,
+                    can_rename_columns,
+                )?;
+
+                patches.push((patch_def, cube, alias));
+            } else {
+                other.push(original_expr);
+            }
+        }
+
+        Ok((patches, other, sql_query))
+    }
+
     fn remap_column_expression(
         schema: &DFSchema,
         original_expr: &Expr,
@@ -1633,18 +1843,22 @@ impl CubeScanWrapperNode {
         Ok((aliased_columns, sql))
     }
 
-    fn make_member_def<'m>(
-        column: &AliasedColumn,
-        used_members: impl IntoIterator<Item = &'m String>,
-        ungrouped_scan_cubes: &Vec<String>,
-    ) -> Result<UngroupedMemberDef> {
-        let used_cubes = used_members
+    fn prepare_used_cubes<'m>(used_members: impl IntoIterator<Item = &'m String>) -> Vec<String> {
+        used_members
             .into_iter()
             .flat_map(|member| member.split_once('.'))
             .map(|(cube, _rest)| cube)
             .unique()
             .map(|cube| cube.to_string())
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+    }
+
+    fn make_member_def<'m>(
+        column: &AliasedColumn,
+        used_members: impl IntoIterator<Item = &'m String>,
+        ungrouped_scan_cubes: &Vec<String>,
+    ) -> Result<UngroupedMemberDef> {
+        let used_cubes = Self::prepare_used_cubes(used_members);
         let cube_name = used_cubes
             .first()
             .or_else(|| ungrouped_scan_cubes.first())
@@ -1685,6 +1899,21 @@ impl CubeScanWrapperNode {
     ) -> Result<String> {
         let mut res = Self::make_member_def(column, used_members, ungrouped_scan_cubes)?;
         res.grouping_set = grouping_type.clone();
+        Ok(serde_json::json!(res).to_string())
+    }
+
+    fn patch_measure_expr(
+        def: PatchMeasureDef,
+        cube_name: String,
+        alias: String,
+    ) -> Result<String> {
+        let res = UngroupedMemberDef {
+            cube_name,
+            alias,
+            expr: UngroupedMemberExpr::PatchMeasure(def),
+            grouping_set: None,
+        };
+
         Ok(serde_json::json!(res).to_string())
     }
 
@@ -2874,6 +3103,7 @@ impl CubeScanWrapperNode {
 
                             Ok((format!("${{{member}}}"), sql_query))
                         }
+                        // There's no branch for PatchMeasure, because it should generate via different path
                         _ => Err(DataFusionError::Internal(format!(
                             "Can't generate SQL for UDAF: {}",
                             fun.name
@@ -3046,5 +3276,40 @@ impl UserDefinedLogicalNode for CubeScanWrapperNode {
             span_id: self.span_id.clone(),
             config_obj: self.config_obj.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_member_expression_sql() {
+        insta::assert_json_snapshot!(UngroupedMemberDef {
+            cube_name: "cube".to_string(),
+            alias: "alias".to_string(),
+            expr: UngroupedMemberExpr::SqlFunction(SqlFunctionExpr {
+                cube_params: vec!["cube".to_string(), "other".to_string()],
+                sql: "1 + 2".to_string(),
+            }),
+            grouping_set: None,
+        });
+    }
+
+    #[test]
+    fn test_member_expression_patch_measure() {
+        insta::assert_json_snapshot!(UngroupedMemberDef {
+            cube_name: "cube".to_string(),
+            alias: "alias".to_string(),
+            expr: UngroupedMemberExpr::PatchMeasure(PatchMeasureDef {
+                source_measure: "cube.measure".to_string(),
+                replace_aggregation_type: None,
+                add_filters: vec![SqlFunctionExpr {
+                    cube_params: vec!["cube".to_string()],
+                    sql: "1 + 2 = 3".to_string(),
+                }],
+            }),
+            grouping_set: None,
+        });
     }
 }

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2948,11 +2948,12 @@ impl CubeScanWrapperNode {
         ungrouped_scan_node: &'scan CubeScanNode,
         column: &'col Column,
     ) -> Result<&'scan MemberField> {
-        let field_index = ungrouped_scan_node
+        let (_field, member) = ungrouped_scan_node
             .schema
             .fields()
             .iter()
-            .find_position(|f| {
+            .zip(ungrouped_scan_node.member_fields.iter())
+            .find(|(f, _mf)| {
                 f.name() == &column.name
                     && match column.relation.as_ref() {
                         Some(r) => Some(r) == f.qualifier(),
@@ -2961,16 +2962,7 @@ impl CubeScanWrapperNode {
             })
             .ok_or_else(|| {
                 DataFusionError::Internal(format!(
-                    "Can't find column {column} in ungrouped scan node",
-                ))
-            })?
-            .0;
-        let member = ungrouped_scan_node
-            .member_fields
-            .get(field_index)
-            .ok_or_else(|| {
-                DataFusionError::Internal(format!(
-                    "Can't find member for column {column} in ungrouped scan node",
+                    "Can't find member for column {column} in ungrouped scan node"
                 ))
             })?;
 

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -1172,7 +1172,6 @@ impl CubeScanWrapperNode {
                                 })?
                                 .clone();
                             let (projection, sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 projection_expr.clone(),
                                 sql,
@@ -1186,7 +1185,6 @@ impl CubeScanWrapperNode {
                             .await?;
                             let flat_group_expr = extract_exprlist_from_groupping_set(&group_expr);
                             let (group_by, sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 flat_group_expr.clone(),
                                 sql,
@@ -1200,7 +1198,6 @@ impl CubeScanWrapperNode {
                             .await?;
                             let group_descs = extract_group_type_from_groupping_set(&group_expr)?;
                             let (aggregate, sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 aggr_expr.clone(),
                                 sql,
@@ -1214,7 +1211,6 @@ impl CubeScanWrapperNode {
                             .await?;
 
                             let (filter, sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 filter_expr.clone(),
                                 sql,
@@ -1228,7 +1224,6 @@ impl CubeScanWrapperNode {
                             .await?;
 
                             let (window, sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 window_expr.clone(),
                                 sql,
@@ -1242,7 +1237,6 @@ impl CubeScanWrapperNode {
                             .await?;
 
                             let (order, mut sql) = Self::generate_column_expr(
-                                plan.clone(),
                                 schema.clone(),
                                 order_expr.clone(),
                                 sql,
@@ -1270,7 +1264,6 @@ impl CubeScanWrapperNode {
                                 {
                                     // Need to call generate_column_expr to apply column_remapping
                                     let (join_condition, new_sql) = Self::generate_column_expr(
-                                        plan.clone(),
                                         schema.clone(),
                                         [condition.clone()],
                                         sql,
@@ -1582,7 +1575,6 @@ impl CubeScanWrapperNode {
     }
 
     async fn generate_column_expr(
-        _plan: Arc<Self>,
         schema: DFSchemaRef,
         exprs: impl IntoIterator<Item = Expr>,
         mut sql: SqlQuery,

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -67,10 +67,13 @@ pub struct SqlQuery {
 
 #[derive(Debug, Clone, Serialize)]
 struct UngrouppedMemberDef {
+    #[serde(rename = "cubeName")]
     cube_name: String,
     alias: String,
+    #[serde(rename = "cubeParams")]
     cube_params: Vec<String>,
     expr: String,
+    #[serde(rename = "groupingSet")]
     grouping_set: Option<GroupingSetDesc>,
 }
 
@@ -82,8 +85,10 @@ pub enum GroupingSetType {
 
 #[derive(Clone, Serialize, Debug, PartialEq, Eq)]
 pub struct GroupingSetDesc {
+    #[serde(rename = "groupType")]
     pub group_type: GroupingSetType,
     pub id: u64,
+    #[serde(rename = "subId")]
     pub sub_id: Option<u64>,
 }
 

--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -2289,6 +2289,39 @@ pub fn create_measure_udaf() -> AggregateUDF {
     )
 }
 
+pub const PATCH_MEASURE_UDAF_NAME: &str = "__patch_measure";
+
+// TODO add sanity check on incoming query to disallow it in input
+pub fn create_patch_measure_udaf() -> AggregateUDF {
+    // TODO actually signature should look like (any, text, boolean)
+    let signature = Signature::any(3, Volatility::Immutable);
+
+    // __PATCH_MEASURE(cube.measure, type, filter) should have same type as just cube.measure
+    let return_type: ReturnTypeFunction = Arc::new(move |inputs| {
+        if inputs.len() != 3 {
+            Err(DataFusionError::Internal(format!(
+                "Unexpected argument types for {PATCH_MEASURE_UDAF_NAME}: {inputs:?}"
+            )))
+        } else {
+            Ok(Arc::new(inputs[0].clone()))
+        }
+    });
+
+    let accumulator: AccumulatorFunctionImplementation =
+        Arc::new(|| todo!("Internal, should not execute"));
+
+    let state_type = Arc::new(vec![DataType::Float64]);
+    let state_type: StateTypeFunction = Arc::new(move |_| Ok(state_type.clone()));
+
+    AggregateUDF::new(
+        PATCH_MEASURE_UDAF_NAME,
+        &signature,
+        &return_type,
+        &accumulator,
+        &state_type,
+    )
+}
+
 macro_rules! generate_series_udtf {
     ($ARGS:expr, $TYPE: ident, $PRIMITIVE_TYPE: ident) => {{
         let mut section_sizes: Vec<usize> = Vec::new();

--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -2259,6 +2259,8 @@ pub fn create_pg_get_constraintdef_udf() -> ScalarUDF {
     )
 }
 
+pub const MEASURE_UDAF_NAME: &str = "measure";
+
 pub fn create_measure_udaf() -> AggregateUDF {
     let signature = Signature::any(1, Volatility::Immutable);
 
@@ -2279,7 +2281,7 @@ pub fn create_measure_udaf() -> AggregateUDF {
     let state_type: StateTypeFunction = Arc::new(move |_| Ok(state_type.clone()));
 
     AggregateUDF::new(
-        "measure",
+        MEASURE_UDAF_NAME,
         &signature,
         &return_type,
         &accumulator,

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -7229,11 +7229,11 @@ ORDER BY
 
         fn trivial_member_expr(cube: &str, member: &str, alias: &str) -> String {
             json!({
-                "cube_name": cube,
+                "cubeName": cube,
                 "alias": alias,
-                "cube_params": [cube],
+                "cubeParams": [cube],
                 "expr": format!("${{{cube}.{member}}}"),
-                "grouping_set": null,
+                "groupingSet": null,
             })
             .to_string()
         }
@@ -7246,35 +7246,35 @@ ORDER BY
             V1LoadRequestQuery {
                 measures: Some(vec![
                     json!({
-                        "cube_name": "WideCube",
+                        "cubeName": "WideCube",
                         "alias": "max_source_measu",
-                        "cube_params": ["WideCube"],
+                        "cubeParams": ["WideCube"],
                         "expr": "${WideCube.measure1}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     })
                     .to_string(),
                     json!({
-                        "cube_name": "WideCube",
+                        "cubeName": "WideCube",
                         "alias": "max_source_measu_1",
-                        "cube_params": ["WideCube"],
+                        "cubeParams": ["WideCube"],
                         "expr": "${WideCube.measure2}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     })
                     .to_string(),
                     json!({
-                        "cube_name": "WideCube",
+                        "cubeName": "WideCube",
                         "alias": "sum_source_measu",
-                        "cube_params": ["WideCube"],
+                        "cubeParams": ["WideCube"],
                         "expr": "${WideCube.measure3}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     })
                     .to_string(),
                     json!({
-                        "cube_name": "WideCube",
+                        "cubeName": "WideCube",
                         "alias": "max_source_measu_2",
-                        "cube_params": ["WideCube"],
+                        "cubeParams": ["WideCube"],
                         "expr": "${WideCube.measure4}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     })
                     .to_string(),
                 ]),
@@ -7283,11 +7283,11 @@ ORDER BY
                     trivial_member_expr("WideCube", "dim3", "dim3"),
                     trivial_member_expr("WideCube", "dim4", "dim4"),
                     json!({
-                        "cube_name": "WideCube",
+                        "cubeName": "WideCube",
                         "alias": "pivot_grouping",
-                        "cube_params": [],
+                        "cubeParams": [],
                         "expr": "0",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     })
                     .to_string()
                 ]),
@@ -11807,20 +11807,20 @@ ORDER BY "source"."str0" ASC
                 measures: Some(vec![]),
                 dimensions: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "ta_1_order_date_",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "((${KibanaSampleDataEcommerce.order_date} = DATE('1994-05-01')) OR (${KibanaSampleDataEcommerce.order_date} = DATE('1996-05-03')))",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 segments: Some(vec![
                     json!({
-                        "cube_name": "Logs",
+                        "cubeName": "Logs",
                         "alias": "lower_ta_2_conte",
-                        "cube_params": ["Logs"],
+                        "cubeParams": ["Logs"],
                         "expr": "(LOWER(${Logs.content}) = $0$)",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 order: Some(vec![]),
@@ -12088,34 +12088,34 @@ ORDER BY "source"."str0" ASC
                 measures: Some(vec![]),
                 dimensions: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "customer_gender",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "${KibanaSampleDataEcommerce.customer_gender}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "cast_dateadd_utf",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "CAST(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') AS DATE)",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "dateadd_utf8__se",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2000000 MILLISECOND')",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 segments: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "dateadd_utf8__da",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') < DATE('2014-06-02'))",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 order: Some(vec![]),
@@ -12914,29 +12914,29 @@ ORDER BY "source"."str0" ASC
             V1LoadRequestQuery {
                 measures: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "avg_kibanasample",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "${KibanaSampleDataEcommerce.avgPrice}",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 dimensions: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "cast_kibanasampl",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": "CAST(${KibanaSampleDataEcommerce.order_date} AS DATE)",
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 segments: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "kibanasampledata",
-                        "cube_params": ["KibanaSampleDataEcommerce"],
+                        "cubeParams": ["KibanaSampleDataEcommerce"],
                         "expr": format!("(((${{KibanaSampleDataEcommerce.order_date}} >= CAST((NOW() + INTERVAL '-30 DAY') AS DATE)) AND (${{KibanaSampleDataEcommerce.order_date}} < CAST(NOW() AS DATE))) AND (((${{KibanaSampleDataEcommerce.notes}} = $0$) OR (${{KibanaSampleDataEcommerce.notes}} = $1$)) OR (${{KibanaSampleDataEcommerce.notes}} = $2$)))"),
-                        "grouping_set": null,
+                        "groupingSet": null,
                     }).to_string(),
                 ]),
                 order: Some(vec![]),

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -2783,17 +2783,14 @@ limit
 
     #[tokio::test]
     async fn test_select_error() {
-        let variants = [
-            (
-                "SELECT AVG(maxPrice) FROM KibanaSampleDataEcommerce".to_string(),
-                CompilationError::user("Error during rewrite: Measure aggregation type doesn't match. The aggregation type for 'maxPrice' is 'MAX()' but 'AVG()' was provided. Please check logs for additional information.".to_string()),
-            ),
+        let variants: &[(&str, _)] = &[
+            // TODO are there any errors that we could test for?
         ];
 
-        for (input_query, expected_error) in variants.iter() {
+        for (input_query, expected_error) in variants {
             let meta = get_test_tenant_ctx();
             let query = convert_sql_to_cube_query(
-                &input_query,
+                input_query,
                 meta.clone(),
                 get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
             )

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -7231,8 +7231,11 @@ ORDER BY
             json!({
                 "cubeName": cube,
                 "alias": alias,
-                "cubeParams": [cube],
-                "expr": format!("${{{cube}.{member}}}"),
+                "expr": {
+                    "type": "SqlFunction",
+                    "cubeParams": [cube],
+                    "sql": format!("${{{cube}.{member}}}"),
+                },
                 "groupingSet": null,
             })
             .to_string()
@@ -7248,32 +7251,44 @@ ORDER BY
                     json!({
                         "cubeName": "WideCube",
                         "alias": "max_source_measu",
-                        "cubeParams": ["WideCube"],
-                        "expr": "${WideCube.measure1}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["WideCube"],
+                            "sql": "${WideCube.measure1}",
+                        },
                         "groupingSet": null,
                     })
                     .to_string(),
                     json!({
                         "cubeName": "WideCube",
                         "alias": "max_source_measu_1",
-                        "cubeParams": ["WideCube"],
-                        "expr": "${WideCube.measure2}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["WideCube"],
+                            "sql": "${WideCube.measure2}",
+                        },
                         "groupingSet": null,
                     })
                     .to_string(),
                     json!({
                         "cubeName": "WideCube",
                         "alias": "sum_source_measu",
-                        "cubeParams": ["WideCube"],
-                        "expr": "${WideCube.measure3}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["WideCube"],
+                            "sql": "${WideCube.measure3}",
+                        },
                         "groupingSet": null,
                     })
                     .to_string(),
                     json!({
                         "cubeName": "WideCube",
                         "alias": "max_source_measu_2",
-                        "cubeParams": ["WideCube"],
-                        "expr": "${WideCube.measure4}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["WideCube"],
+                            "sql": "${WideCube.measure4}",
+                        },
                         "groupingSet": null,
                     })
                     .to_string(),
@@ -7285,8 +7300,11 @@ ORDER BY
                     json!({
                         "cubeName": "WideCube",
                         "alias": "pivot_grouping",
-                        "cubeParams": [],
-                        "expr": "0",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": [],
+                            "sql": "0",
+                        },
                         "groupingSet": null,
                     })
                     .to_string()
@@ -11809,8 +11827,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "ta_1_order_date_",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "((${KibanaSampleDataEcommerce.order_date} = DATE('1994-05-01')) OR (${KibanaSampleDataEcommerce.order_date} = DATE('1996-05-03')))",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "((${KibanaSampleDataEcommerce.order_date} = DATE('1994-05-01')) OR (${KibanaSampleDataEcommerce.order_date} = DATE('1996-05-03')))",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -11818,8 +11839,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "Logs",
                         "alias": "lower_ta_2_conte",
-                        "cubeParams": ["Logs"],
-                        "expr": "(LOWER(${Logs.content}) = $0$)",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["Logs"],
+                            "sql": "(LOWER(${Logs.content}) = $0$)",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -12090,22 +12114,31 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "customer_gender",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "${KibanaSampleDataEcommerce.customer_gender}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "${KibanaSampleDataEcommerce.customer_gender}",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "cast_dateadd_utf",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "CAST(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') AS DATE)",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "CAST(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') AS DATE)",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "dateadd_utf8__se",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2000000 MILLISECOND')",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2000000 MILLISECOND')",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -12113,8 +12146,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "dateadd_utf8__da",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') < DATE('2014-06-02'))",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "(DATE_ADD(${KibanaSampleDataEcommerce.order_date}, INTERVAL '2 DAY') < DATE('2014-06-02'))",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -12916,8 +12952,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "avg_kibanasample",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "${KibanaSampleDataEcommerce.avgPrice}",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "${KibanaSampleDataEcommerce.avgPrice}",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -12925,8 +12964,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "cast_kibanasampl",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": "CAST(${KibanaSampleDataEcommerce.order_date} AS DATE)",
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": "CAST(${KibanaSampleDataEcommerce.order_date} AS DATE)",
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),
@@ -12934,8 +12976,11 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cubeName": "KibanaSampleDataEcommerce",
                         "alias": "kibanasampledata",
-                        "cubeParams": ["KibanaSampleDataEcommerce"],
-                        "expr": format!("(((${{KibanaSampleDataEcommerce.order_date}} >= CAST((NOW() + INTERVAL '-30 DAY') AS DATE)) AND (${{KibanaSampleDataEcommerce.order_date}} < CAST(NOW() AS DATE))) AND (((${{KibanaSampleDataEcommerce.notes}} = $0$) OR (${{KibanaSampleDataEcommerce.notes}} = $1$)) OR (${{KibanaSampleDataEcommerce.notes}} = $2$)))"),
+                        "expr": {
+                            "type": "SqlFunction",
+                            "cubeParams": ["KibanaSampleDataEcommerce"],
+                            "sql": format!("(((${{KibanaSampleDataEcommerce.order_date}} >= CAST((NOW() + INTERVAL '-30 DAY') AS DATE)) AND (${{KibanaSampleDataEcommerce.order_date}} < CAST(NOW() AS DATE))) AND (((${{KibanaSampleDataEcommerce.notes}} = $0$) OR (${{KibanaSampleDataEcommerce.notes}} = $1$)) OR (${{KibanaSampleDataEcommerce.notes}} = $2$)))"),
+                        },
                         "groupingSet": null,
                     }).to_string(),
                 ]),

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -516,6 +516,7 @@ impl QueryEngine for SqlQueryEngine {
 
         // udaf
         ctx.register_udaf(create_measure_udaf());
+        ctx.register_udaf(create_patch_measure_udaf());
 
         // udtf
         ctx.register_udtf(create_generate_series_udtf());

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -1,5 +1,6 @@
 use crate::{
     compile::{
+        engine::udf::MEASURE_UDAF_NAME,
         rewrite::{
             converter::{is_expr_node, node_to_expr, LogicalPlanToLanguageConverter},
             expr_column_name,
@@ -389,7 +390,7 @@ impl LogicalPlanAnalysis {
                 Some(trivial)
             }
             LogicalPlanLanguage::AggregateUDFExprFun(AggregateUDFExprFun(fun)) => {
-                if fun.to_lowercase() == "measure" {
+                if fun.to_lowercase() == MEASURE_UDAF_NAME {
                     Some(0)
                 } else {
                     None

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -644,6 +644,8 @@ macro_rules! variant_field_struct {
                     } else if let Some(value) = typed_str.strip_prefix("f:") {
                         let n: f64 = value.parse().map_err(|err| Self::Err::InvalidFloatValue(err))?;
                         Ok([<$variant $var_field:camel>](ScalarValue::Float64(Some(n))))
+                    } else if typed_str == "null" {
+                        Ok([<$variant $var_field:camel>](ScalarValue::Null))
                     } else {
                         Err(Self::Err::InvalidScalarType)
                     }

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -261,8 +261,12 @@ macro_rules! variant_field_struct {
 
             impl FromStr for [<$variant $var_field:camel>] {
                 type Err = $crate::compile::rewrite::language::LanguageParseError;
-                fn from_str(_s: &str) -> Result<Self, Self::Err> {
-                    Err(Self::Err::NotSupported)
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    const PREFIX: &'static str = concat!(std::stringify!([<$variant $var_field:camel>]), ":");
+                    if let Some(suffix) =  s.strip_prefix(PREFIX) {
+                        return Ok([<$variant $var_field:camel>](suffix.to_string()));
+                    }
+                    Err(Self::Err::ShouldStartWith(PREFIX))
                 }
             }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1780,6 +1780,11 @@ fn literal_bool(literal_bool: bool) -> String {
     format!("(LiteralExpr LiteralExprValue:b:{})", literal_bool)
 }
 
+#[allow(dead_code)]
+fn literal_null() -> String {
+    format!("(LiteralExpr LiteralExprValue:null)")
+}
+
 fn projection(
     expr: impl Display,
     input: impl Display,

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1419,9 +1419,13 @@ fn window_fun_expr_var_arg(
 }
 
 fn udaf_expr(fun_name: impl Display, args: Vec<impl Display>) -> String {
+    let prefix = if fun_name.to_string().starts_with("?") {
+        ""
+    } else {
+        "AggregateUDFExprFun:"
+    };
     format!(
-        "(AggregateUDFExpr {} {})",
-        fun_name,
+        "(AggregateUDFExpr {prefix}{fun_name} {})",
         list_expr("AggregateUDFExprArgs", args),
     )
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1780,7 +1780,6 @@ fn literal_bool(literal_bool: bool) -> String {
     format!("(LiteralExpr LiteralExprValue:b:{})", literal_bool)
 }
 
-#[allow(dead_code)]
 fn literal_null() -> String {
     format!("(LiteralExpr LiteralExprValue:null)")
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1,31 +1,35 @@
 use crate::{
-    compile::rewrite::{
-        agg_fun_expr, aggregate, alias_expr, all_members,
-        analysis::{ConstantFolding, LogicalPlanData, Member, MemberNamesToExpr, OriginalExpr},
-        binary_expr, cast_expr, change_user_expr, column_expr, cross_join, cube_scan,
-        cube_scan_filters_empty_tail, cube_scan_members, cube_scan_members_empty_tail,
-        cube_scan_order_empty_tail, dimension_expr, distinct, expr_column_name, fun_expr, join,
-        like_expr, limit, list_concat_pushdown_replacer, list_concat_pushup_replacer, literal_expr,
-        literal_member, measure_expr, member_pushdown_replacer, member_replacer,
-        merged_members_replacer, original_expr_name, projection, referenced_columns, rewrite,
-        rewriter::{CubeEGraph, CubeRewrite, RewriteRules},
-        rules::{
-            replacer_flat_push_down_node_substitute_rules, replacer_push_down_node,
-            replacer_push_down_node_substitute_rules, utils,
+    compile::{
+        engine::udf::MEASURE_UDAF_NAME,
+        rewrite::{
+            agg_fun_expr, aggregate, alias_expr, all_members,
+            analysis::{ConstantFolding, LogicalPlanData, Member, MemberNamesToExpr, OriginalExpr},
+            binary_expr, cast_expr, change_user_expr, column_expr, cross_join, cube_scan,
+            cube_scan_filters_empty_tail, cube_scan_members, cube_scan_members_empty_tail,
+            cube_scan_order_empty_tail, dimension_expr, distinct, expr_column_name, fun_expr, join,
+            like_expr, limit, list_concat_pushdown_replacer, list_concat_pushup_replacer,
+            literal_expr, literal_member, measure_expr, member_pushdown_replacer, member_replacer,
+            merged_members_replacer, original_expr_name, projection, referenced_columns, rewrite,
+            rewriter::{CubeEGraph, CubeRewrite, RewriteRules},
+            rules::{
+                replacer_flat_push_down_node_substitute_rules, replacer_push_down_node,
+                replacer_push_down_node_substitute_rules, utils,
+            },
+            segment_expr, table_scan, time_dimension_expr, transform_original_expr_to_alias,
+            transforming_chain_rewrite, transforming_rewrite, transforming_rewrite_with_root,
+            udaf_expr, udf_expr, virtual_field_expr, AggregateFunctionExprDistinct,
+            AggregateFunctionExprFun, AliasExprAlias, AllMembersAlias, AllMembersCube,
+            BinaryExprOp, CastExprDataType, ChangeUserCube, ColumnExprColumn, CubeScanAliasToCube,
+            CubeScanCanPushdownJoin, CubeScanLimit, CubeScanOffset, CubeScanUngrouped,
+            DimensionName, JoinLeftOn, JoinRightOn, LikeExprEscapeChar, LikeExprLikeType,
+            LikeExprNegated, LikeType, LimitFetch, LimitSkip, ListType, LiteralExprValue,
+            LiteralMemberRelation, LiteralMemberValue, LogicalPlanLanguage, MeasureName,
+            MemberErrorAliasToCube, MemberErrorError, MemberErrorPriority,
+            MemberPushdownReplacerAliasToCube, MemberReplacerAliasToCube, ProjectionAlias,
+            SegmentName, TableScanFetch, TableScanProjection, TableScanSourceTableName,
+            TableScanTableName, TimeDimensionDateRange, TimeDimensionGranularity,
+            TimeDimensionName, VirtualFieldCube, VirtualFieldName,
         },
-        segment_expr, table_scan, time_dimension_expr, transform_original_expr_to_alias,
-        transforming_chain_rewrite, transforming_rewrite, transforming_rewrite_with_root,
-        udaf_expr, udf_expr, virtual_field_expr, AggregateFunctionExprDistinct,
-        AggregateFunctionExprFun, AliasExprAlias, AllMembersAlias, AllMembersCube, BinaryExprOp,
-        CastExprDataType, ChangeUserCube, ColumnExprColumn, CubeScanAliasToCube,
-        CubeScanCanPushdownJoin, CubeScanLimit, CubeScanOffset, CubeScanUngrouped, DimensionName,
-        JoinLeftOn, JoinRightOn, LikeExprEscapeChar, LikeExprLikeType, LikeExprNegated, LikeType,
-        LimitFetch, LimitSkip, ListType, LiteralExprValue, LiteralMemberRelation,
-        LiteralMemberValue, LogicalPlanLanguage, MeasureName, MemberErrorAliasToCube,
-        MemberErrorError, MemberErrorPriority, MemberPushdownReplacerAliasToCube,
-        MemberReplacerAliasToCube, ProjectionAlias, SegmentName, TableScanFetch,
-        TableScanProjection, TableScanSourceTableName, TableScanTableName, TimeDimensionDateRange,
-        TimeDimensionGranularity, TimeDimensionName, VirtualFieldCube, VirtualFieldName,
     },
     config::ConfigObj,
     transport::{MetaContext, V1CubeMetaDimensionExt, V1CubeMetaExt, V1CubeMetaMeasureExt},
@@ -123,7 +127,7 @@ impl RewriteRules for MemberRules {
             ),
             self.measure_rewrite(
                 "measure-fun",
-                udaf_expr("?aggr_fun", vec![column_expr("?column")]),
+                udaf_expr(MEASURE_UDAF_NAME, vec![column_expr("?column")]),
                 Some("?column"),
                 None,
                 None,
@@ -646,7 +650,7 @@ impl MemberRules {
         ));
         rules.extend(find_matching_old_member(
             "udaf-fun",
-            udaf_expr("?fun_name", vec![column_expr("?column")]),
+            udaf_expr(MEASURE_UDAF_NAME, vec![column_expr("?column")]),
         ));
         rules.extend(find_matching_old_member_with_count(
             "agg-fun-default-count",
@@ -1099,7 +1103,7 @@ impl MemberRules {
         ));
         rules.push(pushdown_measure_rewrite(
             "member-pushdown-replacer-udaf-fun",
-            udaf_expr("?fun_name", vec![column_expr("?column")]),
+            udaf_expr(MEASURE_UDAF_NAME, vec![column_expr("?column")]),
             measure_expr("?name", "?old_alias"),
             None,
             None,
@@ -1108,7 +1112,7 @@ impl MemberRules {
         ));
         rules.push(pushdown_measure_rewrite(
             "member-pushdown-replacer-udaf-fun-on-dimension",
-            udaf_expr("?fun_name", vec![column_expr("?column")]),
+            udaf_expr(MEASURE_UDAF_NAME, vec![column_expr("?column")]),
             dimension_expr("?name", "?old_alias"),
             None,
             None,

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join_grouped.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join_grouped.rs
@@ -117,21 +117,21 @@ GROUP BY
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
     // Dimension from ungrouped side
     assert!(query_plan
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
     // Dimension from grouped side
     assert!(query_plan
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"\\\"kibana_grouped\\\".\\\"avg_price\\\"\""#));
+        .contains(r#"\"sql\":\"\\\"kibana_grouped\\\".\\\"avg_price\\\"\""#));
 }
 
 /// Simple join between ungrouped and grouped query should plan as a push-to-Cube query
@@ -200,21 +200,21 @@ ON (
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
     // Dimension from ungrouped side
     assert!(query_plan
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
     // Dimension from grouped side
     assert!(query_plan
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"\\\"kibana_grouped\\\".\\\"avg_price\\\"\""#));
+        .contains(r#"\"sql\":\"\\\"kibana_grouped\\\".\\\"avg_price\\\"\""#));
 }
 
 /// Join between ungrouped and grouped query with two columns join condition
@@ -284,7 +284,7 @@ ON (
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
 }
 
 /// Join between ungrouped and grouped query with filter + sort + limit
@@ -362,7 +362,7 @@ GROUP BY 1
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
 }
 
 #[tokio::test]
@@ -451,7 +451,7 @@ LIMIT 1000
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.avgPrice}\""#));
 
     // Outer sort
     assert!(wrapped_sql_node
@@ -553,7 +553,7 @@ GROUP BY
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"(CAST(${MultiTypeCube.dim_str1} AS STRING) = $1)\""#));
+        .contains(r#"\"sql\":\"(CAST(${MultiTypeCube.dim_str1} AS STRING) = $1)\""#));
 
     // Dimension from top aggregation
 
@@ -564,14 +564,14 @@ GROUP BY
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"CAST(${MultiTypeCube.dim_str0} AS STRING)\""#));
+        .contains(r#"\"sql\":\"CAST(${MultiTypeCube.dim_str0} AS STRING)\""#));
 
     // Measure from top aggregation
     assert_eq!(wrapped_sql_node.request.measures.as_ref().unwrap().len(), 1);
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${MultiTypeCube.countDistinct}\""#));
+        .contains(r#"\"sql\":\"${MultiTypeCube.countDistinct}\""#));
 }
 
 /// Ungrouped-grouped join with complex condition should plan as push-to-Cube query
@@ -664,14 +664,14 @@ GROUP BY
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${MultiTypeCube.avgPrice}\""#));
+        .contains(r#"\"sql\":\"${MultiTypeCube.avgPrice}\""#));
     // Dimension from ungrouped side
     assert!(query_plan
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${MultiTypeCube.dim_str0}\""#));
+        .contains(r#"\"sql\":\"${MultiTypeCube.dim_str0}\""#));
 }
 
 #[tokio::test]
@@ -747,7 +747,7 @@ GROUP BY
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"(((${KibanaSampleDataEcommerce.notes} >= $1) AND (${KibanaSampleDataEcommerce.notes} <= $2)) OR ((${KibanaSampleDataEcommerce.notes} >= $3) AND (${KibanaSampleDataEcommerce.notes} <= $4)))\""#));
+        .contains(r#"\"sql\":\"(((${KibanaSampleDataEcommerce.notes} >= $1) AND (${KibanaSampleDataEcommerce.notes} <= $2)) OR ((${KibanaSampleDataEcommerce.notes} >= $3) AND (${KibanaSampleDataEcommerce.notes} <= $4)))\""#));
 
     // Dimension from top aggregation
     assert_eq!(
@@ -757,14 +757,14 @@ GROUP BY
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.customer_gender}\""#));
 
     // Measure from top aggregation
     assert_eq!(wrapped_sql_node.request.measures.as_ref().unwrap().len(), 1);
     assert!(wrapped_sql_node
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${KibanaSampleDataEcommerce.sumPrice}\""#));
+        .contains(r#"\"sql\":\"${KibanaSampleDataEcommerce.sumPrice}\""#));
 }
 
 #[tokio::test]

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -97,7 +97,7 @@ async fn test_filter_dim_in_null() {
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"${MultiTypeCube.dim_str1} IN (NULL)\""#));
+        .contains(r#"\"sql\":\"${MultiTypeCube.dim_str1} IN (NULL)\""#));
 }
 
 #[tokio::test]
@@ -131,5 +131,5 @@ SELECT dim_str0 FROM MultiTypeCube WHERE (dim_str1 IS NULL OR dim_str1 IN (NULL)
         .find_cube_scan_wrapped_sql()
         .wrapped_sql
         .sql
-        .contains(r#"\"expr\":\"((${MultiTypeCube.dim_str1} IS NULL) OR (${MultiTypeCube.dim_str1} IN (NULL) AND FALSE))\""#));
+        .contains(r#"\"sql\":\"((${MultiTypeCube.dim_str1} IS NULL) OR (${MultiTypeCube.dim_str1} IN (NULL) AND FALSE))\""#));
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1261,26 +1261,35 @@ async fn test_wrapper_filter_flatten() {
             measures: Some(vec![json!({
                 "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "sum_kibanasample",
-                "cubeParams": ["KibanaSampleDataEcommerce"],
-                // This is grouped query, KibanaSampleDataEcommerce.sumPrice is correct in this context
-                // SUM(sumPrice) will be incrrect here, it would lead to SUM(SUM(sql)) in generated query
-                "expr": "${KibanaSampleDataEcommerce.sumPrice}",
+                "expr": {
+                    "type": "SqlFunction",
+                    "cubeParams": ["KibanaSampleDataEcommerce"],
+                    // This is grouped query, KibanaSampleDataEcommerce.sumPrice is correct in this context
+                    // SUM(sumPrice) will be incrrect here, it would lead to SUM(SUM(sql)) in generated query
+                    "sql": "${KibanaSampleDataEcommerce.sumPrice}",
+                },
                 "groupingSet": null,
             })
             .to_string(),]),
             dimensions: Some(vec![json!({
                 "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "customer_gender",
-                "cubeParams": ["KibanaSampleDataEcommerce"],
-                "expr": "${KibanaSampleDataEcommerce.customer_gender}",
+                "expr": {
+                    "type": "SqlFunction",
+                    "cubeParams": ["KibanaSampleDataEcommerce"],
+                    "sql": "${KibanaSampleDataEcommerce.customer_gender}",
+                },
                 "groupingSet": null,
             })
             .to_string(),]),
             segments: Some(vec![json!({
                 "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "lower_kibanasamp",
-                "cubeParams": ["KibanaSampleDataEcommerce"],
-                "expr": "(LOWER(${KibanaSampleDataEcommerce.customer_gender}) = $0$)",
+                "expr": {
+                    "type": "SqlFunction",
+                    "cubeParams": ["KibanaSampleDataEcommerce"],
+                    "sql": "(LOWER(${KibanaSampleDataEcommerce.customer_gender}) = $0$)",
+                },
                 "groupingSet": null,
             })
             .to_string(),]),
@@ -1684,7 +1693,7 @@ async fn select_agg_where_false() {
 
     // Final query uses grouped query to Cube.js with WHERE FALSE, but without LIMIT 0
     assert!(!sql.contains("\"ungrouped\":"));
-    assert!(sql.contains(r#"\"expr\":\"FALSE\""#));
+    assert!(sql.contains(r#"\"sql\":\"FALSE\""#));
     assert!(sql.contains(r#""limit": 50000"#));
 }
 
@@ -1735,7 +1744,7 @@ async fn wrapper_dimension_agg_where_false() {
 
     // Final query uses grouped query to Cube.js with WHERE FALSE, but without LIMIT 0
     assert!(!sql.contains("\"ungrouped\":"));
-    assert!(sql.contains(r#"\"expr\":\"FALSE\""#));
+    assert!(sql.contains(r#"\"sql\":\"FALSE\""#));
     assert!(!sql.contains(r#""limit""#));
     assert!(sql.contains("LIMIT 50000"));
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -925,9 +925,9 @@ async fn test_case_wrapper_with_system_fields() {
             .wrapped_sql
             .sql
             .contains(
-                "\\\"cube_name\\\":\\\"KibanaSampleDataEcommerce\\\",\\\"alias\\\":\\\"user\\\""
+                "\\\"cubeName\\\":\\\"KibanaSampleDataEcommerce\\\",\\\"alias\\\":\\\"user\\\""
             ),
-        r#"SQL contains `\"cube_name\":\"KibanaSampleDataEcommerce\",\"alias\":\"user\"` {}"#,
+        r#"SQL contains `\"cubeName\":\"KibanaSampleDataEcommerce\",\"alias\":\"user\"` {}"#,
         logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql
     );
 
@@ -1259,29 +1259,29 @@ async fn test_wrapper_filter_flatten() {
             .request,
         TransportLoadRequestQuery {
             measures: Some(vec![json!({
-                "cube_name": "KibanaSampleDataEcommerce",
+                "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "sum_kibanasample",
-                "cube_params": ["KibanaSampleDataEcommerce"],
+                "cubeParams": ["KibanaSampleDataEcommerce"],
                 // This is grouped query, KibanaSampleDataEcommerce.sumPrice is correct in this context
                 // SUM(sumPrice) will be incrrect here, it would lead to SUM(SUM(sql)) in generated query
                 "expr": "${KibanaSampleDataEcommerce.sumPrice}",
-                "grouping_set": null,
+                "groupingSet": null,
             })
             .to_string(),]),
             dimensions: Some(vec![json!({
-                "cube_name": "KibanaSampleDataEcommerce",
+                "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "customer_gender",
-                "cube_params": ["KibanaSampleDataEcommerce"],
+                "cubeParams": ["KibanaSampleDataEcommerce"],
                 "expr": "${KibanaSampleDataEcommerce.customer_gender}",
-                "grouping_set": null,
+                "groupingSet": null,
             })
             .to_string(),]),
             segments: Some(vec![json!({
-                "cube_name": "KibanaSampleDataEcommerce",
+                "cubeName": "KibanaSampleDataEcommerce",
                 "alias": "lower_kibanasamp",
-                "cube_params": ["KibanaSampleDataEcommerce"],
+                "cubeParams": ["KibanaSampleDataEcommerce"],
                 "expr": "(LOWER(${KibanaSampleDataEcommerce.customer_gender}) = $0$)",
-                "grouping_set": null,
+                "groupingSet": null,
             })
             .to_string(),]),
             time_dimensions: None,

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1748,3 +1748,56 @@ async fn wrapper_dimension_agg_where_false() {
     assert!(!sql.contains(r#""limit""#));
     assert!(sql.contains("LIMIT 50000"));
 }
+
+/// MIN(avg_measure) should get pushed to Cube with replaced measure
+#[tokio::test]
+async fn wrapper_min_from_avg_measure() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            MIN(avgPrice)
+        FROM
+            MultiTypeCube
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+
+    assert_eq!(
+        query_plan
+            .as_logical_plan()
+            .find_cube_scan_wrapped_sql()
+            .request,
+        TransportLoadRequestQuery {
+            measures: Some(vec![json!({
+                "cubeName": "MultiTypeCube",
+                "alias": "min_multitypecub",
+                "expr": {
+                    "type": "PatchMeasure",
+                    "sourceMeasure": "MultiTypeCube.avgPrice",
+                    "replaceAggregationType": "min",
+                    "addFilters": [],
+                },
+                "groupingSet": null,
+            })
+            .to_string(),]),
+            dimensions: Some(vec![]),
+            segments: Some(vec![]),
+            order: Some(vec![]),
+            ..Default::default()
+        }
+    );
+}

--- a/rust/cubesql/cubesql/src/transport/ext.rs
+++ b/rust/cubesql/cubesql/src/transport/ext.rs
@@ -12,6 +12,8 @@ pub trait V1CubeMetaMeasureExt {
 
     fn allow_replace_agg_type(&self, query_agg_type: &str, disable_strict_match: bool) -> bool;
 
+    fn allow_add_filter(&self, query_agg_type: Option<&str>) -> bool;
+
     fn get_sql_type(&self) -> ColumnType;
 }
 
@@ -68,6 +70,30 @@ impl V1CubeMetaMeasureExt for CubeMetaMeasure {
                 "count_distinct" | "count_distinct_approx",
             ) => true,
 
+            _ => false,
+        }
+    }
+
+    // This should be aligned with BaseMeasure.preparePatchedMeasure
+    // See packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts:16
+    fn allow_add_filter(&self, query_agg_type: Option<&str>) -> bool {
+        let Some(agg_type) = &self.agg_type else {
+            return false;
+        };
+
+        let agg_type = match query_agg_type {
+            Some(query_agg_type) => query_agg_type,
+            None => agg_type,
+        };
+
+        match agg_type {
+            "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "count"
+            | "count_distinct"
+            | "count_distinct_approx" => true,
             _ => false,
         }
     }

--- a/rust/cubesql/cubesql/src/transport/ext.rs
+++ b/rust/cubesql/cubesql/src/transport/ext.rs
@@ -24,36 +24,24 @@ impl V1CubeMetaMeasureExt for CubeMetaMeasure {
         if disable_strict_match {
             return true;
         }
-        if self.agg_type.is_some() {
-            if expect_agg_type.eq(&"countDistinct".to_string()) {
-                let agg_type = self.agg_type.as_ref().unwrap();
-
-                agg_type.eq(&"countDistinct".to_string())
-                    || agg_type.eq(&"countDistinctApprox".to_string())
-                    || agg_type.eq(&"number".to_string())
-            } else if expect_agg_type.eq(&"sum".to_string()) {
-                let agg_type = self.agg_type.as_ref().unwrap();
-
-                agg_type.eq(&"sum".to_string())
-                    || agg_type.eq(&"count".to_string())
-                    || agg_type.eq(&"number".to_string())
-            } else if expect_agg_type.eq(&"min".to_string())
-                || expect_agg_type.eq(&"max".to_string())
-            {
-                let agg_type = self.agg_type.as_ref().unwrap();
-
-                agg_type.eq(&"number".to_string())
-                    || agg_type.eq(&"string".to_string())
-                    || agg_type.eq(&"time".to_string())
-                    || agg_type.eq(&"boolean".to_string())
-                    || agg_type.eq(expect_agg_type)
-            } else {
-                let agg_type = self.agg_type.as_ref().unwrap();
-
-                agg_type.eq(&"number".to_string()) || agg_type.eq(expect_agg_type)
+        let Some(agg_type) = &self.agg_type else {
+            return false;
+        };
+        match expect_agg_type {
+            "countDistinct" => {
+                agg_type == "countDistinct"
+                    || agg_type == "countDistinctApprox"
+                    || agg_type == "number"
             }
-        } else {
-            false
+            "sum" => agg_type == "sum" || agg_type == "count" || agg_type == "number",
+            "min" | "max" => {
+                agg_type == "number"
+                    || agg_type == "string"
+                    || agg_type == "time"
+                    || agg_type == "boolean"
+                    || agg_type == expect_agg_type
+            }
+            _ => agg_type == "number" || agg_type == expect_agg_type,
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11678,6 +11678,11 @@ asn1@^0.2.6, asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assert-never@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.4.0.tgz#b0d4988628c87f35eb94716cc54422a63927e175"
+  integrity sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==
+
 assert-options@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/assert-options/-/assert-options-0.7.0.tgz#82c27618d9c0baa5e9da8ef607ee261a44ed6e5e"


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Add new member expression: `PatchMeasure`.
It allows to change aggregation type and add measure filters for existing measure. This is to allow queries like `MIN(avgMeasure)` and `SUM(CASE dim = 'foo' WHEN TRUE THEN sumMeasure ELSE NULL END)` in SQL API.

Under the hood
* SQL API now allows mismatched aggregation functions and aggregation on top of `CASE` in SQL pushdown rules, and rewrites that to special expression `__patch_measure(measure_column, 'new_agg_type', boolean_expression)`
* This expression is syntactic-only, it should never execute, instead it would be handled by wrapper SQL generation
* Generated member expression is passed to JS-side
* `api-gateway` evaluates it from JSON from JS functions
* `BaseQuery` and `BaseMeasure` now can handle new form: generate patched measure definition and use original measure during traversing and collecting

Supporting changes
* Changed rewrites for usual measures in SQL pushdown from just `measure_column` to `MEASURE(measure_column)`, to make rewrites uniform
* Turn member expressions to tagged union in JSON representation