### PR TITLE
fix(redshift-driver): Fix empty tableColumnTypes for external (Spectrum) tables

### DIFF
--- a/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
+++ b/packages/cubejs-redshift-driver/src/RedshiftDriver.ts
@@ -16,6 +16,7 @@ import {
   StreamOptions,
   StreamTableDataWithTypes,
   TableColumn,
+  TableStructure,
   UnloadOptions
 } from '@cubejs-backend/base-driver';
 import crypto from 'crypto';
@@ -339,6 +340,19 @@ export class RedshiftDriver extends PostgresDriver<RedshiftDriverConfiguration> 
 
   public async loadUserDefinedTypes(): Promise<void> {
     // @todo Implement for Redshift, column \"typcategory\" does not exist in pg_type
+  }
+
+  public override async tableColumnTypes(table: string): Promise<TableStructure> {
+    const [schema, name] = table.split('.');
+
+    // We might get table from Spectrum schema, so common request via `information_schema.columns`
+    // won't return anything. `getColumnsForSpecificTables` is aware of Spectrum tables.
+    const columns = await this.getColumnsForSpecificTables([{
+      schema_name: schema,
+      table_name: name,
+    }]);
+
+    return columns.map(c => ({ name: c.column_name, type: this.toGenericType(c.data_type) }));
   }
 
   public async isUnloadSupported() {

--- a/packages/cubejs-testing-drivers/src/tests/testExternalSchemas.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testExternalSchemas.ts
@@ -46,4 +46,16 @@ export function redshiftExternalSchemasSuite(
       expect(it.data_type).toEqual(expect.any(String));
     });
   });
+
+  execute('should load columns types for external table', async () => {
+    const columnsForTables = await driver().tableColumnTypes(`${EXTERNAL_SCHEMA}.${EXTERNAL_TABLE}`);
+
+    expect(columnsForTables).toBeInstanceOf(Array);
+    expect(columnsForTables.length).toBeGreaterThan(0);
+
+    columnsForTables.forEach((it) => {
+      expect(it.name).toEqual(expect.any(String));
+      expect(it.type).toEqual(expect.any(String));
+    });
+  });
 }


### PR DESCRIPTION
This PR fixes incorrect gathering table meta data  for Redshift Spectrum tables.

**Check List**
- [X] Tests have been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

