### PR TITLE
DuckDBDriver: add `databasePath` and `motherDuckToken` config options

### DIFF
--- a/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBDriver.ts
@@ -17,8 +17,10 @@ import { HydrationStream, transformRow } from './HydrationStream';
 const { version } = require('../../package.json');
 
 export type DuckDBDriverConfiguration = {
+  databasePath?: string,
   dataSource?: string,
   initSql?: string,
+  motherDuckToken?: string,
   schema?: string,
 };
 
@@ -56,8 +58,8 @@ export class DuckDBDriver extends BaseDriver implements DriverInterface {
   }
 
   protected async init(): Promise<InitPromise> {
-    const token = getEnv('duckdbMotherDuckToken', this.config);
-    const dbPath = getEnv('duckdbDatabasePath', this.config);
+    const token = this.config.motherDuckToken || getEnv('duckdbMotherDuckToken', this.config);
+    const dbPath = this.config.databasePath || getEnv('duckdbDatabasePath', this.config);
     
     // Determine the database URL based on the provided db_path or token
     let dbUrl: string;


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Duckdb can now have `databasePath` and `motherDuckToken` options passed via the driver, rather than soley as environment variables.

(This enables us to pass these options via the `driverFactory` within `cube.js`, which is our preferred configuration option as environment variables are difficult to deploy programmatically).
