### PR TITLE
fix(schema-compiler): fix allowNonStrictDateRangeMatch pre-agg match for dateRange queries without granularities

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -273,7 +273,7 @@ export class BaseTimeDimension extends BaseFilter {
   }
 
   public resolvedGranularity() {
-    return this.granularityObj ? this.granularityObj.resolvedGranularity() : this.dateRangeGranularity();
+    return this.granularityObj ? this.granularityObj.resolvedGranularity() : null;
   }
 
   public wildcardRange() {


### PR DESCRIPTION
This PR fixes pre-agg matching for queries without granularities and with allowNonStrictDateRangeMatch set to true for pre-agg.

**Check List**
- [X] Tests have been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

