### PR TITLE
chore(ci): Use ARM64 shared runners from GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -483,7 +483,7 @@ jobs:
             build-args: WITH_AVX2=1
             postfix: ""
             tag: "latest"
-          - os: self-hosted
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
             build-args: WITH_AVX2=0

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -84,12 +84,12 @@ jobs:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             platforms: linux/amd64
             build-args: WITH_AVX2=1
             postfix: ""
-          - os: self-hosted
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
             build-args: WITH_AVX2=0

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -81,11 +81,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             platforms: linux/amd64
             build-args: WITH_AVX2=1
-          - os: self-hosted
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
             build-args: WITH_AVX2=0


### PR DESCRIPTION
ARM64 runners are in public preview, but It's ready for our use case. This PR allows us to shut down our own self-hosted runner on top of ARM64.

@bsod90 You should happy :)