### PR TITLE
fix(server-core): Handle empty query in getSqlGenerator

### DIFF
--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -137,19 +137,26 @@ export class CompilerApi {
       throw new Error(`Unknown dbType: ${dbType}`);
     }
 
+    // sqlGenerator.dataSource can return undefined for query without members
+    // Queries like this are used by api-gateway to initialize SQL API
+    // At the same time, those queries should use concrete dataSource, so we should be good to go with it
     dataSource = compilers.compiler.withQuery(sqlGenerator, () => sqlGenerator.dataSource);
-    const _dbType = await this.getDbType(dataSource);
-    if (dataSource !== 'default' && dbType !== _dbType) {
-      // TODO consider more efficient way than instantiating query
-      sqlGenerator = await this.createQueryByDataSource(
-        compilers,
-        query,
-        dataSource,
-        _dbType
-      );
+    if (dataSource !== undefined) {
+      const _dbType = await this.getDbType(dataSource);
+      if (dataSource !== 'default' && dbType !== _dbType) {
+        // TODO consider more efficient way than instantiating query
+        sqlGenerator = await this.createQueryByDataSource(
+          compilers,
+          query,
+          dataSource,
+          _dbType
+        );
 
-      if (!sqlGenerator) {
-        throw new Error(`Can't find dialect for '${dataSource}' data source: ${_dbType}`);
+        if (!sqlGenerator) {
+          throw new Error(
+            `Can't find dialect for '${dataSource}' data source: ${_dbType}`
+          );
+        }
       }
     }
 

--- a/packages/cubejs-testing/test/__snapshots__/smoke-multidb.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-multidb.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multidb SQL pushdown queries to different data sources: Products 1`] = `
+Array [
+  Object {
+    "name": "apples",
+  },
+]
+`;
+
+exports[`multidb SQL pushdown queries to different data sources: Suppliers 1`] = `
+Array [
+  Object {
+    "company": "Fruits Inc",
+  },
+]
+`;
+
 exports[`multidb query: query 1`] = `
 Array [
   Object {


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

api-gateway calls getSqlGenerator with empty query and concrete data source to initialize SQL API But because query is empty `sqlGenerator.dataSource` can be undefined, and it would trigger re-creating query with new data source, which would be `default`
