### PR TITLE
fix(cubesql): Match CubeScan timestamp literal types to member types

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/context.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/context.rs
@@ -140,7 +140,7 @@ impl TableProvider for CubeTableProvider {
                             ColumnType::Decimal(p, s) => DataType::Decimal(p, s),
                             ColumnType::List(field) => DataType::List(field.clone()),
                             ColumnType::Timestamp => {
-                                DataType::Timestamp(TimeUnit::Millisecond, None)
+                                DataType::Timestamp(TimeUnit::Nanosecond, None)
                             }
                         },
                         true,

--- a/rust/cubesql/cubesql/src/sql/types.rs
+++ b/rust/cubesql/cubesql/src/sql/types.rs
@@ -89,7 +89,7 @@ impl ColumnType {
             ColumnType::Blob => DataType::Utf8,
             ColumnType::Decimal(p, s) => DataType::Decimal(*p, *s),
             ColumnType::List(field) => DataType::List(field.clone()),
-            ColumnType::Timestamp => DataType::Timestamp(TimeUnit::Millisecond, None),
+            ColumnType::Timestamp => DataType::Timestamp(TimeUnit::Nanosecond, None),
         }
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR changes type of timestamp literal values in `CubeScan` to `TimestampNanosecond`. They previously converted to `TimestampMillisecond` which does not match member type (which is actually `TimestampNanosecond` despite Cube returning millisecond precision values). This led to issues with two CubeScans, one containing a member and another a literal, being unable to `UNION`.

Example plan that fails to execute:
```
Union
  Projection: CAST(NULL AS Timestamp(Millisecond, None)) AS date, #SUM(amount) AS amount
    Aggregate: groupBy=[[]], aggr=[[SUM(#cube.amount)]]
      TableScan: cube projection=None
  Projection: #cube.date AS date, #SUM(amount) AS amount
    Aggregate: groupBy=[[#cube.date]], aggr=[[SUM(#cube.amount)]]
      TableScan: cube projection=None
```

As Cube date time columns are considered `TimestampMillisecond`, initial planning provides `Millisecond` type; but `CubeScan` member types are `TimestampNanosecond`, and two `CubeScan`s cannot be unioned in this case. As such, rewriting produces an invalid plan.