### PR TITLE
fix(cubesql): Use pushdown-pullup scheme for FilterSimplifyReplacer

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -104,6 +104,8 @@ impl BestCubePlan {
             LogicalPlanLanguage::OrderReplacer(_) => 1,
             LogicalPlanLanguage::MemberReplacer(_) => 1,
             LogicalPlanLanguage::FilterReplacer(_) => 1,
+            LogicalPlanLanguage::FilterSimplifyPushDownReplacer(_) => 1,
+            LogicalPlanLanguage::FilterSimplifyPullUpReplacer(_) => 1,
             LogicalPlanLanguage::TimeDimensionDateRangeReplacer(_) => 1,
             LogicalPlanLanguage::InnerAggregateSplitReplacer(_) => 1,
             LogicalPlanLanguage::OuterProjectionSplitReplacer(_) => 1,

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -405,7 +405,10 @@ crate::plan_to_language! {
             members: Vec<LogicalPlan>,
             aliases: Vec<(String, String)>,
         },
-        FilterSimplifyReplacer {
+        FilterSimplifyPushDownReplacer {
+            filters: Vec<LogicalPlan>,
+        },
+        FilterSimplifyPullUpReplacer {
             filters: Vec<LogicalPlan>,
         },
         OrderReplacer {
@@ -1901,8 +1904,12 @@ fn filter_replacer(
     )
 }
 
-fn filter_simplify_replacer(members: impl Display) -> String {
-    format!("(FilterSimplifyReplacer {})", members)
+fn filter_simplify_push_down_replacer(members: impl Display) -> String {
+    format!("(FilterSimplifyPushDownReplacer {})", members)
+}
+
+fn filter_simplify_pull_up_replacer(members: impl Display) -> String {
+    format!("(FilterSimplifyPullUpReplacer {})", members)
 }
 
 fn inner_aggregate_split_replacer(members: impl Display, alias_to_cube: impl Display) -> String {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -208,7 +208,7 @@ impl Rewriter {
         .with_iter_limit(
             env::var("CUBESQL_REWRITE_MAX_ITERATIONS")
                 .map(|v| v.parse::<usize>().unwrap())
-                .unwrap_or(300),
+                .unwrap_or(500),
         )
         .with_node_limit(
             env::var("CUBESQL_REWRITE_MAX_NODES")

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -473,20 +473,16 @@ impl Rewriter {
         eval_stable_functions: bool,
     ) -> Vec<CubeRewrite> {
         let sql_push_down = Self::sql_push_down_enabled();
-        let rules: Vec<Box<dyn RewriteRules>> = vec![
-            Box::new(MemberRules::new(
-                meta_context.clone(),
-                config_obj.clone(),
-                sql_push_down,
-            )),
-            Box::new(FilterRules::new(
+        let rules: &[&dyn RewriteRules] = &[
+            &MemberRules::new(meta_context.clone(), config_obj.clone(), sql_push_down),
+            &FilterRules::new(
                 meta_context.clone(),
                 config_obj.clone(),
                 eval_stable_functions,
-            )),
-            Box::new(DateRules::new(config_obj.clone())),
-            Box::new(OrderRules::new()),
-            Box::new(CommonRules::new(config_obj.clone())),
+            ),
+            &DateRules::new(config_obj.clone()),
+            &OrderRules::new(),
+            &CommonRules::new(config_obj.clone()),
         ];
         let mut rewrites = Vec::new();
         for r in rules {

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -581,6 +581,7 @@ pub fn sql_generator(
                     ("functions/LEAST".to_string(), "LEAST({{ args_concat }})".to_string()),
                     ("functions/DATEDIFF".to_string(), "DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})".to_string()),
                     ("functions/CURRENTDATE".to_string(), "CURRENT_DATE({{ args_concat }})".to_string()),
+                    ("functions/NOW".to_string(), "NOW({{ args_concat }})".to_string()),
                     ("functions/DATE_ADD".to_string(), "DATE_ADD({{ args_concat }})".to_string()),
                     ("functions/CONCAT".to_string(), "CONCAT({{ args_concat }})".to_string()),
                     ("functions/DATE".to_string(), "DATE({{ args_concat }})".to_string()),


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

This should avoid unexpected unifications of simplified expression in unrelated context. For example, same expression can be present in filter and projection, but due to over-unification in filters it can receive different representation in projection, and break aliases later, during extraction
