### PR TITLE
feat(cubesql): Support multiple columns in expression on each side in ungrouped-grouped join condition

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
@@ -22,6 +22,7 @@ use datafusion::{
     prelude::JoinType,
 };
 use egg::{Id, Subst};
+use itertools::Itertools;
 
 impl WrapperRules {
     pub fn join_rules(&self, rules: &mut Vec<CubeRewrite>) {
@@ -831,50 +832,66 @@ impl WrapperRules {
             // * Both inputs depend on a single data source
             // * SQL generator for that data source have `expressions/subquery` template
             // It could be checked later, in WrappedSelect as well
+            // TODO For views: check that each member is coming from same data source (or even cube?)
 
-            let left_columns = egraph[subst[left_expr_var]].data.referenced_expr.as_ref();
-            let Some(left_columns) = left_columns else {
-                return false;
+            let prepare_columns = |var| {
+                let columns = egraph[subst[var]].data.referenced_expr.as_ref();
+                let Some(columns) = columns else {
+                    return Err("Missing referenced_expr");
+                };
+                let columns = columns
+                    .iter()
+                    .map(|column| {
+                        let column = match column {
+                            Expr::Column(column) => column.clone(),
+                            _ => return Err("Unexpected expression in referenced_expr"),
+                        };
+                        Ok(column)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(columns)
             };
-            if left_columns.len() != 1 {
-                return false;
+
+            fn prepare_relation(columns: &[Column]) -> Result<&str, &'static str> {
+                let relation = columns
+                    .iter()
+                    .map(|column| &column.relation)
+                    .all_equal_value();
+                let Ok(Some(relation)) = relation else {
+                    // Outer Err means there's either no values at all, or more than one different value
+                    // Inner Err means that all referenced_expr are not columns
+                    // Inner None means that all columns are without relation, don't support that ATM
+                    return Err("Relation mismatch");
+                };
+                Ok(relation)
             }
-            let left_column = &left_columns[0];
 
-            let right_columns = egraph[subst[right_expr_var]].data.referenced_expr.as_ref();
-            let Some(right_columns) = right_columns else {
+            let Ok(left_columns) = prepare_columns(left_expr_var) else {
                 return false;
             };
-            if right_columns.len() != 1 {
+            let Ok(left_relation) = prepare_relation(&left_columns) else {
                 return false;
-            }
-            let right_column = &right_columns[0];
-
-            let left_column = match left_column {
-                Expr::Column(column) => column,
-                _ => return false,
             };
-            let right_column = match right_column {
-                Expr::Column(column) => column,
-                _ => return false,
+
+            let Ok(right_columns) = prepare_columns(right_expr_var) else {
+                return false;
+            };
+            let Ok(right_relation) = prepare_relation(&right_columns) else {
+                return false;
             };
 
             // Simple check that column expressions reference different join sides
-            let Some(left_relation) = left_column.relation.as_ref() else {
-                return false;
-            };
-            let Some(right_relation) = right_column.relation.as_ref() else {
-                return false;
-            };
             if left_relation == right_relation {
                 return false;
             }
 
-            let left_column = left_column.clone();
-
             // Don't check right, as it is already grouped
 
-            if !Self::are_join_members_supported(egraph, subst[left_members_var], [&left_column]) {
+            if !Self::are_join_members_supported(
+                egraph,
+                subst[left_members_var],
+                left_columns.iter(),
+            ) {
                 return false;
             }
 


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

Before this only expressions like `CAST(left.dim AS TEXT) = CAST(right.col AS TEXT)` were supported.
TopN over calculated fields can actually generate joins with calculated field in condition, so we have to support condition like `CAST(left.dim1 AS TEXT) || CAST(left.dim2 AS TEXT) = CAST(right.col AS TEXT)`
