### PR TITLE
feat(cubesql): Move dimensions-only projections to dimensions for push-to-Cube wrapper

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -7285,7 +7285,7 @@ ORDER BY
                     json!({
                         "cube_name": "WideCube",
                         "alias": "pivot_grouping",
-                        "cube_params": ["WideCube"],
+                        "cube_params": [],
                         "expr": "0",
                         "grouping_set": null,
                     })
@@ -11809,16 +11809,16 @@ ORDER BY "source"."str0" ASC
                     json!({
                         "cube_name": "KibanaSampleDataEcommerce",
                         "alias": "ta_1_order_date_",
-                        "cube_params": ["KibanaSampleDataEcommerce", "Logs"],
+                        "cube_params": ["KibanaSampleDataEcommerce"],
                         "expr": "((${KibanaSampleDataEcommerce.order_date} = DATE('1994-05-01')) OR (${KibanaSampleDataEcommerce.order_date} = DATE('1996-05-03')))",
                         "grouping_set": null,
                     }).to_string(),
                 ]),
                 segments: Some(vec![
                     json!({
-                        "cube_name": "KibanaSampleDataEcommerce",
+                        "cube_name": "Logs",
                         "alias": "lower_ta_2_conte",
-                        "cube_params": ["KibanaSampleDataEcommerce", "Logs"],
+                        "cube_params": ["Logs"],
                         "expr": "(LOWER(${Logs.content}) = $0$)",
                         "grouping_set": null,
                     }).to_string(),

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1556,8 +1556,8 @@ async fn wrapper_cast_limit_explicit_members() {
         .as_logical_plan()
         .find_cube_scan_wrapped_sql()
         .request;
-    assert_eq!(request.measures.unwrap().len(), 1);
-    assert_eq!(request.dimensions.unwrap().len(), 0);
+    assert_eq!(request.measures.unwrap().len(), 0);
+    assert_eq!(request.dimensions.unwrap().len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Turns dimension-only member expressions in projection to `dimensions`, not `measures`
This helps with queries like `SELECT dim1, ... dimN, mea1, ... meaM FROM cube`, whether explicit or implicit (SQL API generate every member in SELECT for zero-member CubeScan in wrapper)
