### PR TITLE
feat(api-gateway): Expanding meta-information endpoints

### DIFF
--- a/docs/pages/product/apis-integrations/rest-api.mdx
+++ b/docs/pages/product/apis-integrations/rest-api.mdx
@@ -124,13 +124,13 @@ by making them accessible to specific users only or disallowing access for
 everyone. By default, API endpoints in all scopes, except for `jobs`, are
 accessible for everyone.
 
-| API scope | REST API endpoints                                                                        | Accessible by default? |
-| --------- | ----------------------------------------------------------------------------------------- | ---------------------- |
-| `meta`    | [`/v1/meta`][ref-ref-meta]                                                                | ✅ Yes                 |
-| `data`    | [`/v1/load`][ref-ref-load], [`/v1/sql`][ref-ref-sql]                                      | ✅ Yes                 |
-| `graphql` | `/graphql`                                                                                | ✅ Yes                 |
-| `jobs`    | [`/v1/pre-aggregations/jobs`][ref-ref-paj]                                                | ❌ No                  |
-| No scope  | `/livez`, `/readyz`                                                                       | ✅ Yes, always |
+| API scope | REST API endpoints                                                                                                                                                                             | Accessible by default? |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `meta`    | [`/v1/meta`][ref-ref-meta], [`/v1/meta/namesModel`][ref-ref-meta-names-model], [`/v1/meta/:nameModel`][ref-ref-meta-name-model], [`/v1/meta/:nameModel/:field`][ref-ref-meta-name-model-field] | ✅ Yes                  |
+| `data`    | [`/v1/load`][ref-ref-load], [`/v1/sql`][ref-ref-sql]                                                                                                                                           | ✅ Yes                  |
+| `graphql` | `/graphql`                                                                                                                                                                                     | ✅ Yes                  |
+| `jobs`    | [`/v1/pre-aggregations/jobs`][ref-ref-paj]                                                                                                                                                     | ❌ No                   |
+| No scope  | `/livez`, `/readyz`                                                                                                                                                                            | ✅ Yes, always          |
 
 You can set accessible API scopes _for all requests_ using the
 `CUBEJS_DEFAULT_API_SCOPES` environment variable. For example, to disallow
@@ -278,6 +278,9 @@ example, the following query will retrieve rows 101-200 from the `Orders` cube:
   /reference/configuration/config#contexttoapiscopes
 [ref-ref-load]: /product/apis-integrations/rest-api/reference#base_pathv1load
 [ref-ref-meta]: /product/apis-integrations/rest-api/reference#base_pathv1meta
+[ref-ref-meta-names-model]: /product/apis-integrations/rest-api/reference#base_pathv1metanamesmodel
+[ref-ref-meta-name-model]: /product/apis-integrations/rest-api/reference#base_pathv1metanamemodel
+[ref-ref-meta-name-model-field]: /product/apis-integrations/rest-api/reference#base_pathv1metanamemodelfield
 [ref-ref-sql]: /product/apis-integrations/rest-api/reference#base_pathv1sql
 [ref-ref-paj]: /product/apis-integrations/rest-api/reference#base_pathv1pre-aggregationsjobs
 [ref-security-context]: /product/auth/context

--- a/docs/pages/product/apis-integrations/rest-api/reference.mdx
+++ b/docs/pages/product/apis-integrations/rest-api/reference.mdx
@@ -265,6 +265,136 @@ Example response:
 }
 ```
 
+## `{base_path}/v1/meta/namesModel`
+
+Get names  for cubes and views defined in the data model.
+
+Response
+
+- `cubes` - Array of cubes and views
+- `name` - Codename of the cube/view
+
+Example request:
+
+```bash{outputLines: 2-4}
+curl \
+  -H "Authorization: EXAMPLE-API-TOKEN" \
+  -G \
+  http://localhost:4000/cubejs-api/v1/meta/namesModel
+```
+
+Example response:
+
+```json
+{
+  "cubes": [
+    {
+      "name": "Users"
+    }
+  ]
+}
+```
+
+## `{base_path}/v1/meta/:nameModel`
+
+Get all the information about cubes or views by knowing the name that is passed to :nameModel.
+
+Response
+
+- `cubes` - Array of cubes and views
+- `name` - Codename of the cube/view
+- `type` - Type can be "cube" or "view"
+- `title` - Human-readable cube/view name
+- `meta` - Custom metadata
+- `measures` - Array of measures in this cube/view
+- `dimensions` - Array of dimensions in this cube/view
+- `hierarchies` - Array of hierarchies in this cube
+- `segments` - Array of segments in this cube/view
+- `folders` - Array of folders in this view
+- `connectedComponent` - An integer representing a join relationship. If the same value is returned for two cubes, then there is
+at least one join path between them.
+
+Example request:
+
+```bash{outputLines: 2-4}
+curl \
+  -H "Authorization: EXAMPLE-API-TOKEN" \
+  -G \
+  http://localhost:4000/cubejs-api/v1/meta/Users
+```
+
+Example response:
+
+```json
+{
+  "cubes": [
+    {
+      "name": "Users",
+      "title": "Users",
+      "meta": {
+          "someKey": "someValue",
+          "nested": {
+            "someKey": "someValue"
+          }
+      },
+      "connectedComponent": 1,
+      "measures": [
+        {
+          "name": "users.count",
+          "title": "Users Count",
+          "shortTitle": "Count",
+          "aliasName": "users.count",
+          "type": "number",
+          "aggType": "count",
+          "drillMembers": ["users.id", "users.city", "users.createdAt"]
+        }
+      ],
+      "dimensions": [
+        {
+          "name": "users.city",
+          "title": "Users City",
+          "type": "string",
+          "aliasName": "users.city",
+          "shortTitle": "City",
+          "suggestFilterValues": true
+        }
+      ],
+      "segments": []
+    }
+  ]
+}
+```
+
+## `{base_path}/v1/meta/:nameModel/:field`
+
+Get information :field about cubes or views, knowing the name that is passed to :nameModel.
+
+Response
+
+- `value` - Value from the field by cubes or views
+
+Example request:
+
+```bash{outputLines: 2-4}
+curl \
+  -H "Authorization: EXAMPLE-API-TOKEN" \
+  -G \
+  http://localhost:4000/cubejs-api/v1/meta/Users/meta
+```
+
+Example response:
+
+```json
+{
+  "value": {
+    "someKey": "someValue",
+    "nested": {
+      "someKey": "someValue"
+    }
+  }
+}
+```
+
 ## `{base_path}/v1/pre-aggregations/jobs`
 
 Trigger pre-aggregation build jobs or retrieve statuses of such jobs.

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -401,7 +401,7 @@ class ApiGateway {
     );
 
     app.get(
-      `${this.basePath}/v1/meta/model_name`,
+      `${this.basePath}/v1/meta/namesModel`,
       userMiddlewares,
       userAsyncHandler(async (req, res) => {
         await this.metaModelName({

--- a/packages/cubejs-api-gateway/test/permissions.test.ts
+++ b/packages/cubejs-api-gateway/test/permissions.test.ts
@@ -91,13 +91,13 @@ describe('Gateway Api Scopes', () => {
     apiGateway.release();
   });
 
-  test('GET /v1/meta/model_name should return model names', async () => {
+  test('GET /v1/meta/namesModel should return model names', async () => {
     const { app, apiGateway } = createApiGateway({
       contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
     });
 
     const response = await request(app)
-      .get('/cubejs-api/v1/meta/model_name')
+      .get('/cubejs-api/v1/meta/namesModel')
       .set('Authorization', AUTH_TOKEN)
       .expect(200);
 

--- a/packages/cubejs-api-gateway/test/permissions.test.ts
+++ b/packages/cubejs-api-gateway/test/permissions.test.ts
@@ -91,6 +91,116 @@ describe('Gateway Api Scopes', () => {
     apiGateway.release();
   });
 
+  test('GET /v1/meta/model_name should return model names', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
+    });
+
+    const response = await request(app)
+      .get('/cubejs-api/v1/meta/model_name')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(200);
+
+    expect(response.body).toEqual({ cubes: [{ name: 'Foo' }] });
+
+    apiGateway.release();
+  });
+
+  test('GET /v1/meta/:nameModel should return model data', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
+    });
+
+    const response = await request(app)
+      .get('/cubejs-api/v1/meta/Foo')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(200);
+
+    expect(response.body).toEqual(
+      {
+        cubes: [
+          {
+            name: 'Foo',
+            description: 'cube from compilerApi mock',
+            measures: [
+              {
+                name: 'Foo.bar',
+                description: 'measure from compilerApi mock',
+                isVisible: true,
+              },
+            ],
+            dimensions: [
+              {
+                name: 'Foo.id',
+                description: 'id dimension from compilerApi mock',
+                isVisible: true,
+              },
+              {
+                name: 'Foo.time',
+                isVisible: true,
+              },
+            ],
+            segments: [
+              {
+                name: 'Foo.quux',
+                description: 'segment from compilerApi mock',
+                isVisible: true,
+              },
+            ],
+            sql: '\'SELECT * FROM Foo\'',
+          }
+        ]
+      }
+    );
+
+    apiGateway.release();
+  });
+
+  test('GET /v1/meta/:nameModel should return error if model not found', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
+    });
+
+    const response = await request(app)
+      .get('/cubejs-api/v1/meta/UnknownModel')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(200);
+
+    expect(response.body).toEqual({ error: 'Model UnknownModel not found' });
+
+    apiGateway.release();
+  });
+
+  test('GET /v1/meta/:nameModel/:field should return specific field', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
+    });
+
+    const response = await request(app)
+      .get('/cubejs-api/v1/meta/Foo/name')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(200);
+
+    expect(response.body).toEqual({ value: 'Foo' });
+
+    apiGateway.release();
+  });
+
+  test('GET /v1/meta/:nameModel/:field should return error if field not found', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'data', 'jobs'],
+    });
+
+    const response = await request(app)
+      .get('/cubejs-api/v1/meta/Foo/unknownField')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(200);
+
+    expect(response.body).toEqual({ error: 'Field unknownField not found in model Foo' });
+
+    apiGateway.release();
+  });
+
   test('GraphQL declined', async () => {
     const { app, apiGateway } = createApiGateway({
       contextToApiScopes: async () => ['meta', 'data', 'jobs'],


### PR DESCRIPTION
With a large number of cubes, the json sent becomes gigantic, which creates an increased load on the network.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #9066]
