### PR TITLE
fix(cubesql): Functions without arguments alias as plain function name

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "chrono",
@@ -890,7 +890,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -934,7 +934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubenativeutils/Cargo.lock
+++ b/rust/cubenativeutils/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "chrono",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "dcf3e4aa26fd112043ef26fa4a78db5dbd443c86", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1a612fc26f762f3837ecf26df2e83ba38f11a8a2", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -1104,7 +1104,7 @@ mod tests {
 
         assert_eq!(
             logical_plan,
-            "Projection: CAST(utctimestamp() AS current_timestamp() AS Timestamp(Nanosecond, None)) AS COL\
+            "Projection: CAST(utctimestamp() AS current_timestamp AS Timestamp(Nanosecond, None)) AS COL\
             \n  EmptyRelation",
         );
     }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_date.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_date.snap
@@ -1,10 +1,9 @@
 ---
 source: cubesql/src/compile/mod.rs
-assertion_line: 11756
-expression: "execute_query(\"SELECT current_timestamp::date = current_date\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"SELECT current_timestamp::date = current_date\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+-----------------------------------------------------+
-| CAST(current_timestamp() AS Date32) = currentdate() |
-+-----------------------------------------------------+
-| true                                                |
-+-----------------------------------------------------+
++-------------------------------------------------+
+| CAST(current_timestamp AS Date32) = currentdate |
++-------------------------------------------------+
+| true                                            |
++-------------------------------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_schema_postgres.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_schema_postgres.snap
@@ -1,9 +1,9 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(\"SELECT current_schema()\".to_string(),\n              DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"SELECT current_schema()\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+------------------+
-| current_schema() |
-+------------------+
-| public           |
-+------------------+
++----------------+
+| current_schema |
++----------------+
+| public         |
++----------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__localtimestamp.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__localtimestamp.snap
@@ -1,9 +1,9 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(\"SELECT localtimestamp = current_timestamp\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"SELECT localtimestamp = current_timestamp\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+----------------------------------------+
-| localtimestamp() = current_timestamp() |
-+----------------------------------------+
-| true                                   |
-+----------------------------------------+
++------------------------------------+
+| localtimestamp = current_timestamp |
++------------------------------------+
+| true                               |
++------------------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_catalog_udf_search_path.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_catalog_udf_search_path.snap
@@ -3,7 +3,7 @@ source: cubesql/src/compile/mod.rs
 expression: "execute_query(\"SELECT version() UNION ALL SELECT pg_catalog.version();\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
 +-----------------------------------+
-| version()                         |
+| version                           |
 +-----------------------------------+
 | PostgreSQL 14.2 on x86_64-cubesql |
 | PostgreSQL 14.2 on x86_64-cubesql |

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__quicksight_sql_implementation_info.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__quicksight_sql_implementation_info.snap
@@ -1,9 +1,9 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(r#\"\n                SELECT character_value, version() \n                FROM INFORMATION_SCHEMA.SQL_IMPLEMENTATION_INFO\n                WHERE implementation_info_id IN ('17','18')\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(r#\"\n                SELECT character_value, version()\n                FROM INFORMATION_SCHEMA.SQL_IMPLEMENTATION_INFO\n                WHERE implementation_info_id IN ('17','18')\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
 +-----------------+-----------------------------------+
-| character_value | version()                         |
+| character_value | version                           |
 +-----------------+-----------------------------------+
 | PostgreSQL      | PostgreSQL 14.2 on x86_64-cubesql |
 | 14.02.0000)     | PostgreSQL 14.2 on x86_64-cubesql |

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__set_good_user.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__set_good_user.snap
@@ -1,10 +1,9 @@
 ---
 source: cubesql/src/compile/mod.rs
-assertion_line: 7198
-expression: "execute_queries_with_flags(vec![\"SET user = 'good_user'\".to_string(),\n                    \"select current_user\".to_string()],\n                DatabaseProtocol::PostgreSQL).await?.0"
+expression: "execute_queries_with_flags(vec![\"SET user = 'good_user'\".to_string(),\n\"select current_user\".to_string()], DatabaseProtocol::PostgreSQL).await? .0"
 ---
-+----------------+
-| current_user() |
-+----------------+
-| good_user      |
-+----------------+
++--------------+
+| current_user |
++--------------+
+| good_user    |
++--------------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__datagrip_introspection.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__datagrip_introspection.snap
@@ -2,8 +2,8 @@
 source: cubesql/src/compile/test/test_introspection.rs
 expression: "execute_query(\"select current_database(), current_schema(), current_user;\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+--------------------+------------------+----------------+
-| current_database() | current_schema() | current_user() |
-+--------------------+------------------+----------------+
-| cubedb             | public           | ovr            |
-+--------------------+------------------+----------------+
++------------------+----------------+--------------+
+| current_database | current_schema | current_user |
++------------------+----------------+--------------+
+| cubedb           | public         | ovr          |
++------------------+----------------+--------------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__dbeaver_introspection_init.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__dbeaver_introspection_init.snap
@@ -2,8 +2,8 @@
 source: cubesql/src/compile/test/test_introspection.rs
 expression: "execute_query(\"SELECT current_schema(), session_user;\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+------------------+----------------+
-| current_schema() | session_user() |
-+------------------+----------------+
-| public           | ovr            |
-+------------------+----------------+
++----------------+--------------+
+| current_schema | session_user |
++----------------+--------------+
+| public         | ovr          |
++----------------+--------------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__zoho_inet_server_addr.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__zoho_inet_server_addr.snap
@@ -2,8 +2,8 @@
 source: cubesql/src/compile/test/test_introspection.rs
 expression: "execute_query(\"\n                select\n                    pg_backend_pid(),\n                    coalesce(cast(inet_server_addr() as text ),'addr'),\n                    current_database()\n                ;\".to_string(),\nDatabaseProtocol::PostgreSQL,).await?"
 ---
-+------------------+---------------------------------------------------------+--------------------+
-| pg_backend_pid() | coalesce(CAST(inet_server_addr() AS Utf8),Utf8("addr")) | current_database() |
-+------------------+---------------------------------------------------------+--------------------+
-| 1                | 127.0.0.1/32                                            | cubedb             |
-+------------------+---------------------------------------------------------+--------------------+
++----------------+-------------------------------------------------------+------------------+
+| pg_backend_pid | coalesce(CAST(inet_server_addr AS Utf8),Utf8("addr")) | current_database |
++----------------+-------------------------------------------------------+------------------+
+| 1              | 127.0.0.1/32                                          | cubedb           |
++----------------+-------------------------------------------------------+------------------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_udfs__pg_backend_pid.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_udfs__pg_backend_pid.snap
@@ -2,8 +2,8 @@
 source: cubesql/src/compile/test/test_udfs.rs
 expression: "execute_query(\"select pg_backend_pid();\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+------------------+
-| pg_backend_pid() |
-+------------------+
-| 1                |
-+------------------+
++----------------+
+| pg_backend_pid |
++----------------+
+| 1              |
++----------------+

--- a/rust/cubesqlplanner/Cargo.lock
+++ b/rust/cubesqlplanner/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "chrono",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=dcf3e4aa26fd112043ef26fa4a78db5dbd443c86#dcf3e4aa26fd112043ef26fa4a78db5dbd443c86"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a612fc26f762f3837ecf26df2e83ba38f11a8a2#1a612fc26f762f3837ecf26df2e83ba38f11a8a2"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesqlplanner/cubesqlplanner/Cargo.toml
+++ b/rust/cubesqlplanner/cubesqlplanner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "dcf3e4aa26fd112043ef26fa4a78db5dbd443c86", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1a612fc26f762f3837ecf26df2e83ba38f11a8a2", default-features = false, features = ["regex_expressions", "unicode_expressions"] }
 tokio = { version = "^1.35", features = ["full", "rt", "tracing"] }
 itertools = "0.10.2"
 cubeclient = { path = "../../cubesql/cubeclient" }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with functions being aliased as the expression when no alias is specified. For instance, the query `SELECT version()` would name the resulting column `version()` instead of `version` like PostgreSQL does. Related tests are adjusted.
