### PR TITLE
docs: Update DAX API function reference

### DIFF
--- a/docs/pages/product/apis-integrations/dax-api/reference.mdx
+++ b/docs/pages/product/apis-integrations/dax-api/reference.mdx
@@ -26,13 +26,24 @@ of the DAX documentation.
 | Function | <nobr>Unsupported features</nobr> | Caveats |
 | --- | --- | --- |
 | [`AVERAGE`](https://learn.microsoft.com/en-us/dax/average-function-dax) | — | — |
+| [`AVERAGEA`](https://learn.microsoft.com/en-us/dax/averagea-function-dax) | Non-numeric values | — |
+| [`AVERAGEX`](https://learn.microsoft.com/en-us/dax/averagex-function-dax) | Non-base table as input table | — |
 | [`COUNT`](https://learn.microsoft.com/en-us/dax/count-function-dax) | — | — |
 | [`COUNTA`](https://learn.microsoft.com/en-us/dax/counta-function-dax) | — | — |
+| [`COUNTAX`](https://learn.microsoft.com/en-us/dax/countax-function-dax) | Non-base table as input table | — |
+| [`COUNTBLANK`](https://learn.microsoft.com/en-us/dax/countblank-function-dax) | — | — |
 | [`COUNTROWS`](https://learn.microsoft.com/en-us/dax/countrows-function-dax) | — | Disregards input table expression and always returns 1 |
+| [`COUNTX`](https://learn.microsoft.com/en-us/dax/countx-function-dax) | Non-base table as input table | — |
 | [`DISTINCTCOUNT`](https://learn.microsoft.com/en-us/dax/distinctcount-function-dax) | — | Blanks are ignored |
+| [`DISTINCTCOUNTNOBLANK`](https://learn.microsoft.com/en-us/dax/distinctcountnoblank-function-dax) | — | — |
 | [`MAX`](https://learn.microsoft.com/en-us/dax/max-function-dax) | 2 arguments | Blanks are disregarded instead of being treated as 0 |
+| [`MAXA`](https://learn.microsoft.com/en-us/dax/maxa-function-dax) | — | — |
+| [`MAXX`](https://learn.microsoft.com/en-us/dax/maxx-function-dax) | Non-base table as input table | — |
 | [`MIN`](https://learn.microsoft.com/en-us/dax/min-function-dax) | 2 arguments | Blanks are disregarded instead of being treated as 0 |
+| [`MINA`](https://learn.microsoft.com/en-us/dax/mina-function-dax) | — | — |
+| [`MINX`](https://learn.microsoft.com/en-us/dax/minx-function-dax) | Non-base table as input table | — |
 | [`SUM`](https://learn.microsoft.com/en-us/dax/sum-function-dax) | — | — |
+| [`SUMX`](https://learn.microsoft.com/en-us/dax/sumx-function-dax) | Non-base table as input table | — |
 
 ### Date and time functions
 
@@ -47,7 +58,19 @@ of the DAX documentation.
 | Function | <nobr>Unsupported features</nobr> | Caveats |
 | --- | --- | --- |
 | [`DATE`](https://learn.microsoft.com/en-us/dax/date-function-dax) | Non-literal date parts | — |
+| [`DAY`](https://learn.microsoft.com/en-us/dax/day-function-dax) | Text date input | — |
+| [`HOUR`](https://learn.microsoft.com/en-us/dax/hour-function-dax) | Text date input | — |
+| [`MINUTE`](https://learn.microsoft.com/en-us/dax/minute-function-dax) | Text date input | — |
+| [`MONTH`](https://learn.microsoft.com/en-us/dax/month-function-dax) | Text date input | — |
+| [`NOW`](https://learn.microsoft.com/en-us/dax/now-function-dax) | — | Returns datetime in UTC time zone |
+| [`QUARTER`](https://learn.microsoft.com/en-us/dax/quarter-function-dax) | Text date input | — |
+| [`SECOND`](https://learn.microsoft.com/en-us/dax/second-function-dax) | Text date input | — |
 | [`TIME`](https://learn.microsoft.com/en-us/dax/time-function-dax) | Non-literal date parts. Execution outside `DATE(...) + TIME(...)` expression | — |
+| [`TODAY`](https://learn.microsoft.com/en-us/dax/today-function-dax) | — | Returns date in UTC time zone. Time is at 12:00:00 AM; contrary to documentation, Analysis Services returns that time |
+| [`UTCNOW`](https://learn.microsoft.com/en-us/dax/utcnow-function-dax) | — | — |
+| [`UTCTODAY`](https://learn.microsoft.com/en-us/dax/utctoday-function-dax) | — | Time is at 12:00:00 AM; contrary to documentation, Analysis Services returns that time |
+| [`WEEKDAY`](https://learn.microsoft.com/en-us/dax/weekday-function-dax) | Text date input | — |
+| [`YEAR`](https://learn.microsoft.com/en-us/dax/year-function-dax) | Text date input | — |
 
 ### Filter functions
 
@@ -91,9 +114,13 @@ of the DAX documentation.
 
 | Function | <nobr>Unsupported features</nobr> | Caveats |
 | --- | --- | --- |
+| [`ISAFTER`](https://learn.microsoft.com/en-us/dax/isafter-function-dax) | — | — |
 | [`ISBLANK`](https://learn.microsoft.com/en-us/dax/isblank-function-dax) | — | Blanks are treated as equivalent to nulls and vice versa |
+| [`ISEVEN`](https://learn.microsoft.com/en-us/dax/iseven-function-dax) | — | — |
+| [`ISODD`](https://learn.microsoft.com/en-us/dax/isodd-function-dax) | — | — |
 | [`ISONORAFTER`](https://learn.microsoft.com/en-us/dax/isonorafter-function-dax) | — | — |
 | [`NONVISUAL`](https://learn.microsoft.com/en-us/dax/nonvisual-function-dax) | — | Doesn't modify behavior, silently ignored |
+| [`USERCULTURE`](https://learn.microsoft.com/en-us/dax/userculture-function-dax) | — | Always returns "en-US" |
 
 ### Logical functions
 
@@ -108,8 +135,12 @@ of the DAX documentation.
 | Function | <nobr>Unsupported features</nobr> | Caveats |
 | --- | --- | --- |
 | [`AND`](https://learn.microsoft.com/en-us/dax/and-function-dax) | — | — |
+| [`FALSE`](https://learn.microsoft.com/en-us/dax/false-function-dax) | — | — |
+| [`IF`](https://learn.microsoft.com/en-us/dax/if-function-dax) | Variant data types | — |
 | [`NOT`](https://learn.microsoft.com/en-us/dax/not-function-dax) | — | — |
 | [`OR`](https://learn.microsoft.com/en-us/dax/or-function-dax) | — | — |
+| [`SWITCH`](https://learn.microsoft.com/en-us/dax/switch-function-dax) | — | — |
+| [`TRUE`](https://learn.microsoft.com/en-us/dax/true-function-dax) | — | — |
 
 ### Math and trig functions
 
@@ -121,7 +152,34 @@ of the DAX documentation.
 
 </InfoBox>
 
-No math and trig functions currently supported.
+| Function | <nobr>Unsupported features</nobr> | Caveats |
+| --- | --- | --- |
+| [`ABS`](https://learn.microsoft.com/en-us/dax/abs-function-dax) | — | — |
+| [`ACOS`](https://learn.microsoft.com/en-us/dax/acos-function-dax) | — | — |
+| [`ASIN`](https://learn.microsoft.com/en-us/dax/asin-function-dax) | — | — |
+| [`ATAN`](https://learn.microsoft.com/en-us/dax/atan-function-dax) | — | — |
+| [`CEILING`](https://learn.microsoft.com/en-us/dax/ceiling-function-dax) | Significance other than 1 | — |
+| [`COS`](https://learn.microsoft.com/en-us/dax/cos-function-dax) | — | — |
+| [`EXP`](https://learn.microsoft.com/en-us/dax/exp-function-dax) | — | — |
+| [`FLOOR`](https://learn.microsoft.com/en-us/dax/floor-function-dax) | Significance other than 1 | — |
+| [`INT`](https://learn.microsoft.com/en-us/dax/int-function-dax) | — | — |
+| [`LN`](https://learn.microsoft.com/en-us/dax/ln-function-dax) | — | — |
+| [`LOG`](https://learn.microsoft.com/en-us/dax/log-function-dax) | Base other than 10 | — |
+| [`LOG10`](https://learn.microsoft.com/en-us/dax/log10-function-dax) | — | — |
+| [`MOD`](https://learn.microsoft.com/en-us/dax/mod-function-dax) | — | — |
+| [`MROUND`](https://learn.microsoft.com/en-us/dax/mround-function-dax) | Multiple other than 1 | — |
+| [`PI`](https://learn.microsoft.com/en-us/dax/pi-function-dax) | — | — |
+| [`POWER`](https://learn.microsoft.com/en-us/dax/power-function-dax) | — | — |
+| [`QUOTIENT`](https://learn.microsoft.com/en-us/dax/quotient-function-dax) | — | — |
+| [`RAND`](https://learn.microsoft.com/en-us/dax/rand-function-dax) | — | — |
+| [`ROUND`](https://learn.microsoft.com/en-us/dax/round-function-dax) | Num digits other than 0 | — |
+| [`ROUNDDOWN`](https://learn.microsoft.com/en-us/dax/rounddown-function-dax) | Num digits other than 0 | — |
+| [`ROUNDUP`](https://learn.microsoft.com/en-us/dax/roundup-function-dax) | Num digits other than 0 | — |
+| [`SIN`](https://learn.microsoft.com/en-us/dax/sin-function-dax) | — | — |
+| [`SQRT`](https://learn.microsoft.com/en-us/dax/sqrt-function-dax) | — | — |
+| [`SQRTPI`](https://learn.microsoft.com/en-us/dax/sqrtpi-function-dax) | — | — |
+| [`TAN`](https://learn.microsoft.com/en-us/dax/tan-function-dax) | — | — |
+| [`TRUNC`](https://learn.microsoft.com/en-us/dax/trunc-function-dax) | Num digits other than 0 | — |
 
 ### Other functions
 
@@ -215,7 +273,20 @@ of the DAX documentation.
 
 | Function | <nobr>Unsupported features</nobr> | Caveats |
 | --- | --- | --- |
+| [`CONCATENATE`](https://learn.microsoft.com/en-us/dax/concatenate-function-dax) | — | — |
+| [`EXACT`](https://learn.microsoft.com/en-us/dax/exact-function-dax) | — | — |
+| [`FIND`](https://learn.microsoft.com/en-us/dax/find-function-dax) | Start num other than 1 and not found value other than 0 | — |
+| [`LEFT`](https://learn.microsoft.com/en-us/dax/left-function-dax) | — | — |
+| [`LEN`](https://learn.microsoft.com/en-us/dax/len-function-dax) | — | — |
+| [`LOWER`](https://learn.microsoft.com/en-us/dax/lower-function-dax) | — | — |
+| [`MID`](https://learn.microsoft.com/en-us/dax/mid-function-dax) | — | — |
+| [`REPT`](https://learn.microsoft.com/en-us/dax/rept-function-dax) | — | Returns empty string when num times is 0 |
+| [`RIGHT`](https://learn.microsoft.com/en-us/dax/right-function-dax) | — | — |
+| [`SUBSTITUTE`](https://learn.microsoft.com/en-us/dax/substitute-function-dax) | Instance number | — |
 | [`SEARCH`](https://learn.microsoft.com/en-us/dax/search-function-dax) | Execution outside filter context functions | — |
+| [`TRIM`](https://learn.microsoft.com/en-us/dax/trim-function-dax) | Trimming inner whitespace | — |
+| [`UPPER`](https://learn.microsoft.com/en-us/dax/upper-function-dax) | — | — |
+| [`VALUE`](https://learn.microsoft.com/en-us/dax/value-function-dax) | — | — |
 
 ### Time intelligence functions
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR updates DAX API function reference, specifically:
- Document newly supported arithmetic functions along with their caveats: `AVERAGEA`, `AVERAGEX`, `COUNTAX`, `COUNTBLANK`, `COUNTX`, `DISTINCTCOUNTNOBLANK`, `MAXA`, `MAXX`, `MINA`, `MINX`, `SUMX`
- Document newly supported date and time functions along with their caveats: `DAY`, `HOUR`, `MINUTE`, `MONTH`, `NOW`, `QUARTER`, `SECOND`, `TODAY`, `UTCNOW`, `UTCTODAY`, `WEEKDAY`, `YEAR`
- Document newly supported information functions along with their caveats: `ISAFTER`, `ISEVEN`, `ISODD`, `USERCULTURE`
- Document newly supported logical functions along with their caveats: `FALSE`, `IF`, `SWITCH`, `TRUE`
- Document newly supported math and trig functions along with their caveats: `ABS`, `ACOS`, `ASIN`, `ATAN`, `CEILING`, `COS`, `EXP`, `FLOOR`, `INT`, `LN`, `LOG`, `LOG10`, `MOD`, `MROUND`, `PI`, `POWER`, `QUOTIENT`, `RAND`, `ROUND`, `ROUNDDOWN`, `ROUNDUP`, `SIN`, `SQRT`, `SQRTPI`, `TAN`, `TRUNC`
- Document newly supported text functions along with their caveats: `CONCATENATE`, `EXACT`, `FIND`, `LEFT`, `LEN`, `LOWER`, `MID`, `REPT`, `RIGHT`, `SUBSTITUTE`, `TRIM`, `UPPER`, `VALUE`
