### PR TITLE
fix(cubesql): Disable projection_push_down DF optimizer

### DIFF
--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -10,7 +10,7 @@ use crate::{
             df::{
                 optimizers::{FilterPushDown, FilterSplitMeta, LimitPushDown, SortPushDown},
                 scan::CubeScanNode,
-                wrapper::CubeScanWrapperNode,
+                wrapper::{CubeScanWrappedSqlNode, CubeScanWrapperNode},
             },
             udf::*,
             CubeContext, VariablesProvider,
@@ -580,7 +580,11 @@ fn is_olap_query(parent: &LogicalPlan) -> Result<bool, CompilationError> {
 
         fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
             if let LogicalPlan::Extension(ext) = plan {
-                if let Some(_) = ext.node.as_any().downcast_ref::<CubeScanNode>() {
+                let node = ext.node.as_any();
+                if node.is::<CubeScanNode>()
+                    || node.is::<CubeScanWrapperNode>()
+                    || node.is::<CubeScanWrappedSqlNode>()
+                {
                     self.0 = true;
 
                     return Ok(false);

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-2.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-2.snap
@@ -12,7 +12,6 @@ expression: "execute_query(\"EXPLAIN VERBOSE SELECT 1+1;\".to_string(),\n       
 | logical_plan after common_sub_expression_eliminate    | SAME TEXT AS ABOVE                              |
 | logical_plan after eliminate_limit                    | SAME TEXT AS ABOVE                              |
 | logical_plan after projection_drop_out                | SAME TEXT AS ABOVE                              |
-| logical_plan after projection_push_down               | SAME TEXT AS ABOVE                              |
 | logical_plan after filter_push_down                   | SAME TEXT AS ABOVE                              |
 | logical_plan after limit_push_down                    | SAME TEXT AS ABOVE                              |
 | logical_plan after SingleDistinctAggregationToGroupBy | SAME TEXT AS ABOVE                              |

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__union_all_alias_mismatch.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__union_all_alias_mismatch.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(query.to_string(), DatabaseProtocol::PostgreSQL,).await.unwrap()"
+---
++-----+-----+
+| foo | bar |
++-----+-----+
+| foo | bar |
++-----+-----+

--- a/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
@@ -61,3 +61,33 @@ async fn test_triple_join_with_coercion() {
     .await
     .unwrap());
 }
+
+#[tokio::test]
+async fn union_all_alias_mismatch() {
+    init_testing_logger();
+
+    // language=PostgreSQL
+    let query = r#"
+SELECT
+    foo,
+    bar
+FROM (
+    SELECT
+        'foo' as foo,
+        'bar' as bar
+    UNION ALL
+    SELECT
+        'foo' as foo,
+        'bar' as qux
+) t
+GROUP BY
+    foo, bar
+;
+        "#;
+
+    insta::assert_snapshot!(
+        execute_query(query.to_string(), DatabaseProtocol::PostgreSQL,)
+            .await
+            .unwrap()
+    );
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

It can drop projection for mismatched alias in UNION ALL, leading to missing columns and out-of-bounds panic during execution in DF