### PR TITLE
fix(schema-compiler): Fix doubled calls to convertTz() for compound time dimensions with custom granularities

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2639,6 +2639,9 @@ export class BaseQuery {
             dimension: this.cubeEvaluator.pathFromArray([cubeName, name]),
             granularity: subPropertyName
           });
+          // for time dimension with granularity convertedToTz() is called internally in dimensionSql() flow,
+          // so we need to ignore convertTz later even if context convertTzForRawTimeDimension is set to true
+          this.safeEvaluateSymbolContext().ignoreConvertTzForTimeDimension = true;
           return td.dimensionSql();
         } else {
           let res = this.autoPrefixAndEvaluateSql(cubeName, symbol.sql, isMemberExpr);
@@ -2647,6 +2650,7 @@ export class BaseQuery {
             res = `(${this.addTimestampInterval(res, symbol.shiftInterval)})`;
           }
           if (this.safeEvaluateSymbolContext().convertTzForRawTimeDimension &&
+            !this.safeEvaluateSymbolContext().ignoreConvertTzForTimeDimension &&
             !memberExpressionType &&
             symbol.type === 'time' &&
             this.cubeEvaluator.byPathAnyType(memberPathArray).ownedByCube

--- a/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
@@ -25,7 +25,21 @@ describe('PostgresQuery', () => {
       dimensions: {
         createdAt: {
           type: 'time',
-          sql: 'created_at'
+          sql: 'created_at',
+          granularities: {
+            fiscal_year: {
+              interval: '1 year',
+              offset: '1 month',
+            },
+            fiscal_quarter: {
+              interval: '1 quarter',
+              offset: '1 month',
+            },
+          }
+        },
+        fiscalCreatedAtLabel: {
+          type: 'string',
+          sql: \`'FY' || (EXTRACT(YEAR FROM \${createdAt.fiscal_year}) + 1)  || ' Q' || (EXTRACT(QUARTER FROM \${createdAt.fiscal_quarter}))\`
         },
         name: {
           type: 'string',
@@ -36,7 +50,7 @@ describe('PostgresQuery', () => {
 
     cube(\`Deals\`, {
       sql: \`select * from deals\`,
-    
+
       measures: {
         amount: {
           sql: \`amount\`,
@@ -52,31 +66,31 @@ describe('PostgresQuery', () => {
         }
       }
     })
-    
+
     cube(\`SalesManagers\`, {
       sql: \`select * from sales_managers\`,
-    
+
       joins: {
         Deals: {
           relationship: \`hasMany\`,
           sql: \`\${SalesManagers}.id = \${Deals}.sales_manager_id\`
         }
       },
-      
+
       measures: {
         averageDealAmount: {
           sql: \`\${dealsAmount}\`,
           type: \`avg\`
         }
       },
-    
+
       dimensions: {
         id: {
           sql: \`id\`,
           type: \`string\`,
           primaryKey: true
         },
-    
+
         dealsAmount: {
           sql: \`\${Deals.amount}\`,
           type: \`number\`,
@@ -113,5 +127,19 @@ describe('PostgresQuery', () => {
       const queryAndParams = query.buildSqlAndParams();
       expect(queryAndParams[0]).toContain(expected);
     }
+  });
+
+  it('test compound time dimension with custom granularity', async () => {
+    await compiler.compile();
+
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      dimensions: [
+        'visitors.fiscalCreatedAtLabel'
+      ],
+      timezone: 'America/Los_Angeles'
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    expect(queryAndParams[0].split('AT TIME ZONE \'America/Los_Angeles\'').length).toEqual(3);
   });
 });


### PR DESCRIPTION
This fixes incorrect SQL generation for compound time dimensions with custom granularities.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
