### PR TITLE
refactor(cubesql): Use corresponding name for checkSqlAuth

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -107,10 +107,9 @@ export class SQLServer {
     this.sqlInterfaceInstance = await registerInterface({
       gatewayPort: this.gatewayPort,
       pgPort: options.pgSqlPort,
-      checkAuth: async ({ request, user, password }) => {
+      checkSqlAuth: async ({ request, user, password }) => {
         const { password: returnedPassword, superuser, securityContext, skipPasswordCheck } = await checkSqlAuth(request, user, password);
 
-        // Strip securityContext to improve speed deserialization
         return {
           password: returnedPassword,
           superuser: superuser || false,

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -88,7 +88,7 @@ export interface CanSwitchUserPayload {
 
 export type SQLInterfaceOptions = {
   pgPort?: number,
-  checkAuth: (payload: CheckAuthPayload) => CheckAuthResponse | Promise<CheckAuthResponse>,
+  checkSqlAuth: (payload: CheckAuthPayload) => CheckAuthResponse | Promise<CheckAuthResponse>,
   load: (payload: LoadPayload) => unknown | Promise<unknown>,
   sql: (payload: SqlPayload) => unknown | Promise<unknown>,
   meta: (payload: MetaPayload) => unknown | Promise<unknown>,
@@ -347,8 +347,8 @@ export const registerInterface = async (options: SQLInterfaceOptions): Promise<S
     throw new Error('Argument options must be an object');
   }
 
-  if (typeof options.checkAuth !== 'function') {
-    throw new Error('options.checkAuth must be a function');
+  if (typeof options.checkSqlAuth !== 'function') {
+    throw new Error('options.checkSqlAuth must be a function');
   }
 
   if (typeof options.load !== 'function') {
@@ -378,7 +378,7 @@ export const registerInterface = async (options: SQLInterfaceOptions): Promise<S
   const native = loadNative();
   return native.registerInterface({
     ...options,
-    checkAuth: wrapNativeFunctionWithChannelCallback(options.checkAuth),
+    checkSqlAuth: wrapNativeFunctionWithChannelCallback(options.checkSqlAuth),
     load: wrapNativeFunctionWithChannelCallback(options.load),
     sql: wrapNativeFunctionWithChannelCallback(options.sql),
     meta: wrapNativeFunctionWithChannelCallback(options.meta),

--- a/packages/cubejs-backend-native/src/auth.rs
+++ b/packages/cubejs-backend-native/src/auth.rs
@@ -17,14 +17,14 @@ use crate::channel::call_js_with_channel_as_callback;
 #[derive(Debug)]
 pub struct NodeBridgeAuthService {
     channel: Arc<Channel>,
-    check_auth: Arc<Root<JsFunction>>,
+    check_sql_auth: Arc<Root<JsFunction>>,
 }
 
 impl NodeBridgeAuthService {
-    pub fn new(channel: Channel, check_auth: Root<JsFunction>) -> Self {
+    pub fn new(channel: Channel, check_sql_auth: Root<JsFunction>) -> Self {
         Self {
             channel: Arc::new(channel),
-            check_auth: Arc::new(check_auth),
+            check_sql_auth: Arc::new(check_sql_auth),
         }
     }
 }
@@ -36,14 +36,14 @@ pub struct TransportRequest {
 }
 
 #[derive(Debug, Serialize)]
-struct CheckAuthRequest {
+struct CheckSQLAuthRequest {
     request: TransportRequest,
     user: Option<String>,
     password: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct CheckAuthResponse {
+struct CheckSQLAuthResponse {
     password: Option<String>,
     superuser: bool,
     #[serde(rename = "securityContext", skip_serializing_if = "Option::is_none")]
@@ -76,7 +76,7 @@ impl SqlAuthService for NodeBridgeAuthService {
 
         let request_id = Uuid::new_v4().to_string();
 
-        let extra = serde_json::to_string(&CheckAuthRequest {
+        let extra = serde_json::to_string(&CheckSQLAuthRequest {
             request: TransportRequest {
                 id: format!("{}-span-1", request_id),
                 meta: None,
@@ -84,9 +84,9 @@ impl SqlAuthService for NodeBridgeAuthService {
             user: user.clone(),
             password: password.clone(),
         })?;
-        let response: CheckAuthResponse = call_js_with_channel_as_callback(
+        let response: CheckSQLAuthResponse = call_js_with_channel_as_callback(
             self.channel.clone(),
-            self.check_auth.clone(),
+            self.check_sql_auth.clone(),
             Some(extra),
         )
         .await?;

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -48,8 +48,8 @@ impl SQLInterface {
 
 fn register_interface<C: NodeConfiguration>(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let options = cx.argument::<JsObject>(0)?;
-    let check_auth = options
-        .get::<JsFunction, _, _>(&mut cx, "checkAuth")?
+    let check_sql_auth = options
+        .get::<JsFunction, _, _>(&mut cx, "checkSqlAuth")?
         .root(&mut cx);
     let transport_sql_api_load = options
         .get::<JsFunction, _, _>(&mut cx, "sqlApiLoad")?
@@ -101,7 +101,7 @@ fn register_interface<C: NodeConfiguration>(mut cx: FunctionContext) -> JsResult
         transport_sql_generator,
         transport_can_switch_user_for_session,
     );
-    let auth_service = NodeBridgeAuthService::new(cx.channel(), check_auth);
+    let auth_service = NodeBridgeAuthService::new(cx.channel(), check_sql_auth);
 
     std::thread::spawn(move || {
         let config = C::new(NodeConfigurationFactoryOptions {

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -103,8 +103,8 @@ function interfaceMethods() {
         dataSourceToSqlGenerator: {},
       };
     }),
-    checkAuth: jest.fn(async ({ request, user }) => {
-      console.log('[js] checkAuth', {
+    checkSqlAuth: jest.fn(async ({ request, user }) => {
+      console.log('[js] checkSqlAuth', {
         request,
         user,
       });
@@ -146,7 +146,7 @@ describe('SQLInterface', () => {
 
   it('SHOW FULL TABLES FROM `db`', async () => {
     const methods = interfaceMethods();
-    const { checkAuth, meta } = methods;
+    const { checkSqlAuth, meta } = methods;
 
     const instance = await native.registerInterface({
       pgPort: 5555,
@@ -178,9 +178,9 @@ describe('SQLInterface', () => {
           );
         }
 
-        console.log(checkAuth.mock.calls);
-        expect(checkAuth.mock.calls.length).toEqual(1);
-        expect(checkAuth.mock.calls[0][0]).toEqual({
+        console.log(checkSqlAuth.mock.calls);
+        expect(checkSqlAuth.mock.calls.length).toEqual(1);
+        expect(checkSqlAuth.mock.calls[0][0]).toEqual({
           request: {
             id: expect.any(String),
             meta: null,
@@ -195,19 +195,19 @@ describe('SQLInterface', () => {
         user: 'random user',
         password: undefined,
       });
-      checkAuth.mockClear();
+      checkSqlAuth.mockClear();
 
       await testConnectionFailed({
         user: 'allowed_user',
         password: undefined,
       });
-      checkAuth.mockClear();
+      checkSqlAuth.mockClear();
 
       await testConnectionFailed({
         user: 'allowed_user',
         password: 'wrong_password',
       });
-      checkAuth.mockClear();
+      checkSqlAuth.mockClear();
 
       const connection = new Client({
         host: '127.0.0.1',
@@ -236,8 +236,8 @@ describe('SQLInterface', () => {
         ]);
       }
 
-      expect(checkAuth.mock.calls.length).toEqual(1);
-      expect(checkAuth.mock.calls[0][0]).toEqual({
+      expect(checkSqlAuth.mock.calls.length).toEqual(1);
+      expect(checkSqlAuth.mock.calls[0][0]).toEqual({
         request: {
           id: expect.any(String),
           meta: null,


### PR DESCRIPTION
I am going to expose `checkAuth` in the next PR. To protect a situation with name collisions, I am going to rename functions that are used as `checkSqlAuth`.