### PR TITLE
fix(schema-compiler): Fix BigQuery DATETIME_TRUNC() week processing

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -236,7 +236,7 @@ export class BigqueryQuery extends BaseQuery {
     const templates = super.sqlTemplates();
     templates.quotes.identifiers = '`';
     templates.quotes.escape = '\\`';
-    templates.functions.DATETRUNC = 'DATETIME_TRUNC(CAST({{ args[1] }} AS DATETIME), {{ date_part }})';
+    templates.functions.DATETRUNC = 'DATETIME_TRUNC(CAST({{ args[1] }} AS DATETIME), {% if date_part|upper == \'WEEK\' %}{{ \'WEEK(MONDAY)\' }}{% else %}{{ date_part }}{% endif %})';
     templates.functions.LOG = 'LOG({{ args_concat }}{% if args[1] is undefined %}, 10{% endif %})';
     templates.functions.BTRIM = 'TRIM({{ args_concat }})';
     templates.functions.STRPOS = 'STRPOS({{ args_concat }})';


### PR DESCRIPTION
This PR fixes datetime WEEK truncing for BigQuery.

Closes #9330

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

