### PR TITLE
chore(dev-env): Use referenced project for typescript code building

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -18,14 +18,15 @@ install_root_dependencies() {
 build_packages() {
     echo "Building all packages..."
     cd "$SCRIPT_DIR"
+
+    # Building typescript packages first from root (it's referenced project)
+    yarn tsc
+
     for package in packages/*; do
         if [ -d "$package" ]; then
             echo "Building $package..."
             cd "$package"
-            if ! yarn build 2>/dev/null; then
-                #echo "yarn build failed for $package, trying yarn tsc..."
-                yarn tsc 2>/dev/null || true
-            fi
+            yarn build 2>/dev/null || true
             cd "$SCRIPT_DIR"
         fi
     done


### PR DESCRIPTION
https://cube-js.slack.com/archives/C01FU5AP9LJ/p1741252890815729

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/f8b859d5-fd0f-4fbe-823f-9b45f22316e3" />

We need to use referenced project (building typescript code from the root), because it resolves dependency graph.