### PR TITLE
chore(ci): PR workflow - reorganize core builds (speedup builds)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -120,21 +120,6 @@ jobs:
 #          files: ./packages/*/coverage/clover.xml
 #          flags: cube-backend
 #          verbose: true # optional (default = false)
-      - name: Cargo test cubeorchestrator
-        run: |
-          cargo test --manifest-path rust/cubeorchestrator/Cargo.toml -j 1
-      - name: Cargo test cubenativeutils
-        run: |
-          cargo test --manifest-path rust/cubenativeutils/Cargo.toml -j 1
-      - name: Cargo test cubeshared
-        run: |
-          cargo test --manifest-path rust/cubeshared/Cargo.toml -j 1
-#      - name: Cargo test cubesql
-#        run: |
-#          cargo test --manifest-path rust/cubesql/Cargo.toml -j 1
-      - name: Cargo test cubesqlplanner
-        run: |
-          cargo test --manifest-path rust/cubesqlplanner/cubesqlplanner/Cargo.toml -j 1
 
   lint:
     runs-on: ubuntu-24.04
@@ -179,6 +164,8 @@ jobs:
           retry_wait_seconds: 15
           timeout_minutes: 20
           command: yarn install --frozen-lockfile
+      - name: Check Yarn lock wasn't modified
+        run: if [ "$(git status | grep nothing)x" = "x" ]; then echo "Non empty changeset after lerna bootstrap"; git status; exit 1; else echo "Nothing to commit. Proceeding"; fi;
       - name: NPM lint
         run: yarn lint:npm
       - name: Lerna lint
@@ -199,7 +186,7 @@ jobs:
         run: |
           cargo fmt --manifest-path rust/cubesqlplanner/cubesqlplanner/Cargo.toml -- --check
 
-  build:
+  unit-core:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     needs: latest-tag-sha
@@ -212,59 +199,15 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.84.1
-          # override: true # this is by default on
-          rustflags: ""
           components: rustfmt
-      - name: Install Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
-        shell: bash
-      - name: Restore yarn cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Set Yarn version
-        run: yarn policies set-version v1.22.22
-      - name: Yarn install
-        uses: nick-fields/retry@v3
-        env:
-          CUBESTORE_SKIP_POST_INSTALL: true
-        with:
-          max_attempts: 3
-          retry_on: error
-          retry_wait_seconds: 15
-          timeout_minutes: 20
-          command: yarn install --frozen-lockfile
-      - name: Check Yarn lock wasn't modified
-        run: if [ "$(git status | grep nothing)x" = "x" ]; then echo "Non empty changeset after lerna bootstrap"; git status; exit 1; else echo "Nothing to commit. Proceeding"; fi;
-      - name: Build Core Client libraries
-        run: yarn build
-      - name: Build other packages
-        run: yarn lerna run --concurrency 1 build
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
-      - name: Cargo build cubeorchestrator
-        run: |
-          cargo build --manifest-path rust/cubeorchestrator/Cargo.toml -j 4
-      - name: Cargo build cubenativeutils
-        run: |
-          cargo build --manifest-path rust/cubenativeutils/Cargo.toml -j 4
-      - name: Cargo build cubeshared
-        run: |
-          cargo build --manifest-path rust/cubeshared/Cargo.toml -j 4
-#      - name: Cargo build cubesql
-#        run: |
-#          cargo build --manifest-path rust/cubesql/Cargo.toml -j 4
-      - name: Cargo build cubesqlplanner
-        run: |
-          cargo build --manifest-path rust/cubesqlplanner/cubesqlplanner/Cargo.toml -j 4
+      - name: Cargo test cubeorchestrator
+        run: cargo test --manifest-path rust/cubeorchestrator/Cargo.toml -j 4
+      - name: Cargo test cubenativeutils
+        run: cargo test --manifest-path rust/cubenativeutils/Cargo.toml -j 4
+      - name: Cargo test cubeshared
+        run: cargo test --manifest-path rust/cubeshared/Cargo.toml -j 4
+      - name: Cargo test cubesqlplanner
+        run: cargo test --manifest-path rust/cubesqlplanner/cubesqlplanner/Cargo.toml -j 4
 
   build-cubestore:
     needs: [latest-tag-sha]


### PR DESCRIPTION
### Before:

`21 minutes` for unit tests, but `integration` depends on it.

![image](https://github.com/user-attachments/assets/9e6e5335-50b6-4a9e-ad0f-b0eb1e56c54c)
![image](https://github.com/user-attachments/assets/9462519f-f574-49fa-be9b-f6a6cc34ab66)
![image](https://github.com/user-attachments/assets/57cbf0f9-18ae-4b30-af10-0b48bab1c12f)

### After

![image](https://github.com/user-attachments/assets/4ae00645-5969-418a-b48d-018e0d5669eb)
![image](https://github.com/user-attachments/assets/4be989dd-28ea-4a54-8658-7e3275ab67d6)

`9` minutes for unit tests, integration tests will start earlier by `21-9=12 minutes` & the whole workflow will end earlier.