### PR TITLE
fix(schema-compiler): Fix model validation for aliased included members for views

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -792,8 +792,8 @@ const viewSchema = inherit(baseSchema, {
         Joi.array().items(Joi.alternatives([
           Joi.string().required(),
           Joi.object().keys({
-            name: Joi.string().required(),
-            alias: Joi.string()
+            name: identifier.required(),
+            alias: identifier
           })
         ]))
       ]).required(),

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -134,6 +134,37 @@ describe('Cube Validation', () => {
     expect(validationResult.error).toBeFalsy();
   });
 
+  it('view with incorrect included member with alias', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      // it's a hidden field which we use internally
+      isView: true,
+      fileName: 'fileName',
+      cubes: [
+        {
+          joinPath: () => '',
+          prefix: false,
+          includes: [
+            'member-by-name',
+            {
+              name: 'member-by-alias',
+              alias: 'incorrect Alias'
+            }
+          ]
+        }
+      ]
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message: any, _e: any) => {
+        console.log(message);
+      }
+    } as any);
+
+    expect(validationResult.error).toBeTruthy();
+  });
+
   it('refreshKey alternatives', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {


### PR DESCRIPTION
Fix validation to throw error for incorrect aliased included members for view.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

