### PR TITLE
chore(schema-compiler)!: Drop support for top-level includes/excludes in views

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -58,7 +58,7 @@ features:
 | Removed    | [Using Redis for in-memory cache and queue](#using-redis-for-in-memory-cache-and-queue)                                           | v0.32.0    | v0.36.0   |
 | Deprecated | [`SECURITY_CONTEXT`](#security_context)                                                                                           | v0.33.0    |           |
 | Deprecated | [`running_total` measure type](#running_total-measure-type)                                                                       | v0.33.39   |           |
-| Deprecated | [Top-level `includes` parameter in views](#top-level-includes-parameter-in-views)                                                 | v0.34.34   |           |
+| Removed    | [Top-level `includes` parameter in views](#top-level-includes-parameter-in-views)                                                 | v0.34.34   | v1.3.0    |
 | Removed    | [Node.js 16](#nodejs-16)                                                                                                          | v0.35.0    | v0.36.0   |
 | Removed    | [MySQL-based SQL API](#mysql-based-sql-api)                                                                                       | v0.35.0    | v0.35.0   |
 | Removed    | [`initApp` hook](#initapp-hook)                                                                                                   | v0.35.0    | v0.35.0   |
@@ -350,9 +350,9 @@ to calculate running totals instead.
 
 ### Top-level `includes` parameter in views
 
-**Deprecated in Release: v0.34.34**
+**Removed in Release: v1.3.0**
 
-The top-level `includes` parameter is now deprecated. Please always use the
+The top-level `includes` parameter is now removed. Please always use the
 `includes` parameter within [`cubes` and `join_path`
 parameters](https://cube.dev/docs/reference/data-model/view#cubes) so you can
 explicitly control the join path.

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -779,8 +779,6 @@ const cubeSchema = inherit(baseSchema, {
 
 const viewSchema = inherit(baseSchema, {
   isView: Joi.boolean().strict(),
-  includes: Joi.func(),
-  excludes: Joi.func(),
   cubes: Joi.array().items(
     Joi.object().keys({
       joinPath: Joi.func().required(),

--- a/packages/cubejs-schema-compiler/test/integration/postgres/cube-views.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/cube-views.test.ts
@@ -200,8 +200,19 @@ cube(\`ProductCategories\`, {
 });
 
 view(\`OrdersView\`, {
-  includes: [Orders],
-  excludes: [Orders.createdAt],
+  cubes: [{
+    join_path: Orders,
+    includes: '*',
+    excludes: ['createdAt']
+  }, {
+    join_path: Orders.Products,
+    includes: '*',
+    prefix: true
+  }, {
+    join_path: Orders.Products.ProductCategories,
+    includes: '*',
+    prefix: true
+  }],
 
   measures: {
     productCategoryCount: {
@@ -231,10 +242,6 @@ view(\`OrdersView\`, {
       type: \`string\`
     },
   }
-});
-
-view(\`OrdersView2\`, {
-  includes: [Orders.count],
 });
 
 view(\`OrdersView3\`, {

--- a/packages/cubejs-schema-compiler/test/unit/views.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/views.test.ts
@@ -391,42 +391,6 @@ describe('Views YAML', () => {
     });
   });
 
-  it('includes * (legacy)', async () => {
-    const { cubeEvaluator } = await schemaCompile([{
-      name: 'simple_view',
-      includes: [
-        'CubeA.id',
-        // conflict
-        // 'CubeB.id',
-        'CubeB.other_id',
-      ]
-    }]);
-
-    expect(cubeEvaluator.getCubeDefinition('simple_view').dimensions).toEqual({
-      id: dimensionFixtureForCube('CubeA.id'),
-      other_id: dimensionFixtureForCube('CubeB.other_id'),
-    });
-  });
-
-  it('includes * (legacy) + exclude b.id', async () => {
-    const { cubeEvaluator } = await schemaCompile([{
-      name: 'simple_view',
-      includes: [
-        'CubeA.id',
-        'CubeB.id',
-        'CubeB.other_id',
-      ],
-      excludes: [
-        'CubeB.id'
-      ]
-    }]);
-
-    expect(cubeEvaluator.getCubeDefinition('simple_view').dimensions).toEqual({
-      id: dimensionFixtureForCube('CubeA.id'),
-      other_id: dimensionFixtureForCube('CubeB.other_id'),
-    });
-  });
-
   it('throws error for unresolved members', async () => {
     const { compiler } = prepareYamlCompiler(`
       cubes:


### PR DESCRIPTION
Dropping support for top-level includes/excludes in views, which were deprecated long ago...

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required
