### PR TITLE
chore!: Drop support for node.js v18, deprecate v20

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 20.x ]
+        node-version: [ 22.x ]
         db: [ 'athena', 'bigquery', 'snowflake' ]
         target: [ "x86_64-unknown-linux-gnu" ]
       fail-fast: false

--- a/.github/workflows/drivers-tests.yml
+++ b/.github/workflows/drivers-tests.yml
@@ -91,7 +91,7 @@ jobs:
     name: Build native Linux ${{ matrix.node-version }} ${{ matrix.target }} Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        node-version: [ 20 ]
+        node-version: [ 22 ]
         python-version: [ "fallback" ]
         target: [ "x86_64-unknown-linux-gnu" ]
       fail-fast: false
@@ -254,10 +254,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Node.js 20.x
+      - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Configure `yarn`
         run: yarn policies set-version v1.22.22

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,10 +67,10 @@ jobs:
           workspaces: ./rust/cubesql -> target
           key: cubesql-x86_64-unknown-linux-gnu
           shared-key: cubesql-x86_64-unknown-linux-gnu
-      - name: Install Node.js 20
+      - name: Install Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install Yarn
         run: npm install -g yarn
       - name: Set Yarn version

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,10 +103,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Node.js 20.x
+      - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Restore lerna
         uses: actions/cache@v4
         with:
@@ -167,10 +167,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Node.js 20.x
+      - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Restore lerna
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,10 @@ jobs:
           # override: true # this is by default on
           rustflags: ""
           components: rustfmt
-      - name: Install Node.js 20.x
+      - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -73,7 +73,7 @@ jobs:
     name: Build native Linux ${{ matrix.node-version }} ${{ matrix.target }} Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
         python-version: ["3.9", "3.10", "3.11", "3.12", "fallback"]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
         include:
@@ -152,7 +152,7 @@ jobs:
     name: Build ${{ matrix.os-version }} ${{ matrix.target }} ${{ matrix.node-version }} Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os-version: ["macos-13"]
         target: ["x86_64-apple-darwin", "aarch64-apple-darwin"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "fallback"]
@@ -240,7 +240,7 @@ jobs:
     name: Build ${{ matrix.os-version }} ${{ matrix.node-version }} Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         python-version: ["fallback"]
         os-version: [windows-2019]
         include:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # Current docker version + next LTS
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
         # Don't forget to update build-native-release
         python-version: [3.11]
         transpile-worker-threads: [false, true]
@@ -115,7 +115,7 @@ jobs:
       - name: Lerna test
         run: yarn lerna run --concurrency 1 --stream --no-prefix unit
 #      - uses: codecov/codecov-action@v1
-#        if: (matrix.node-version == '20.x')
+#        if: (matrix.node-version == '22.x')
 #        with:
 #          files: ./packages/*/coverage/clover.xml
 #          flags: cube-backend
@@ -137,10 +137,10 @@ jobs:
           # override: true # this is by default on
           rustflags: ""
           components: rustfmt
-      - name: Install Node.js 20.x
+      - name: Install Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
@@ -272,10 +272,10 @@ jobs:
           workspaces: ./packages/cubejs-backend-native
           key: native-${{ runner.OS }}-x86_64-unknown-linux-gnu
           shared-key: native-${{ runner.OS }}-x86_64-unknown-linux-gnu
-      - name: Install Node.js 20
+      - name: Install Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install Yarn
         run: npm install -g yarn
       - name: Set Yarn version
@@ -304,7 +304,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
       fail-fast: false
 
     steps:
@@ -392,7 +392,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         db: [
             'clickhouse', 'druid', 'elasticsearch', 'mssql', 'mysql', 'postgres', 'prestodb',
             'mysql-aurora-serverless', 'crate', 'mongobi', 'firebolt', 'dremio', 'vertica'
@@ -479,7 +479,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 20.x ]
+        node-version: [ 22.x ]
         python-version: [ 3.11 ]
       fail-fast: false
 
@@ -607,7 +607,7 @@ jobs:
           - 5000:5000
     strategy:
       matrix:
-        node-version: [ 20 ]
+        node-version: [ 22 ]
         target: [ "x86_64-unknown-linux-gnu" ]
         dockerfile:
           - dev.Dockerfile

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -118,13 +118,11 @@ jobs:
     strategy:
       matrix:
         # Current used version + 1 LTS
-        node-version: [20, 22]
+        node-version: [22]
         python-version: ["3.9", "3.10", "3.11", "3.12", "fallback"]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
         # minimize number of jobs
         exclude:
-          - node-version: 20
-            target: "aarch64-unknown-linux-gnu"
           - python-version: 3.10
             target: "aarch64-unknown-linux-gnu"
           - python-version: 3.11
@@ -221,7 +219,7 @@ jobs:
     strategy:
       matrix:
         # We do not need to test under all versions, we do it under linux
-        node-version: [20.x]
+        node-version: [22.x]
         os-version: ["macos-13"]
         target: ["x86_64-apple-darwin", "aarch64-apple-darwin"]
         include:
@@ -314,7 +312,7 @@ jobs:
     strategy:
       matrix:
         # We do not need to test under all versions, we do it under linux
-        node-version: [20.x]
+        node-version: [22.x]
         os-version: [windows-2019]
         python-version: ["fallback"]
       fail-fast: false

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -63,8 +63,9 @@ features:
 | Removed    | [MySQL-based SQL API](#mysql-based-sql-api)                                                                                       | v0.35.0    | v0.35.0   |
 | Removed    | [`initApp` hook](#initapp-hook)                                                                                                   | v0.35.0    | v0.35.0   |
 | Removed    | [`/v1/run-scheduled-refresh` REST API endpoint](#v1run-scheduled-refresh-rest-api-endpoint)                                       | v0.35.0    | v0.36.0   |
-| Deprecated | [Node.js 18](#nodejs-18)                                                                                                          | v0.36.0    |           |
-| Deprecated | [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](#cubejs_scheduled_refresh_concurrency) | v1.2.7 | |
+| Removed    | [Node.js 18](#nodejs-18)                                                                                                          | v0.36.0    | v1.3.0    |
+| Deprecated | [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](#cubejs_scheduled_refresh_concurrency)                                                   | v1.2.7 |           |
+| Deprecated | [Node.js 20](#nodejs-20)                                                                                                          | v1.3.0    |           |
 
 ### Node.js 8
 
@@ -392,6 +393,13 @@ API](https://cube.dev/docs/product/apis-integrations/orchestration-api) and
 
 Node.js 18 reaches [End of Life on April 30, 2025][link-nodejs-eol]. This means
 no more updates. Please upgrade to Node.js 20 or higher.
+
+### Node.js 20
+
+**Deprecated in Release: v1.3.0**
+
+Node.js 20 is in maintenance mode from [November 22, 2024][link-nodejs-eol]. This means
+no more new features, only security updates. Please upgrade to Node.js 22 or higher.
 
 ### `CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`
 

--- a/packages/cubejs-backend-maven/package.json
+++ b/packages/cubejs-backend-maven/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.2.27",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "jest": "^27",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.2.27",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "cargo-cp-artifact": "^0.1.9",
     "jest": "^27",
     "pg": "^8.11.3",

--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -27,7 +27,7 @@
     "@types/cli-progress": "^3.9.1",
     "@types/decompress": "^4.2.7",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/node-fetch": "^2.5.8",
     "@types/shelljs": "^0.8.5",
     "@types/throttle-debounce": "^2.1.0",

--- a/packages/cubejs-backend-shared/src/node-check.ts
+++ b/packages/cubejs-backend-shared/src/node-check.ts
@@ -1,36 +1,36 @@
 import process from 'process';
 import color from '@oclif/color';
 
+const leastSupportedVersion = 20;
 const currentNodeVersion = process.versions.node;
 const semver = currentNodeVersion.split('.');
 const major = parseInt(<string> semver[0], 10);
-// const _minor = parseInt(<string> semver[1], 10);
 
-if (major < 18) {
+if (major < leastSupportedVersion) {
   console.error(
     color.red(
       `You are running Node.js ${currentNodeVersion}.\n` +
-      'Cube.js CLI requires Node.js 20 or higher \n' +
+      `Cube.js CLI requires Node.js ${leastSupportedVersion} or higher.\n` +
       'Please update your Node.js version.'
     )
   );
   process.exit(1);
 }
 
-if (major === 19) {
+if (major === (leastSupportedVersion + 1)) {
   process.emitWarning(
     color.red(
       `You are running Node.js ${currentNodeVersion}.\n` +
-      'Support for Node.js 19 not guaranty. Please upgrade to Node.js 20 or higher.'
+      `Support for Node.js ${leastSupportedVersion + 1} not guaranteed. Please upgrade to Node.js ${leastSupportedVersion + 2} or higher.`
     )
   );
 }
 
-if (major === 18) {
+if (major === leastSupportedVersion) {
   process.emitWarning(
     color.red(
       `You are running Node.js ${currentNodeVersion}.\n` +
-      'Support for Node.js 18 will be removed soon. Please upgrade to Node.js 20 or higher.'
+      `Support for Node.js ${leastSupportedVersion} will be removed soon. Please upgrade to Node.js ${leastSupportedVersion + 2} or higher.`
     )
   );
 }

--- a/packages/cubejs-base-driver/package.json
+++ b/packages/cubejs-base-driver/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.2.27",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "jest": "^27",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-cli/package.json
+++ b/packages/cubejs-cli/package.json
@@ -59,7 +59,7 @@
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^27",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/semver": "^7.5.8",
     "husky": "^4.2.3",
     "jest": "^27",

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -44,7 +44,7 @@
     "@cubejs-backend/linter": "1.2.27",
     "@types/csv-write-stream": "^2.0.0",
     "@types/generic-pool": "^3.8.2",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/ws": "^7.4.0",
     "jest": "^27",
     "typescript": "~5.2.2"

--- a/packages/cubejs-databricks-jdbc-driver/package.json
+++ b/packages/cubejs-databricks-jdbc-driver/package.json
@@ -43,7 +43,7 @@
     "@cubejs-backend/linter": "1.2.27",
     "@types/generic-pool": "^3.8.2",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/ramda": "^0.27.34",
     "@types/uuid": "^8.3.4",
     "jest": "^27",

--- a/packages/cubejs-druid-driver/package.json
+++ b/packages/cubejs-druid-driver/package.json
@@ -37,7 +37,7 @@
     "@cubejs-backend/linter": "1.2.27",
     "@types/generic-pool": "^3.8.2",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "jest": "^27",
     "testcontainers": "^10.13.0",
     "typescript": "~5.2.2"

--- a/packages/cubejs-duckdb-driver/package.json
+++ b/packages/cubejs-duckdb-driver/package.json
@@ -37,7 +37,7 @@
     "@cubejs-backend/linter": "1.2.27",
     "@cubejs-backend/testing-shared": "1.2.27",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "jest": "^27",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-jdbc-driver/package.json
+++ b/packages/cubejs-jdbc-driver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.2.27",
     "@types/generic-pool": "^3.8.2",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/sqlstring": "^2.3.0",
     "typescript": "~5.2.2"
   }

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@cubejs-backend/base-driver": "1.2.27",
     "@cubejs-backend/shared": "1.2.27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "generic-pool": "^3.8.2",
     "moment": "^2.29.1",
     "mysql2": "^3.11.5"

--- a/packages/cubejs-mssql-driver/package.json
+++ b/packages/cubejs-mssql-driver/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/mssql": "^9.1.5",
-    "@types/node": "^18"
+    "@types/node": "^20"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -71,7 +71,7 @@
     "@cubejs-client/core": "1.2.27",
     "@cubejs-client/react": "1.2.27",
     "@types/flexsearch": "^0.7.3",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/react": "^18.3.4",
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^18.3.0",

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -41,7 +41,7 @@
     "@cubejs-backend/linter": "1.2.27",
     "@types/generic-pool": "^3.8.2",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/ramda": "^0.27.32",
     "@types/uuid": "^8.3.0",
     "jest": "^27",

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -67,7 +67,7 @@
     "@types/inflection": "^1.5.28",
     "@types/jest": "^27",
     "@types/lru-cache": "^5.1.0",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/ramda": "^0.27.34",
     "@types/sqlstring": "^2.3.0",
     "@types/syntax-error": "^1.4.1",

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -68,7 +68,7 @@
     "@types/jest": "^27",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/lru-cache": "^5.1.0",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/node-fetch": "^2.5.7",
     "@types/ramda": "^0.27.34",
     "@types/uuid": "^8.3.0",

--- a/packages/cubejs-server/package.json
+++ b/packages/cubejs-server/package.json
@@ -67,7 +67,7 @@
     "@types/body-parser": "^1.19.0",
     "@types/cors": "^2.8.8",
     "@types/express": "^4.17.21",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "@types/semver": "^7.5.8",
     "@types/ws": "^7.2.9",
     "@types/yarnpkg__lockfile": "^1.1.4",

--- a/packages/cubejs-testing-drivers/package.json
+++ b/packages/cubejs-testing-drivers/package.json
@@ -79,7 +79,7 @@
     "@cubejs-client/ws-transport": "1.2.27",
     "@jest/globals": "^27",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "dotenv": "^16.0.3",
     "fs-extra": "^11.1.1",
     "jest": "^27",

--- a/packages/cubejs-testing-shared/package.json
+++ b/packages/cubejs-testing-shared/package.json
@@ -34,7 +34,7 @@
     "@jest/globals": "^27",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "jest": "^27",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -119,7 +119,7 @@
     "@types/dedent": "^0.7.0",
     "@types/http-proxy": "^1.17.5",
     "@types/jest": "^27",
-    "@types/node": "^18",
+    "@types/node": "^20",
     "cypress": "14.0.0",
     "cypress-image-snapshot": "^4.0.1",
     "cypress-localstorage-commands": "^1.4.5",


### PR DESCRIPTION
- **update "@types/node" → v20**
- **update node-check**
- **add deprecation for node v20 in deprecation.md**
- **update node version in ci**
