### PR TITLE
feat(api-gateway)!: Move '/v1/sql' to new `sql` API Scope

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -153,7 +153,7 @@ class ApiGateway {
   public readonly contextToApiScopesFn: ContextToApiScopesFn;
 
   public readonly contextToApiScopesDefFn: ContextToApiScopesFn =
-    async () => ['graphql', 'meta', 'data'];
+    async () => ['graphql', 'meta', 'data', 'sql'];
 
   protected readonly requestLoggerMiddleware: RequestLoggerMiddlewareFn;
 
@@ -1309,7 +1309,7 @@ class ApiGateway {
     res,
   }: {query: string, disablePostProcessing: boolean} & BaseRequest) {
     try {
-      await this.assertApiScope('data', context.securityContext);
+      await this.assertApiScope('sql', context.securityContext);
 
       const result = await this.sqlServer.sql4sql(query, disablePostProcessing, context.securityContext);
       res({ sql: result });
@@ -1337,7 +1337,7 @@ class ApiGateway {
     const requestStarted = new Date();
 
     try {
-      await this.assertApiScope('data', context.securityContext);
+      await this.assertApiScope('sql', context.securityContext);
 
       const [queryType, normalizedQueries] =
         await this.getNormalizedQueries(query, context, disableLimitEnforcing, memberExpressions);
@@ -2413,7 +2413,7 @@ class ApiGateway {
           );
         } else {
           scopes.forEach((p) => {
-            if (['graphql', 'meta', 'data', 'jobs'].indexOf(p) === -1) {
+            if (['graphql', 'meta', 'data', 'sql', 'jobs'].indexOf(p) === -1) {
               throw new Error(
                 `A user-defined contextToApiScopes function returns a wrong scope: ${p}`
               );

--- a/packages/cubejs-api-gateway/src/types/strings.ts
+++ b/packages/cubejs-api-gateway/src/types/strings.ts
@@ -107,6 +107,7 @@ type ApiScopes =
   'graphql' |
   'meta' |
   'data' |
+  'sql' |
   'jobs';
 
 export {

--- a/packages/cubejs-api-gateway/test/permissions.test.ts
+++ b/packages/cubejs-api-gateway/test/permissions.test.ts
@@ -63,6 +63,13 @@ describe('Gateway Api Scopes', () => {
       .toStrictEqual('API scope is missing: data');
 
     res = await request(app)
+      .get('/cubejs-api/v1/sql')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(403);
+    expect(res.body && res.body.error)
+      .toStrictEqual('API scope is missing: sql');
+
+    res = await request(app)
       .post('/cubejs-api/v1/pre-aggregations/jobs')
       .set('Authorization', AUTH_TOKEN)
       .expect(403);
@@ -175,23 +182,6 @@ describe('Gateway Api Scopes', () => {
     expect(res3.body && res3.body.error)
       .toStrictEqual('API scope is missing: data');
 
-    const res4 = await request(app)
-      .get('/cubejs-api/v1/sql')
-      .set('Authorization', AUTH_TOKEN)
-      .expect(403);
-
-    expect(res4.body && res4.body.error)
-      .toStrictEqual('API scope is missing: data');
-
-    const res5 = await request(app)
-      .post('/cubejs-api/v1/sql')
-      .set('Content-type', 'application/json')
-      .set('Authorization', AUTH_TOKEN)
-      .expect(403);
-
-    expect(res5.body && res5.body.error)
-      .toStrictEqual('API scope is missing: data');
-
     const res6 = await request(app)
       .get('/cubejs-api/v1/dry-run')
       .set('Authorization', AUTH_TOKEN)
@@ -208,6 +198,31 @@ describe('Gateway Api Scopes', () => {
 
     expect(res7.body && res7.body.error)
       .toStrictEqual('API scope is missing: data');
+
+    apiGateway.release();
+  });
+
+  test('Sql declined', async () => {
+    const { app, apiGateway } = createApiGateway({
+      contextToApiScopes: async () => ['graphql', 'meta', 'jobs', 'data'],
+    });
+
+    const res1 = await request(app)
+      .get('/cubejs-api/v1/sql')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(403);
+
+    expect(res1.body && res1.body.error)
+      .toStrictEqual('API scope is missing: sql');
+
+    const res2 = await request(app)
+      .post('/cubejs-api/v1/sql')
+      .set('Content-type', 'application/json')
+      .set('Authorization', AUTH_TOKEN)
+      .expect(403);
+
+    expect(res2.body && res2.body.error)
+      .toStrictEqual('API scope is missing: sql');
 
     apiGateway.release();
   });


### PR DESCRIPTION
This Pr moves `/sql` REST API Endpoint under the new API Scope `sql`. Please, adjust your context to api scopes functions accordingly.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

