### PR TITLE
fix(cubesql): Allow more filters in CubeScan before aggregation pushdown

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -737,6 +737,13 @@ impl LogicalPlanAnalysis {
     ) -> Option<Vec<(String, String)>> {
         let filter_operators = |id| egraph.index(id).data.filter_operators.clone();
         match enode {
+            LogicalPlanLanguage::CubeScanFilters(params) => {
+                let mut map = Vec::new();
+                for id in params.iter() {
+                    map.extend(filter_operators(*id)?.into_iter());
+                }
+                Some(map)
+            }
             LogicalPlanLanguage::FilterOp(params) => filter_operators(params[0]),
             LogicalPlanLanguage::FilterOpFilters(params) => {
                 let mut map = Vec::new();
@@ -762,6 +769,9 @@ impl LogicalPlanAnalysis {
                     .unwrap()
                     .to_string();
                 Some(vec![(member, "equals".to_string())])
+            }
+            LogicalPlanLanguage::ChangeUserMember(_) => {
+                Some(vec![("__user".to_string(), "equals".to_string())])
             }
             _ => None,
         }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1625,11 +1625,16 @@ impl MemberRules {
                     if *ungrouped {
                         continue;
                     }
-                    let Some(empty_filters) = &egraph.index(subst[filters_var]).data.is_empty_list
+                    let Some(filter_operators) =
+                        &egraph.index(subst[filters_var]).data.filter_operators
                     else {
                         return false;
                     };
-                    if !empty_filters {
+                    let only_allowed_filters = filter_operators.iter().all(|(member, _op)| {
+                        // TODO this should allow even more, like dimensions and segments
+                        member == "__user"
+                    });
+                    if !only_allowed_filters {
                         return false;
                     }
                     if referenced_aggr_expr.len() == 0 {

--- a/rust/cubesql/cubesql/src/compile/test/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/test/utils.rs
@@ -11,6 +11,13 @@ use crate::{
 };
 
 pub trait LogicalPlanTestUtils {
+    fn try_expect_root_cube_scan(&self) -> Option<&CubeScanNode>;
+
+    fn expect_root_cube_scan(&self) -> &CubeScanNode {
+        self.try_expect_root_cube_scan()
+            .expect("Root node is not CubeScan")
+    }
+
     fn find_cube_scan(&self) -> CubeScanNode;
 
     fn find_cube_scan_wrapped_sql(&self) -> CubeScanWrappedSqlNode;
@@ -21,6 +28,13 @@ pub trait LogicalPlanTestUtils {
 }
 
 impl LogicalPlanTestUtils for LogicalPlan {
+    fn try_expect_root_cube_scan(&self) -> Option<&CubeScanNode> {
+        let LogicalPlan::Extension(ext) = self else {
+            return None;
+        };
+        ext.node.as_any().downcast_ref::<CubeScanNode>()
+    }
+
     fn find_cube_scan(&self) -> CubeScanNode {
         let cube_scans = find_cube_scans_deep_search(Arc::new(self.clone()), true);
         if cube_scans.len() != 1 {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Without this queries with duplicated aggregations on top of `__user` filter can execute with unnecessary post-processing, or, in aggregate-sort-limit case, even can fall back to SQL pushdown.
For now, only `__user` filters are enabled, others will be done later