### PR TITLE
fix(schema-compiler): Respect ungrouped alias in measures

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2845,6 +2845,9 @@ export class BaseQuery {
       return evaluateSql === '*' ? '1' : evaluateSql;
     }
     if (this.ungrouped) {
+      if (this.safeEvaluateSymbolContext().ungroupedAliases?.[measurePath]) {
+        evaluateSql = this.safeEvaluateSymbolContext().ungroupedAliases[measurePath];
+      }
       if ((this.safeEvaluateSymbolContext().ungroupedAliasesForCumulative || {})[measurePath]) {
         evaluateSql = this.safeEvaluateSymbolContext().ungroupedAliasesForCumulative[measurePath];
       }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR changes the behavior of `renderSqlMeasure` to respect `ungroupedAliases` from context for ungrouped measures.