### PR TITLE
feat(server-core): Make OrchestratorStorage LRUCache

### DIFF
--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import R from 'ramda';
 import { createQuery, compile, queryClass, PreAggregations, QueryFactory } from '@cubejs-backend/schema-compiler';
 import { v4 as uuidv4, parse as uuidParse } from 'uuid';
 import { LRUCache } from 'lru-cache';
@@ -128,9 +127,9 @@ export class CompilerApi {
   async createQueryFactory(compilers) {
     const { cubeEvaluator } = compilers;
 
-    const cubeToQueryClass = R.fromPairs(
+    const cubeToQueryClass = Object.fromEntries(
       await Promise.all(
-        cubeEvaluator.cubeNames().map(async cube => {
+        cubeEvaluator.cubeNames().map(async (cube) => {
           const dataSource = cubeEvaluator.cubeFromPath(cube).dataSource ?? 'default';
           const dbType = await this.getDbType(dataSource);
           const dialectClass = this.getDialectClass(dataSource, dbType);
@@ -146,7 +145,7 @@ export class CompilerApi {
   }
 
   getDialectClass(dataSource = 'default', dbType) {
-    return this.dialectClass && this.dialectClass({ dataSource, dbType });
+    return this.dialectClass?.({ dataSource, dbType });
   }
 
   async getSqlGenerator(query, dataSource) {
@@ -192,8 +191,8 @@ export class CompilerApi {
       external: sqlGenerator.externalPreAggregationQuery(),
       sql: sqlGenerator.buildSqlAndParams(exportAnnotatedSql),
       lambdaQueries: sqlGenerator.buildLambdaQuery(),
-      timeDimensionAlias: sqlGenerator.timeDimensions[0] && sqlGenerator.timeDimensions[0].unescapedAliasName(),
-      timeDimensionField: sqlGenerator.timeDimensions[0] && sqlGenerator.timeDimensions[0].dimension,
+      timeDimensionAlias: sqlGenerator.timeDimensions[0]?.unescapedAliasName(),
+      timeDimensionField: sqlGenerator.timeDimensions[0]?.dimension,
       order: sqlGenerator.order,
       cacheKeyQueries: sqlGenerator.cacheKeyQueries(),
       preAggregations: sqlGenerator.preAggregations.preAggregationsDescription(),
@@ -227,7 +226,7 @@ export class CompilerApi {
   }
 
   roleMeetsConditions(evaluatedConditions) {
-    if (evaluatedConditions && evaluatedConditions.length) {
+    if (evaluatedConditions?.length) {
       return evaluatedConditions.reduce((a, b) => {
         if (typeof b !== 'boolean') {
           throw new Error(`Access policy condition must return boolean, got ${JSON.stringify(b)}`);


### PR DESCRIPTION
In this PR OrchestratorStorage is switched to use LRUCache instead of simple js Map.

This PR depends on [9424](https://github.com/cube-js/cube/pull/9424) because it uses `lru-cache` v11.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
