### PR TITLE
fix(schema-compiler): Fix BigQuery DATE_ADD push down template for years/quarters/months

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -252,7 +252,7 @@ export class BigqueryQuery extends BaseQuery {
     templates.functions.STRPOS = 'STRPOS({{ args_concat }})';
     templates.functions.DATEDIFF = 'DATETIME_DIFF(CAST({{ args[2] }} AS DATETIME), CAST({{ args[1] }} AS DATETIME), {{ date_part }})';
     // DATEADD is being rewritten to DATE_ADD
-    templates.functions.DATE_ADD = '{% if date_part|upper in [\'YEAR\', \'MONTH\', \'QUARTER\'] %}TIMESTAMP(DATETIME_ADD(DATETIME({{ args[2] }}), INTERVAL {{ interval }} {{ date_part }})){% else %}TIMESTAMP_ADD({{ args[2] }}, INTERVAL {{ interval }} {{ date_part }}){% endif %}';
+    templates.functions.DATE_ADD = '{% if date_part|upper in [\'YEAR\', \'MONTH\', \'QUARTER\'] %}TIMESTAMP(DATETIME_ADD(DATETIME({{ args[0] }}), INTERVAL {{ interval }} {{ date_part }})){% else %}TIMESTAMP_ADD({{ args[0] }}, INTERVAL {{ interval }} {{ date_part }}){% endif %}';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
     delete templates.functions.TO_CHAR;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -14633,36 +14633,11 @@ ORDER BY "source"."str0" ASC
         }
         init_testing_logger();
 
-        let query_plan = convert_select_to_query_plan(
-            "
-            SELECT DATEADD(DAY, 7, order_date) AS d
-            FROM KibanaSampleDataEcommerce AS k
-            GROUP BY 1
-            ORDER BY 1 DESC
-            "
-            .to_string(),
-            DatabaseProtocol::PostgreSQL,
-        )
-        .await;
-
-        let physical_plan = query_plan.as_physical_plan().await.unwrap();
-        println!(
-            "Physical plan: {}",
-            displayable(physical_plan.as_ref()).indent()
-        );
-
-        let logical_plan = query_plan.as_logical_plan();
-        assert!(logical_plan
-            .find_cube_scan_wrapped_sql()
-            .wrapped_sql
-            .sql
-            .contains("DATEADD(day, 7,"));
-
         // BigQuery
         let bq_templates = vec![("functions/DATE_ADD".to_string(), "{% if date_part|upper in ['YEAR', 'MONTH', 'QUARTER'] %}TIMESTAMP(DATETIME_ADD(DATETIME({{ args[2] }}), INTERVAL {{ interval }} {{ date_part }})){% else %}TIMESTAMP_ADD({{ args[2] }}, INTERVAL {{ interval }} {{ date_part }}){% endif %}".to_string())];
         let query_plan = convert_select_to_query_plan_customized(
             "
-            SELECT DATEADD(DAY, 7, order_date) AS d
+            SELECT DATE_ADD(DAY, 7, order_date) AS d
             FROM KibanaSampleDataEcommerce AS k
             GROUP BY 1
             ORDER BY 1 DESC
@@ -14687,7 +14662,7 @@ ORDER BY "source"."str0" ASC
 
         let query_plan = convert_select_to_query_plan_customized(
             "
-            SELECT DATEADD(MONTH, 7, order_date) AS d
+            SELECT DATE_ADD(MONTH, 7, order_date) AS d
             FROM KibanaSampleDataEcommerce AS k
             GROUP BY 1
             ORDER BY 1 DESC
@@ -14713,7 +14688,7 @@ ORDER BY "source"."str0" ASC
         // Postgres
         let query_plan = convert_select_to_query_plan_customized(
             "
-            SELECT DATEADD(DAY, 7, order_date) AS d
+            SELECT DATE_ADD(DAY, 7, order_date) AS d
             FROM KibanaSampleDataEcommerce AS k
             GROUP BY 1
             ORDER BY 1 DESC


### PR DESCRIPTION
This fixes the BigQuery dateadd/timestampadd functions genereation, because of:
`TIMESTAMP_ADD doesn't support YEAR interval`.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

