### PR TITLE
feat(schema-compiler)!: Turn CUBEJS_TESSERACT_ORCHESTRATOR=true by default

### DIFF
--- a/docs/pages/reference/configuration/environment-variables.mdx
+++ b/docs/pages/reference/configuration/environment-variables.mdx
@@ -1301,6 +1301,15 @@ If `true`, then use WebSocket for data fetching.
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true`                 | `true`                |
 
+## `CUBEJS_TESSERACT_ORCHESTRATOR`
+
+If `true`, enables performance optimizations in the query orchestrator,
+such as deserializing Cube Store result sets in native Rust code.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `true`                 | `true`                |
+
 ## `CUBESTORE_AWS_ACCESS_KEY_ID`
 
 The Access Key ID for AWS. Required when using AWS S3.

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -221,7 +221,7 @@ const variables: Record<string, (...args: any) => any> = {
     .asInt(),
   nativeSqlPlanner: () => get('CUBEJS_TESSERACT_SQL_PLANNER').default('false').asBool(),
   nativeOrchestrator: () => get('CUBEJS_TESSERACT_ORCHESTRATOR')
-    .default('false')
+    .default('true')
     .asBoolStrict(),
   transpilationWorkerThreads: () => get('CUBEJS_TRANSPILATION_WORKER_THREADS')
     .default('false')


### PR DESCRIPTION
It's time to enable CUBEJS_TESSERACT_ORCHESTRATOR by default.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required
