### PR TITLE
fix(cubestore): Fix LocalDirRemoteFs::list_recursive is not portable on Windows

### DIFF
--- a/rust/cubestore/cubestore/src/remotefs/mod.rs
+++ b/rust/cubestore/cubestore/src/remotefs/mod.rs
@@ -429,10 +429,11 @@ impl LocalDirRemoteFs {
                         .to_str()
                         .unwrap()
                         .to_string()
-                        .replace(&remote_dir.to_str().unwrap().to_string(), "")
+                        .replace("\\","/")
+                        .replace(&remote_dir.to_str().unwrap().to_string().replace("\\","/"), "")
                         .trim_start_matches("/")
                         .to_string();
-                    if relative_name.starts_with(&remote_prefix) {
+                    if relative_name.starts_with(&remote_prefix.replace("\\","/")) {
                         result.push(RemoteFile {
                             remote_path: relative_name.to_string(),
                             updated: DateTime::from(metadata.modified()?),


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
https://github.com/cube-js/cube/issues/9460
