### PR TITLE
fix(cubesql): Fix SortPushDown pushing sort through joins

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_left.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_left.snap
@@ -3,9 +3,9 @@ source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
 expression: optimize(&plan)
 ---
 Projection: #j1.c1, #j2.c2
-  CrossJoin:
-    Sort: #j1.c1 ASC NULLS LAST
+  Sort: #j1.c1 ASC NULLS LAST
+    CrossJoin:
       Projection: #j1.key, #j1.c1
         TableScan: j1 projection=None
-    Projection: #j2.key, #j2.c2
-      TableScan: j2 projection=None
+      Projection: #j2.key, #j2.c2
+        TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_left.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_left.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #j1.c1, #j2.c2
+  CrossJoin:
+    Sort: #j1.c1 ASC NULLS LAST
+      Projection: #j1.key, #j1.c1
+        TableScan: j1 projection=None
+    Projection: #j2.key, #j2.c2
+      TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_right.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_cross_join_sort_right.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #j1.c1, #j2.c2
+  Sort: #j2.c2 ASC NULLS LAST
+    CrossJoin:
+      Projection: #j1.key, #j1.c1
+        TableScan: j1 projection=None
+      Projection: #j2.key, #j2.c2
+        TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_left.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_left.snap
@@ -3,9 +3,9 @@ source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
 expression: optimize(&plan)
 ---
 Projection: #j1.c1, #j2.c2
-  Inner Join: #j1.key = #j2.key
-    Sort: #j1.c1 ASC NULLS LAST
+  Sort: #j1.c1 ASC NULLS LAST
+    Inner Join: #j1.key = #j2.key
       Projection: #j1.key, #j1.c1
         TableScan: j1 projection=None
-    Projection: #j2.key, #j2.c2
-      TableScan: j2 projection=None
+      Projection: #j2.key, #j2.c2
+        TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_left.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_left.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #j1.c1, #j2.c2
+  Inner Join: #j1.key = #j2.key
+    Sort: #j1.c1 ASC NULLS LAST
+      Projection: #j1.key, #j1.c1
+        TableScan: j1 projection=None
+    Projection: #j2.key, #j2.c2
+      TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_right.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_join_sort_right.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #j1.c1, #j2.c2
+  Sort: #j2.c2 ASC NULLS LAST
+    Inner Join: #j1.key = #j2.key
+      Projection: #j1.key, #j1.c1
+        TableScan: j1 projection=None
+      Projection: #j2.key, #j2.c2
+        TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_multiple_projections.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_multiple_projections.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #t3.n3, #t3.n4, #t3.n2, alias=t4
+  Projection: #t2.n1 AS n3, #t2.c2 AS n4, #t2.n2, alias=t3
+    Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2
+      Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST
+        Projection: #t1.c1, #t1.c2, #t1.c3
+          TableScan: t1 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_projection.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_projection.snap
@@ -1,0 +1,8 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2
+  Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST
+    Projection: #t1.c1, #t1.c2, #t1.c3
+      TableScan: t1 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_sort.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_down_sort.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Projection: #t3.n3, #t3.n4, #t3.n2, alias=t4
+  Projection: #t2.n1 AS n3, #t2.c2 AS n4, #t2.n2, alias=t3
+    Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2
+      Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST
+        Projection: #t1.c1, #t1.c2, #t1.c3
+          TableScan: t1 projection=None


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`LogicalPlan::Join` and `CrossJoin` do not preserve the ordering semantically
When planned as `HashJoin` it will output batches in same order as they are coming from right stream
But both `Join` and `CrossJoin` will have same partitioning as right input (even when `repartition_joins` disabled), and these partitions can be collected in arbitrary order by `CoalescePartitions`

Side note: Substrait says that for both Join and Cross Product

> Orderedness is empty post operation

See https://substrait.io/relations/logical_relations/#join-operation