### PR TITLE
feat: Allow additional filters in PatchMeasure for number measures

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
@@ -81,8 +81,14 @@ export class BaseMeasure {
         case 'count_distinct_approx':
           // ok, do nothing
           break;
+        case 'number':
+          // Additional filters for `number` measures should be propagated to leaf measures
+          // And only leaf `number` measures should trigger an error
+          throw new UserError(
+            `Additional filters for measure ${sourceMeasure} type ${source.type} are supported only in Tesseract`
+          );
         default:
-          // Can not add filters to string, time, boolean, number
+          // Can not add filters to string, time, boolean
           // Aggregation is already included in SQL, it's hard to patch that
           throw new UserError(
             `Unsupported additional filters for measure ${sourceMeasure} type ${source.type}`

--- a/rust/cubesql/cubesql/src/transport/ext.rs
+++ b/rust/cubesql/cubesql/src/transport/ext.rs
@@ -93,7 +93,9 @@ impl V1CubeMetaMeasureExt for CubeMetaMeasure {
             | "max"
             | "count"
             | "count_distinct"
-            | "count_distinct_approx" => true,
+            | "count_distinct_approx"
+            // For number measures new filter should be propagated to leaf measures
+            | "number" => true,
             _ => false,
         }
     }


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Additional filters for `number` measures should be propagated to leaf measures
And only leaf `number` measures should trigger an error
Supported only in Tesseract