### PR TITLE
feat(cubesql): Support trivial casts in member pushdown

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13429,7 +13429,7 @@ ORDER BY "source"."str0" ASC
         V1LoadResultAnnotation::new(json!([]), json!([]), json!([]), json!([]))
     }
 
-    fn simple_load_response(data: Vec<serde_json::Value>) -> V1LoadResponse {
+    pub(crate) fn simple_load_response(data: Vec<serde_json::Value>) -> V1LoadResponse {
         V1LoadResponse::new(vec![V1LoadResult::new(empty_annotation(), data)])
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -560,7 +560,7 @@ macro_rules! var_list_iter {
 #[macro_export]
 macro_rules! var {
     ($var_str:expr) => {
-        $var_str.parse().unwrap()
+        $var_str.parse::<::egg::Var>().unwrap()
     };
 }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -537,7 +537,7 @@ impl MemberRules {
 
         let find_matching_old_member_with_count =
             |name: &str, column_expr: String, default_count: bool| {
-                vec![transforming_rewrite(
+                transforming_rewrite(
                     &format!(
                         "member-pushdown-replacer-column-find-matching-old-member-{}",
                         name
@@ -560,7 +560,7 @@ impl MemberRules {
                         "?filtered_member_pushdown_replacer_alias_to_cube",
                         default_count,
                     ),
-                )]
+                )
             };
 
         let find_matching_old_member = |name: &str, column_expr: String| {
@@ -606,27 +606,27 @@ impl MemberRules {
                 member_replacer_fn,
             ));
         }
-        rules.extend(find_matching_old_member("column", column_expr("?column")));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member("column", column_expr("?column")));
+        rules.push(find_matching_old_member(
             "alias",
             alias_expr(column_expr("?column"), "?alias"),
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "agg-fun",
             agg_fun_expr("?fun_name", vec![column_expr("?column")], "?distinct"),
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "agg-fun-alias",
             alias_expr(
                 agg_fun_expr("?fun_name", vec![column_expr("?column")], "?distinct"),
                 "?alias",
             ),
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "udaf-fun",
             udaf_expr(MEASURE_UDAF_NAME, vec![column_expr("?column")]),
         ));
-        rules.extend(find_matching_old_member_with_count(
+        rules.push(find_matching_old_member_with_count(
             "agg-fun-default-count",
             agg_fun_expr(
                 "Count",
@@ -635,7 +635,7 @@ impl MemberRules {
             ),
             true,
         ));
-        rules.extend(find_matching_old_member_with_count(
+        rules.push(find_matching_old_member_with_count(
             "agg-fun-default-count-alias",
             alias_expr(
                 agg_fun_expr(
@@ -647,7 +647,7 @@ impl MemberRules {
             ),
             true,
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "agg-fun-with-cast",
             // TODO need to check data_type if we can remove the cast
             agg_fun_expr(
@@ -656,14 +656,14 @@ impl MemberRules {
                 "?distinct",
             ),
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "date-trunc",
             self.fun_expr(
                 "DateTrunc",
                 vec![literal_expr("?granularity"), column_expr("?column")],
             ),
         ));
-        rules.extend(find_matching_old_member(
+        rules.push(find_matching_old_member(
             "date-trunc-with-alias",
             // TODO need to check data_type if we can remove the cast
             alias_expr(

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -552,7 +552,7 @@ impl MemberRules {
                         "?terminal_member",
                         "?filtered_member_pushdown_replacer_alias_to_cube",
                     ),
-                    self.find_matching_old_member(
+                    self.transform_find_matching_old_member(
                         "?member_pushdown_replacer_alias_to_cube",
                         "?column",
                         "?old_members",
@@ -1944,7 +1944,7 @@ impl MemberRules {
         )
     }
 
-    fn find_matching_old_member(
+    fn transform_find_matching_old_member(
         &self,
         member_pushdown_replacer_alias_to_cube_var: &'static str,
         column_var: &'static str,

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_cube_join__join_with_trivial_cast.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_cube_join__join_with_trivial_cast.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/test/test_cube_join.rs
+expression: context.execute_query(query).await.unwrap()
+---
++-------+--------------+
+| notes | content_cast |
++-------+--------------+
+| foo   | bar          |
+| baz   | quux         |
++-------+--------------+


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This should allow pushing down expressions like `CAST(dimension AS TEXT) AS alias` into `CubeScan` as regular dimensions.
This should allow `__cubeJoinField` joins to see more `CubeScan`s

Supporting changes:

Remove unused rule for member pushdown from `AllMembers`
All matching happening with `CubeScanMembers` on top of actual members node, and this rule does not expect that
`member_name_to_expr` part of analysis can extract members from `CubeScanMembers(AllMembers)`, so there's no reason to keep this rule

Add explicit type in `var!` macro, to avoid type confusion.