### PR TITLE
fix(cubesql): Disallow mixing measure and dimension filters in a single FilterOp

### DIFF
--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -133,3 +133,59 @@ SELECT dim_str0 FROM MultiTypeCube WHERE (dim_str1 IS NULL OR dim_str1 IN (NULL)
         .sql
         .contains(r#"\"sql\":\"((${MultiTypeCube.dim_str1} IS NULL) OR (${MultiTypeCube.dim_str1} IN (NULL) AND FALSE))\""#));
 }
+
+/// Single filter in CubeScan does not support both measuser in dimensions, so it should not get pushed to CubeScan
+#[tokio::test]
+async fn test_mixed_filters() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+SELECT
+    dim_str0,
+    avgPrice
+FROM (
+    SELECT
+        dim_str0,
+        AVG(avgPrice) AS avgPrice
+    FROM
+        MultiTypeCube
+    GROUP BY 1
+) t
+WHERE
+    avgPrice > 1
+    OR (
+        avgPrice = 1
+        AND
+        dim_str0 = 'completed'
+    )
+;
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert_eq!(
+        logical_plan.find_cube_scan().request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["MultiTypeCube.avgPrice".to_string()]),
+            dimensions: Some(vec!["MultiTypeCube.dim_str0".to_string()]),
+            segments: Some(vec![]),
+            order: Some(vec![]),
+            filters: None,
+            ..Default::default()
+        }
+    );
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Consider this query
```
SELECT
    dim_str0,
    avgPrice
FROM (
    SELECT
        dim_str0,
        AVG(avgPrice) AS avgPrice
    FROM
        MultiTypeCube
    GROUP BY 1
) t
WHERE
    avgPrice > 1
    OR (
        avgPrice = 1
        AND
        dim_str0 = 'completed'
    )
;
```

Before this filter replacer would push a single filter to CubeScan with all of predicates together.
Cube.js does not support mixing measures and dimension in a single filter, only as a separate filters.
So, now it stops rewriting if resulting filter would contain both measures and dimensions.

Initial plan 

```
Initial Plan: Projection: #t.dim_str0, #t.avgPrice
  Filter: #t.avgPrice > Int64(1) OR #t.avgPrice = Int64(1) AND #t.dim_str0 = Utf8("completed")
    Projection: #MultiTypeCube.dim_str0, #AVG(MultiTypeCube.avgPrice) AS avgPrice, alias=t
      Aggregate: groupBy=[[#MultiTypeCube.dim_str0]], aggr=[[AVG(#MultiTypeCube.avgPrice)]]
        TableScan: MultiTypeCube projection=None
```

Rewritten plan, before

```
Rewrite: CubeScan: request={
  "measures": [
    "MultiTypeCube.avgPrice"
  ],
  "dimensions": [
    "MultiTypeCube.dim_str0"
  ],
  "segments": [],
  "order": [],
  "filters": [
    {
      "or": [
        {
          "member": "MultiTypeCube.avgPrice",
          "operator": "gt",
          "values": [
            "1"
          ]
        },
        {
          "and": [
            {
              "member": "MultiTypeCube.avgPrice",
              "operator": "equals",
              "values": [
                "1"
              ]
            },
            {
              "member": "MultiTypeCube.dim_str0",
              "operator": "equals",
              "values": [
                "completed"
              ]
            }
          ]
        }
      ]
    }
  ]
}
```

Rewritten plan, after

```
Rewrite: Filter: #t.avgPrice > Int64(1) OR #t.avgPrice = Int64(1) AND #t.dim_str0 = Utf8("completed")
  CubeScan: request={
  "measures": [
    "MultiTypeCube.avgPrice"
  ],
  "dimensions": [
    "MultiTypeCube.dim_str0"
  ],
  "segments": [],
  "order": []
}
```