### PR TITLE
docs: Update reserved jwt params

### DIFF
--- a/docs/pages/product/auth/context.mdx
+++ b/docs/pages/product/auth/context.mdx
@@ -52,7 +52,7 @@ with nested structure:
 ### Reserved elements
 
 Some features of Cube Cloud (e.g., [authentication integration][ref-auth-integration]
-and [LDAP integration][ref-ldap-integration]) use the `cloud` element in the security context.
+and [LDAP integration][ref-ldap-integration]) use the `cubeCloud` element in the security context.
 This element is reserved and should not be used for other purposes.
 
 ## Using query_rewrite


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required


We moved the location where the auth metadata is located in the security context from `cloud` to `cubeCloud`.