### PR TITLE
feat(schema-compiler): Support custom granularities with Year-Month intervals for AWS Redshift dialect

### DIFF
--- a/packages/cubejs-testing-drivers/fixtures/redshift.json
+++ b/packages/cubejs-testing-drivers/fixtures/redshift.json
@@ -155,17 +155,10 @@
   },
   "skip": [
     "---------------------------------------",
-    "Error: Interval values with month or year parts are not supported",
+    "Error: Complex intervals like \"3 months 2 weeks 3 days\" are not supported. @see dateBin impl in ReshiftQuery",
     "---------------------------------------",
-    "querying BigECommerce: rolling window by 2 month",
-    "querying custom granularities ECommerce: count by half_year + no dimension",
-    "querying custom granularities ECommerce: count by half_year_by_1st_april + no dimension",
     "querying custom granularities ECommerce: count by three_months_by_march + no dimension",
-    "querying custom granularities ECommerce: count by half_year + dimension",
-    "querying custom granularities ECommerce: count by half_year_by_1st_april + dimension",
     "querying custom granularities ECommerce: count by three_months_by_march + dimension",
-    "querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByTrailing",
-    "querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByLeading",
 
     "---------------------------------------",
     "SKIPPED FOR ALL                        ",

--- a/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
@@ -11190,6 +11190,71 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/redshift-driver querying BigECommerce: rolling window by 2 month 1`] = `
+Array [
+  Object {
+    "BigECommerce.orderDate": "2020-01-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-01-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "2",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-02-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-02-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "3",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-03-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-03-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "3",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-04-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-04-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "3",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-05-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-05-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "6",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-06-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-06-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "12",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-07-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-07-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "7",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-08-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-08-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": null,
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-09-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-09-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "6",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-10-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-10-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "10",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-11-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-11-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "13",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-12-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-12-01T00:00:00.000",
+    "BigECommerce.rollingCountBy2Month": "16",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/redshift-driver querying BigECommerce: rolling window by 2 week 1`] = `
 Array [
   Object {
@@ -15611,6 +15676,502 @@ Array [
     "ECommerce.orderDate": "2021-01-01T00:00:00.000",
     "ECommerce.orderDate.half_year": "2021-01-01T00:00:00.000",
     "ECommerce.totalQuantity": "103",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by half_year + dimension 1`] = `
+Array [
+  Object {
+    "ECommerce.city": "Detroit",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lorain",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Auburn",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Baltimore",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Columbus",
+    "ECommerce.count": "3",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Decatur",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Houston",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Los Angeles",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Louisville",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "New York City",
+    "ECommerce.count": "4",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Olympia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Omaha",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Philadelphia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Arlington",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Bakersfield",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Bowling",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Columbus",
+    "ECommerce.count": "9",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Dallas",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Detroit",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Glendale",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lafayette",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lakewood",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Marion",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Morristown",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "New York City",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Oakland",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Philadelphia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Provo",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "San Francisco",
+    "ECommerce.count": "2",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Vancouver",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by half_year + no dimension 1`] = `
+Array [
+  Object {
+    "ECommerce.count": "2",
+    "ECommerce.customOrderDateNoPreAgg": "2020-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "16",
+    "ECommerce.customOrderDateNoPreAgg": "2020-07-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2020-07-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "26",
+    "ECommerce.customOrderDateNoPreAgg": "2021-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year": "2021-01-01T00:00:00.000",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by half_year_by_1st_april + dimension 1`] = `
+Array [
+  Object {
+    "ECommerce.city": "Decatur",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Detroit",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Houston",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lorain",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "New York City",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Philadelphia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Arlington",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Auburn",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Bakersfield",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Baltimore",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Columbus",
+    "ECommerce.count": "4",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Detroit",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lakewood",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Los Angeles",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Louisville",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Morristown",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "New York City",
+    "ECommerce.count": "3",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Olympia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Omaha",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Provo",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "San Francisco",
+    "ECommerce.count": "2",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Vancouver",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Bowling",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Columbus",
+    "ECommerce.count": "8",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Dallas",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Glendale",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Lafayette",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Marion",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "New York City",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Oakland",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.city": "Philadelphia",
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by half_year_by_1st_april + no dimension 1`] = `
+Array [
+  Object {
+    "ECommerce.count": "6",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "22",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "16",
+    "ECommerce.customOrderDateNoPreAgg": "2021-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.half_year_by_1st_april": "2021-04-01T00:00:00.000",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByLeading 1`] = `
+Array [
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2019-12-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2019-12-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": "8",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-02-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-02-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": "12",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-04-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": "6",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-06-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-06-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": "19",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-08-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-08-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": "16",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-10-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": null,
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-12-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-12-01T10:00:00.000",
+    "ECommerce.rollingCountByLeading": null,
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByTrailing 1`] = `
+Array [
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2019-12-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2019-12-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": "3",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-02-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-02-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": "3",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-04-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": "12",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-06-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-06-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": null,
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-08-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-08-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": "10",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-10-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": "16",
+  },
+  Object {
+    "ECommerce.customOrderDateNoPreAgg": "2020-12-01T10:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-12-01T10:00:00.000",
+    "ECommerce.rollingCountByTrailing": null,
   },
 ]
 `;


### PR DESCRIPTION
Previously only `day-to-second` intervals were supported for Redshift custom granularities maths. This adds support for `Year-to-month` intervals. So all of this is now possible:

```yaml
      - name: saletime
        sql: saletime
        type: time
        granularities:
          - name: half_year
            title: 6 month intervals
            interval: 6 months
          - name: half_year_by_1st_april
            title: Half year from Apr to Oct
            interval: 6 months
            offset: 3 months
          - name: fiscal_year_by_1st_feb
            title: Fiscal year by Feb
            interval: 1 year
            offset: 1 month
          - name: fiscal_year_by_15th_march
            interval: 1 year
            origin: '2024-03-15'
          - name: two_weeks_by_friday
            interval: 2 weeks
            origin: '2024-09-20 03:00:00+03:00'
```


**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
