### PR TITLE
feat(schema-compiler): Support overriding `title`, `description`, `meta`, and `format` on view members

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -257,7 +257,9 @@ export class CubeEvaluator extends CubeSymbols {
   }
 
   private prepareHierarchies(cube: any, errorReporter: ErrorReporter): void {
-    if (Object.keys(cube.hierarchies).length) {
+    // Hierarchies from views are not fully populated at this moment and are processed later,
+    // so we should not pollute the cube hierarchies definition here.
+    if (!cube.isView && Object.keys(cube.hierarchies).length) {
       cube.evaluatedHierarchies = Object.entries(cube.hierarchies).map(([name, hierarchy]) => ({
         name,
         ...(typeof hierarchy === 'object' ? hierarchy : {}),
@@ -306,6 +308,8 @@ export class CubeEvaluator extends CubeSymbols {
                 throw new UserError(`Hierarchy '${it.name}' not found in cube '${cubeName}'`);
               }
               return {
+                // Title might be overridden in the view
+                title: cube.hierarchies?.[it.name]?.override?.title || it.title,
                 ...it,
                 name,
                 levels

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -63,7 +63,7 @@ export class CubeSymbols {
 
   public cubeList: any[];
 
-  private evaluateViews: boolean;
+  private readonly evaluateViews: boolean;
 
   private resolveSymbolsCallContext: any;
 
@@ -447,13 +447,13 @@ export class CubeSymbols {
         includes = Object.keys(membersObj).map(memberName => ({ member: `${fullPath}.${memberName}`, name: fullMemberName(memberName) }));
       } else {
         includes = cubeInclude.includes.map((include: any) => {
-          const member = include.alias || include;
+          const member = include.alias || include.name || include;
 
           if (member.includes('.')) {
             errorReporter.error(`Paths aren't allowed in cube includes but '${member}' provided as include member`);
           }
 
-          const name = fullMemberName(include.alias || member);
+          const name = fullMemberName(member);
           memberSets.allMembers.add(name);
 
           const includedMemberName = include.name || include;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -147,7 +147,7 @@ export class CubeSymbols {
         }
         return preAggregations;
       },
-      set preAggregations(v) {
+      set preAggregations(_v) {
         // Dont allow to modify
       },
 
@@ -157,7 +157,7 @@ export class CubeSymbols {
         }
         return joins;
       },
-      set joins(v) {
+      set joins(_v) {
         // Dont allow to modify
       },
 
@@ -167,7 +167,7 @@ export class CubeSymbols {
         }
         return measures;
       },
-      set measures(v) {
+      set measures(_v) {
         // Dont allow to modify
       },
 
@@ -177,7 +177,7 @@ export class CubeSymbols {
         }
         return dimensions;
       },
-      set dimensions(v) {
+      set dimensions(_v) {
         // Dont allow to modify
       },
 
@@ -187,7 +187,7 @@ export class CubeSymbols {
         }
         return segments;
       },
-      set segments(v) {
+      set segments(_v) {
         // Dont allow to modify
       },
 
@@ -197,7 +197,7 @@ export class CubeSymbols {
         }
         return hierarchies;
       },
-      set hierarchies(v) {
+      set hierarchies(_v) {
         // Dont allow to modify
       },
 
@@ -213,7 +213,7 @@ export class CubeSymbols {
           return undefined;
         }
       },
-      set accessPolicy(v) {
+      set accessPolicy(_v) {
         // Dont allow to modify
       }
     },

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -110,6 +110,14 @@ const GranularityInterval = Joi.string().pattern(/^\d+\s+(second|minute|hour|day
 // Do not allow negative intervals for granularities, while offsets could be negative
 const GranularityOffset = Joi.string().pattern(/^-?(\d+\s+)(second|minute|hour|day|week|month|quarter|year)s?(\s-?\d+\s+(second|minute|hour|day|week|month|quarter|year)s?){0,7}$/, 'granularity offset');
 
+const formatSchema = Joi.alternatives([
+  Joi.string().valid('imageUrl', 'link', 'currency', 'percent', 'number', 'id'),
+  Joi.object().keys({
+    type: Joi.string().valid('link'),
+    label: Joi.string().required()
+  })
+]);
+
 const BaseDimensionWithoutSubQuery = {
   aliases: Joi.array().items(Joi.string()),
   type: Joi.any().valid('string', 'number', 'boolean', 'time', 'geo').required(),
@@ -122,13 +130,7 @@ const BaseDimensionWithoutSubQuery = {
   description: Joi.string(),
   suggestFilterValues: Joi.boolean().strict(),
   enableSuggestions: Joi.boolean().strict(),
-  format: Joi.alternatives([
-    Joi.string().valid('imageUrl', 'link', 'currency', 'percent', 'number', 'id'),
-    Joi.object().keys({
-      type: Joi.string().valid('link'),
-      label: Joi.string().required()
-    })
-  ]),
+  format: formatSchema,
   meta: Joi.any(),
   granularities: Joi.when('type', {
     is: 'time',
@@ -796,7 +798,11 @@ const viewSchema = inherit(baseSchema, {
           Joi.string().required(),
           Joi.object().keys({
             name: identifier.required(),
-            alias: identifier
+            alias: identifier,
+            title: Joi.string(),
+            description: Joi.string(),
+            format: formatSchema,
+            meta: Joi.any(),
           })
         ]))
       ]).required(),

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -1408,3 +1408,168 @@ Object {
   "type": "number",
 }
 `;
+
+exports[`Schema Testing Views allows to override \`title\`, \`description\`, \`meta\`, and \`format\` on includes members 1`] = `
+Object {
+  "accessPolicy": undefined,
+  "allDefinitions": [Function],
+  "cubes": Array [
+    Object {
+      "includes": Array [
+        Object {
+          "alias": "my_beloved_status",
+          "description": "Don't you believe this?",
+          "meta": Array [
+            Object {
+              "whose": "mine",
+            },
+            Object {
+              "what": "status",
+            },
+          ],
+          "name": "status",
+          "title": "My Favorite and not Beloved Status!",
+        },
+        Object {
+          "alias": "my_beloved_created_at",
+          "description": "Created at this point in time",
+          "meta": Array [
+            Object {
+              "c1": "iddqd",
+            },
+            Object {
+              "c2": "idkfa",
+            },
+          ],
+          "name": "created_at",
+          "title": "My Favorite and not Beloved created_at!",
+        },
+        Object {
+          "description": "It's not possible!",
+          "format": "percent",
+          "meta": Array [
+            Object {
+              "whose": "bread",
+            },
+            Object {
+              "what": "butter",
+            },
+            Object {
+              "why": "cheese",
+            },
+          ],
+          "name": "count",
+          "title": "My Overridden Count!",
+        },
+        Object {
+          "name": "hello",
+          "title": "My Overridden hierarchy!",
+        },
+      ],
+      "joinPath": [Function],
+    },
+  ],
+  "dimensions": Object {
+    "my_beloved_created_at": Object {
+      "aliasMember": "orders.created_at",
+      "description": "Created at this point in time",
+      "format": undefined,
+      "meta": Array [
+        Object {
+          "c1": "iddqd",
+        },
+        Object {
+          "c2": "idkfa",
+        },
+      ],
+      "ownedByCube": false,
+      "sql": [Function],
+      "title": "My Favorite and not Beloved created_at!",
+      "type": "time",
+    },
+    "my_beloved_status": Object {
+      "aliasMember": "orders.status",
+      "description": "Don't you believe this?",
+      "format": undefined,
+      "meta": Array [
+        Object {
+          "whose": "mine",
+        },
+        Object {
+          "what": "status",
+        },
+      ],
+      "ownedByCube": false,
+      "sql": [Function],
+      "title": "My Favorite and not Beloved Status!",
+      "type": "string",
+    },
+  },
+  "evaluatedHierarchies": Array [
+    Object {
+      "levels": Array [
+        "orders_view.my_beloved_status",
+      ],
+      "name": "hello",
+      "title": "World",
+    },
+  ],
+  "fileName": "order_view.yml",
+  "hierarchies": Object {
+    "hello": Object {
+      "levels": [Function],
+      "title": "My Overridden hierarchy!",
+    },
+  },
+  "includedMembers": Array [
+    Object {
+      "memberPath": "orders.hello",
+      "name": "hello",
+      "type": "hierarchies",
+    },
+    Object {
+      "memberPath": "orders.count",
+      "name": "count",
+      "type": "measures",
+    },
+    Object {
+      "memberPath": "orders.status",
+      "name": "my_beloved_status",
+      "type": "dimensions",
+    },
+    Object {
+      "memberPath": "orders.created_at",
+      "name": "my_beloved_created_at",
+      "type": "dimensions",
+    },
+  ],
+  "isView": true,
+  "joins": Object {},
+  "measures": Object {
+    "count": Object {
+      "aggType": "count",
+      "aliasMember": "orders.count",
+      "description": "It's not possible!",
+      "format": "percent",
+      "meta": Array [
+        Object {
+          "whose": "bread",
+        },
+        Object {
+          "what": "butter",
+        },
+        Object {
+          "why": "cheese",
+        },
+      ],
+      "ownedByCube": false,
+      "sql": [Function],
+      "title": "My Overridden Count!",
+      "type": "number",
+    },
+  },
+  "name": "orders_view",
+  "preAggregations": Object {},
+  "segments": Object {},
+}
+`;

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -165,6 +165,47 @@ describe('Cube Validation', () => {
     expect(validationResult.error).toBeTruthy();
   });
 
+  it('view with overridden included members properties', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      // it's a hidden field which we use internally
+      isView: true,
+      fileName: 'fileName',
+      cubes: [
+        {
+          joinPath: () => '',
+          prefix: false,
+          includes: [
+            'member_by_name',
+            {
+              name: 'member_by_alias',
+              alias: 'correct_alias'
+            },
+            {
+              name: 'member_by_alias_with_overrides',
+              title: 'Overridden title',
+              description: 'Overridden description',
+              format: 'percent',
+              meta: {
+                f1: 'Overridden 1',
+                f2: 'Overridden 2',
+              },
+            }
+          ]
+        }
+      ]
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message: any, _e: any) => {
+        console.log(message);
+      }
+    } as any);
+
+    expect(validationResult.error).toBeFalsy();
+  });
+
   it('refreshKey alternatives', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -685,6 +685,64 @@ describe('Schema Testing', () => {
         expect(e.toString()).toMatch(/Included member 'id' conflicts with existing member of 'orders_view'\. Please consider excluding this member or assigning it an alias/);
       }
     });
+
+    it('allows to override `title`, `description`, `meta`, and `format` on includes members', async () => {
+      const orders = fs.readFileSync(
+        path.join(process.cwd(), '/test/unit/fixtures/orders.js'),
+        'utf8'
+      );
+      const ordersView = `
+        views:
+          - name: orders_view
+            cubes:
+              - join_path: orders
+                includes:
+                - name: status
+                  alias: my_beloved_status
+                  title: My Favorite and not Beloved Status!
+                  description: Don't you believe this?
+                  meta:
+                    - whose: mine
+                    - what: status
+
+                - name: created_at
+                  alias: my_beloved_created_at
+                  title: My Favorite and not Beloved created_at!
+                  description: Created at this point in time
+                  meta:
+                    - c1: iddqd
+                    - c2: idkfa
+
+                - name: count
+                  title: My Overridden Count!
+                  description: It's not possible!
+                  format: percent
+                  meta:
+                    - whose: bread
+                    - what: butter
+                    - why: cheese
+
+                - name: hello
+                  title: My Overridden hierarchy!
+      `;
+
+      const { compiler, cubeEvaluator } = prepareCompiler([
+        {
+          content: orders,
+          fileName: 'orders.js',
+        },
+        {
+          content: ordersView,
+          fileName: 'order_view.yml',
+        },
+      ]);
+
+      await compiler.compile();
+      compiler.throwIfAnyErrors();
+
+      const cubeB = cubeEvaluator.cubeFromPath('orders_view');
+      expect(cubeB).toMatchSnapshot();
+    });
   });
 
   describe('Inheritance', () => {


### PR DESCRIPTION
This change allows to override of some descriptive properties in the view's included members.

So now it's possible to do things like this:
```yaml
        views:
          - name: orders_view
            cubes:
              - join_path: orders
                includes:
                - name: status
                  alias: my_beloved_status
                  title: My Beloved and not Favorite Status!    <<<<<<< this <<<<<<<
                  description: Don't you believe this?          <<<<<<< this <<<<<<<
                  meta:                                         <<<<<<< this. Please note, <<<<<<<
                    - c1: iddqd                                 <<<<<<< that Meta is overridden as a whole <<<<<<<
                    - c2: idkfa                                 <<<<<<< and not extended <<<<<<<
```


**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
