### PR TITLE
fix(schema-compiler): Fix non-match for exact custom granularity pre-aggregation

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseDimension.ts
@@ -1,6 +1,6 @@
 import type { BaseQuery } from './BaseQuery';
 import type { DimensionDefinition, SegmentDefinition } from '../compiler/CubeEvaluator';
-import { CubeSymbols } from "../compiler/CubeSymbols";
+import { CubeSymbols } from '../compiler/CubeSymbols';
 
 export class BaseDimension {
   public readonly expression: any;

--- a/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseMeasure.ts
@@ -1,7 +1,7 @@
 import { UserError } from '../compiler/UserError';
 import type { BaseQuery } from './BaseQuery';
 import { MeasureDefinition } from '../compiler/CubeEvaluator';
-import { CubeSymbols } from "../compiler/CubeSymbols";
+import { CubeSymbols } from '../compiler/CubeSymbols';
 
 export class BaseMeasure {
   public readonly expression: any;

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -24,7 +24,7 @@ import {
   timeSeriesFromCustomInterval
 } from '@cubejs-backend/shared';
 
-import { CubeSymbols } from "../compiler/CubeSymbols";
+import { CubeSymbols } from '../compiler/CubeSymbols';
 import { UserError } from '../compiler/UserError';
 import { SqlParser } from '../parser/SqlParser';
 import { BaseDimension } from './BaseDimension';

--- a/packages/cubejs-schema-compiler/src/adapter/BaseSegment.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseSegment.ts
@@ -1,5 +1,5 @@
 import type { BaseQuery } from './BaseQuery';
-import { CubeSymbols } from "../compiler/CubeSymbols";
+import { CubeSymbols } from '../compiler/CubeSymbols';
 
 export class BaseSegment {
   public readonly expression: any;

--- a/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseTimeDimension.ts
@@ -249,17 +249,15 @@ export class BaseTimeDimension extends BaseFilter {
               return this.dateRangeGranularity();
             }
 
-            if (!this.dateRange) {
-              return this.granularityObj.minGranularity();
-            }
-
             // If we have granularity and date range, we need to check
             // that the interval and the granularity offset are stacked/fits with date range
-            if (this.granularityObj.isPredefined() ||
-              !this.granularityObj.isAlignedWithDateRange([this.dateFromFormatted(), this.dateToFormatted()])) {
+            if (this.dateRange && (this.granularityObj.isPredefined() ||
+              !this.granularityObj.isAlignedWithDateRange([this.dateFromFormatted(), this.dateToFormatted()]))) {
               return this.query.minGranularity(this.granularityObj.minGranularity(), this.dateRangeGranularity());
             }
 
+            // We return the granularity as-is, including custom ones,
+            // because baseQuery.granularityHierarchies correctly expands all custom granularities into hierarchies.
             return this.granularityObj.granularity;
           }
         );

--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -31,7 +31,7 @@ export class Granularity {
   ) {
     this.granularity = timeDimension.granularity;
     this.predefinedGranularity = isPredefinedGranularity(this.granularity);
-    this.queryTimezone = query.timezone;
+    this.queryTimezone = query.timezone || 'UTC';
     this.origin = moment.tz(query.timezone).startOf('year'); // Defaults to current year start
 
     if (this.predefinedGranularity) {

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
@@ -1,7 +1,7 @@
 import R from 'ramda';
 import { FROM_PARTITION_RANGE, getEnv, TO_PARTITION_RANGE } from '@cubejs-backend/shared';
 
-import { CubeSymbols } from "../compiler/CubeSymbols";
+import { CubeSymbols } from '../compiler/CubeSymbols';
 import { UserError } from '../compiler/UserError';
 
 export class PreAggregations {

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -510,7 +510,9 @@ describe('PreAggregations', () => {
     });
     `);
 
-  it('simple pre-aggregation', () => compiler.compile().then(() => {
+  it('simple pre-aggregation', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -549,9 +551,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('simple pre-aggregation (allowNonStrictDateRangeMatch: true)', () => compiler.compile().then(() => {
+  it('simple pre-aggregation (allowNonStrictDateRangeMatch: true)', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -592,9 +596,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('simple pre-aggregation with custom granularity (exact match)', () => compiler.compile().then(() => {
+  it('simple pre-aggregation with custom granularity (exact match)', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -635,9 +641,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('simple pre-aggregation with custom granularity (exact match) 2', () => compiler.compile().then(() => {
+  it('simple pre-aggregation with custom granularity (exact match) 2', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.countAnother'
@@ -664,9 +672,37 @@ describe('PreAggregations', () => {
         },
       ]);
     });
-  }));
+  });
 
-  it('leaf measure pre-aggregation', () => compiler.compile().then(() => {
+  it('pre-aggregation with custom granularity should match its own references', async () => {
+    await compiler.compile();
+
+    const preAggregationId = 'visitors.countAnotherCountCustomGranularity';
+    const preAggregations = cubeEvaluator.preAggregations({ preAggregationIds: [preAggregationId]});
+
+    const preAggregation = preAggregations[0];
+    if (preAggregation === undefined) {
+      throw expect(preAggregation).toBeDefined();
+    }
+
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      ...preAggregation.references,
+      preAggregationId: preAggregation.id,
+      timezone: 'UTC',
+    });
+
+    const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+    const preAggregationFromQuery = preAggregationsDescription.find(p => p.preAggregationId === preAggregation.id);
+    if (preAggregationFromQuery === undefined) {
+      throw expect(preAggregationFromQuery).toBeDefined();
+    }
+
+    expect(preAggregationFromQuery.preAggregationId).toBe(preAggregationId);
+  });
+
+  it('leaf measure pre-aggregation', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.ratio'
@@ -711,9 +747,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('leaf measure view pre-aggregation', () => compiler.compile().then(() => {
+  it('leaf measure view pre-aggregation', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.ratio'
@@ -758,9 +796,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('non-additive measure view pre-aggregation', () => compiler.compile().then(() => {
+  it('non-additive measure view pre-aggregation', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.uniqueSourceCount'
@@ -805,9 +845,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('non-additive single value view filter', () => compiler.compile().then(() => {
+  it('non-additive single value view filter', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.uniqueSourceCount'
@@ -845,9 +887,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('non-additive single value view filtered measure', () => compiler.compile().then(() => {
+  it('non-additive single value view filtered measure', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.googleUniqueSourceCount'
@@ -885,9 +929,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('multiplied measure no match', () => compiler.compile().then(() => {
+  it('multiplied measure no match', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -921,9 +967,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('multiplied measure match', () => compiler.compile().then(() => {
+  it('multiplied measure match', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -980,9 +1028,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('non-leaf additive measure', () => compiler.compile().then(() => {
+  it('non-leaf additive measure', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.count'
@@ -1023,9 +1073,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('non-leaf additive measure with time dimension', () => compiler.compile().then(() => {
+  it('non-leaf additive measure with time dimension', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.count'
@@ -1077,9 +1129,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('inherited original sql', () => compiler.compile().then(() => {
+  it('inherited original sql', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'GoogleVisitors.count'
@@ -1111,9 +1165,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('immutable partition default refreshKey', () => compiler.compile().then(() => {
+  it('immutable partition default refreshKey', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'GoogleVisitors.checkinsTotal'
@@ -1151,9 +1207,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('immutable every hour', () => compiler.compile().then(() => {
+  it('immutable every hour', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'EveryHourVisitors.checkinsTotal'
@@ -1194,9 +1252,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('reference original sql', () => compiler.compile().then(() => {
+  it('reference original sql', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'ReferenceOriginalSql.count'
@@ -1235,9 +1295,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned scheduled refresh', () => compiler.compile().then(async () => {
+  it('partitioned scheduled refresh', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitor_checkins.count'
@@ -1269,9 +1331,11 @@ describe('PreAggregations', () => {
     expect(res).toEqual(
       [{ max: '2017-01-06T00:00:00.000Z' }]
     );
-  }));
+  });
 
-  it('empty scheduled refresh', () => compiler.compile().then(async () => {
+  it('empty scheduled refresh', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitor_checkins.count'
@@ -1301,9 +1365,11 @@ describe('PreAggregations', () => {
     expect(res).toEqual(
       [{ max: null }]
     );
-  }));
+  });
 
-  it('mutable partition default refreshKey', () => compiler.compile().then(() => {
+  it('mutable partition default refreshKey', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1356,9 +1422,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('hll bigquery rollup', () => compiler.compile().then(() => {
+  it('hll bigquery rollup', async () => {
+    await compiler.compile();
+
     const query = new BigqueryQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.countDistinctApprox'
@@ -1382,9 +1450,11 @@ describe('PreAggregations', () => {
 
     expect(queryAndParams[0]).toMatch(/HLL_COUNT\.MERGE/);
     expect(preAggregationsDescription.loadSql[0]).toMatch(/HLL_COUNT\.INIT/);
-  }));
+  });
 
-  it('sub query', () => compiler.compile().then(() => {
+  it('sub query', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.count'
@@ -1416,9 +1486,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('multi-stage', () => compiler.compile().then(() => {
+  it('multi-stage', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1461,9 +1533,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('incremental renewal threshold', () => compiler.compile().then(() => {
+  it('incremental renewal threshold', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1510,9 +1584,11 @@ describe('PreAggregations', () => {
         }]
       );
     });
-  }));
+  });
 
-  it('partitioned', () => compiler.compile().then(() => {
+  it('partitioned', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1563,9 +1639,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned inDateRange', () => compiler.compile().then(() => {
+  it('partitioned inDateRange', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1609,9 +1687,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned hourly', () => compiler.compile().then(() => {
+  it('partitioned hourly', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1659,9 +1739,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned rolling', () => compiler.compile().then(() => {
+  it('partitioned rolling', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsRollingTotal',
@@ -1734,9 +1816,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned rolling 2 day', () => compiler.compile().then(() => {
+  it('partitioned rolling 2 day', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsRolling2day',
@@ -1794,9 +1878,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('not aligned time dimension', () => compiler.compile().then(() => {
+  it('not aligned time dimension', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1843,9 +1929,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('segment', () => compiler.compile().then(() => {
+  it('segment', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -1886,9 +1974,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('rollup join', () => compiler.compile().then(() => {
+  it('rollup join', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitor_checkins.count',
@@ -1921,7 +2011,7 @@ describe('PreAggregations', () => {
         ],
       );
     });
-  }));
+  });
 
   it('rollup join existing joins', async () => {
     await compiler.compile();
@@ -1963,7 +2053,9 @@ describe('PreAggregations', () => {
     });
   });
 
-  it('rollup join partitioned', () => compiler.compile().then(() => {
+  it('rollup join partitioned', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitor_checkins.count',
@@ -2004,9 +2096,11 @@ describe('PreAggregations', () => {
         ],
       );
     });
-  }));
+  });
 
-  it('partitioned without time', () => compiler.compile().then(() => {
+  it('partitioned without time', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors.checkinsTotal'
@@ -2038,9 +2132,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('partitioned huge span', () => compiler.compile().then(() => {
+  it('partitioned huge span', async () => {
+    await compiler.compile();
+
     let queryAndParams;
     let preAggregationsDescription;
     let query;
@@ -2102,9 +2198,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('simple view', () => compiler.compile().then(() => {
+  it('simple view', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.checkinsTotal'
@@ -2157,9 +2255,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('simple view non matching time-dimension granularity', () => compiler.compile().then(() => {
+  it('simple view non matching time-dimension granularity', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'visitors_view.checkinsTotal'
@@ -2207,9 +2307,11 @@ describe('PreAggregations', () => {
         ]
       );
     });
-  }));
+  });
 
-  it('lambda cross data source refresh key and ungrouped', () => compiler.compile().then(() => {
+  it('lambda cross data source refresh key and ungrouped', async () => {
+    await compiler.compile();
+
     const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
       measures: [
         'LambdaVisitors.count'
@@ -2249,5 +2351,5 @@ describe('PreAggregations', () => {
     expect(partitionInvalidateKeyQueries).toStrictEqual([]);
     expect(loadSql[0]).not.toMatch(/GROUP BY/);
     expect(loadSql[0]).toMatch(/THEN 1 END `real_time_lambda_visitors__count`/);
-  }));
+  });
 });

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -678,7 +678,7 @@ describe('PreAggregations', () => {
     await compiler.compile();
 
     const preAggregationId = 'visitors.countAnotherCountCustomGranularity';
-    const preAggregations = cubeEvaluator.preAggregations({ preAggregationIds: [preAggregationId]});
+    const preAggregations = cubeEvaluator.preAggregations({ preAggregationIds: [preAggregationId] });
 
     const preAggregation = preAggregations[0];
     if (preAggregation === undefined) {

--- a/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-agg-time-dim-match.test.ts
@@ -1,7 +1,7 @@
 import { PostgresQuery } from '../../src/adapter/PostgresQuery';
 import { prepareCube } from './PrepareCompiler';
 import { PreAggregations } from '../../src/adapter/PreAggregations';
-import { PreAggregationReferences } from "../../src/compiler/CubeEvaluator";
+import { PreAggregationReferences } from '../../src/compiler/CubeEvaluator';
 
 describe('Pre Aggregation by filter match tests', () => {
   function getCube(cube) {


### PR DESCRIPTION
This fixes cases when a query with custom granularity doesn't hit the pre-aggregation with the same custom granularity.


**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
