### PR TITLE
fix(schema-compiler): Fix filtering by time measure

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseFilter.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseFilter.ts
@@ -90,6 +90,17 @@ export class BaseFilter extends BaseDimension {
     }
   }
 
+  /**
+   * BaseFilter inherits from BaseDimension while Filter may be measure-based !!
+   */
+  public override dateFieldType() {
+    if (this.measure) {
+      return this.measureDefinition().type; // There is no fieldType in measure, but it seems that it's enough
+    } else {
+      return this.dimensionDefinition().fieldType;
+    }
+  }
+
   public cube() {
     return this.query.cubeEvaluator.cubeFromPath(this.measure || this.dimension);
   }


### PR DESCRIPTION
Fixes errors for queries with measures with type `time` used as date filters.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet

Closes https://github.com/cube-js/cube/issues/9435
