### PR TITLE
BUG: Avoid Maximum recursive updates exceeded

### DIFF
--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -381,11 +381,17 @@ export default {
         };
 
         this.chartType = chartType || this.chartType;
-        this.pivotConfig = ResultSet.getNormalizedPivotConfig(
+        let pivot = ResultSet.getNormalizedPivotConfig(
           validatedQuery,
           pivotConfig !== undefined ? pivotConfig : this.pivotConfig
         );
-        this.copyQueryFromProps(validatedQuery);
+        if (!equals(pivot, this.pivotConfig)) {
+          this.pivotConfig = pivot;
+        }
+
+        if (!areQueriesEqual(this.prevValidatedQuery, validatedQuery)) {
+          this.copyQueryFromProps(validatedQuery);
+        }
       }
 
       // query heuristics should only apply on query change (not applied to the initial query)
@@ -393,7 +399,9 @@ export default {
         this.skipHeuristics = false;
       }
 
-      this.prevValidatedQuery = validatedQuery;
+      if (!areQueriesEqual(this.prevValidatedQuery, validatedQuery)) {
+        this.prevValidatedQuery = validatedQuery;
+      }
       return validatedQuery;
     },
   },

--- a/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
@@ -928,6 +928,80 @@ describe('QueryBuilder.vue', () => {
         expect(wrapper.vm.pivotConfig).toEqual(expectedPivotForLine);
         expect(wrapper.vm.chartType).toBe('line');
       });
+      it('should not reassign validatedQuery if it has not changed', async () => {
+        const cube = createCubeApi();
+        jest
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
+
+        const wrapper = shallowMount(QueryBuilder, {
+          propsData: {
+            cubeApi: cube,
+            query: {
+              measures: ['Orders.count'],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
+            },
+          },
+        });
+
+        const initialValidatedQuery = {
+          measures: ['measure1'],
+          dimensions: ['dimension1'],
+        };
+        wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+
+        wrapper.setData({
+          measures: [{ name: 'measure1' }],
+          dimensions: [{ name: 'dimension1' }],
+        });
+
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.prevValidatedQuery.measures).toEqual(initialValidatedQuery.measures);
+        expect(wrapper.vm.prevValidatedQuery.dimensions).toEqual(initialValidatedQuery.dimensions);
+      });
+
+      it('should reassign validatedQuery if it has changed', async () => {
+        const cube = createCubeApi();
+        jest
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
+
+        const wrapper = shallowMount(QueryBuilder, {
+          propsData: {
+            cubeApi: cube,
+            query: {
+              measures: ['Orders.count'],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
+            },
+          },
+        });
+        const initialValidatedQuery = {
+          measures: ['measure1'],
+          dimensions: ['dimension1'],
+        };
+        wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+
+        wrapper.setData({
+          measures: [{ name: 'measure2' }],
+          dimensions: [{ name: 'dimension1' }],
+        });
+
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.prevValidatedQuery.measures).not.toEqual(initialValidatedQuery.measures);
+        expect(wrapper.vm.prevValidatedQuery.dimensions).toEqual(initialValidatedQuery.dimensions);
+      });
     });
     describe('orderMembers', () => {
       it('does not contain time dimension if granularity is set to none', async () => {
@@ -1000,6 +1074,48 @@ describe('QueryBuilder.vue', () => {
               })
             ])
         );
+      });
+      it('calls copyQueryFromProps if query is changed', async () => {
+        const cube = createCubeApi();
+        jest
+          .spyOn(cube, 'request')
+          .mockImplementation(fetchMock(load))
+          .mockImplementationOnce(fetchMock(meta));
+
+        const copyQueryFromProps = jest.spyOn(QueryBuilder.methods, 'copyQueryFromProps');
+
+        const wrapper = shallowMount(QueryBuilder, {
+          propsData: {
+            cubeApi: cube,
+            query: {
+              measures: ['Orders.count'],
+              timeDimensions: [
+                {
+                  dimension: 'Orders.createdAt',
+                },
+              ],
+            },
+          },
+        });
+        await flushPromises();
+
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.measures.length).toEqual(1);
+        expect(wrapper.vm.measures[0].name).toEqual('Orders.count');
+
+        await wrapper.vm.$nextTick();
+
+        expect(copyQueryFromProps).toHaveBeenCalled();
+        expect(copyQueryFromProps).toHaveBeenCalledTimes(1);
+        const initialValidatedQuery = {
+          measures: ['measure1'],
+          dimensions: ['dimension1'],
+        };
+        wrapper.setData({ prevValidatedQuery: initialValidatedQuery });
+        await wrapper.vm.$nextTick();
+
+        expect(copyQueryFromProps).toHaveBeenCalledTimes(2);
+        copyQueryFromProps.mockRestore();
       });
     });
   });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
In response to the still open https://github.com/cube-js/cube/issues/8557
This is basically a copy of https://github.com/cube-js/cube/pull/8556

**Description of Changes Made (if issue reference is not provided)**
I opened this PR with the changes of the closed PR by @nsandroni as the issue is persisting for our project with following version:

- "@cubejs-client/core": "1.3.11",
- "@cubejs-client/vue3": "1.3.11"

Minimum reproduction project was created to see if the error still occurs outside of our current frontend project where we wanted to migrate from vue2 to vue3, containing only :

```
<template>
  <h1>Vue Cube.js </h1>
  <query-builder :cube-api="cubejsApi" :query="queryChart"></query-builder>
</template>

<script>
import cubejs from '@cubejs-client/core';
import {QueryBuilder} from '@cubejs-client/vue3';

const cubejsApi = cubejs(
    'token',
    {
      apiUrl: 'http://localhost:4000/cubejs-api/v1',
    }
);

export default {
  name: 'App',
  components: {
    QueryBuilder,
  },
  data() {
    return {
      queryChart: {
        measures: [
          'ReportProductViews.pisSum'
        ]
      },
      cubejsApi
    };
  }
};
</script>
```

Error was still present and after adding the changes it fixed the maximum recursive update exceeded error. 
It is fine to either merge the closed PR or this one if possible? 
