### PR TITLE
fix(schema-compiler): Collect join hints from subquery join conditions

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -288,6 +288,10 @@ export class BaseQuery {
       return dimension;
     }).filter(R.identity).map(this.newTimeDimension.bind(this));
     this.allFilters = this.timeDimensions.concat(this.segments).concat(this.filters);
+    /**
+     * @type {Array<{sql: string, on: {expression: Function}, joinType: 'LEFT' | 'INNER', alias: string}>}
+     */
+    this.customSubQueryJoins = this.options.subqueryJoins ?? [];
     this.useNativeSqlPlanner = this.options.useNativeSqlPlanner ?? getEnv('nativeSqlPlanner');
     this.canUseNativeSqlPlannerPreAggregation = false;
     if (this.useNativeSqlPlanner) {
@@ -299,11 +303,6 @@ export class BaseQuery {
     this.cubeAliasPrefix = this.options.cubeAliasPrefix;
     this.preAggregationsSchemaOption = this.options.preAggregationsSchema ?? DEFAULT_PREAGGREGATIONS_SCHEMA;
     this.externalQueryClass = this.options.externalQueryClass;
-
-    /**
-     * @type {Array<{sql: string, on: {expression: Function}, joinType: 'LEFT' | 'INNER', alias: string}>}
-     */
-    this.customSubQueryJoins = this.options.subqueryJoins ?? [];
 
     // Set the default order only when options.order is not provided at all
     // if options.order is set (empty array [] or with data) - use it as is
@@ -2284,14 +2283,34 @@ export class BaseQuery {
    * @returns {Array<Array<string>>}
    */
   collectJoinHints(excludeTimeDimensions = false) {
-    const membersToCollectFrom = this.allMembersConcat(excludeTimeDimensions)
-      .concat(this.join ? this.join.joins.map(j => ({
-        getMembers: () => [{
-          path: () => null,
-          cube: () => this.cubeEvaluator.cubeFromPath(j.originalFrom),
-          definition: () => j.join,
-        }]
-      })) : []);
+    const customSubQueryJoinMembers = this.customSubQueryJoins.map(j => {
+      const res = {
+        path: () => null,
+        cube: () => this.cubeEvaluator.cubeFromPath(j.on.cubeName),
+        definition: () => ({
+          sql: j.on.expression,
+          // TODO use actual type even though it isn't used right now
+          type: 'number'
+        }),
+      };
+      return {
+        getMembers: () => [res],
+      };
+    });
+
+    const joinMembers = this.join ? this.join.joins.map(j => ({
+      getMembers: () => [{
+        path: () => null,
+        cube: () => this.cubeEvaluator.cubeFromPath(j.originalFrom),
+        definition: () => j.join,
+      }]
+    })) : [];
+
+    const membersToCollectFrom = [
+      ...this.allMembersConcat(excludeTimeDimensions),
+      ...joinMembers,
+      ...customSubQueryJoinMembers,
+    ];
 
     return this.collectJoinHintsFromMembers(membersToCollectFrom);
   }

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -520,6 +520,17 @@ Array [
 ]
 `;
 
+exports[`SQL API Postgres (Data) join with grouped query and empty members: join grouped empty members 1`] = `
+Array [
+  Object {
+    "status": "processed",
+  },
+  Object {
+    "status": "shipped",
+  },
+]
+`;
+
 exports[`SQL API Postgres (Data) join with grouped query on coalesce: join grouped on coalesce 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -666,6 +666,34 @@ filter_subq AS (
       expect(res.rows).toMatchSnapshot('join grouped on coalesce');
     });
 
+    test('join with grouped query and empty members', async () => {
+      const query = `
+        SELECT
+          top_orders.status
+        FROM
+          "Orders"
+          INNER JOIN
+          (
+            SELECT
+              status,
+              SUM(totalAmount)
+            FROM
+              "Orders"
+            GROUP BY 1
+            ORDER BY 2 DESC
+            LIMIT 2
+          ) top_orders
+        ON
+          "Orders".status = top_orders.status
+        GROUP BY 1
+        ORDER BY 1
+        `;
+
+      const res = await connection.query(query);
+      // Expect only top statuses 2 by total amount: processed and shipped
+      expect(res.rows).toMatchSnapshot('join grouped empty members');
+    });
+
     test('where segment is false', async () => {
       const query =
         'SELECT value AS val, * FROM "SegmentTest" WHERE segment_eq_1 IS FALSE ORDER BY value;';


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This is necessary to support queries where output references only join subqueries.
Before, when query does have subqeury joins, but does not have any measures/dimensions/... join hints would be empty, and join tree would be `null`, which is almost okay, but to generate query with join subqueries we need to build join query, so join tree is more-or-less required.