### PR TITLE
feat(cubesql): Push down `DATE_TRUNC` expressions as member expressions with granularity

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -14572,8 +14572,7 @@ ORDER BY "source"."str0" ASC
 
         let logical_plan = query_plan.as_logical_plan();
         let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-        assert!(sql.contains("DATETIME_TRUNC("));
-        assert!(sql.contains("WEEK(MONDAY)"));
+        assert!(sql.contains(".week"));
     }
 
     #[tokio::test]

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1657,11 +1657,11 @@ GROUP BY
     let dimensions = request.dimensions.unwrap();
     assert_eq!(dimensions.len(), 1);
     let dimension = &dimensions[0];
-    assert!(dimension.contains("DATE_TRUNC"));
+    assert!(dimension.contains(".day"));
     let segments = request.segments.unwrap();
     assert_eq!(segments.len(), 1);
     let segment = &segments[0];
-    assert!(segment.contains("DATE_TRUNC"));
+    assert!(segment.contains(".day"));
 }
 
 /// Aggregation with falsy filter should NOT get pushed to CubeScan with limit=0


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR changes the behavior of SQL push down generation for `DATE_TRUNC` expressions, generating a member expression with granularity rather than `DATE_TRUNC` SQL equivalent. Related tests are adjusted.
