### PR TITLE
fix(cubestore): Avoid empty result set with LocalDirRemoteFs:list_wit…

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -6362,7 +6362,6 @@ mod tests {
             let list = LocalDirRemoteFs::list_recursive(
                 config.remote_dir().clone(),
                 "metastore-".to_string(),
-                config.remote_dir().clone(),
             )
             .await
             .unwrap();


### PR DESCRIPTION
…h_metadata on Windows

This is to replace #9463 because it also avoids affecting any paths with backslashes in them on Linux.

@oldoldman 

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Closes #9460
Closes #9463
