### PR TITLE
fix(schema-compiler): Fix rolling window queries with expressions from SQL API

### DIFF
--- a/packages/cubejs-testing/test/__snapshots__/birdbox-postgresql-pre-aggregations.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/birdbox-postgresql-pre-aggregations.test.ts.snap
@@ -5,7 +5,7 @@ exports[`postgresql-cubestore HTTP Transport Empty partitions: Empty partitions 
 exports[`postgresql-cubestore HTTP Transport Rolling Mixed With Dimension No Granularity: Rolling Mixed With Dimension No Granularity 1`] = `
 Array [
   Object {
-    "visitors.checkinsRollingTotal": null,
+    "visitors.checkinsRollingTotal": "5",
     "visitors.source": "some",
   },
 ]

--- a/packages/cubejs-testing/test/__snapshots__/cli-postgresql-pre-aggregations.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/cli-postgresql-pre-aggregations.test.ts.snap
@@ -5,7 +5,7 @@ exports[`postgresql HTTP Transport Empty partitions: Empty partitions 1`] = `Arr
 exports[`postgresql HTTP Transport Rolling Mixed With Dimension No Granularity: Rolling Mixed With Dimension No Granularity 1`] = `
 Array [
   Object {
-    "visitors.checkinsRollingTotal": null,
+    "visitors.checkinsRollingTotal": "5",
     "visitors.source": "some",
   },
 ]


### PR DESCRIPTION
This PR fixes incorrect sql generation for queries with rolling windows coming from SQL API with member expressions instead of time dimensions.

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
