### PR TITLE
fix(cubesql): Do not merge time dimension ranges in "or" filter into date range

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -1783,7 +1783,7 @@ impl LanguageToLogicalPlanConverter {
                                     query_time_dimensions,
                                     filters,
                                     node_by_id,
-                                    !is_in_or || !is_and_op,
+                                    is_in_or || !is_and_op,
                                 )?;
                                 match op.as_str() {
                                     "and" => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR changes the erroneous behavior of filter to date range transformation, which previously could merge filters inside OR filter. Related test is included.
