### PR TITLE
fix(cubesql): Quote subquery joins alias in SQL push down to cube

### DIFF
--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -209,6 +209,7 @@
     "SQL API: Nested Rollup over asterisk",
     "SQL API: Rollup over exprs",
     "SQL API: Rollup with aliases",
-    "SQL API: Simple Rollup"
+    "SQL API: Simple Rollup",
+    "SQL API: SQL push down push to cube quoted alias"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/mssql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mssql.json
@@ -160,6 +160,7 @@
     "SQL API: Nested Rollup over asterisk",
     "SQL API: Extended nested Rollup over asterisk",
     "SQL API: ungrouped pre-agg",
-    "SQL API: NULLS FIRST/LAST SQL push down"
+    "SQL API: NULLS FIRST/LAST SQL push down",
+    "SQL API: SQL push down push to cube quoted alias"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/mysql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mysql.json
@@ -156,6 +156,7 @@
     "SQL API: Rollup over exprs",
     "SQL API: Nested Rollup with aliases",
     "SQL API: Nested Rollup over asterisk",
-    "SQL API: Extended nested Rollup over asterisk"
+    "SQL API: Extended nested Rollup over asterisk",
+    "SQL API: SQL push down push to cube quoted alias"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/redshift.json
+++ b/packages/cubejs-testing-drivers/fixtures/redshift.json
@@ -173,6 +173,11 @@
     "querying BigECommerce: rolling window by 2 day without date range",
     "querying BigECommerce: rolling window by 2 month without date range",
     "querying BigECommerce: rolling window YTD",
-    "querying BigECommerce: rolling window YTD without date range"
+    "querying BigECommerce: rolling window YTD without date range",
+    
+    "---------------------------------------",
+    "SKIPPED SQL API (Need work)            ",
+    "---------------------------------------",
+    "SQL API: SQL push down push to cube quoted alias"
   ]
 }

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -2092,5 +2092,31 @@ from
       `);
       expect(res.rows).toMatchSnapshot();
     });
+
+    executePg('SQL API: SQL push down push to cube quoted alias', async (connection) => {
+      const res = await connection.query(`
+        SELECT
+          (NOT ("t0"."$temp1_output" IS NULL)) AS "result"
+        FROM
+          "public"."ECommerce" "ECommerce"
+          LEFT JOIN (
+            SELECT
+              CAST("ECommerce"."customerName" AS TEXT) AS "customerName",
+              1 AS "$temp1_output",
+              MEASURE("ECommerce"."totalQuantity") AS "$__alias__0"
+            FROM "public"."ECommerce" "ECommerce"
+            GROUP BY 1
+            ORDER BY
+              3 DESC NULLS LAST,
+              1 ASC NULLS FIRST
+            LIMIT 3
+          ) "t0" ON (
+            CAST("ECommerce"."customerName" AS TEXT) IS NOT DISTINCT
+            FROM "t0"."customerName"
+          )
+        GROUP BY 1
+      `);
+      expect(res.rows).toMatchSnapshot();
+    });
   });
 }

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
@@ -14,6 +14,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/athena-driver SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/athena-driver SQL API: Timeshift measure from cube 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
@@ -2423,6 +2423,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/bigquery-driver SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/bigquery-driver SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
@@ -5214,6 +5214,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/postgres-driver SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -7270,6 +7270,14 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: SQL push down push to cube quoted alias 1`] = `
+Array [
+  Object {
+    "result": true,
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: Simple Rollup: simple_rollup 1`] = `
 Array [
   Object {

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -3177,9 +3177,13 @@ impl WrappedSelectNode {
                     }
                 };
 
+                let mut alias = subq_alias.unwrap_or_else(|| alias.clone());
+                if let Some(generator) = meta.data_source_to_sql_generator.get(data_source) {
+                    alias = generator.get_sql_templates().quote_identifier(&alias)?;
+                };
                 join_subqueries.push(JoinSubquery {
                     // TODO what alias to actually use here? two more-or-less valid options: returned from generate_sql_for_node ot realiased from `alias`. Plain `alias` is incorrect here
-                    alias: subq_alias.unwrap_or_else(|| alias.clone()),
+                    alias,
                     sql: subq_sql_string,
                     condition: cond.clone(),
                     join_type: *join_type,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR quotes join aliases as identifiers when generating SQL for SQL push down to cube. Related test is included.
