### PR TITLE
feat(schema-compiler): Allow to specify td with granularity in REST API query order section

### DIFF
--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -57,7 +57,8 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 });
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
-const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$/);
+// It might be member name, td+granularity or member expression
+const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 const dimensionWithTime = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/);
 const parsedMemberExpression = Joi.object().keys({
   expression: Joi.alternatives(

--- a/packages/cubejs-backend-shared/src/time.ts
+++ b/packages/cubejs-backend-shared/src/time.ts
@@ -12,6 +12,18 @@ export type TimeSeriesOptions = {
 };
 type ParsedInterval = Partial<Record<unitOfTime.DurationConstructor, number>>;
 
+export const GRANULARITY_LEVELS: Record<string, number> = {
+  second: 1,
+  minute: 2,
+  hour: 3,
+  day: 4,
+  week: 5,
+  month: 6,
+  quarter: 7,
+  year: 8,
+  MAX: 1000,
+};
+
 export const TIME_SERIES: Record<string, (range: DateRange, timestampPrecision: number) => QueryDateRange[]> = {
   day: (range: DateRange, digits) => Array.from(range.snapTo('day').by('day'))
     .map(d => [d.format(`YYYY-MM-DDT00:00:00.${'0'.repeat(digits)}`), d.format(`YYYY-MM-DDT23:59:59.${'9'.repeat(digits)}`)]),

--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -144,40 +144,17 @@ export class DatabricksQuery extends BaseQuery {
     return `\`${name}\``;
   }
 
-  public getFieldIndex(id: string) {
-    const dimension = this.dimensionsForSelect().find((d: any) => d.dimension === id);
-    if (dimension) {
-      return super.getFieldIndex(id);
+  public override getFieldIndex(id: string): string | number | null {
+    const idx = super.getFieldIndex(id);
+    if (idx !== null) {
+      return idx;
     }
+
     return this.escapeColumnName(this.aliasName(id, false));
   }
 
   public unixTimestampSql() {
     return 'unix_timestamp()';
-  }
-
-  public orderHashToString(hash: any) {
-    if (!hash || !hash.id) {
-      return null;
-    }
-
-    const fieldIndex = this.getFieldIndex(hash.id);
-    if (fieldIndex === null) {
-      return null;
-    }
-
-    const dimensionsForSelect = this.dimensionsForSelect();
-    const dimensionColumns = R.flatten(
-      dimensionsForSelect.map((s: any) => s.selectColumns() && s.aliasName())
-    )
-      .filter(s => !!s);
-
-    if (dimensionColumns.length) {
-      const direction = hash.desc ? 'DESC' : 'ASC';
-      return `${fieldIndex} ${direction}`;
-    }
-
-    return null;
   }
 
   public defaultRefreshKeyRenewalThreshold() {

--- a/packages/cubejs-questdb-driver/src/QuestQuery.ts
+++ b/packages/cubejs-questdb-driver/src/QuestQuery.ts
@@ -1,4 +1,8 @@
-import { BaseFilter, BaseQuery, ParamAllocator } from '@cubejs-backend/schema-compiler';
+import {
+  BaseFilter,
+  BaseQuery,
+  ParamAllocator
+} from '@cubejs-backend/schema-compiler';
 
 const GRANULARITY_TO_INTERVAL: Record<string, string> = {
   second: 's',
@@ -109,7 +113,7 @@ export class QuestQuery extends BaseQuery {
     }
   }
 
-  public orderHashToString(hash: any): string | null {
+  public orderHashToString(hash: { id: string, desc: boolean }): string | null {
     // QuestDB has partial support for order by index column, so map these to the alias names.
     // So, instead of:
     // SELECT col_a as "a", col_b as "b" FROM tab ORDER BY 2 ASC
@@ -129,32 +133,6 @@ export class QuestQuery extends BaseQuery {
 
     const direction = hash.desc ? 'DESC' : 'ASC';
     return `${fieldAlias} ${direction}`;
-  }
-
-  private getFieldAlias(id: string): string | null {
-    const equalIgnoreCase = (a: any, b: any) => (
-      typeof a === 'string' && typeof b === 'string' && a.toUpperCase() === b.toUpperCase()
-    );
-
-    let field;
-
-    field = this.dimensionsForSelect().find(
-      (d: any) => equalIgnoreCase(d.dimension, id),
-    );
-
-    if (field) {
-      return field.aliasName();
-    }
-
-    field = this.measures.find(
-      (d: any) => equalIgnoreCase(d.measure, id) || equalIgnoreCase(d.expressionName, id),
-    );
-
-    if (field) {
-      return field.aliasName();
-    }
-
-    return null;
   }
 
   public groupByClause(): string {

--- a/packages/cubejs-schema-compiler/src/adapter/AWSElasticSearchQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/AWSElasticSearchQuery.ts
@@ -1,6 +1,5 @@
-import R from 'ramda';
 import { BaseFilter } from './BaseFilter';
-import { BaseQuery } from './BaseQuery';
+import { ElasticSearchQuery } from './ElasticSearchQuery';
 
 const GRANULARITY_TO_INTERVAL = {
   day: (date) => `DATE_FORMAT(${date}, 'yyyy-MM-dd 00:00:00.000')`,
@@ -21,83 +20,24 @@ class AWSElasticSearchQueryFilter extends BaseFilter {
   }
 }
 
-export class AWSElasticSearchQuery extends BaseQuery {
-  public newFilter(filter) {
+export class AWSElasticSearchQuery extends ElasticSearchQuery {
+  public override newFilter(filter) {
     return new AWSElasticSearchQueryFilter(this, filter);
   }
 
-  public convertTz(field) {
-    return `${field}`; // TODO
-  }
-
-  public timeStampCast(value) {
-    return `${value}`;
-  }
-
-  public dateTimeCast(value) {
-    return `${value}`; // TODO
-  }
-
-  public subtractInterval(date, interval) {
+  public override subtractInterval(date, interval) {
     return `DATE_SUB(${date}, INTERVAL ${interval})`;
   }
 
-  public addInterval(date, interval) {
+  public override addInterval(date, interval) {
     return `DATE_ADD(${date}, INTERVAL ${interval})`;
   }
 
-  public timeGroupedColumn(granularity, dimension) {
+  public override timeGroupedColumn(granularity, dimension) {
     return GRANULARITY_TO_INTERVAL[granularity](dimension);
   }
 
-  public groupByClause() {
-    if (this.ungrouped) {
-      return '';
-    }
-    const dimensionsForSelect = this.dimensionsForSelect();
-    const dimensionColumns = R.flatten(dimensionsForSelect.map(s => s.selectColumns() && s.dimensionSql()))
-      .filter(s => !!s);
-    return dimensionColumns.length ? ` GROUP BY ${dimensionColumns.join(', ')}` : '';
-  }
-
-  public orderHashToString(hash) {
-    if (!hash || !hash.id) {
-      return null;
-    }
-
-    const fieldAlias = this.getFieldAlias(hash.id);
-
-    if (fieldAlias === null) {
-      return null;
-    }
-
-    const direction = hash.desc ? 'DESC' : 'ASC';
-    return `${fieldAlias} ${direction}`;
-  }
-
-  public getFieldAlias(id) {
-    const equalIgnoreCase = (a, b) => (
-      typeof a === 'string' && typeof b === 'string' && a.toUpperCase() === b.toUpperCase()
-    );
-
-    let field;
-
-    field = this.dimensionsForSelect().find(d => equalIgnoreCase(d.dimension, id));
-
-    if (field) {
-      return field.dimensionSql();
-    }
-
-    field = this.measures.find(d => equalIgnoreCase(d.measure, id) || equalIgnoreCase(d.expressionName, id));
-
-    if (field) {
-      return field.aliasName(); // TODO isn't supported
-    }
-
-    return null;
-  }
-
-  public escapeColumnName(name) {
-    return `${name}`; // TODO
+  public override unixTimestampSql() {
+    return 'EXTRACT(EPOCH FROM NOW())';
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2568,7 +2568,7 @@ export class BaseQuery {
   }
 
   /**
-   * XXX: String as return value is added because of HiveQuery.getFieldIndex()
+   * XXX: String as return value is added because of HiveQuery.getFieldIndex() and DatabricksQuery.getFieldIndex()
    * @protected
    * @param {string} id member name in form of "cube.member[.granularity]"
    * @returns {number|string|null}

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -508,8 +508,9 @@ export class BaseQuery {
 
       res.push({ id, desc: true });
     } else if (this.dimensions.length > 0) {
+      const dim = this.dimensions[0];
       res.push({
-        id: this.dimensions[0].dimension,
+        id: dim.expressionName ?? dim.dimension,
         desc: false,
       });
     }

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -123,33 +123,7 @@ export class ClickHouseQuery extends BaseQuery {
       .join(' AND ');
   }
 
-  public getFieldAlias(id) {
-    const equalIgnoreCase = (a, b) => (
-      typeof a === 'string' && typeof b === 'string' && a.toUpperCase() === b.toUpperCase()
-    );
-
-    let field;
-
-    field = this.dimensionsForSelect().find(
-      d => equalIgnoreCase(d.dimension, id),
-    );
-
-    if (field) {
-      return field.aliasName();
-    }
-
-    field = this.measures.find(
-      d => equalIgnoreCase(d.measure, id) || equalIgnoreCase(d.expressionName, id),
-    );
-
-    if (field) {
-      return field.aliasName();
-    }
-
-    return null;
-  }
-
-  public orderHashToString(hash) {
+  public override orderHashToString(hash: { id: string, desc: boolean }) {
     //
     // ClickHouse doesn't support order by index column, so map these to the alias names
     //

--- a/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-classes-per-file */
 import R from 'ramda';
 
+import { GRANULARITY_LEVELS } from '@cubejs-backend/shared';
 import { BaseQuery } from './BaseQuery';
 import { BaseFilter } from './BaseFilter';
-import { GRANULARITY_LEVELS } from '@cubejs-backend/shared';
 import { BaseMeasure } from './BaseMeasure';
 import { BaseDimension } from './BaseDimension';
 import { BaseTimeDimension } from './BaseTimeDimension';

--- a/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ElasticSearchQuery.ts
@@ -28,41 +28,41 @@ class ElasticSearchQueryFilter extends BaseFilter {
 }
 
 export class ElasticSearchQuery extends BaseQuery {
-  public newFilter(filter) {
+  public override newFilter(filter) {
     return new ElasticSearchQueryFilter(this, filter);
   }
 
-  public convertTz(field) {
+  public override convertTz(field) {
     return `${field}`; // TODO
   }
 
-  public timeStampCast(value) {
+  public override timeStampCast(value) {
     return `${value}`;
   }
 
-  public dateTimeCast(value) {
+  public override dateTimeCast(value) {
     return `${value}`; // TODO
   }
 
-  public subtractInterval(date, interval) {
+  public override subtractInterval(date, interval) {
     // TODO: Test this, note sure how value gets populated here
     return `${date} - INTERVAL ${interval}`;
   }
 
-  public addInterval(date, interval) {
+  public override addInterval(date, interval) {
     // TODO: Test this, note sure how value gets populated here
     return `${date} + INTERVAL ${interval}`;
   }
 
-  public timeGroupedColumn(granularity, dimension) {
+  public override timeGroupedColumn(granularity, dimension) {
     return GRANULARITY_TO_INTERVAL[granularity](dimension);
   }
 
-  public unixTimestampSql() {
+  public override unixTimestampSql() {
     return 'TIMESTAMP_DIFF(\'seconds\', \'1970-01-01T00:00:00.000Z\'::datetime, CURRENT_TIMESTAMP())';
   }
 
-  public groupByClause() {
+  public override groupByClause() {
     if (this.ungrouped) {
       return '';
     }
@@ -74,7 +74,7 @@ export class ElasticSearchQuery extends BaseQuery {
     return dimensionColumns.length ? ` GROUP BY ${dimensionColumns.join(', ')}` : '';
   }
 
-  public orderHashToString(hash) {
+  public override orderHashToString(hash: { id: string, desc: boolean }) {
     if (!hash || !hash.id) {
       return null;
     }
@@ -89,10 +89,10 @@ export class ElasticSearchQuery extends BaseQuery {
     return `${fieldAlias} ${direction}`;
   }
 
-  public getFieldAlias(id) {
-    const equalIgnoreCase = (a, b) => typeof a === 'string' &&
-      typeof b === 'string' &&
-      a.toUpperCase() === b.toUpperCase();
+  public getFieldAlias(id: string): string | null {
+    const equalIgnoreCase = (a: any, b: any) => (
+      typeof a === 'string' && typeof b === 'string' && a.toUpperCase() === b.toUpperCase()
+    );
 
     let field;
 
@@ -113,7 +113,7 @@ export class ElasticSearchQuery extends BaseQuery {
     return null;
   }
 
-  public escapeColumnName(name) {
-    return `${name}`; // TODO
+  public override escapeColumnName(name) {
+    return `${name}`;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/HiveQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/HiveQuery.ts
@@ -92,10 +92,12 @@ export class HiveQuery extends BaseQuery {
   }
 
   public getFieldIndex(id) {
-    const dimension = this.dimensionsForSelect().find(d => d.dimension === id);
-    if (dimension) {
-      return super.getFieldIndex(id);
+    const idx = super.getFieldIndex(id);
+
+    if (idx !== null) {
+      return idx;
     }
+
     return this.escapeColumnName(this.aliasName(id));
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
@@ -40,9 +40,9 @@ const ADAPTERS = {
   cubestore: CubeStoreQuery,
 };
 
-export const queryClass = (dbType, dialectClass) => dialectClass || ADAPTERS[dbType];
+export const queryClass = (dbType: string, dialectClass) => dialectClass || ADAPTERS[dbType];
 
-export const createQuery = (compilers, dbType, queryOptions) => {
+export const createQuery = (compilers, dbType: string, queryOptions: any) => {
   if (!queryOptions.dialectClass && !ADAPTERS[dbType]) {
     return null;
   }

--- a/packages/cubejs-schema-compiler/src/adapter/QueryCache.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/QueryCache.ts
@@ -1,14 +1,14 @@
 export class QueryCache {
-  constructor() {
+  private readonly storage: {};
+
+  public constructor() {
     this.storage = {};
   }
 
   /**
-   * @param {Array} key
-   * @param {Function} fn
    * @returns Returns the result of executing a function (Either call a function or take a value from the cache)
    */
-  cache(key, fn) {
+  public cache(key: any[], fn: Function): any {
     let keyHolder = this.storage;
     const { length } = key;
     for (let i = 0; i < length - 1; i++) {

--- a/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
@@ -35,6 +35,9 @@ describe('PostgresQuery', () => {
               interval: '1 quarter',
               offset: '1 month',
             },
+            fiscal_quarter_no_offset: {
+              interval: '1 quarter',
+            },
           }
         },
         fiscalCreatedAtLabel: {
@@ -141,5 +144,188 @@ describe('PostgresQuery', () => {
 
     const queryAndParams = query.buildSqlAndParams();
     expect(queryAndParams[0].split('AT TIME ZONE \'America/Los_Angeles\'').length).toEqual(3);
+  });
+
+  describe('order by clause', () => {
+    it('multi granularity ordered by min granularity (auto)', async () => {
+      await compiler.compile();
+
+      let query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'fiscal_quarter',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      let queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 2 ASC');
+
+      query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'fiscal_quarter',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 1 ASC');
+
+      query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'year',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'fiscal_quarter_no_offset',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 2 ASC');
+    });
+
+    it('multi granularity ordered by specified granularity', async () => {
+      await compiler.compile();
+
+      let query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt.week', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      let queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 2 ASC');
+
+      query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt.month', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 1 ASC');
+
+      query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt.month', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 2 ASC');
+
+      query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'visitors.count'
+        ],
+        timeDimensions: [{
+          dimension: 'visitors.createdAt',
+          granularity: 'week',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          granularity: 'fiscal_quarter_no_offset',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }, {
+          dimension: 'visitors.createdAt',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [{ id: 'visitors.createdAt.fiscal_quarter_no_offset', desc: false }],
+        timezone: 'America/Los_Angeles'
+      });
+
+      queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('ORDER BY 3 ASC');
+    });
   });
 });


### PR DESCRIPTION
This PR introduces the ability to specify granularity in the order section of the query and fixes the ordering when same time dimension is requested multiple times (with different granularities).

Imaging you have a query like this:

```js
{
        measures: [
          'BigECommerce.rollingCountYTD',
        ],
        timeDimensions: [{
          dimension: 'BigECommerce.orderDate',
          granularity: 'month',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'BigECommerce.orderDate',
          granularity: 'week',
          dateRange: ['2020-01-01', '2020-12-31'],
        }],
        order: [
          ['BigECommerce.orderDate', 'asc'],
        ],
}
```
Note the `order` part.

Before now - the sorting will be done by 1st td with `month` granularity. But resulting rows still could jump around because week timestamps inside one month are not guaranteed to be ordered. Now column with the lowest granularity (week in the example) will be used for ordering.

Btw, this also works with custom granularities! ;)

To have full control, now you can specify the `granularity` in the order section like this:
```js
{
        measures: [
          'visitors.count'
        ],
        timeDimensions: [{
          dimension: 'visitors.createdAt',
          granularity: 'week',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'visitors.createdAt',
          granularity: 'month',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'visitors.createdAt',
          dateRange: ['2020-01-01', '2020-12-31'],
        }],
        order: [{ id: 'visitors.createdAt.month', desc: false }],
        timezone: 'America/Los_Angeles'
}
```
or like this:
```js
{
        measures: [
          'visitors.count'
        ],
        timeDimensions: [{
          dimension: 'visitors.createdAt',
          granularity: 'week',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'visitors.createdAt',
          granularity: 'month',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'visitors.createdAt',
          granularity: 'fiscal_quarter',
          dateRange: ['2020-01-01', '2020-12-31'],
        }, {
          dimension: 'visitors.createdAt',
          dateRange: ['2020-01-01', '2020-12-31'],
        }],
        order: [{ id: 'visitors.createdAt.fiscal_quarter', desc: false }],
        timezone: 'America/Los_Angeles'
}
```

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
