### PR TITLE
feat(trino-driver): Add special testConnection for Trino

### DIFF
--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@cubejs-backend/base-driver": "1.3.19",
     "@cubejs-backend/shared": "1.3.19",
-    "presto-client": "^0.12.2",
+    "presto-client": "^1.1.0",
     "ramda": "^0.27.0",
     "sqlstring": "^2.3.1"
   },

--- a/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
+++ b/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
@@ -60,11 +60,11 @@ export class PrestoDriver extends BaseDriver implements DriverInterface {
     return 2;
   }
 
-  private config: PrestoDriverConfiguration;
+  protected readonly config: PrestoDriverConfiguration;
 
-  private catalog: string | undefined;
+  protected readonly catalog: string | undefined;
 
-  private client: any;
+  protected client: any;
 
   /**
    * Class constructor.

--- a/packages/cubejs-schema-compiler/src/adapter/index.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/index.ts
@@ -16,9 +16,9 @@ export * from './CubeStoreQuery';
 export * from './MysqlQuery';
 export * from './PostgresQuery';
 export * from './MssqlQuery';
+export * from './PrestodbQuery';
 
 // Candidates to move from this package to drivers packages
-// export * from './PrestodbQuery';
 // export * from './RedshiftQuery';
 // export * from './SnowflakeQuery';
 // export * from './SqliteQuery';

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -29,6 +29,7 @@
     "@cubejs-backend/prestodb-driver": "1.3.19",
     "@cubejs-backend/schema-compiler": "1.3.19",
     "@cubejs-backend/shared": "1.3.19",
+    "node-fetch": "^2.6.1",
     "presto-client": "^0.12.2",
     "sqlstring": "^2.3.1"
   },

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -30,7 +30,7 @@
     "@cubejs-backend/schema-compiler": "1.3.19",
     "@cubejs-backend/shared": "1.3.19",
     "node-fetch": "^2.6.1",
-    "presto-client": "^0.12.2",
+    "presto-client": "^1.1.0",
     "sqlstring": "^2.3.1"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -1,5 +1,6 @@
+import fetch from 'node-fetch';
 import { PrestoDriver } from '@cubejs-backend/prestodb-driver';
-import { PrestodbQuery } from '@cubejs-backend/schema-compiler/dist/src/adapter/PrestodbQuery';
+import { PrestodbQuery } from '@cubejs-backend/schema-compiler';
 
 export class TrinoDriver extends PrestoDriver {
   public constructor(options: any) {
@@ -8,5 +9,25 @@ export class TrinoDriver extends PrestoDriver {
 
   public static dialectClass() {
     return PrestodbQuery;
+  }
+
+  public override async testConnection(): Promise<void> {
+    const { host, port, ssl,basic_auth: basicAuth } = this.config;
+    const protocol = ssl ? 'https' : 'http';
+    const url = `${protocol}://${host}:${port}/v1/info`;
+    const headers: Record<string, string> = {};
+
+    if (basicAuth) {
+      const { user, password } = basicAuth;
+      const encoded = Buffer.from(`${user}:${password}`).toString('base64');
+      headers.Authorization = `Basic ${encoded}`;
+    }
+
+    const response = await fetch(url, { method: 'GET', headers });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Connection test failed: ${response.status} ${response.statusText} - ${text}`);
+    }
   }
 }

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -12,7 +12,7 @@ export class TrinoDriver extends PrestoDriver {
   }
 
   public override async testConnection(): Promise<void> {
-    const { host, port, ssl,basic_auth: basicAuth } = this.config;
+    const { host, port, ssl, basic_auth: basicAuth } = this.config;
     const protocol = ssl ? 'https' : 'http';
     const url = `${protocol}://${host}:${port}/v1/info`;
     const headers: Record<string, string> = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14373,7 +14373,7 @@ focus-lock@^1.3.5:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0, follow-redirects@^1.15.3, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -21338,10 +21338,12 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-presto-client@^0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/presto-client/-/presto-client-0.12.2.tgz#9719064bed0bd98166ae4bf2ac2c08c0f6996544"
-  integrity sha512-rmoBoxM5mSQZ06SxwEHzMM8nn8W0XQJ2YmmxU9xMOM4r7Hs9Nec72VsM+M1FIYdteU9UIi40550weGs1uiTBNA==
+presto-client@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/presto-client/-/presto-client-1.1.0.tgz#cf0fe8a445db73c1e025256f5868fadaef4017a0"
+  integrity sha512-DOWEKp0eHP/x6Fupk5673vZND7OUxFtV9VUO9HMvf4DFzoWKTLMRAJ3o5/7Mgs5z9w5BEUKU88IZaume6LMelw==
+  dependencies:
+    follow-redirects "^1.15.3"
 
 prettier@^1.16.4:
   version "1.19.1"


### PR DESCRIPTION
This PR includes a special `testConnection()` implementation for Trino, as the one for PrestoDB is not working for Trino Server.

Also updated the "presto-client" to the latest "^1.1.0".

This fixes https://github.com/cube-js/cube/issues/9303

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
