### PR TITLE
feat: Expose aliasMember for hierarchy in View

### DIFF
--- a/packages/cubejs-api-gateway/openspec.yml
+++ b/packages/cubejs-api-gateway/openspec.yml
@@ -182,6 +182,9 @@ components:
       properties:
         name:
           type: "string"
+        aliasMember:
+          description: "When hierarchy is defined in Cube, it keeps the original path: Cube.hierarchy"
+          type: "string"
         title:
           type: "string"
         levels:

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -308,6 +308,7 @@ export class CubeEvaluator extends CubeSymbols {
     if (cube.isView && (cube.includedMembers || []).length) {
       const includedMemberPaths: string[] = R.uniq(cube.includedMembers.map(it => it.memberPath));
       const includedCubeNames: string[] = R.uniq(includedMemberPaths.map(it => it.split('.')[0]));
+
       // Path to name (which can be prefixed or aliased) map for hierarchy
       const hierarchyPathToName = cube.includedMembers.filter(it => it.type === 'hierarchies').reduce((acc, it) => ({
         ...acc,
@@ -336,14 +337,18 @@ export class CubeEvaluator extends CubeSymbols {
               })
                 .filter(Boolean);
 
-              const name = hierarchyPathToName[[cubeName, it.name].join('.')];
+              const aliasMember = [cubeName, it.name].join('.');
+
+              const name = hierarchyPathToName[aliasMember];
               if (!name) {
                 throw new UserError(`Hierarchy '${it.name}' not found in cube '${cubeName}'`);
               }
+
               return {
                 // Title might be overridden in the view
                 title: cube.hierarchies?.[it.name]?.override?.title || it.title,
                 ...it,
+                aliasMember,
                 name,
                 levels
               };

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
@@ -109,6 +109,7 @@ export class CubeToMetaTransformer {
         )(cube.segments || {}),
         hierarchies: (cube.evaluatedHierarchies || []).map((it) => ({
           ...it,
+          aliasMember: it.aliasMember,
           public: it.public ?? true,
           name: `${cube.name}.${it.name}`,
         })),

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -1446,6 +1446,7 @@ Object {
   },
   "evaluatedHierarchies": Array [
     Object {
+      "aliasMember": "orders.hello",
       "levels": Array [
         "orders_view.my_beloved_status",
       ],

--- a/packages/cubejs-schema-compiler/test/unit/hierarchies.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/hierarchies.test.ts
@@ -23,6 +23,7 @@ describe('Cube hierarchies', () => {
         name: 'orders_users_view.orders_hierarchy',
         title: 'Hello Hierarchy',
         public: true,
+        aliasMember: 'orders.orders_hierarchy',
         levels: [
           'orders_users_view.status',
           'orders_users_view.number',
@@ -32,6 +33,7 @@ describe('Cube hierarchies', () => {
       {
         name: 'orders_users_view.some_other_hierarchy',
         public: true,
+        aliasMember: 'orders.some_other_hierarchy',
         title: 'Some other hierarchy',
         levels: ['orders_users_view.state', 'orders_users_view.user_city']
       }
@@ -54,6 +56,7 @@ describe('Cube hierarchies', () => {
 
     const prefixedHierarchy = allHierarchyView.config.hierarchies.find((it) => it.name === 'all_hierarchy_view.users_users_hierarchy');
     expect(prefixedHierarchy).toBeTruthy();
+    expect(prefixedHierarchy?.aliasMember).toEqual('users.users_hierarchy');
     expect(prefixedHierarchy?.levels).toEqual(['all_hierarchy_view.users_age', 'all_hierarchy_view.users_city']);
   });
 
@@ -146,12 +149,14 @@ describe('Cube hierarchies', () => {
 
     expect(testView?.config.hierarchies).toEqual([
       {
+        aliasMember: 'orders.base_orders_hierarchy',
         name: 'test_view.base_orders_hierarchy',
         title: 'Hello Hierarchy',
         levels: ['test_view.status', 'test_view.number'],
         public: true
       },
       {
+        aliasMember: 'orders.orders_hierarchy',
         name: 'test_view.orders_hierarchy',
         levels: ['test_view.state', 'test_view.city'],
         public: true
@@ -174,6 +179,7 @@ describe('Cube hierarchies', () => {
 
     expect(ordersCube.config.hierarchies).toEqual([
       {
+        aliasMember: undefined,
         name: 'orders.hello',
         title: 'World',
         levels: ['orders.status'],

--- a/rust/cubesql/cubeclient/src/models/v1_cube_meta_hierarchy.rs
+++ b/rust/cubesql/cubeclient/src/models/v1_cube_meta_hierarchy.rs
@@ -12,6 +12,9 @@
 pub struct V1CubeMetaHierarchy {
     #[serde(rename = "name")]
     pub name: String,
+    /// When hierarchy is defined in Cube, it keeps the original path: Cube.hierarchy
+    #[serde(rename = "aliasMember", skip_serializing_if = "Option::is_none")]
+    pub alias_member: Option<String>,
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(rename = "levels")]
@@ -22,6 +25,7 @@ impl V1CubeMetaHierarchy {
     pub fn new(name: String, levels: Vec<String>) -> V1CubeMetaHierarchy {
         V1CubeMetaHierarchy {
             name,
+            alias_member: None,
             title: None,
             levels,
         }


### PR DESCRIPTION
While working on new hierarchy support for MDX, I've figured out that there is no `aliasMember` (and generally no way) for hierarchies in views. It's important because I am using it to construct Analysis Services hierarchies.

### After the change

![image](https://github.com/user-attachments/assets/81d03c1a-4889-48e6-b563-3084e5db4fa6)


**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet