### PR TITLE
fix(schema-compiler): Support for `export function xxx()` during transpilation

### DIFF
--- a/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
@@ -57,6 +57,10 @@ describe('Transpilers', () => {
       export const helperFunction = () => 'hello'
       export { helperFunction as alias }
       export default helperFunction
+      export function requireFilterParam() {
+        return 'required';
+      }
+      export const someVar = 42
     `;
     const ast = parse(
       code,
@@ -77,7 +81,17 @@ addExport({
 addExport({
   alias: helperFunction
 });
-setExport(helperFunction);`);
+setExport(helperFunction);
+function requireFilterParam() {
+  return 'required';
+}
+addExport({
+  requireFilterParam: requireFilterParam
+})
+const someVar = 42;
+addExport({
+  someVar: someVar
+})`);
 
     errorsReport.throwIfAny(); // should not throw
   });


### PR DESCRIPTION
This PR adds support for exports like:

```js
export function requireFilterParam() {
  return 'required';
}
```

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
