### PR TITLE
feat(schema-compiler): Add support for time dimensions with granularities in multi-stage measures add_group_by

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1453,7 +1453,22 @@ export class BaseQuery {
     const memberDef = member.definition();
     // TODO can addGroupBy replaced by something else?
     if (memberDef.addGroupByReferences) {
-      queryContext = { ...queryContext, dimensions: R.uniq(queryContext.dimensions.concat(memberDef.addGroupByReferences)) };
+      const dims = memberDef.addGroupByReferences.reduce((acc, cur) => {
+        const pathArr = cur.split('.');
+        // addGroupBy may include time dimension with granularity
+        // But we don't need it as time dimension
+        if (pathArr.length > 2) {
+          pathArr.splice(2, 0, 'granularities');
+          acc.push(pathArr.join('.'));
+        } else {
+          acc.push(cur);
+        }
+        return acc;
+      }, []);
+      queryContext = {
+        ...queryContext,
+        dimensions: R.uniq(queryContext.dimensions.concat(dims)),
+      };
     }
     if (memberDef.timeShiftReferences?.length) {
       let { commonTimeShift } = queryContext;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -683,7 +683,7 @@ export class CubeSymbols {
       return cubeEvaluator.pathFromArray(fullPath(cubeEvaluator.joinHints(), [referencedCube, name]));
     }, {
       // eslint-disable-next-line no-shadow
-      sqlResolveFn: (symbol, currentCube, n) => cubeEvaluator.pathFromArray(fullPath(cubeEvaluator.joinHints(), [currentCube, n])),
+      sqlResolveFn: (symbol, currentCube, refProperty, propertyName) => cubeEvaluator.pathFromArray(fullPath(cubeEvaluator.joinHints(), [currentCube, refProperty, ...(propertyName ? [propertyName] : [])])),
       // eslint-disable-next-line no-shadow
       cubeAliasFn: (currentCube) => cubeEvaluator.pathFromArray(fullPath(cubeEvaluator.joinHints(), [currentCube])),
       collectJoinHints: options.collectJoinHints,

--- a/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
@@ -231,6 +231,12 @@ describe('SQL Generation', () => {
           type: 'sum',
           add_group_by: [visitors.created_at],
         },
+        revenue_sum_group_by_granularity: {
+          multi_stage: true,
+          sql: \`\${revenue}\`,
+          type: 'number',
+          add_group_by: [visitors.created_at.month],
+        },
         revenue_rank: {
           multi_stage: true,
           type: \`rank\`,
@@ -3455,6 +3461,33 @@ SELECT 1 AS revenue,  cast('2024-01-01' AS timestamp) as time UNION ALL
       visitors__updated_at_day: '2017-01-25T00:00:00.000Z',
       visitors__adjusted_rank_sum: null,
       visitors__visitor_revenue: null
+    }]
+  ));
+
+  it('multi stage revenue_sum_group_by_granularity and group by td with granularity', async () => runQueryTest(
+    {
+      measures: ['visitors.revenue_sum_group_by_granularity'],
+      dimensions: ['visitors.source'],
+      order: [{
+        id: 'visitors.source'
+      }],
+      timezone: 'UTC',
+    },
+    [{
+      visitors__revenue_sum_group_by_granularity: '300',
+      visitors__source: 'google',
+    },
+    {
+      visitors__revenue_sum_group_by_granularity: '300',
+      visitors__source: 'some',
+    },
+    {
+      visitors__revenue_sum_group_by_granularity: '900',
+      visitors__source: null,
+    },
+    {
+      visitors__revenue_sum_group_by_granularity: '500',
+      visitors__source: null,
     }]
   ));
 


### PR DESCRIPTION
With this fix you can reference time dimension granularity within `add_group_by` property of multi-stage measure.

```yaml
      - name: xirr
        multi_stage: true
        sql: "XIRR({total_payments}, {created_at.day})"
        type: number_agg
        add_group_by:
          - created_at.day   # here day is a granularity of created_at dimension
```

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
