### PR TITLE
feat(prestodb-driver, trino-driver): Support dbUseSelectTestConnection flag

### DIFF
--- a/.github/actions/integration/trino.sh
+++ b/.github/actions/integration/trino.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eo pipefail
+
+# Debug log for test containers
+export DEBUG=testcontainers
+
+export TEST_PRESTO_VERSION=341-SNAPSHOT
+export TEST_PGSQL_VERSION=12.4
+
+echo "::group::Trino ${TEST_PRESTO_VERSION} with PostgreSQL ${TEST_PGSQL_VERSION}"
+docker pull lewuathe/presto-coordinator:${TEST_PRESTO_VERSION}
+docker pull lewuathe/presto-worker:${TEST_PRESTO_VERSION}
+docker pull postgres:${TEST_PGSQL_VERSION}
+yarn lerna run --concurrency 1 --stream --no-prefix integration:trino
+echo "::endgroup::"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -412,7 +412,7 @@ jobs:
       matrix:
         node-version: [22.x]
         db: [
-            'athena', 'bigquery', 'snowflake',
+            'athena', 'bigquery', 'snowflake', 'trino',
             'clickhouse', 'druid', 'elasticsearch', 'mssql', 'mysql', 'postgres', 'prestodb',
             'mysql-aurora-serverless', 'crate', 'mongobi', 'firebolt', 'dremio', 'vertica'
         ]

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -338,6 +338,33 @@ const variables: Record<string, (...args: any) => any> = {
   ),
 
   /**
+   * Use `SELECT 1` query for testConnection.
+   * It might be used in any driver where there is a specific testConnection
+   * like a REST call, but for some reason it's not possible to use it in
+   * deployment environment.
+   */
+  dbUseSelectTestConnection: ({
+    dataSource,
+  }: {
+    dataSource: string,
+  }) => {
+    const val = process.env[
+      keyByDataSource('CUBEJS_DB_USE_SELECT_TEST_CONNECTION', dataSource)
+    ] || 'false';
+    if (val.toLocaleLowerCase() === 'true') {
+      return true;
+    } else if (val.toLowerCase() === 'false') {
+      return false;
+    } else {
+      throw new TypeError(
+        `The ${
+          keyByDataSource('CUBEJS_DB_USE_SELECT_TEST_CONNECTION', dataSource)
+        } must be either 'true' or 'false'.`
+      );
+    }
+  },
+
+  /**
    * Kafka host for direct downloads from ksqlDb
    */
   dbKafkaHost: ({ dataSource }: {

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1798,7 +1798,7 @@ const variables: Record<string, (...args: any) => any> = {
     return [];
   },
   /** ***************************************************************
-   * Presto Driver                                                  *
+   * Presto/Trino Driver                                                  *
    **************************************************************** */
 
   /**
@@ -1814,12 +1814,25 @@ const variables: Record<string, (...args: any) => any> = {
     ]
   ),
 
+  /**
+   * Presto/Trino Auth Token
+   */
+  prestoAuthToken: ({
+    dataSource,
+  }: {
+    dataSource: string,
+  }) => (
+    process.env[
+      keyByDataSource('CUBEJS_DB_PRESTO_AUTH_TOKEN', dataSource)
+    ]
+  ),
+
   /** ***************************************************************
    * Pinot Driver                                                  *
    **************************************************************** */
 
   /**
-   * Pinot / Startree Auth Token
+   * Pinot/Startree Auth Token
    */
   pinotAuthToken: ({
     dataSource,

--- a/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
+++ b/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
@@ -42,6 +42,8 @@ export type PrestoDriverConfiguration = PrestoDriverExportBucket & {
   schema?: string;
   user?: string;
   // eslint-disable-next-line camelcase
+  custom_auth?: string;
+  // eslint-disable-next-line camelcase
   basic_auth?: { user: string, password: string };
   ssl?: string | TLSConnectionOptions;
   dataSource?: string;
@@ -76,6 +78,14 @@ export class PrestoDriver extends BaseDriver implements DriverInterface {
       config.dataSource ||
       assertDataSource('default');
 
+    const dbUser = getEnv('dbUser', { dataSource });
+    const dbPassword = getEnv('dbPass', { dataSource });
+    const authToken = getEnv('prestoAuthToken', { dataSource });
+
+    if (authToken && dbPassword) {
+      throw new Error('Both user/password and auth token are set. Please remove password or token.');
+    }
+
     this.config = {
       host: getEnv('dbHost', { dataSource }),
       port: getEnv('dbPort', { dataSource }),
@@ -85,13 +95,9 @@ export class PrestoDriver extends BaseDriver implements DriverInterface {
       schema:
         getEnv('dbName', { dataSource }) ||
         getEnv('dbSchema', { dataSource }),
-      user: getEnv('dbUser', { dataSource }),
-      basic_auth: getEnv('dbPass', { dataSource })
-        ? {
-          user: getEnv('dbUser', { dataSource }),
-          password: getEnv('dbPass', { dataSource }),
-        }
-        : undefined,
+      user: dbUser,
+      ...(authToken ? { custom_auth: `Bearer ${authToken}` } : {}),
+      ...(dbPassword ? { basic_auth: { user: dbUser, password: dbPassword } } : {}),
       ssl: this.getSslOptions(dataSource),
       bucketType: getEnv('dbExportBucketType', { supported: ['gcs'], dataSource }),
       exportBucket: getEnv('dbExportBucket', { dataSource }),

--- a/packages/cubejs-trino-driver/docker-compose.yml
+++ b/packages/cubejs-trino-driver/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.2'
+
+services:
+  coordinator:
+    image: trinodb/trino
+    ports:
+      - "8080:8080"
+    container_name: "coordinator"
+    healthcheck:
+      test: "trino --execute 'SELECT 1' || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -21,6 +21,8 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
+    "integration": "jest dist/test",
+    "integration:trino": "jest dist/test",
     "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts"
   },
@@ -38,7 +40,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@cubejs-backend/linter": "1.3.19"
+    "@cubejs-backend/linter": "1.3.19",
+    "@types/jest": "^29",
+    "jest": "^29",
+    "testcontainers": "^10.13.0",
+    "typescript": "~5.2.2"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -11,7 +11,12 @@ export class TrinoDriver extends PrestoDriver {
     return PrestodbQuery;
   }
 
+  // eslint-disable-next-line consistent-return
   public override async testConnection(): Promise<void> {
+    if (this.useSelectTestConnection) {
+      return this.testConnectionViaSelect();
+    }
+
     const { host, port, ssl, basic_auth: basicAuth, custom_auth: customAuth } = this.config;
     const protocol = ssl ? 'https' : 'http';
     const url = `${protocol}://${host}:${port}/v1/info`;

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -12,12 +12,14 @@ export class TrinoDriver extends PrestoDriver {
   }
 
   public override async testConnection(): Promise<void> {
-    const { host, port, ssl, basic_auth: basicAuth } = this.config;
+    const { host, port, ssl, basic_auth: basicAuth, custom_auth: customAuth } = this.config;
     const protocol = ssl ? 'https' : 'http';
     const url = `${protocol}://${host}:${port}/v1/info`;
     const headers: Record<string, string> = {};
 
-    if (basicAuth) {
+    if (customAuth) {
+      headers.Authorization = customAuth;
+    } else if (basicAuth) {
       const { user, password } = basicAuth;
       const encoded = Buffer.from(`${user}:${password}`).toString('base64');
       headers.Authorization = `Basic ${encoded}`;

--- a/packages/cubejs-trino-driver/test/trino-driver.test.ts
+++ b/packages/cubejs-trino-driver/test/trino-driver.test.ts
@@ -1,16 +1,16 @@
-import { PrestoDriver } from '../src/PrestoDriver';
+import { TrinoDriver } from '../src/TrinoDriver';
 
 const path = require('path');
 const { DockerComposeEnvironment, Wait } = require('testcontainers');
 
-describe('PrestoHouseDriver', () => {
+describe('TrinoDriver', () => {
   jest.setTimeout(6 * 60 * 1000);
 
   let env: any;
   let config: any;
 
   const doWithDriver = async (callback: any) => {
-    const driver = new PrestoDriver(config);
+    const driver = new TrinoDriver(config);
 
     await callback(driver);
   };


### PR DESCRIPTION
Introduce new env `CUBEJS_DB_USE_SELECT_TEST_CONNECTION` which if set to true switches `testConnection()` in Prestodb/Trino drivers to use `SELECT 1` query for testConnection. 


**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

