### PR TITLE
fix(cubesql): Propagate errors from SqlAuthService to the user

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -128,14 +128,25 @@ export class SQLServer {
         };
       },
       checkSqlAuth: async ({ request, user, password }) => {
-        const { password: returnedPassword, superuser, securityContext, skipPasswordCheck } = await checkSqlAuth(request, user, password);
+        try {
+          const { password: returnedPassword, superuser, securityContext, skipPasswordCheck } = await checkSqlAuth(request, user, password);
 
-        return {
-          password: returnedPassword,
-          superuser: superuser || false,
-          securityContext,
-          skipPasswordCheck,
-        };
+          return {
+            password: returnedPassword,
+            superuser: superuser || false,
+            securityContext,
+            skipPasswordCheck,
+          };
+        } catch (e) {
+          this.apiGateway.log({
+            type: 'Auth Error',
+            protocol: (request as any).protocol,
+            method: (request as any).method,
+            apiType: 'sql',
+            error: (e as Error).stack || (e as Error).toString(),
+          });
+          throw e;
+        }
       },
       meta: async ({ request, session, onlyCompilerId }) => {
         const context = await this.apiGateway.contextByReq(<any> request, session.securityContext, request.id);


### PR DESCRIPTION
When using cube.py it’s fundamental to see errors and even better the stack trace of errors generated from python code, currently the logs doesn’t show any errors generated from python check_sql_auth.

This PR propagates such errors to the log.

Imaging this cube.py config:
```py
# Validate the username and password of the user submitting the API request
@config('check_sql_auth')
def check_sql_auth(query: dict, username: str, password: str) -> dict:
  raise Exception('You should be able to see this error in the logs')
```

And let's try to connect to Cube via psql:
```sh
❯ psql -h 127.0.0.1 -p 15432 -U cube
psql: error: connection to server at "127.0.0.1", port 15432 failed: FATAL:  password authentication failed for user "cube"
```

And here is what we now can see in logs:
```
cubejs-server
🔥 Cube Store (1.3.19) is assigned to 3030 port.
🔓 Authentication checks are disabled in developer mode. Please use NODE_ENV=production to enable it.
🦅 Dev environment available at http://localhost:4000
🔗 Cube SQL (pg) is listening on 0.0.0.0:15432
🚀 Cube API server (1.3.19) is listening on 4000
Auth Error: undefined
{}
Error: Python error: Exception: You should be able to see this error in the logs
Traceback (most recent call last):
  File "cube.py", line 14, in check_sql_auth
    raise Exception('You should be able to see this error in the logs')

```


**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
