### PR TITLE
fix: Report more accurate time to APM on heavy used deployments

### DIFF
--- a/packages/cubejs-backend-shared/src/track.ts
+++ b/packages/cubejs-backend-shared/src/track.ts
@@ -5,7 +5,7 @@ import { internalExceptions } from './errors';
 
 export type BaseEvent = {
   event: string,
-  // it's possible to fill timestamp at place of logging, otherwise it will be automatically
+  // It's possible to fill timestamp at the place of logging, otherwise, it will be filled in automatically
   timestamp?: string,
   [key: string]: any,
 };

--- a/packages/cubejs-backend-shared/src/track.ts
+++ b/packages/cubejs-backend-shared/src/track.ts
@@ -5,7 +5,8 @@ import { internalExceptions } from './errors';
 
 export type BaseEvent = {
   event: string,
-  timestamp: string,
+  // it's possible to fill timestamp at place of logging, otherwise it will be automatically
+  timestamp?: string,
   [key: string]: any,
 };
 

--- a/packages/cubejs-backend-shared/src/track.ts
+++ b/packages/cubejs-backend-shared/src/track.ts
@@ -5,14 +5,16 @@ import { internalExceptions } from './errors';
 
 export type BaseEvent = {
   event: string,
+  timestamp: string,
   [key: string]: any,
 };
 
-export type Event = BaseEvent & {
+export type Event = {
   id: string,
   clientTimestamp: string,
   anonymousId: string,
   platform: string,
+  arch: string,
   nodeVersion: string,
   sentFrom: 'backend';
 };
@@ -79,8 +81,8 @@ export async function track(opts: BaseEvent) {
 
   trackEvents.push({
     ...opts,
+    clientTimestamp: opts.timestamp || new Date().toJSON(),
     id: crypto.randomBytes(16).toString('hex'),
-    clientTimestamp: new Date().toJSON(),
     platform: process.platform,
     arch: process.arch,
     nodeVersion: process.version,

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -11,7 +11,7 @@ import jwt from 'jsonwebtoken';
 import isDocker from 'is-docker';
 import type { Application as ExpressApplication, Request, Response } from 'express';
 import type { ChildProcess } from 'child_process';
-import { executeCommand, getEnv, keyByDataSource, packageExists } from '@cubejs-backend/shared';
+import {executeCommand, getAnonymousId, getEnv, keyByDataSource, packageExists} from '@cubejs-backend/shared';
 import crypto from 'crypto';
 
 import type { BaseDriver } from '@cubejs-backend/query-orchestrator';
@@ -115,7 +115,7 @@ export class DevServer {
       res.json({
         cubejsToken,
         basePath: options.basePath,
-        anonymousId: this.cubejsServer.anonymousId,
+        anonymousId: getAnonymousId(),
         coreServerVersion: this.cubejsServer.coreServerVersion,
         dockerVersion: this.options.dockerVersion || null,
         projectFingerprint: this.cubejsServer.projectFingerprint,

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -11,7 +11,7 @@ import jwt from 'jsonwebtoken';
 import isDocker from 'is-docker';
 import type { Application as ExpressApplication, Request, Response } from 'express';
 import type { ChildProcess } from 'child_process';
-import {executeCommand, getAnonymousId, getEnv, keyByDataSource, packageExists} from '@cubejs-backend/shared';
+import { executeCommand, getAnonymousId, getEnv, keyByDataSource, packageExists } from '@cubejs-backend/shared';
 import crypto from 'crypto';
 
 import type { BaseDriver } from '@cubejs-backend/query-orchestrator';

--- a/packages/cubejs-server-core/src/core/agentCollect.ts
+++ b/packages/cubejs-server-core/src/core/agentCollect.ts
@@ -8,6 +8,7 @@ import crypto from 'crypto';
 import WebSocket from 'ws';
 import zlib from 'zlib';
 import { promisify } from 'util';
+import {LoggerFn} from "./types";
 
 const deflate = promisify(zlib.deflate);
 interface AgentTransport {
@@ -175,11 +176,11 @@ const clearTransport = () => {
   agentInterval = null;
 };
 
-export default async (event: Record<string, any>, endpointUrl: string, logger: any) => {
+export default async (event: Record<string, any>, endpointUrl: string, logger: LoggerFn) => {
   trackEvents.push({
+    timestamp: new Date().toJSON(),
     ...event,
     id: crypto.randomBytes(16).toString('hex'),
-    timestamp: new Date().toJSON(),
     instanceId: getEnv('instanceId'),
   });
   lastEvent = new Date();

--- a/packages/cubejs-server-core/src/core/agentCollect.ts
+++ b/packages/cubejs-server-core/src/core/agentCollect.ts
@@ -8,7 +8,7 @@ import crypto from 'crypto';
 import WebSocket from 'ws';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import { LoggerFn } from './types';
+import { LoggerFnParams, LoggerFn } from './types';
 
 const deflate = promisify(zlib.deflate);
 interface AgentTransport {
@@ -176,7 +176,7 @@ const clearTransport = () => {
   agentInterval = null;
 };
 
-export default async (event: Record<string, any>, endpointUrl: string, logger: LoggerFn) => {
+export const agentCollect = async (event: LoggerFnParams, endpointUrl: string, logger: LoggerFn) => {
   trackEvents.push({
     timestamp: new Date().toJSON(),
     ...event,
@@ -228,3 +228,5 @@ export default async (event: Record<string, any>, endpointUrl: string, logger: L
     }, getEnv('agentFlushInterval'));
   }
 };
+
+export default agentCollect;

--- a/packages/cubejs-server-core/src/core/agentCollect.ts
+++ b/packages/cubejs-server-core/src/core/agentCollect.ts
@@ -8,7 +8,7 @@ import crypto from 'crypto';
 import WebSocket from 'ws';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import {LoggerFn} from "./types";
+import { LoggerFn } from './types';
 
 const deflate = promisify(zlib.deflate);
 interface AgentTransport {

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -30,7 +30,7 @@ import { RefreshScheduler, ScheduledRefreshOptions } from './RefreshScheduler';
 import { OrchestratorApi, OrchestratorApiOptions } from './OrchestratorApi';
 import { CompilerApi } from './CompilerApi';
 import { DevServer } from './DevServer';
-import agentCollect from './agentCollect';
+import { agentCollect } from './agentCollect';
 import { OrchestratorStorage } from './OrchestratorStorage';
 import { prodLogger, devLogger } from './logger';
 import { OptsHandler } from './OptsHandler';
@@ -58,7 +58,8 @@ import type {
   LoggerFn,
   DriverConfig,
   ScheduledRefreshTimeZonesFn,
-  ContextToCubeStoreRouterIdFn, LoggerEventParams,
+  ContextToCubeStoreRouterIdFn,
+  LoggerFnParams,
 } from './types';
 import {
   ContextToOrchestratorIdFn,
@@ -230,7 +231,7 @@ export class CubejsServerCore {
 
     this.startScheduledRefreshTimer();
 
-    this.event = async (event, props: LoggerEventParams) => {
+    this.event = async (event, props: LoggerFnParams) => {
       if (!this.options.telemetry) {
         return;
       }

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -168,7 +168,7 @@ export type ExternalDriverFactoryFn = (context: RequestContext) => Promise<BaseD
 export type ExternalDialectFactoryFn = (context: RequestContext) => BaseQuery;
 
 export type LoggerFnParams = {
-  // it's possible to fill timestamp at place of logging, otherwise it will be automatically
+  // It's possible to fill timestamp at the place of logging, otherwise, it will be filled in automatically
   timestamp?: string,
   [key: string]: any,
 };

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -167,11 +167,12 @@ export type ExternalDbTypeFn = (context: RequestContext) => DatabaseType;
 export type ExternalDriverFactoryFn = (context: RequestContext) => Promise<BaseDriver> | BaseDriver;
 export type ExternalDialectFactoryFn = (context: RequestContext) => BaseQuery;
 
-export type LoggerEventParams = {
+export type LoggerFnParams = {
+  // it's possible to fill timestamp at place of logging, otherwise it will be automatically
   timestamp?: string,
   [key: string]: any,
 };
-export type LoggerFn = (msg: string, params: LoggerEventParams) => void;
+export type LoggerFn = (msg: string, params: LoggerFnParams) => void;
 
 export type BiToolSyncConfig = {
   type: string;

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -167,7 +167,11 @@ export type ExternalDbTypeFn = (context: RequestContext) => DatabaseType;
 export type ExternalDriverFactoryFn = (context: RequestContext) => Promise<BaseDriver> | BaseDriver;
 export type ExternalDialectFactoryFn = (context: RequestContext) => BaseQuery;
 
-export type LoggerFn = (msg: string, params: Record<string, any>) => void;
+export type LoggerEventParams = {
+  timestamp?: string,
+  [key: string]: any,
+};
+export type LoggerFn = (msg: string, params: LoggerEventParams) => void;
 
 export type BiToolSyncConfig = {
   type: string;

--- a/rust/cubesql/cubesql/src/sql/compiler_cache.rs
+++ b/rust/cubesql/cubesql/src/sql/compiler_cache.rs
@@ -191,7 +191,8 @@ impl CompilerCache for CompilerCacheImpl {
                 .get(&(compiler_id, protocol.clone()))
                 .cloned()
         };
-        // Double checked locking
+
+        // Double-checked locking
         let cache_entry = if let Some(cache_entry) = cache_entry {
             cache_entry
         } else {


### PR DESCRIPTION
The idea is simple: When an `async` function is called in an `async` function with `await`, the real execution can be delayed to micro tasking in Node.js. It results in incorrect timestamps, which I see in APM.