### PR TITLE
fix(schema-compiler): Correct join hints collection for transitive joins

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -417,10 +417,29 @@ export class BaseQuery {
    */
   get allJoinHints() {
     if (!this.collectedJoinHints) {
+      let joinHints = this.collectJoinHints();
+      // let joinHints = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
+
+      // One cube may join the other cube via transitive joined cubes,
+      // members from which are referenced in the join `on` clauses.
+      // We need to collect such join hints and push them upfront of the joining one.
+      // It is important to use queryLevelJoinHints during the calculation if it is set.
+
+      const prevJoins = this.join;
+
+      let newJoin = this.joinGraph.buildJoin([...this.queryLevelJoinHints, ...joinHints]);
+      while (!R.equals(this.join, newJoin)) {
+        this.join = newJoin;
+        joinHints = R.uniq([joinHints[0], ...this.collectJoinHintsFromMembers(this.joinMembersFromJoin()), ...joinHints]);
+        newJoin = this.joinGraph.buildJoin([...this.queryLevelJoinHints, ...joinHints]);
+      }
+
       this.collectedJoinHints = [
         ...this.queryLevelJoinHints,
-        ...this.collectJoinHints(),
+        ...joinHints,
       ];
+
+      this.join = prevJoins;
     }
     return this.collectedJoinHints;
   }
@@ -2393,7 +2412,20 @@ export class BaseQuery {
     } else if (s.patchedMeasure?.patchedFrom) {
       return [s.patchedMeasure.patchedFrom.cubeName].concat(this.evaluateSymbolSql(s.patchedMeasure.patchedFrom.cubeName, s.patchedMeasure.patchedFrom.name, s.definition()));
     } else {
-      return this.evaluateSql(s.cube().name, s.definition().sql);
+      const res = this.evaluateSql(s.cube().name, s.definition().sql);
+      if (s.isJoinCondition) {
+        // In a join between Cube A and Cube B, sql() may reference members from other cubes.
+        // These referenced cubes must be added as join hints before Cube B to ensure correct SQL generation.
+        const targetCube = s.targetCubeName();
+        const { joinHints } = this.safeEvaluateSymbolContext();
+        let targetIdx = joinHints.findIndex(e => e === targetCube);
+        while (targetIdx > -1) {
+          joinHints.splice(targetIdx, 1);
+          targetIdx = joinHints.findIndex(e => e === targetCube);
+        }
+        joinHints.push(targetCube);
+      }
+      return res;
     }
   }
 
@@ -2430,21 +2462,25 @@ export class BaseQuery {
       };
     });
 
-    const joinMembers = this.join ? this.join.joins.map(j => ({
-      getMembers: () => [{
-        path: () => null,
-        cube: () => this.cubeEvaluator.cubeFromPath(j.originalFrom),
-        definition: () => j.join,
-      }]
-    })) : [];
-
     const membersToCollectFrom = [
       ...this.allMembersConcat(excludeTimeDimensions),
-      ...joinMembers,
+      ...this.joinMembersFromJoin(),
       ...customSubQueryJoinMembers,
     ];
 
     return this.collectJoinHintsFromMembers(membersToCollectFrom);
+  }
+
+  joinMembersFromJoin() {
+    return this.join ? this.join.joins.map(j => ({
+      getMembers: () => [{
+        path: () => null,
+        cube: () => this.cubeEvaluator.cubeFromPath(j.originalFrom),
+        definition: () => j.join,
+        isJoinCondition: true,
+        targetCubeName: () => j.originalTo,
+      }]
+    })) : [];
   }
 
   collectJoinHintsFromMembers(members) {
@@ -2762,7 +2798,7 @@ export class BaseQuery {
 
   pushJoinHints(joinHints) {
     if (this.safeEvaluateSymbolContext().joinHints && joinHints) {
-      if (joinHints.length === 1) {
+      if (Array.isArray(joinHints) && joinHints.length === 1) {
         [joinHints] = joinHints;
       }
       this.safeEvaluateSymbolContext().joinHints.push(joinHints);

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -417,7 +417,7 @@ export class BaseQuery {
    */
   get allJoinHints() {
     if (!this.collectedJoinHints) {
-      // let joinHints = this.collectJoinHints();
+      // this.collectedJoinHints = this.collectJoinHints();
       const allMembersJoinHints = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
       const customSubQueryJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromCustomSubQuery());
       let joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
@@ -435,7 +435,7 @@ export class BaseQuery {
         ...joinMembersJoinHints,
         ...customSubQueryJoinHints,
       ]);
-      while (!R.equals(this.join, newJoin)) {
+      while (newJoin?.joins.length > 0 && !R.equals(this.join, newJoin)) {
         this.join = newJoin;
         joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
         newJoin = this.joinGraph.buildJoin([
@@ -2438,6 +2438,26 @@ export class BaseQuery {
           targetIdx = joinHints.findIndex(e => e === targetCube);
         }
         joinHints.push(targetCube);
+
+        // Special processing is required when one cube extends another, because in this case
+        // cube names collected during joins evaluation might belong to ancestors which are out of scope of
+        // the current query and thus will lead to `Can't find join path to join cubes` error.
+        // To work around this we change the all ancestors cube names in collected join hints to the original one.
+        if (s.cube().extends) {
+          const cubeName = s.cube().name;
+          let parentCube = this.cubeEvaluator.resolveSymbolsCall(s.cube().extends, (name) => this.cubeEvaluator.cubeFromPath(name));
+          while (parentCube) {
+            // eslint-disable-next-line no-loop-func
+            joinHints.forEach((item, index, array) => {
+              if (item === parentCube.name) {
+                array[index] = cubeName;
+              }
+            });
+            parentCube = parentCube.extends ?
+              this.cubeEvaluator.resolveSymbolsCall(parentCube.extends, (name) => this.cubeEvaluator.cubeFromPath(name))
+              : null;
+          }
+        }
       }
       return res;
     }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -417,8 +417,10 @@ export class BaseQuery {
    */
   get allJoinHints() {
     if (!this.collectedJoinHints) {
-      let joinHints = this.collectJoinHints();
-      // let joinHints = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
+      // let joinHints = this.collectJoinHints();
+      const allMembersJoinHints = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
+      const customSubQueryJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromCustomSubQuery());
+      let joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
 
       // One cube may join the other cube via transitive joined cubes,
       // members from which are referenced in the join `on` clauses.
@@ -427,16 +429,28 @@ export class BaseQuery {
 
       const prevJoins = this.join;
 
-      let newJoin = this.joinGraph.buildJoin([...this.queryLevelJoinHints, ...joinHints]);
+      let newJoin = this.joinGraph.buildJoin([
+        ...this.queryLevelJoinHints,
+        ...allMembersJoinHints,
+        ...joinMembersJoinHints,
+        ...customSubQueryJoinHints,
+      ]);
       while (!R.equals(this.join, newJoin)) {
         this.join = newJoin;
-        joinHints = R.uniq([joinHints[0], ...this.collectJoinHintsFromMembers(this.joinMembersFromJoin()), ...joinHints]);
-        newJoin = this.joinGraph.buildJoin([...this.queryLevelJoinHints, ...joinHints]);
+        joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
+        newJoin = this.joinGraph.buildJoin([
+          ...this.queryLevelJoinHints,
+          ...allMembersJoinHints,
+          ...joinMembersJoinHints,
+          ...customSubQueryJoinHints,
+        ]);
       }
 
       this.collectedJoinHints = [
         ...this.queryLevelJoinHints,
-        ...joinHints,
+        ...allMembersJoinHints,
+        ...joinMembersJoinHints,
+        ...customSubQueryJoinHints,
       ];
 
       this.join = prevJoins;
@@ -2447,7 +2461,17 @@ export class BaseQuery {
    * @returns {Array<Array<string>>}
    */
   collectJoinHints(excludeTimeDimensions = false) {
-    const customSubQueryJoinMembers = this.customSubQueryJoins.map(j => {
+    const membersToCollectFrom = [
+      ...this.allMembersConcat(excludeTimeDimensions),
+      ...this.joinMembersFromJoin(),
+      ...this.joinMembersFromCustomSubQuery(),
+    ];
+
+    return this.collectJoinHintsFromMembers(membersToCollectFrom);
+  }
+
+  joinMembersFromCustomSubQuery() {
+    return this.customSubQueryJoins.map(j => {
       const res = {
         path: () => null,
         cube: () => this.cubeEvaluator.cubeFromPath(j.on.cubeName),
@@ -2461,14 +2485,6 @@ export class BaseQuery {
         getMembers: () => [res],
       };
     });
-
-    const membersToCollectFrom = [
-      ...this.allMembersConcat(excludeTimeDimensions),
-      ...this.joinMembersFromJoin(),
-      ...customSubQueryJoinMembers,
-    ];
-
-    return this.collectJoinHintsFromMembers(membersToCollectFrom);
   }
 
   joinMembersFromJoin() {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -418,40 +418,38 @@ export class BaseQuery {
   get allJoinHints() {
     if (!this.collectedJoinHints) {
       // this.collectedJoinHints = this.collectJoinHints();
-      const allMembersJoinHints = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
+      const [rootOfJoin, ...allMembersJoinHints] = this.collectJoinHintsFromMembers(this.allMembersConcat(false));
       const customSubQueryJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromCustomSubQuery());
       let joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
 
       // One cube may join the other cube via transitive joined cubes,
       // members from which are referenced in the join `on` clauses.
-      // We need to collect such join hints and push them upfront of the joining one.
+      // We need to collect such join hints and push them upfront of the joining one
+      // but only if they don't exist yet. Cause in other case we might affect what
+      // join path will be constructed in join graph.
       // It is important to use queryLevelJoinHints during the calculation if it is set.
+
+      const constructJP = () => {
+        const filteredJoinMembersJoinHints = joinMembersJoinHints.filter(m => !allMembersJoinHints.includes(m));
+        return [
+          ...this.queryLevelJoinHints,
+          rootOfJoin,
+          ...filteredJoinMembersJoinHints,
+          ...allMembersJoinHints,
+          ...customSubQueryJoinHints,
+        ];
+      };
 
       const prevJoins = this.join;
 
-      let newJoin = this.joinGraph.buildJoin([
-        ...this.queryLevelJoinHints,
-        ...allMembersJoinHints,
-        ...joinMembersJoinHints,
-        ...customSubQueryJoinHints,
-      ]);
+      let newJoin = this.joinGraph.buildJoin(constructJP());
       while (newJoin?.joins.length > 0 && !R.equals(this.join, newJoin)) {
         this.join = newJoin;
         joinMembersJoinHints = this.collectJoinHintsFromMembers(this.joinMembersFromJoin());
-        newJoin = this.joinGraph.buildJoin([
-          ...this.queryLevelJoinHints,
-          ...allMembersJoinHints,
-          ...joinMembersJoinHints,
-          ...customSubQueryJoinHints,
-        ]);
+        newJoin = this.joinGraph.buildJoin(constructJP());
       }
 
-      this.collectedJoinHints = [
-        ...this.queryLevelJoinHints,
-        ...allMembersJoinHints,
-        ...joinMembersJoinHints,
-        ...customSubQueryJoinHints,
-      ];
+      this.collectedJoinHints = constructJP();
 
       this.join = prevJoins;
     }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -773,6 +773,9 @@ export class CubeSymbols {
 
   protected joinHints() {
     const { joinHints } = this.resolveSymbolsCallContext || {};
+    if (Array.isArray(joinHints)) {
+      return R.uniq(joinHints);
+    }
     return joinHints;
   }
 
@@ -879,7 +882,7 @@ export class CubeSymbols {
       } else if (this.symbols[cubeName]?.[name]) {
         cube = this.cubeReferenceProxy(
           cubeName,
-          undefined,
+          collectJoinHints ? [] : undefined,
           name
         );
       }


### PR DESCRIPTION
This PR fixes incorrect SQL generation for queries that include members from joined cubes, but which require transitive joins.

This fixes https://github.com/cube-js/cube/issues/9557

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
