### PR TITLE
fix(client-core): Fix for the issue with Generated SQL tab in playground

### DIFF
--- a/packages/cubejs-client-core/src/SqlQuery.ts
+++ b/packages/cubejs-client-core/src/SqlQuery.ts
@@ -1,16 +1,16 @@
-export type SqlQueryTuple = [string, any[], any];
+export type SqlQueryTuple = [string, any[], any?];
 
 export type SqlData = {
   aliasNameToMember: Record<string, string>;
   cacheKeyQueries: SqlQueryTuple[];
-  dataSource: boolean;
+  dataSource: string;
   external: boolean;
   sql: SqlQueryTuple;
   preAggregations: any[];
   rollupMatchResults: any[];
 };
 
-type SqlQueryWrapper = { sql: SqlData };
+export type SqlQueryWrapper = { sql: SqlData };
 
 export default class SqlQuery {
   private readonly sqlQuery: SqlQueryWrapper;

--- a/packages/cubejs-client-core/src/SqlQuery.ts
+++ b/packages/cubejs-client-core/src/SqlQuery.ts
@@ -10,15 +10,17 @@ export type SqlData = {
   rollupMatchResults: any[];
 };
 
-export default class SqlQuery {
-  private readonly sqlQuery: SqlData;
+type SqlQueryWrapper = { sql: SqlData };
 
-  public constructor(sqlQuery: SqlData) {
+export default class SqlQuery {
+  private readonly sqlQuery: SqlQueryWrapper;
+
+  public constructor(sqlQuery: SqlQueryWrapper) {
     this.sqlQuery = sqlQuery;
   }
 
   public rawQuery(): SqlData {
-    return this.sqlQuery;
+    return this.sqlQuery.sql;
   }
 
   public sql(): string {

--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -627,7 +627,7 @@ class CubeApi {
         query,
         signal: options?.signal
       }),
-      (response: any) => (Array.isArray(response) ? response.map((body) => new SqlQuery(body.sql)) : new SqlQuery(response.sql)),
+      (response: any) => (Array.isArray(response) ? response.map((body) => new SqlQuery(body)) : new SqlQuery(response)),
       options,
       callback
     );

--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -627,7 +627,7 @@ class CubeApi {
         query,
         signal: options?.signal
       }),
-      (response: any) => (Array.isArray(response) ? response.map((body) => new SqlQuery(body)) : new SqlQuery(response)),
+      (response: any) => (Array.isArray(response) ? response.map((body) => new SqlQuery(body.sql)) : new SqlQuery(response.sql)),
       options,
       callback
     );

--- a/packages/cubejs-client-core/test/SqlQuery.test.ts
+++ b/packages/cubejs-client-core/test/SqlQuery.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license Apache-2.0
+ * @copyright Cube Dev, Inc.
+ * @fileoverview SqlQuery class unit tests.
+ */
+
+/* globals describe,it,expect */
+
+import SqlQuery, { SqlQueryTuple, SqlData, SqlQueryWrapper } from '../src/SqlQuery';
+
+describe('SqlQuery', () => {
+  const mockCacheKeyQueriesTuple: SqlQueryTuple = [
+    'SELECT FLOOR((-25200 + EXTRACT(EPOCH FROM NOW())) / 600) as refresh_key',
+    [],
+    {
+      external: false,
+      renewalThreshold: 60
+    }
+  ];
+
+  const mockSqlTuple: SqlQueryTuple = [
+    'SELECT count(*) "base_orders__count" FROM base_orders WHERE base_orders.continent = ?',
+    ['Europe'],
+  ];
+
+  const mockSqlData: SqlData = {
+    aliasNameToMember: { base_orders__count: 'base_orders.count' },
+    cacheKeyQueries: [mockCacheKeyQueriesTuple],
+    dataSource: 'default',
+    external: false,
+    sql: mockSqlTuple,
+    preAggregations: [],
+    rollupMatchResults: [],
+  };
+
+  const mockWrapper: SqlQueryWrapper = {
+    sql: mockSqlData,
+  };
+
+  it('should construct without error', () => {
+    expect(() => new SqlQuery(mockWrapper)).not.toThrow();
+  });
+
+  it('rawQuery should return the original SqlData', () => {
+    const query = new SqlQuery(mockWrapper);
+    expect(query.rawQuery()).toEqual(mockSqlData);
+  });
+
+  it('sql should return the first element (SQL string) from the sql tuple', () => {
+    const query = new SqlQuery(mockWrapper);
+    expect(query.sql()).toBe('SELECT count(*) "base_orders__count" FROM base_orders WHERE base_orders.continent = ?');
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

This PR fixes issue [9589](https://github.com/cube-js/cube/issues/9589)

**Description of Changes Made (if issue reference is not provided)**

The generated SQL tab started crashing since v1.3.16 and it was linked to the PR [9562](https://github.com/cube-js/cube/pull/9562/files). There are multiple ways of fixing the issue so I have attempted the one with minimal changes. Since I have limited understanding of the codebase, happy to modify the PR if a different approach should be taken to fix the problem. 
