### PR TITLE
fix(schema-compiler): Fix BigQuery queries datetime/timestamp comparisons

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -182,29 +182,29 @@ export class BigqueryQuery extends BaseQuery {
   }
 
   public subtractInterval(date, interval) {
-    return `DATETIME_SUB(${date}, INTERVAL ${this.formatInterval(interval)[0]})`;
-  }
-
-  public addInterval(date, interval) {
-    return `DATETIME_ADD(${date}, INTERVAL ${this.formatInterval(interval)[0]})`;
-  }
-
-  public subtractTimestampInterval(date, interval) {
     const [intervalFormatted, timeUnit] = this.formatInterval(interval);
-    if (['YEAR', 'MONTH', 'QUARTER'].includes(timeUnit)) {
+    if (['YEAR', 'MONTH', 'QUARTER'].includes(timeUnit) || intervalFormatted.includes('WEEK')) {
       return this.timeStampCast(`DATETIME_SUB(DATETIME(${date}), INTERVAL ${intervalFormatted})`);
     }
 
     return `TIMESTAMP_SUB(${date}, INTERVAL ${intervalFormatted})`;
   }
 
-  public addTimestampInterval(date, interval) {
+  public addInterval(date, interval) {
     const [intervalFormatted, timeUnit] = this.formatInterval(interval);
-    if (['YEAR', 'MONTH', 'QUARTER'].includes(timeUnit)) {
+    if (['YEAR', 'MONTH', 'QUARTER'].includes(timeUnit) || intervalFormatted.includes('WEEK')) {
       return this.timeStampCast(`DATETIME_ADD(DATETIME(${date}), INTERVAL ${intervalFormatted})`);
     }
 
     return `TIMESTAMP_ADD(${date}, INTERVAL ${intervalFormatted})`;
+  }
+
+  public subtractTimestampInterval(timestamp, interval) {
+    return this.subtractInterval(timestamp, interval);
+  }
+
+  public addTimestampInterval(timestamp, interval) {
+    return this.addInterval(timestamp, interval);
   }
 
   public nowTimestampSql() {

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -42,7 +42,7 @@ export class BigqueryQuery extends BaseQuery {
   }
 
   public convertTz(field) {
-    return `DATETIME(${this.timeStampCast(field)}, '${this.timezone}')`;
+    return `TIMESTAMP(DATETIME(${field}), '${this.timezone}')`;
   }
 
   public timeStampCast(value) {
@@ -58,7 +58,7 @@ export class BigqueryQuery extends BaseQuery {
   }
 
   public timeGroupedColumn(granularity, dimension) {
-    return `DATETIME_TRUNC(${dimension}, ${GRANULARITY_TO_INTERVAL[granularity]})`;
+    return this.timeStampCast(`DATETIME_TRUNC(${dimension}, ${GRANULARITY_TO_INTERVAL[granularity]})`);
   }
 
   /**
@@ -72,7 +72,7 @@ export class BigqueryQuery extends BaseQuery {
 
     return `(${this.dateTimeCast(`'${origin}'`)} + INTERVAL ${intervalFormatted} *
       CAST(FLOOR(
-        DATETIME_DIFF(${source}, ${this.dateTimeCast(`'${origin}'`)}, ${timeUnit}) /
+        DATETIME_DIFF(${this.dateTimeCast(source)}, ${this.dateTimeCast(`'${origin}'`)}, ${timeUnit}) /
         DATETIME_DIFF(${beginOfTime} + INTERVAL ${intervalFormatted}, ${beginOfTime}, ${timeUnit})
       ) AS INT64))`;
   }

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -2118,5 +2118,25 @@ from
       `);
       expect(res.rows).toMatchSnapshot();
     });
+
+    executePg('SQL API: Date/time comparison with SQL push down', async (connection) => {
+      const res = await connection.query(`
+        SELECT MEASURE(BigECommerce.rollingCountBy2Day)
+        FROM BigECommerce
+        WHERE BigECommerce.orderDate < CAST('2021-01-01' AS TIMESTAMP) AND
+              LOWER("city") = 'columbus'
+      `);
+      expect(res.rows).toMatchSnapshot();
+    });
+
+    executePg('SQL API: Date/time comparison with date_trunc with SQL push down', async (connection) => {
+      const res = await connection.query(`
+        SELECT MEASURE(BigECommerce.rollingCountBy2Week)
+        FROM BigECommerce
+        WHERE date_trunc('day', BigECommerce.orderDate) < CAST('2021-01-01' AS TIMESTAMP) AND
+              LOWER("city") = 'columbus'
+      `);
+      expect(res.rows).toMatchSnapshot();
+    });
   });
 }

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
@@ -8007,3 +8007,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/athena-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/athena-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Queries with the @cubejs-backend/bigquery-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/bigquery-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/bigquery-driver SQL API: NULLS FIRST/LAST SQL push down: nulls_first_last_sql_push_down 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-export-bucket-s3-full.test.ts.snap
@@ -8952,3 +8952,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver export-bucket-s3 SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver export-bucket-s3 SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-export-bucket-s3-prefix-full.test.ts.snap
@@ -8952,3 +8952,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver export-bucket-s3-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver export-bucket-s3-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/clickhouse-full.test.ts.snap
@@ -8952,3 +8952,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/clickhouse-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
@@ -14342,3 +14342,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
@@ -14147,3 +14147,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
@@ -14342,3 +14342,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
@@ -14147,3 +14147,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
@@ -14342,3 +14342,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
@@ -14147,3 +14147,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
@@ -14342,3 +14342,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/mssql-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/mssql-full.test.ts.snap
@@ -6654,3 +6654,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/mssql-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/mssql-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/mysql-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/mysql-full.test.ts.snap
@@ -7395,3 +7395,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/mysql-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": 12,
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/mysql-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": 12,
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -1797,6 +1797,22 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/postgres-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/postgres-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver SQL API: Extended nested Rollup over asterisk: extended_nested_rollup_over_asterisk 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/redshift-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/redshift-export-bucket-s3-full.test.ts.snap
@@ -16260,3 +16260,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/redshift-driver export-bucket-s3 SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver export-bucket-s3 SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
@@ -16260,3 +16260,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/redshift-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/redshift-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
@@ -16415,3 +16415,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
@@ -16610,3 +16610,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
@@ -16415,3 +16415,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
@@ -16610,3 +16610,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
@@ -16610,3 +16610,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
@@ -16415,3 +16415,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
@@ -16610,3 +16610,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
@@ -16415,3 +16415,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -16610,3 +16610,19 @@ Array [
   },
 ]
 `;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: Date/time comparison with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Day)": "12",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/snowflake-driver SQL API: Date/time comparison with date_trunc with SQL push down 1`] = `
+Array [
+  Object {
+    "measure(BigECommerce.rollingCountBy2Week)": "12",
+  },
+]
+`;


### PR DESCRIPTION
This is an attempt to fix BigQuery queries that fail with:
```
Error: No matching signature for operator < for argument types: DATETIME, TIMESTAMP
  Signature: T1 < T1
    Unable to find common supertype for templated argument <T1>
      Input types for <T1>: {TIMESTAMP, DATETIME} at [6:85]
```

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
