### PR TITLE
feat(server): Add server config for headers and keep alive timeouts

### DIFF
--- a/docs/pages/product/configuration/reference/environment-variables.mdx
+++ b/docs/pages/product/configuration/reference/environment-variables.mdx
@@ -1128,6 +1128,26 @@ Until v0.35, the default value was `schema`.
 It can be also set using the [`schema_path` configuration
 option](/product/configuration/reference/config#schema_path).
 
+## `CUBEJS_SERVER_HEADERS_TIMEOUT`
+
+The number of milliseconds to limit the amount of time the parser will wait
+to receive the complete HTTP headers.
+If the timeout expires, the server responds with status 408 without
+forwarding the request to the request listener and then closes the connection.
+
+| Possible Values                           | Default in Development   | Default in Production    |
+| ----------------------------------------- | ------------------------ | ------------------------ |
+| A valid number or string representing one | NodeJS's version default | NodeJS's version default |
+
+## `CUBEJS_SERVER_KEEP_ALIVE_TIMEOUT`
+
+The number of milliseconds of inactivity a server needs to wait for additional incoming data,
+after it has finished writing the last response, before a socket will be destroyed.
+
+| Possible Values                           | Default in Development   | Default in Production    |
+| ----------------------------------------- | ------------------------ | ------------------------ |
+| A valid number or string representing one | NodeJS's version default | NodeJS's version default |
+
 ## `CUBEJS_SQL_USER`
 
 A username required to access the [SQL API][ref-sql-api].

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -144,6 +144,10 @@ const variables: Record<string, (...args: any) => any> = {
   webSockets: () => get('CUBEJS_WEB_SOCKETS')
     .default('false')
     .asBoolStrict(),
+  serverHeadersTimeout: () => get('CUBEJS_SERVER_HEADERS_TIMEOUT')
+    .asInt(),
+  serverKeepAliveTimeout: () => get('CUBEJS_SERVER_KEEP_ALIVE_TIMEOUT')
+    .asInt(),
   rollupOnlyMode: () => get('CUBEJS_ROLLUP_ONLY')
     .default('false')
     .asBoolStrict(),

--- a/packages/cubejs-server/src/server.ts
+++ b/packages/cubejs-server/src/server.ts
@@ -36,6 +36,8 @@ export interface CreateOptions extends CoreCreateOptions, WebSocketServerOptions
   webSockets?: boolean;
   http?: HttpOptions;
   gracefulShutdown?: number;
+  serverKeepAliveTimeout?: number;
+  serverHeadersTimeout?: number;
 }
 
 type RequireOne<T, K extends keyof T> = {

--- a/packages/cubejs-server/src/server.ts
+++ b/packages/cubejs-server/src/server.ts
@@ -47,7 +47,7 @@ type RequireOne<T, K extends keyof T> = {
 export class CubejsServer {
   protected readonly core: CubeCore;
 
-  protected readonly config: RequireOne<CreateOptions, 'webSockets' | 'http' | 'sqlPort' | 'pgSqlPort'>;
+  protected readonly config: RequireOne<CreateOptions, 'webSockets' | 'http' | 'sqlPort' | 'pgSqlPort' | 'serverHeadersTimeout' | 'serverKeepAliveTimeout'>;
 
   protected server: GracefulHttpServer | null = null;
 
@@ -64,6 +64,8 @@ export class CubejsServer {
       sqlPort: config.sqlPort || getEnv('sqlPort'),
       pgSqlPort: config.pgSqlPort || getEnv('pgSqlPort'),
       gatewayPort: config.gatewayPort || getEnv('nativeApiGatewayPort'),
+      serverHeadersTimeout: config.serverHeadersTimeout ?? getEnv('serverHeadersTimeout'),
+      serverKeepAliveTimeout: config.serverKeepAliveTimeout ?? getEnv('serverKeepAliveTimeout'),
       http: {
         ...config.http,
         cors: {
@@ -112,6 +114,14 @@ export class CubejsServer {
       if (this.config.sqlPort || this.config.pgSqlPort) {
         this.sqlServer = this.core.initSQLServer();
         await this.sqlServer.init(this.config);
+      }
+
+      if (this.config.serverKeepAliveTimeout) {
+        this.server.keepAliveTimeout = this.config.serverKeepAliveTimeout;
+      }
+
+      if (this.config.serverHeadersTimeout) {
+        this.server.headersTimeout = this.config.serverHeadersTimeout;
       }
 
       const PORT = getEnv('port');


### PR DESCRIPTION




**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Docs have been added / updated if required
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

This is a change that we've been using in our application to sync the timeouts with the LoadBalancer correctly.

Added two new environment variables to configure HTTP server options:
- `CUBEJS_SERVER_HEADERS_TIMEOUT`
- `CUBEJS_SERVER_KEEP_ALIVE_TIMEOUT`

Each default to the default values in the `Server` class found in the `HTTP` Node module.
