### PR TITLE
fix(cubesql): Split meta on `CAST` over `__user` column

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/filter_split_meta.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/filter_split_meta.rs
@@ -249,7 +249,8 @@ fn is_meta_predicate(predicate: &Expr) -> bool {
 
 /// Determines if the provided expression is meta column reference.
 /// Currently, only `__user` is considered a meta column.
-/// Additionally, `Lower` function over a meta column is also considered a meta column.
+/// Additionally, `Lower` function over a meta column or casting meta column
+/// is also considered a meta column.
 fn is_meta_column(expr: &Expr) -> bool {
     match expr {
         Expr::Column(Column { name, .. }) => name.eq_ignore_ascii_case("__user"),
@@ -259,6 +260,7 @@ fn is_meta_column(expr: &Expr) -> bool {
             }
             false
         }
+        Expr::Cast { expr, .. } => is_meta_column(expr),
         _ => false,
     }
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_user_change.rs
@@ -280,6 +280,45 @@ GROUP BY 1
     assert_eq!(load_calls[0].meta.change_user(), Some("gopher".to_string()));
 }
 
+/// This should test that query with CubeScanWrapper uses proper change_user for both SQL generation and execution calls
+#[tokio::test]
+async fn test_user_change_sql_generation_cast() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let context = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+
+    context
+        .execute_query(
+            // language=PostgreSQL
+            r#"
+SELECT
+    COALESCE(customer_gender, 'N/A'),
+    AVG(avgPrice)
+FROM
+    KibanaSampleDataEcommerce
+WHERE
+    CAST(__user AS TEXT) = 'gopher'
+    AND LOWER(customer_gender) = 'test'
+GROUP BY 1
+;
+        "#
+            .to_string(),
+        )
+        .await
+        .expect_err("Test transport does not support load with SQL");
+
+    let load_calls = context.load_calls().await;
+    assert_eq!(load_calls.len(), 1);
+    let sql_query = load_calls[0].sql_query.as_ref().unwrap();
+    // This should be placed from load meta to query by TestConnectionTransport::sql
+    // It would mean that SQL generation used changed user
+    assert!(sql_query.sql.contains(r#""changeUser": "gopher""#));
+    assert_eq!(load_calls[0].meta.change_user(), Some("gopher".to_string()));
+}
+
 /// Repeated aggregation should be flattened even in presence of __user filter
 #[tokio::test]
 async fn flatten_aggregation_into_user_change() {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR enhances `FilterSplitMeta` optimizer to split `__user` filter when it's wrapped in a cast. Related test is included.
