### PR TITLE
chore(deps): bump DuckDB from 1.2.1 to 1.3.1

### DIFF
--- a/packages/cubejs-duckdb-driver/package.json
+++ b/packages/cubejs-duckdb-driver/package.json
@@ -30,7 +30,7 @@
     "@cubejs-backend/base-driver": "1.3.25",
     "@cubejs-backend/schema-compiler": "1.3.25",
     "@cubejs-backend/shared": "1.3.25",
-    "duckdb": "^1.2.1"
+    "duckdb": "^1.3.1"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12809,10 +12809,10 @@ draft-js@^0.10.0, draft-js@~0.10.0:
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
-duckdb@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-1.2.1.tgz#03a7a109b3ecd96e2294c00326d894c122ea116c"
-  integrity sha512-gs3KT2J3SOCghai0Q5nw/joYpOs63/gud+RX1hQmJ+ombUn5BEFn/FUqQKa3HSVZ95+otWDDMGsspLVEr4hJzA==
+duckdb@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-1.3.1.tgz#984427fba39e0d321a4dc592bbf9b06cdd39992f"
+  integrity sha512-wSCxu6zSkHkGHtLrI5MmHYUOpbi08s2eIY/QCg2f1YsSyohjA3MRnUMdDb88oqgLa7/h+/wHuIe1RXRu4k04Sw==
   dependencies:
     "@mapbox/node-pre-gyp" "^2.0.0"
     node-addon-api "^7.0.0"


### PR DESCRIPTION
Bumped DuckDB version to 1.3.1 to support DuckLake

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

