### PR TITLE
chore(ci): Update the Windows image to use

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,9 +242,9 @@ jobs:
       matrix:
         node-version: [22.x]
         python-version: ["fallback"]
-        os-version: [windows-2019]
+        os-version: [windows-2022]
         include:
-          - os-version: windows-2019
+          - os-version: windows-2022
             package_target_arch: x64
             package_target_platform: win32
             package_target_libc: unknown
@@ -670,7 +670,7 @@ jobs:
           - aarch64-apple-darwin
         include:
           - target: x86_64-pc-windows-msvc
-            os: windows-2019
+            os: windows-2022
             executable_name: cubestored.exe
             strip: true
             # cubestored.exe: CantPackException: superfluous data between sections

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -189,7 +189,7 @@ jobs:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
         include:
-          - os: windows-2019
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             executable_name: cubestored.exe
             strip: true


### PR DESCRIPTION
The windows-2019 runner image is being deprecated, consider switching to windows-2022(windows-latest) or windows-2025 instead. For more details see https://github.com/actions/runner-images/issues/12045.

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

