### PR TITLE
feat(cubestore): Rockstore - optimize index scanning

### DIFF
--- a/rust/cubestore/cubestore/src/cachestore/cache_eviction_manager.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_eviction_manager.rs
@@ -958,7 +958,7 @@ impl CacheEvictionManager {
                     cache_schema.update_extended_ttl_secondary_index(
                         row_id,
                         &CacheItemRocksIndex::ByPath,
-                        item.key_hash.to_vec(),
+                        item.key_hash,
                         RocksSecondaryIndexValueTTLExtended {
                             lfu: item.lfu,
                             lru: item.lru.decode_value_as_opt_datetime()?,

--- a/rust/cubestore/cubestore/src/cachestore/compaction.rs
+++ b/rust/cubestore/cubestore/src/cachestore/compaction.rs
@@ -362,7 +362,7 @@ mod tests {
         let index = CacheItemRocksIndex::ByPath;
         let key = RowKey::SecondaryIndex(
             CacheItemRocksTable::index_id(index.get_id()),
-            index.key_hash(&row).to_be_bytes().to_vec(),
+            index.key_hash(&row).to_be_bytes(),
             1,
         );
 
@@ -386,7 +386,7 @@ mod tests {
         let index = CacheItemRocksIndex::ByPath;
         let key = RowKey::SecondaryIndex(
             CacheItemRocksTable::index_id(index.get_id()),
-            index.key_hash(&row).to_be_bytes().to_vec(),
+            index.key_hash(&row).to_be_bytes(),
             1,
         );
 
@@ -410,11 +410,11 @@ mod tests {
         let index = CacheItemRocksIndex::ByPath;
         let key = RowKey::SecondaryIndex(
             CacheItemRocksTable::index_id(index.get_id()),
-            index.key_hash(&row).to_be_bytes().to_vec(),
+            index.key_hash(&row).to_be_bytes(),
             1,
         );
 
-        // Indexes with TTL use new format (v2) for indexes, but index migration doesnt skip
+        // Indexes with TTL use a new format (v2) for indexes, but index migration doesn't skip
         // compaction for old rows
         let index_value = RocksSecondaryIndexValue::Hash("kek".as_bytes())
             .to_bytes(RocksSecondaryIndexValueVersion::OnlyHash)

--- a/rust/cubestore/cubestore/src/metastore/rocks_table.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_table.rs
@@ -2,7 +2,7 @@ use crate::metastore::rocks_store::TableId;
 use crate::metastore::{
     get_fixed_prefix, BatchPipe, DbTableRef, IdRow, IndexId, KeyVal, MemorySequence,
     MetaStoreEvent, RocksSecondaryIndexValue, RocksSecondaryIndexValueTTLExtended,
-    RocksSecondaryIndexValueVersion, RocksTableStats, RowKey, SecondaryIndexInfo, SecondaryKey,
+    RocksSecondaryIndexValueVersion, RocksTableStats, RowKey, SecondaryIndexInfo, SecondaryKeyHash,
     TableInfo,
 };
 use crate::CubeError;
@@ -303,7 +303,7 @@ pub struct IndexScanIter<'a, RT: RocksTable + ?Sized> {
     table: &'a RT,
     index_id: u32,
     secondary_key_val: Vec<u8>,
-    secondary_key_hash: Vec<u8>,
+    secondary_key_hash: SecondaryKeyHash,
     iter: DBIterator<'a>,
 }
 
@@ -364,7 +364,7 @@ where
 #[derive(Debug)]
 pub struct SecondaryIndexValueScanIterItem {
     pub row_id: u64,
-    pub key_hash: SecondaryKey,
+    pub key_hash: SecondaryKeyHash,
     pub ttl: Option<DateTime<Utc>>,
     pub extended: Option<RocksSecondaryIndexValueTTLExtended>,
 }
@@ -496,11 +496,8 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
             if index.is_unique() {
                 let hash = index.key_hash(&row);
                 let index_val = index.index_key_by(&row);
-                let existing_keys = self.get_row_ids_from_index(
-                    index.get_id(),
-                    &index_val,
-                    &hash.to_be_bytes().to_vec(),
-                )?;
+                let existing_keys =
+                    self.get_row_ids_from_index(index.get_id(), &index_val, hash.to_be_bytes())?;
                 if existing_keys.len() > 0 {
                     return Err(CubeError::user(
                         format!(
@@ -759,7 +756,7 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         let existing_keys = self.get_row_ids_from_index(
             RocksSecondaryIndex::get_id(secondary_index),
             &index_val,
-            &hash.to_be_bytes().to_vec(),
+            hash.to_be_bytes(),
         )?;
 
         Ok(existing_keys)
@@ -832,8 +829,7 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         K: Hash,
     {
         let row_ids = self.get_row_ids_by_index(row_key, secondary_index)?;
-
-        let mut res = Vec::new();
+        let mut res = Vec::with_capacity(row_ids.len());
 
         for id in row_ids {
             if let Some(row) = self.get_row(id)? {
@@ -969,7 +965,7 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         &self,
         row_id: u64,
         secondary_index: &'a impl RocksSecondaryIndex<Self::T, K>,
-        secondary_key_hash: SecondaryKey,
+        secondary_key_hash: SecondaryKeyHash,
         extended: RocksSecondaryIndexValueTTLExtended,
         batch_pipe: &mut BatchPipe,
     ) -> Result<bool, CubeError>
@@ -1141,11 +1137,8 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
     ) -> KeyVal {
         let hash = index.key_hash(row);
         let index_val = index.index_value(row);
-        let key = RowKey::SecondaryIndex(
-            Self::index_id(index.get_id()),
-            hash.to_be_bytes().to_vec(),
-            row_id,
-        );
+        let key =
+            RowKey::SecondaryIndex(Self::index_id(index.get_id()), hash.to_be_bytes(), row_id);
 
         KeyVal {
             key: key.to_bytes(),
@@ -1157,11 +1150,8 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         let mut res = Vec::new();
         for index in Self::indexes().iter() {
             let hash = index.key_hash(&row);
-            let key = RowKey::SecondaryIndex(
-                Self::index_id(index.get_id()),
-                hash.to_be_bytes().to_vec(),
-                row_id,
-            );
+            let key =
+                RowKey::SecondaryIndex(Self::index_id(index.get_id()), hash.to_be_bytes(), row_id);
             res.push(KeyVal {
                 key: key.to_bytes(),
                 val: vec![],
@@ -1247,17 +1237,17 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         &self,
         secondary_id: u32,
         secondary_key_val: &Vec<u8>,
-        secondary_key_hash: &Vec<u8>,
+        secondary_key_hash: SecondaryKeyHash,
     ) -> Result<Vec<u64>, CubeError> {
         let ref db = self.snapshot();
         let key_len = secondary_key_hash.len();
-        let key_min =
-            RowKey::SecondaryIndex(Self::index_id(secondary_id), secondary_key_hash.clone(), 0);
+        let key_min = RowKey::SecondaryIndex(Self::index_id(secondary_id), secondary_key_hash, 0);
 
         let mut res: Vec<u64> = Vec::new();
 
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(true);
+
         let iter = db.iterator_opt(
             IteratorMode::From(&key_min.to_bytes()[0..(key_len + 5)], Direction::Forward),
             opts,
@@ -1269,10 +1259,8 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
             if let RowKey::SecondaryIndex(_, secondary_index_hash, row_id) =
                 RowKey::from_bytes(&key)
             {
-                if !secondary_index_hash
-                    .iter()
-                    .zip(secondary_key_hash)
-                    .all(|(a, b)| a == b)
+                if secondary_index_hash.len() != secondary_key_hash.len()
+                    || secondary_index_hash != secondary_key_hash
                 {
                     break;
                 }
@@ -1284,9 +1272,7 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
                         RocksSecondaryIndexValue::HashAndTTLExtended(h, expire, _) => (h, expire),
                     };
 
-                if secondary_key_val.len() != hash.len()
-                    || !hash.iter().zip(secondary_key_val).all(|(a, b)| a == b)
-                {
+                if hash.len() != secondary_key_val.len() || hash != secondary_key_val.as_slice() {
                     continue;
                 }
 
@@ -1341,8 +1327,9 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         batch: &mut WriteBatch,
     ) -> Result<u64, CubeError> {
         let ref db = self.snapshot();
-        let zero_vec = vec![0 as u8; 8];
-        let key_min = RowKey::SecondaryIndex(Self::index_id(secondary_id), zero_vec.clone(), 0);
+
+        let zero_vec = [0 as u8; 8];
+        let key_min = RowKey::SecondaryIndex(Self::index_id(secondary_id), zero_vec, 0);
 
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(false);
@@ -1408,7 +1395,8 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
         let ref db = self.snapshot();
 
         let index_id = RocksSecondaryIndex::get_id(secondary_index);
-        let row_key = RowKey::SecondaryIndex(Self::index_id(index_id), vec![], 0);
+        let zero_vec = [0 as u8; 8];
+        let row_key = RowKey::SecondaryIndex(Self::index_id(index_id), zero_vec, 0);
 
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(false);
@@ -1433,16 +1421,12 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
     {
         let ref db = self.snapshot();
 
-        let secondary_key_hash = secondary_index
-            .typed_key_hash(&row_key)
-            .to_be_bytes()
-            .to_vec();
+        let secondary_key_hash = secondary_index.typed_key_hash(&row_key).to_be_bytes() as [u8; 8];
         let secondary_key_val = secondary_index.key_to_bytes(&row_key);
 
         let index_id = RocksSecondaryIndex::get_id(secondary_index);
         let key_len = secondary_key_hash.len();
-        let key_min =
-            RowKey::SecondaryIndex(Self::index_id(index_id), secondary_key_hash.clone(), 0);
+        let key_min = RowKey::SecondaryIndex(Self::index_id(index_id), secondary_key_hash, 0);
 
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(true);


### PR DESCRIPTION
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/88647d0e-c953-4dee-8695-35556cf4e3d9" />

queue_add queues:1, size:64 kb/512:
time:  [644.70 ms 648.88 ms 653.45 ms] -> [547.18 ms 558.58 ms 571.78 ms]

queue_add queues:1, size:256 kb/512
time:  [334.21 ms 336.78 ms 339.56 ms] -> [286.95 ms 291.70 ms 297.12 ms]

queue_add queues:1, size:512 kb/512
time:   [363.73 ms 367.60 ms 371.73 ms] -> [304.42 ms 310.45 ms 317.43 ms]

### before

```
queue_add queues:1, size:64 kb/512
                        time:   [644.70 ms 648.88 ms 653.45 ms]
                        change: [-4.3588% -2.6419% -0.9566%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking queue_add queues:1, size:256 kb/512: Warming up for 3.0000 s
queue_add queues:1, size:256 kb/512
                        time:   [334.21 ms 336.78 ms 339.56 ms]
                        change: [-0.7991% +0.4350% +1.7476%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

Benchmarking queue_add queues:1, size:512 kb/512: Warming up for 3.0000 s
queue_add queues:1, size:512 kb/512
                        time:   [363.73 ms 367.60 ms 371.73 ms]
                        change: [+2.4181% +3.7749% +5.1900%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking queue_list status_filter: Some(Pending) queues:5, size:128 kb, per_queue:1000/128: Warming up for 3.0000 s
Benchmarking queue_list status_filter: Some(Pending) queues:5, size:128 kb, per_queue:1000/128: Collecting 100 samples in estimated 5.queue_list status_filter: Some(Pending) queues:5, size:128 kb, per_queue:1000/128
                        time:   [967.02 µs 985.48 µs 1.0076 ms]
                        change: [-8.7331% -5.5801% -2.3738%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

Benchmarking queue_list status_filter: Some(Active) queues:5, size:128 kb, per_queue:1000/128: Warming up for 3.0000 s
Benchmarking queue_list status_filter: Some(Active) queues:5, size:128 kb, per_queue:1000/128: Collecting 100 samples in estimated 5.6queue_list status_filter: Some(Active) queues:5, size:128 kb, per_queue:1000/128
                        time:   [960.16 µs 976.31 µs 995.10 µs]
                        change: [-5.0910% -0.4810% +4.6747%] (p = 0.84 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

queue_get queues:5, size:128 kb, per_queue:10000/128
                        time:   [9.9325 ms 10.060 ms 10.209 ms]
                        change: [-5.4308% -3.1552% -0.8813%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
```

### after

```
Benchmarking queue_add queues:1, size:64 kb/512: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 28.3s, or reduce sample count to 10.
queue_add queues:1, size:64 kb/512
                        time:   [546.95 ms 553.24 ms 560.41 ms]
                        change: [-18.034% -16.633% -15.105%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

Benchmarking queue_add queues:1, size:256 kb/512: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 33.2s, or reduce sample count to 10.
queue_add queues:1, size:256 kb/512
                        time:   [291.96 ms 298.85 ms 306.33 ms]
                        change: [-39.325% -34.710% -29.651%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  10 (10.00%) high mild
  2 (2.00%) high severe

Benchmarking queue_add queues:1, size:512 kb/512: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 63.7s, or reduce sample count to 10.
```