### PR TITLE
feat(cubesql): Filter push down for date_part('year', ?col)  = ?literal

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -9482,7 +9482,85 @@ ORDER BY "source"."str0" ASC
     }
 
     #[tokio::test]
-    async fn test_tableau_filter_by_year() {
+    async fn test_filter_date_part_by_year() {
+        init_testing_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT
+                COUNT(*) AS "count",
+                date_part('YEAR', "KibanaSampleDataEcommerce"."order_date") AS "yr:completedAt:ok"
+            FROM "public"."KibanaSampleDataEcommerce" "KibanaSampleDataEcommerce"
+            WHERE date_part('YEAR', "KibanaSampleDataEcommerce"."order_date") = 2019
+            GROUP BY 2
+            ;"#
+                .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+            .await
+            .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
+                dimensions: Some(vec![]),
+                segments: Some(vec![]),
+                time_dimensions: Some(vec![V1LoadRequestQueryTimeDimension {
+                    dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                    granularity: Some("year".to_string()),
+                    date_range: Some(json!(vec![
+                        "2019-01-01".to_string(),
+                        "2019-12-31".to_string(),
+                    ])),
+                },]),
+                order: Some(vec![]),
+                ..Default::default()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn test_filter_extract_by_year() {
+        init_testing_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT
+                COUNT(*) AS "count",
+                EXTRACT(YEAR FROM "KibanaSampleDataEcommerce"."order_date") AS "yr:completedAt:ok"
+            FROM "public"."KibanaSampleDataEcommerce" "KibanaSampleDataEcommerce"
+            WHERE EXTRACT(YEAR FROM "KibanaSampleDataEcommerce"."order_date") = 2019
+            GROUP BY 2
+            ;"#
+                .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+            .await
+            .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string()]),
+                dimensions: Some(vec![]),
+                segments: Some(vec![]),
+                time_dimensions: Some(vec![V1LoadRequestQueryTimeDimension {
+                    dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                    granularity: Some("year".to_string()),
+                    date_range: Some(json!(vec![
+                        "2019-01-01".to_string(),
+                        "2019-12-31".to_string(),
+                    ])),
+                },]),
+                order: Some(vec![]),
+                ..Default::default()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn test_tableau_filter_extract_by_year() {
         init_testing_logger();
 
         let logical_plan = convert_select_to_query_plan(

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -9494,11 +9494,11 @@ ORDER BY "source"."str0" ASC
             WHERE date_part('YEAR', "KibanaSampleDataEcommerce"."order_date") = 2019
             GROUP BY 2
             ;"#
-                .to_string(),
+            .to_string(),
             DatabaseProtocol::PostgreSQL,
         )
-            .await
-            .as_logical_plan();
+        .await
+        .as_logical_plan();
 
         assert_eq!(
             logical_plan.find_cube_scan().request,
@@ -9533,11 +9533,11 @@ ORDER BY "source"."str0" ASC
             WHERE EXTRACT(YEAR FROM "KibanaSampleDataEcommerce"."order_date") = 2019
             GROUP BY 2
             ;"#
-                .to_string(),
+            .to_string(),
             DatabaseProtocol::PostgreSQL,
         )
-            .await
-            .as_logical_plan();
+        .await
+        .as_logical_plan();
 
         assert_eq!(
             logical_plan.find_cube_scan().request,

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -1675,7 +1675,34 @@ impl RewriteRules for FilterRules {
                     binary_expr(
                         self.fun_expr(
                             "DatePart",
-                            // LOL, DF plans date_part granularity in lowercase, while Extract is uppercase
+                            vec![literal_string("YEAR"), column_expr("?column")],
+                        ),
+                        "=",
+                        literal_expr("?year"),
+                    ),
+                    "?alias_to_cube",
+                    "?members",
+                    "?filter_aliases",
+                ),
+                filter_member("?member", "FilterMemberOp:inDateRange", "?values"),
+                self.transform_filter_extract_year_equals(
+                    "?year",
+                    "?column",
+                    "?alias_to_cube",
+                    "?members",
+                    "?member",
+                    "?values",
+                    "?filter_aliases",
+                ),
+            ),
+            // Same as the rule above, but it uses different case for granularity.
+            // TODO: Remove, whenever we will fix bug with granularity cases. CORE-1761
+            transforming_rewrite(
+                "extract-year-equals",
+                filter_replacer(
+                    binary_expr(
+                        self.fun_expr(
+                            "DatePart",
                             vec![literal_string("year"), column_expr("?column")],
                         ),
                         "=",
@@ -1696,7 +1723,6 @@ impl RewriteRules for FilterRules {
                     "?filter_aliases",
                 ),
             ),
-            // Same as the rule above, but wrapped with TRUNC
             // TRUNC(EXTRACT(YEAR FROM "KibanaSampleDataEcommerce"."order_date")) = 2019
             transforming_rewrite(
                 "extract-trunc-year-equals",

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -3612,13 +3612,13 @@ impl FilterRules {
                     let year = match year {
                         ScalarValue::Int64(Some(year)) => year,
                         ScalarValue::Int32(Some(year)) => year as i64,
-                        ScalarValue::Utf8(Some(year_str)) if year_str.len() == 4 => {
+                        ScalarValue::Utf8(Some(ref year_str)) if year_str.len() == 4 => {
                             if let Ok(year) = year_str.parse::<i64>() {
-                                return year;
+                                year
+                            } else {
+                                continue;
                             }
-
-                            continue;
-                        } ,
+                        }
                         _ => continue,
                     };
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -1698,7 +1698,7 @@ impl RewriteRules for FilterRules {
             // Same as the rule above, but it uses different case for granularity.
             // TODO: Remove, whenever we will fix bug with granularity cases. CORE-1761
             transforming_rewrite(
-                "extract-year-equals",
+                "extract-year-equals-lower-case",
                 filter_replacer(
                     binary_expr(
                         self.fun_expr(


### PR DESCRIPTION
This PR allows filters to be pushed down with `DATE_PART('year')` by pushing it as `inDateRange`. Now, such queries will be accelerated with pre-aggregations. 

<img width="2053" alt="image" src="https://github.com/user-attachments/assets/46e25632-ab59-4452-8ed7-74879bbfd3df" />

```
ovr=> explain select count(*), date_part('YEAR', created) as year from orders where date_part('YEAR', created) = '2022' group by year;
   plan_type   |                                                                                               plan                                                                                                
---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 logical_plan  | Projection: #COUNT(UInt8(1)), #datepart(Utf8("year"),orders.created) AS year                                                                                                                     +
               |   Aggregate: groupBy=[[datepart(Utf8("year"), #orders.datepart(Utf8("year"),orders.created)) AS datepart(Utf8("year"),orders.created)]], aggr=[[SUM(#orders.COUNT(UInt8(1))) AS COUNT(UInt8(1))]]+
               |     CubeScan: request={                                                                                                                                                                          +
               |   "measures": [                                                                                                                                                                                  +
               |     "orders.count"                                                                                                                                                                               +
               |   ],                                                                                                                                                                                             +
               |   "dimensions": [],                                                                                                                                                                              +
               |   "segments": [],                                                                                                                                                                                +
               |   "timeDimensions": [                                                                                                                                                                            +
               |     {                                                                                                                                                                                            +
               |       "dimension": "orders.created",                                                                                                                                                             +
               |       "granularity": "year",                                                                                                                                                                     +
               |       "dateRange": [                                                                                                                                                                             +
               |         "2022-01-01",                                                                                                                                                                            +
               |         "2022-12-31"                                                                                                                                                                             +
               |       ]                                                                                                                                                                                          +
               |     }                                                                                                                                                                                            +
               |   ],                                                                                                                                                                                             +
               |   "order": []                                                                                                                                                                                    +
               | }
 physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@1 as COUNT(UInt8(1)), datepart(Utf8("year"),orders.created)@0 as year]                                                                                     +
               |   HashAggregateExec: mode=FinalPartitioned, gby=[datepart(Utf8("year"),orders.created)@0 as datepart(Utf8("year"),orders.created)], aggr=[COUNT(UInt8(1))]                                       +
               |     CoalesceBatchesExec: target_batch_size=4096                                                                                                                                                  +
               |       RepartitionExec: partitioning=Hash([Column { name: "datepart(Utf8(\"year\"),orders.created)", index: 0 }], 14)                                                                             +
               |         HashAggregateExec: mode=Partial, gby=[datepart(year, datepart(Utf8("year"),orders.created)@0) as datepart(Utf8("year"),orders.created)], aggr=[COUNT(UInt8(1))]                          +
               |           CubeScanExecutionPlan, Request:                                                                                                                                                        +
               | {"measures":["orders.count"],"dimensions":[],"segments":[],"timeDimensions":[{"dimension":"orders.created","granularity":"year","dateRange":["2022-01-01","2022-12-31"]}],"order":[]}            +
               | 
(2 rows)
```
