### PR TITLE
chore(cubesql): Bump cube-js/arrow-datafusion@637003a

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "chrono",
@@ -884,7 +884,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "async-trait",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubenativeutils/Cargo.lock
+++ b/rust/cubenativeutils/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "chrono",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "async-trait",
  "chrono",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "async-trait",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "edbe6a8b62c1cc9f1feb0be83f089f155c662298", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "637003a448a98bbc5e1585d0f01cc19ba9d50668", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesqlplanner/Cargo.lock
+++ b/rust/cubesqlplanner/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "chrono",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "async-trait",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=edbe6a8b62c1cc9f1feb0be83f089f155c662298#edbe6a8b62c1cc9f1feb0be83f089f155c662298"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=637003a448a98bbc5e1585d0f01cc19ba9d50668#637003a448a98bbc5e1585d0f01cc19ba9d50668"
 dependencies = [
  "ahash 0.7.8",
  "arrow",


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@637003a, extending arithmetic negation support for `Float64` and `Decimal128` types when their values are `NULL`.
