### PR TITLE
fix(cubesql): Fix sort push down projection on complex expressions

### DIFF
--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -232,7 +232,7 @@ jobs:
       matrix:
         # We do not need to test under all versions, we do it under linux
         node-version: [22.x]
-        os-version: ["macos-13"]
+        os-version: ["macos-14"]
         target: ["x86_64-apple-darwin", "aarch64-apple-darwin"]
         include:
           - target: x86_64-apple-darwin
@@ -308,8 +308,8 @@ jobs:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
         run: cd packages/cubejs-backend-native && yarn run native:build-debug-python
       - name: Tests
-        # We cannot test arm64 on x64
-        if: (matrix.target == 'x86_64-apple-darwin')
+        # We cannot test x64 on arm64
+        if: (matrix.target == 'aarch64-apple-darwin')
         env:
           CUBESQL_STREAM_MODE: true
           CUBEJS_NATIVE_INTERNAL_DEBUG: true

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
@@ -7,7 +7,7 @@ use egg::Subst;
 
 use crate::{
     compile::{
-        datafusion::logical_plan::Column,
+        datafusion::logical_plan::{Column, Expr},
         rewrite::{
             analysis::OriginalExpr,
             column_expr, column_name_to_member_vec,
@@ -369,6 +369,13 @@ impl OrderRules {
                     }) else {
                         continue;
                     };
+
+                    // TODO: workaround the issue with `generate_sql_for_push_to_cube`
+                    // accepting only columns and erroring on more complex expressions.
+                    // Remove this when `generate_sql_for_push_to_cube` is fixed.
+                    if !matches!(expr, Expr::Column(_)) {
+                        continue;
+                    }
 
                     let Ok(new_expr_id) =
                         LogicalPlanToLanguageConverter::add_expr(egraph, expr, flat_list)


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR workarounds an issue with recently introduced Limit-Sort push down Projection rules, throwing an error when sort column has been replaced with a complex expression and SQL push down is involved. This is a bug in SQL push down generation, so for now only expressions that resolve to columns are being pushed down.
