### PR TITLE
feat(schema-compiler): Introduce cube join aliases

### DIFF
--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -67,6 +67,7 @@
     "@types/babel__traverse": "^7.20.5",
     "@types/inflection": "^1.5.28",
     "@types/jest": "^29",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/node-dijkstra": "^2.5.6",
     "@types/ramda": "^0.27.34",

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -2,10 +2,13 @@
 import R from 'ramda';
 
 import {
+  AccessPolicyDefinition,
   CubeDefinitionExtended,
   CubeSymbols,
-  HierarchyDefinition, JoinDefinition,
-  PreAggregationDefinition, PreAggregationDefinitionRollup,
+  HierarchyDefinition,
+  JoinDefinition,
+  PreAggregationDefinition,
+  PreAggregationDefinitionRollup,
   type ToString
 } from './CubeSymbols';
 import { UserError } from './UserError';
@@ -110,30 +113,6 @@ export type EvaluatedHierarchy = {
   [key: string]: any;
 };
 
-export type Filter =
-  | {
-      member: string;
-      memberReference?: string;
-      [key: string]: any;
-    }
-  | {
-      and?: Filter[];
-      or?: Filter[];
-      [key: string]: any;
-    };
-
-export type AccessPolicy = {
-  rowLevel?: {
-    filters: Filter[];
-  };
-  memberLevel?: {
-    includes?: string | string[];
-    excludes?: string | string[];
-    includesMembers?: string[];
-    excludesMembers?: string[];
-  };
-};
-
 export type EvaluatedFolder = {
   name: string;
   includes: (EvaluatedFolder | DimensionDefinition | MeasureDefinition)[];
@@ -153,7 +132,7 @@ export type EvaluatedCube = {
   folders: EvaluatedFolder[];
   sql?: (...args: any[]) => string;
   sqlTable?: (...args: any[]) => string;
-  accessPolicy?: AccessPolicy[];
+  accessPolicy?: AccessPolicyDefinition[];
 };
 
 export class CubeEvaluator extends CubeSymbols {
@@ -200,7 +179,7 @@ export class CubeEvaluator extends CubeSymbols {
     );
   }
 
-  protected prepareCube(cube, errorReporter: ErrorReporter) {
+  protected prepareCube(cube, errorReporter: ErrorReporter): EvaluatedCube {
     this.prepareJoins(cube, errorReporter);
     this.preparePreAggregations(cube, errorReporter);
     this.prepareMembers(cube.measures, cube, errorReporter);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -423,35 +423,39 @@ export class CubeEvaluator extends CubeSymbols {
   }
 
   protected prepareJoins(cube: any, _errorReporter: ErrorReporter) {
-    if (cube.joins) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const join of Object.values(cube.joins) as any[]) {
-        // eslint-disable-next-line default-case
-        switch (join.relationship) {
-          case 'belongs_to':
-          case 'many_to_one':
-          case 'manyToOne':
-            join.relationship = 'belongsTo';
-            break;
-          case 'has_many':
-          case 'one_to_many':
-          case 'oneToMany':
-            join.relationship = 'hasMany';
-            break;
-          case 'has_one':
-          case 'one_to_one':
-          case 'oneToOne':
-            join.relationship = 'hasOne';
-            break;
-        }
-      }
+    if (!cube.joins) {
+      return;
     }
+
+    const joins: JoinDefinition[] = Array.isArray(cube.joins) ? cube.joins : Object.values(cube.joins);
+
+    joins.forEach(join => {
+      // eslint-disable-next-line default-case
+      switch (join.relationship) {
+        case 'belongs_to':
+        case 'many_to_one':
+        case 'manyToOne':
+          join.relationship = 'belongsTo';
+          break;
+        case 'has_many':
+        case 'one_to_many':
+        case 'oneToMany':
+          join.relationship = 'hasMany';
+          break;
+        case 'has_one':
+        case 'one_to_one':
+        case 'oneToOne':
+          join.relationship = 'hasOne';
+          break;
+      }
+    });
   }
 
   protected preparePreAggregations(cube: any, errorReporter: ErrorReporter) {
     if (cube.preAggregations) {
       // eslint-disable-next-line no-restricted-syntax
       for (const preAggregation of Object.values(cube.preAggregations) as any) {
+        // preAggregation is actually (PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql)
         if (preAggregation.timeDimension) {
           preAggregation.timeDimensionReference = preAggregation.timeDimension;
           delete preAggregation.timeDimension;
@@ -553,7 +557,7 @@ export class CubeEvaluator extends CubeSymbols {
     }
   }
 
-  public cubesByFileName(fileName) {
+  public cubesByFileName(fileName): CubeDefinitionExtended[] {
     return this.byFileName[fileName] || [];
   }
 
@@ -670,7 +674,7 @@ export class CubeEvaluator extends CubeSymbols {
     return this.preAggregations({ scheduled: true });
   }
 
-  public cubeNames() {
+  public cubeNames(): string[] {
     return Object.keys(this.evaluatedCubes);
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -124,7 +124,7 @@ export type EvaluatedCube = {
   measures: Record<string, MeasureDefinition>;
   dimensions: Record<string, DimensionDefinition>;
   segments: Record<string, SegmentDefinition>;
-  joins: Record<string, JoinDefinition>;
+  joins: JoinDefinition[];
   hierarchies: Record<string, HierarchyDefinition>;
   evaluatedHierarchies: EvaluatedHierarchy[];
   preAggregations: Record<string, PreAggregationDefinitionExtended>;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -105,6 +105,30 @@ export type JoinDefinition = {
   sql: (...args: any[]) => string,
 };
 
+export type Filter =
+  | {
+      member: string;
+      memberReference?: string;
+      [key: string]: any;
+    }
+  | {
+      and?: Filter[];
+      or?: Filter[];
+      [key: string]: any;
+    };
+
+export type AccessPolicyDefinition = {
+  rowLevel?: {
+    filters: Filter[];
+  };
+  memberLevel?: {
+    includes?: string | string[];
+    excludes?: string | string[];
+    includesMembers?: string[];
+    excludesMembers?: string[];
+  };
+};
+
 export interface CubeDefinition {
   name: string;
   extends?: (...args: Array<unknown>) => { __cubeName: string };
@@ -121,7 +145,7 @@ export interface CubeDefinition {
   // eslint-disable-next-line camelcase
   pre_aggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
   joins?: Record<string, JoinDefinition>;
-  accessPolicy?: any[];
+  accessPolicy?: AccessPolicyDefinition[];
   folders?: any[];
   includes?: any;
   excludes?: any;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -100,7 +100,7 @@ export type PreAggregationDefinitionRollup = BasePreAggregationDefinition & {
 export type PreAggregationDefinition = PreAggregationDefinitionRollup;
 
 export type JoinDefinition = {
-  name?: string, // TODO: Make it required
+  name: string,
   relationship: string,
   sql: (...args: any[]) => string,
 };
@@ -144,7 +144,7 @@ export interface CubeDefinition {
   preAggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
   // eslint-disable-next-line camelcase
   pre_aggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
-  joins?: Record<string, JoinDefinition>;
+  joins?: JoinDefinition[];
   accessPolicy?: AccessPolicyDefinition[];
   folders?: any[];
   includes?: any;
@@ -320,7 +320,8 @@ export class CubeSymbols {
 
       get joins() {
         if (!joins) {
-          joins = this.allDefinitions('joins');
+          const parentJoins = cubeDefinition.extends ? super.joins : [];
+          joins = [...parentJoins, ...(cubeDefinition.joins || [])];
         }
         return joins;
       },

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -802,14 +802,25 @@ const baseSchema = {
   shown: Joi.boolean().strict(),
   public: Joi.boolean().strict(),
   meta: Joi.any(),
-  joins: Joi.object().pattern(identifierRegex, Joi.object().keys({
-    sql: Joi.func().required(),
-    relationship: Joi.any().valid(
-      'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
-      'hasMany', 'has_many', 'one_to_many', 'oneToMany',
-      'hasOne', 'has_one', 'one_to_one', 'oneToOne'
-    ).required()
-  })),
+  joins: Joi.alternatives([
+    Joi.object().pattern(identifierRegex, Joi.object().keys({
+      sql: Joi.func().required(),
+      relationship: Joi.any().valid(
+        'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
+        'hasMany', 'has_many', 'one_to_many', 'oneToMany',
+        'hasOne', 'has_one', 'one_to_one', 'oneToOne'
+      ).required()
+    })),
+    Joi.array().items(Joi.object().keys({
+      name: identifier.required(),
+      sql: Joi.func().required(),
+      relationship: Joi.any().valid(
+        'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
+        'hasMany', 'has_many', 'one_to_many', 'oneToMany',
+        'hasOne', 'has_one', 'one_to_one', 'oneToOne'
+      ).required()
+    }))
+  ]),
   measures: MeasuresSchema,
   dimensions: DimensionsSchema,
   segments: SegmentsSchema,

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -94,7 +94,7 @@ export class YamlCompiler {
       return;
     }
 
-    const yamlObj = YAML.load(file.content);
+    const yamlObj: any = YAML.load(file.content);
     if (!yamlObj) {
       return;
     }
@@ -116,7 +116,7 @@ export class YamlCompiler {
     }
   }
 
-  private transpileAndPrepareJsFile(file, methodFn, cubeObj, errorsReport: ErrorReporter) {
+  private transpileAndPrepareJsFile(file: FileContent, methodFn: ('cube' | 'view'), cubeObj, errorsReport: ErrorReporter): FileContent {
     const yamlAst = this.transformYamlCubeObj(cubeObj, errorsReport);
 
     const cubeOrViewCall = t.callExpression(t.identifier(methodFn), [t.stringLiteral(cubeObj.name), yamlAst]);
@@ -135,7 +135,7 @@ export class YamlCompiler {
     cubeObj.dimensions = this.yamlArrayToObj(cubeObj.dimensions || [], 'dimension', errorsReport);
     cubeObj.segments = this.yamlArrayToObj(cubeObj.segments || [], 'segment', errorsReport);
     cubeObj.preAggregations = this.yamlArrayToObj(cubeObj.preAggregations || [], 'preAggregation', errorsReport);
-    cubeObj.joins = this.yamlArrayToObj(cubeObj.joins || [], 'join', errorsReport);
+    cubeObj.joins = cubeObj.joins || []; // For edge cases where joins are not defined/null
     cubeObj.hierarchies = this.yamlArrayToObj(cubeObj.hierarchies || [], 'hierarchies', errorsReport);
 
     return this.transpileYaml(cubeObj, [], cubeObj.name, errorsReport);

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -166,7 +166,7 @@ Object {
   },
   "fileName": "custom_calendar.js",
   "hierarchies": Object {},
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "ownedByCube": true,
@@ -385,7 +385,7 @@ Object {
       "title": "Retail Calendar Hierarchy",
     },
   },
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "ownedByCube": true,
@@ -585,25 +585,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): measures 1`] = `
@@ -925,25 +928,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): measures 1`] = `
@@ -1223,25 +1229,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): measures 1`] = `
@@ -1563,25 +1572,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): measures 1`] = `
@@ -1813,7 +1825,7 @@ Object {
     },
   ],
   "isView": true,
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "aggType": "count",
@@ -2075,6 +2087,26 @@ Array [
     ],
     "name": "folder2",
     "type": "folder",
+  },
+]
+`;
+
+exports[`Schema Testing join types 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
   },
 ]
 `;

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -447,11 +447,7 @@ describe('Schema Testing', () => {
     ]);
     await compiler.compile();
 
-    expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchObject({
-      CubeB: { relationship: 'hasOne' },
-      CubeC: { relationship: 'hasMany' },
-      CubeD: { relationship: 'belongsTo' }
-    });
+    expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
   });
 
   describe('Access Policies', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,6 +7769,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-bigint@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/json-bigint/-/json-bigint-1.0.1.tgz#201062a6990119a8cc18023cfe1fed12fc2fc8a7"


### PR DESCRIPTION
- **more types in CubeSymbols**
- **change joins schema in Validator**
- **specify type for accessPolicy**
- **make prepareJoins() aware of arrays**
- **make joins in CubeSymbols / CubeEvaluator as array instead of hashmap**
- **update JoinGraph to treat joins as array instead of hashmap**
- **fix CubePropContextTranspiler to convert joins hashmap into array**
- **add @types/js-yaml**
- **make YamlCompiler aware of joins as array**
- **fix/update snapshots for schema tests**

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
