### PR TITLE
chore(schema-compiler): Make cube joins to be an array instead of hashmap

### DIFF
--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -67,6 +67,7 @@
     "@types/babel__traverse": "^7.20.5",
     "@types/inflection": "^1.5.28",
     "@types/jest": "^29",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/node-dijkstra": "^2.5.6",
     "@types/ramda": "^0.27.34",

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -2,10 +2,13 @@
 import R from 'ramda';
 
 import {
+  AccessPolicyDefinition,
   CubeDefinitionExtended,
   CubeSymbols,
-  HierarchyDefinition, JoinDefinition,
-  PreAggregationDefinition, PreAggregationDefinitionRollup,
+  HierarchyDefinition,
+  JoinDefinition,
+  PreAggregationDefinition,
+  PreAggregationDefinitionRollup,
   type ToString
 } from './CubeSymbols';
 import { UserError } from './UserError';
@@ -110,30 +113,6 @@ export type EvaluatedHierarchy = {
   [key: string]: any;
 };
 
-export type Filter =
-  | {
-      member: string;
-      memberReference?: string;
-      [key: string]: any;
-    }
-  | {
-      and?: Filter[];
-      or?: Filter[];
-      [key: string]: any;
-    };
-
-export type AccessPolicy = {
-  rowLevel?: {
-    filters: Filter[];
-  };
-  memberLevel?: {
-    includes?: string | string[];
-    excludes?: string | string[];
-    includesMembers?: string[];
-    excludesMembers?: string[];
-  };
-};
-
 export type EvaluatedFolder = {
   name: string;
   includes: (EvaluatedFolder | DimensionDefinition | MeasureDefinition)[];
@@ -153,7 +132,7 @@ export type EvaluatedCube = {
   folders: EvaluatedFolder[];
   sql?: (...args: any[]) => string;
   sqlTable?: (...args: any[]) => string;
-  accessPolicy?: AccessPolicy[];
+  accessPolicy?: AccessPolicyDefinition[];
 };
 
 export class CubeEvaluator extends CubeSymbols {
@@ -200,7 +179,7 @@ export class CubeEvaluator extends CubeSymbols {
     );
   }
 
-  protected prepareCube(cube, errorReporter: ErrorReporter) {
+  protected prepareCube(cube, errorReporter: ErrorReporter): EvaluatedCube {
     this.prepareJoins(cube, errorReporter);
     this.preparePreAggregations(cube, errorReporter);
     this.prepareMembers(cube.measures, cube, errorReporter);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -423,35 +423,39 @@ export class CubeEvaluator extends CubeSymbols {
   }
 
   protected prepareJoins(cube: any, _errorReporter: ErrorReporter) {
-    if (cube.joins) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const join of Object.values(cube.joins) as any[]) {
-        // eslint-disable-next-line default-case
-        switch (join.relationship) {
-          case 'belongs_to':
-          case 'many_to_one':
-          case 'manyToOne':
-            join.relationship = 'belongsTo';
-            break;
-          case 'has_many':
-          case 'one_to_many':
-          case 'oneToMany':
-            join.relationship = 'hasMany';
-            break;
-          case 'has_one':
-          case 'one_to_one':
-          case 'oneToOne':
-            join.relationship = 'hasOne';
-            break;
-        }
-      }
+    if (!cube.joins) {
+      return;
     }
+
+    const joins: JoinDefinition[] = Array.isArray(cube.joins) ? cube.joins : Object.values(cube.joins);
+
+    joins.forEach(join => {
+      // eslint-disable-next-line default-case
+      switch (join.relationship) {
+        case 'belongs_to':
+        case 'many_to_one':
+        case 'manyToOne':
+          join.relationship = 'belongsTo';
+          break;
+        case 'has_many':
+        case 'one_to_many':
+        case 'oneToMany':
+          join.relationship = 'hasMany';
+          break;
+        case 'has_one':
+        case 'one_to_one':
+        case 'oneToOne':
+          join.relationship = 'hasOne';
+          break;
+      }
+    });
   }
 
   protected preparePreAggregations(cube: any, errorReporter: ErrorReporter) {
     if (cube.preAggregations) {
       // eslint-disable-next-line no-restricted-syntax
       for (const preAggregation of Object.values(cube.preAggregations) as any) {
+        // preAggregation is actually (PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql)
         if (preAggregation.timeDimension) {
           preAggregation.timeDimensionReference = preAggregation.timeDimension;
           delete preAggregation.timeDimension;
@@ -553,7 +557,7 @@ export class CubeEvaluator extends CubeSymbols {
     }
   }
 
-  public cubesByFileName(fileName) {
+  public cubesByFileName(fileName): CubeDefinitionExtended[] {
     return this.byFileName[fileName] || [];
   }
 
@@ -670,7 +674,7 @@ export class CubeEvaluator extends CubeSymbols {
     return this.preAggregations({ scheduled: true });
   }
 
-  public cubeNames() {
+  public cubeNames(): string[] {
     return Object.keys(this.evaluatedCubes);
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -124,7 +124,7 @@ export type EvaluatedCube = {
   measures: Record<string, MeasureDefinition>;
   dimensions: Record<string, DimensionDefinition>;
   segments: Record<string, SegmentDefinition>;
-  joins: Record<string, JoinDefinition>;
+  joins: JoinDefinition[];
   hierarchies: Record<string, HierarchyDefinition>;
   evaluatedHierarchies: EvaluatedHierarchy[];
   preAggregations: Record<string, PreAggregationDefinitionExtended>;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -105,6 +105,30 @@ export type JoinDefinition = {
   sql: (...args: any[]) => string,
 };
 
+export type Filter =
+  | {
+      member: string;
+      memberReference?: string;
+      [key: string]: any;
+    }
+  | {
+      and?: Filter[];
+      or?: Filter[];
+      [key: string]: any;
+    };
+
+export type AccessPolicyDefinition = {
+  rowLevel?: {
+    filters: Filter[];
+  };
+  memberLevel?: {
+    includes?: string | string[];
+    excludes?: string | string[];
+    includesMembers?: string[];
+    excludesMembers?: string[];
+  };
+};
+
 export interface CubeDefinition {
   name: string;
   extends?: (...args: Array<unknown>) => { __cubeName: string };
@@ -121,7 +145,7 @@ export interface CubeDefinition {
   // eslint-disable-next-line camelcase
   pre_aggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
   joins?: Record<string, JoinDefinition>;
-  accessPolicy?: any[];
+  accessPolicy?: AccessPolicyDefinition[];
   // eslint-disable-next-line camelcase
   access_policy?: any[];
   folders?: any[];

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -100,6 +100,7 @@ export type PreAggregationDefinitionRollup = BasePreAggregationDefinition & {
 export type PreAggregationDefinition = PreAggregationDefinitionRollup;
 
 export type JoinDefinition = {
+  name?: string, // TODO: Make it required
   relationship: string,
   sql: (...args: any[]) => string,
 };
@@ -221,17 +222,17 @@ export class CubeSymbols {
   }
 
   public createCube(cubeDefinition: CubeDefinition): CubeDefinitionExtended {
-    let preAggregations: any;
-    let joins: any;
-    let measures: any;
-    let dimensions: any;
-    let segments: any;
-    let hierarchies: any;
-    let accessPolicy: any;
-    let folders: any;
-    let cubes: any;
+    let preAggregations: CubeDefinition['preAggregations'];
+    let joins: CubeDefinition['joins'];
+    let measures: CubeDefinition['measures'];
+    let dimensions: CubeDefinition['dimensions'];
+    let segments: CubeDefinition['segments'];
+    let hierarchies: CubeDefinition['hierarchies'];
+    let accessPolicy: CubeDefinition['accessPolicy'];
+    let folders: CubeDefinition['folders'];
+    let cubes: CubeDefinition['cubes'];
 
-    const cubeObject = Object.assign({
+    const cubeObject: CubeDefinitionExtended = Object.assign({
       allDefinitions(type: string) {
         if (cubeDefinition.extends) {
           return {
@@ -383,9 +384,10 @@ export class CubeSymbols {
     return cubeObject;
   }
 
-  protected transform(cubeName: string, errorReporter: ErrorReporter, splitViews: SplitViews) {
+  protected transform(cubeName: string, errorReporter: ErrorReporter, splitViews: SplitViews): CubeSymbolsDefinition {
     const cube = this.getCubeDefinition(cubeName);
-    const duplicateNames = R.compose(
+    // @ts-ignore
+    const duplicateNames: string[] = R.compose(
       R.map((nameToDefinitions: any) => nameToDefinitions[0]),
       R.toPairs,
       R.filter((definitionsByName: any) => definitionsByName.length > 1),
@@ -397,9 +399,7 @@ export class CubeSymbols {
       // @ts-ignore
     )([cube.measures, cube.dimensions, cube.segments, cube.preAggregations, cube.hierarchies]);
 
-    // @ts-ignore
     if (duplicateNames.length > 0) {
-      // @ts-ignore
       errorReporter.error(`${duplicateNames.join(', ')} defined more than once`);
     }
 
@@ -427,23 +427,24 @@ export class CubeSymbols {
       ...cube.dimensions || {},
       ...cube.segments || {},
       ...cube.preAggregations || {}
-    };
+    } as CubeSymbolsDefinition;
   }
 
-  private camelCaseTypes(obj: Object | undefined) {
+  private camelCaseTypes(obj: Object | Array<any> | undefined) {
     if (!obj) {
       return;
     }
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const member of Object.values(obj)) {
+    const members = Array.isArray(obj) ? obj : Object.values(obj);
+
+    members.forEach(member => {
       if (member.type && member.type.indexOf('_') !== -1) {
         member.type = camelize(member.type, true);
       }
       if (member.relationship && member.relationship.indexOf('_') !== -1) {
         member.relationship = camelize(member.relationship, true);
       }
-    }
+    });
   }
 
   protected transformPreAggregations(preAggregations: Object) {
@@ -548,7 +549,7 @@ export class CubeSymbols {
         }
       }
 
-      const includeMembers = this.generateIncludeMembers(cubeIncludes, cube.name, type);
+      const includeMembers = this.generateIncludeMembers(cubeIncludes, type);
       this.applyIncludeMembers(includeMembers, cube, type, errorReporter);
 
       const existing = cube.includedMembers ?? [];
@@ -699,11 +700,7 @@ export class CubeSymbols {
           splitViewDef = splitViews[viewName];
         }
 
-        const includeMembers = this.generateIncludeMembers(
-          finalIncludes,
-          parentCube.name,
-          type
-        );
+        const includeMembers = this.generateIncludeMembers(finalIncludes, type);
         this.applyIncludeMembers(includeMembers, splitViewDef, type, errorReporter);
       } else {
         for (const member of finalIncludes) {
@@ -733,7 +730,7 @@ export class CubeSymbols {
     return this.symbols[cubeName]?.cubeObj()?.[type]?.[memberName];
   }
 
-  protected generateIncludeMembers(members: any[], cubeName: string, type: string) {
+  protected generateIncludeMembers(members: any[], type: string) {
     return members.map(memberRef => {
       const path = memberRef.member.split('.');
       const resolvedMember = this.getResolvedMember(type, path[path.length - 2], path[path.length - 1]);
@@ -870,9 +867,8 @@ export class CubeSymbols {
 
   /**
    * Split join path to member to join hint and member path: `A.B.C.D.E.dim` => `[A, B, C, D, E]` + `E.dim`
-   * @param path
    */
-  public static joinHintFromPath(path: string): { path: string, joinHint: Array<string> } {
+  public static joinHintFromPath(path: string): { path: string, joinHint: string[] } {
     const parts = path.split('.');
     if (parts.length > 2) {
       // Path contains join path
@@ -908,7 +904,7 @@ export class CubeSymbols {
     }
   }
 
-  protected withSymbolsCallContext(func, context) {
+  protected withSymbolsCallContext(func: Function, context) {
     const oldContext = this.resolveSymbolsCallContext;
     this.resolveSymbolsCallContext = context;
     try {
@@ -933,7 +929,7 @@ export class CubeSymbols {
     return this.funcArgumentsValues[funcDefinition];
   }
 
-  protected joinHints() {
+  protected joinHints(): string | string[] | undefined {
     const { joinHints } = this.resolveSymbolsCallContext || {};
     if (Array.isArray(joinHints)) {
       return R.uniq(joinHints);
@@ -1014,7 +1010,7 @@ export class CubeSymbols {
     return (...filterParamArgs) => '';
   }
 
-  public resolveSymbol(cubeName, name) {
+  public resolveSymbol(cubeName, name: string) {
     const { sqlResolveFn, contextSymbols, collectJoinHints, depsResolveFn, currResolveIndexFn } = this.resolveSymbolsCallContext || {};
     if (name === 'USER_CONTEXT') {
       throw new Error('Support for USER_CONTEXT was removed, please migrate to SECURITY_CONTEXT.');

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -100,7 +100,7 @@ export type PreAggregationDefinitionRollup = BasePreAggregationDefinition & {
 export type PreAggregationDefinition = PreAggregationDefinitionRollup;
 
 export type JoinDefinition = {
-  name?: string, // TODO: Make it required
+  name: string,
   relationship: string,
   sql: (...args: any[]) => string,
 };
@@ -144,7 +144,7 @@ export interface CubeDefinition {
   preAggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
   // eslint-disable-next-line camelcase
   pre_aggregations?: Record<string, PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql>;
-  joins?: Record<string, JoinDefinition>;
+  joins?: JoinDefinition[];
   accessPolicy?: AccessPolicyDefinition[];
   // eslint-disable-next-line camelcase
   access_policy?: any[];
@@ -322,7 +322,8 @@ export class CubeSymbols {
 
       get joins() {
         if (!joins) {
-          joins = this.allDefinitions('joins');
+          const parentJoins = cubeDefinition.extends ? super.joins : [];
+          joins = [...parentJoins, ...(cubeDefinition.joins || [])];
         }
         return joins;
       },

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -802,14 +802,25 @@ const baseSchema = {
   shown: Joi.boolean().strict(),
   public: Joi.boolean().strict(),
   meta: Joi.any(),
-  joins: Joi.object().pattern(identifierRegex, Joi.object().keys({
-    sql: Joi.func().required(),
-    relationship: Joi.any().valid(
-      'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
-      'hasMany', 'has_many', 'one_to_many', 'oneToMany',
-      'hasOne', 'has_one', 'one_to_one', 'oneToOne'
-    ).required()
-  })),
+  joins: Joi.alternatives([
+    Joi.object().pattern(identifierRegex, Joi.object().keys({
+      sql: Joi.func().required(),
+      relationship: Joi.any().valid(
+        'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
+        'hasMany', 'has_many', 'one_to_many', 'oneToMany',
+        'hasOne', 'has_one', 'one_to_one', 'oneToOne'
+      ).required()
+    })),
+    Joi.array().items(Joi.object().keys({
+      name: identifier.required(),
+      sql: Joi.func().required(),
+      relationship: Joi.any().valid(
+        'belongsTo', 'belongs_to', 'many_to_one', 'manyToOne',
+        'hasMany', 'has_many', 'one_to_many', 'oneToMany',
+        'hasOne', 'has_one', 'one_to_one', 'oneToOne'
+      ).required()
+    }))
+  ]),
   measures: MeasuresSchema,
   dimensions: DimensionsSchema,
   segments: SegmentsSchema,

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -116,7 +116,7 @@ export class YamlCompiler {
     }
   }
 
-  private transpileAndPrepareJsFile(file, methodFn, cubeObj, errorsReport: ErrorReporter) {
+  private transpileAndPrepareJsFile(file: FileContent, methodFn: ('cube' | 'view'), cubeObj, errorsReport: ErrorReporter): FileContent {
     const yamlAst = this.transformYamlCubeObj(cubeObj, errorsReport);
 
     const cubeOrViewCall = t.callExpression(t.identifier(methodFn), [t.stringLiteral(cubeObj.name), yamlAst]);
@@ -135,7 +135,7 @@ export class YamlCompiler {
     cubeObj.dimensions = this.yamlArrayToObj(cubeObj.dimensions || [], 'dimension', errorsReport);
     cubeObj.segments = this.yamlArrayToObj(cubeObj.segments || [], 'segment', errorsReport);
     cubeObj.preAggregations = this.yamlArrayToObj(cubeObj.preAggregations || [], 'preAggregation', errorsReport);
-    cubeObj.joins = this.yamlArrayToObj(cubeObj.joins || [], 'join', errorsReport);
+    cubeObj.joins = cubeObj.joins || []; // For edge cases where joins are not defined/null
     cubeObj.hierarchies = this.yamlArrayToObj(cubeObj.hierarchies || [], 'hierarchies', errorsReport);
 
     return this.transpileYaml(cubeObj, [], cubeObj.name, errorsReport);

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -135,7 +135,13 @@ export class YamlCompiler {
     cubeObj.dimensions = this.yamlArrayToObj(cubeObj.dimensions || [], 'dimension', errorsReport);
     cubeObj.segments = this.yamlArrayToObj(cubeObj.segments || [], 'segment', errorsReport);
     cubeObj.preAggregations = this.yamlArrayToObj(cubeObj.preAggregations || [], 'preAggregation', errorsReport);
+
     cubeObj.joins = cubeObj.joins || []; // For edge cases where joins are not defined/null
+    if (!Array.isArray(cubeObj.joins)) {
+      errorsReport.error('joins must be defined as array');
+      cubeObj.joins = [];
+    }
+
     cubeObj.hierarchies = this.yamlArrayToObj(cubeObj.hierarchies || [], 'hierarchies', errorsReport);
 
     return this.transpileYaml(cubeObj, [], cubeObj.name, errorsReport);

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -2091,6 +2091,46 @@ Array [
 ]
 `;
 
+exports[`Schema Testing join types (joins as array) 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
+  },
+]
+`;
+
+exports[`Schema Testing join types (joins as object) 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
+  },
+]
+`;
+
 exports[`Schema Testing join types 1`] = `
 Array [
   Object {

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -1689,6 +1689,46 @@ Object {
 }
 `;
 
+exports[`Schema Testing Joins join types (joins as array) 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
+  },
+]
+`;
+
+exports[`Schema Testing Joins join types (joins as object) 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
+  },
+]
+`;
+
 exports[`Schema Testing Views allows to override \`title\`, \`description\`, \`meta\`, and \`format\` on includes members 1`] = `
 Object {
   "accessPolicy": undefined,
@@ -2087,66 +2127,6 @@ Array [
     ],
     "name": "folder2",
     "type": "folder",
-  },
-]
-`;
-
-exports[`Schema Testing join types (joins as array) 1`] = `
-Array [
-  Object {
-    "name": "CubeB",
-    "relationship": "hasOne",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeC",
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeD",
-    "relationship": "belongsTo",
-    "sql": [Function],
-  },
-]
-`;
-
-exports[`Schema Testing join types (joins as object) 1`] = `
-Array [
-  Object {
-    "name": "CubeB",
-    "relationship": "hasOne",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeC",
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeD",
-    "relationship": "belongsTo",
-    "sql": [Function],
-  },
-]
-`;
-
-exports[`Schema Testing join types 1`] = `
-Array [
-  Object {
-    "name": "CubeB",
-    "relationship": "hasOne",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeC",
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  Object {
-    "name": "CubeD",
-    "relationship": "belongsTo",
-    "sql": [Function],
   },
 ]
 `;

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -166,7 +166,7 @@ Object {
   },
   "fileName": "custom_calendar.js",
   "hierarchies": Object {},
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "ownedByCube": true,
@@ -385,7 +385,7 @@ Object {
       "title": "Retail Calendar Hierarchy",
     },
   },
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "ownedByCube": true,
@@ -585,25 +585,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (with additions): measures 1`] = `
@@ -925,25 +928,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (with additions): measures 1`] = `
@@ -1223,25 +1229,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (with additions): measures 1`] = `
@@ -1563,25 +1572,28 @@ Object {
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): joins 1`] = `
-Object {
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): joins 2`] = `
-Object {
-  "line_items": Object {
-    "relationship": "hasMany",
-    "sql": [Function],
-  },
-  "order_users": Object {
+Array [
+  Object {
+    "name": "order_users",
     "relationship": "belongsTo",
     "sql": [Function],
   },
-}
+  Object {
+    "name": "line_items",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+]
 `;
 
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (with additions): measures 1`] = `
@@ -1813,7 +1825,7 @@ Object {
     },
   ],
   "isView": true,
-  "joins": Object {},
+  "joins": Array [],
   "measures": Object {
     "count": Object {
       "aggType": "count",
@@ -2075,6 +2087,26 @@ Array [
     ],
     "name": "folder2",
     "type": "folder",
+  },
+]
+`;
+
+exports[`Schema Testing join types 1`] = `
+Array [
+  Object {
+    "name": "CubeB",
+    "relationship": "hasOne",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeC",
+    "relationship": "hasMany",
+    "sql": [Function],
+  },
+  Object {
+    "name": "CubeD",
+    "relationship": "belongsTo",
+    "sql": [Function],
   },
 ]
 `;

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -447,11 +447,7 @@ describe('Schema Testing', () => {
     ]);
     await compiler.compile();
 
-    expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchObject({
-      CubeB: { relationship: 'hasOne' },
-      CubeC: { relationship: 'hasMany' },
-      CubeD: { relationship: 'belongsTo' }
-    });
+    expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
   });
 
   describe('Access Policies', () => {

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -416,38 +416,78 @@ describe('Schema Testing', () => {
     expect(gr.origin).toBe('2020-06-01 10:00:00');
   });
 
-  it('join types', async () => {
-    const { compiler, cubeEvaluator } = prepareJsCompiler([
-      createCubeSchema({
-        name: 'CubeA',
-        joins: `{
-          CubeB: {
-            sql: \`SQL ON clause\`,
-            relationship: 'one_to_one'
-          },
-          CubeC: {
-            sql: \`SQL ON clause\`,
-            relationship: 'one_to_many'
-          },
-          CubeD: {
-            sql: \`SQL ON clause\`,
-            relationship: 'many_to_one'
-          },
-        }`
-      }),
-      createCubeSchema({
-        name: 'CubeB',
-      }),
-      createCubeSchema({
-        name: 'CubeC',
-      }),
-      createCubeSchema({
-        name: 'CubeD',
-      }),
-    ]);
-    await compiler.compile();
+  describe('Joins', () => {
+    it('join types (joins as object)', async () => {
+      const { compiler, cubeEvaluator } = prepareJsCompiler([
+        createCubeSchema({
+          name: 'CubeA',
+          joins: `{
+            CubeB: {
+              sql: \`SQL ON clause\`,
+              relationship: 'one_to_one'
+            },
+            CubeC: {
+              sql: \`SQL ON clause\`,
+              relationship: 'one_to_many'
+            },
+            CubeD: {
+              sql: \`SQL ON clause\`,
+              relationship: 'many_to_one'
+            },
+          }`
+        }),
+        createCubeSchema({
+          name: 'CubeB',
+        }),
+        createCubeSchema({
+          name: 'CubeC',
+        }),
+        createCubeSchema({
+          name: 'CubeD',
+        }),
+      ]);
+      await compiler.compile();
 
-    expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
+      expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
+    });
+
+    it('join types (joins as array)', async () => {
+      const { compiler, cubeEvaluator } = prepareJsCompiler([
+        createCubeSchema({
+          name: 'CubeA',
+          joins: `[
+            {
+              name: 'CubeB',
+              sql: \`SQL ON clause\`,
+              relationship: 'one_to_one'
+            },
+            {
+              name: 'CubeC',
+              sql: \`SQL ON clause\`,
+              relationship: 'one_to_many'
+            },
+            {
+              name: 'CubeD',
+              sql: \`SQL ON clause\`,
+              relationship: 'many_to_one'
+            },
+          ]`
+        }),
+        createCubeSchema({
+          name: 'CubeB',
+        }),
+        createCubeSchema({
+          name: 'CubeC',
+        }),
+        createCubeSchema({
+          name: 'CubeD',
+        }),
+      ]);
+      await compiler.compile();
+
+      expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
+    });
+
   });
 
   describe('Access Policies', () => {

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -487,7 +487,6 @@ describe('Schema Testing', () => {
 
       expect(cubeEvaluator.cubeFromPath('CubeA').joins).toMatchSnapshot();
     });
-
   });
 
   describe('Access Policies', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7769,6 +7769,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-bigint@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/json-bigint/-/json-bigint-1.0.1.tgz#201062a6990119a8cc18023cfe1fed12fc2fc8a7"


### PR DESCRIPTION
- **more types in CubeSymbols**
- **change joins schema in Validator**
- **specify type for accessPolicy**
- **make prepareJoins() aware of arrays**
- **make joins in CubeSymbols / CubeEvaluator as array instead of hashmap**
- **update JoinGraph to treat joins as array instead of hashmap**
- **fix CubePropContextTranspiler to convert joins hashmap into array**
- **add @types/js-yaml**
- **make YamlCompiler aware of joins as array**
- **fix/update snapshots for schema tests**
- **fix transform yaml joins**
- **add schema tests for joins as array/object**

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
