### PR TITLE
feat(partners): rename link

### DIFF
--- a/docs/components/common/Footer/Footer.tsx
+++ b/docs/components/common/Footer/Footer.tsx
@@ -66,8 +66,8 @@ const RESOURCES_LINKS = [
     link: "https://cube.dev/case-studies",
   },
   {
-    label: "Cube Partner Network",
-    link: "https://cube.dev/consulting/cube-partner-network",
+    label: "Consulting Partners",
+    link: "https://cube.dev/consulting/consulting-partners",
   },
 ];
 


### PR DESCRIPTION
**Description of Changes Made (if issue reference is not provided)**

Replaced the footer link to point to /consulting/consulting-partners and updated the link label from "Cube Partner Network" to "Consulting Partners".