### PR TITLE
feat(query-ochestrator): Reduce number of cache set for used flag

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -652,6 +652,13 @@ const variables: Record<string, (...args: any) => any> = {
   /**
    * Max number of elements
    */
+  usedPreAggregationCacheMaxCount: (): number => get('CUBEJS_USED_PRE_AGG_CACHE_MAX_COUNT')
+    .default(8192)
+    .asInt(),
+
+  /**
+   * Max number of elements
+   */
   touchPreAggregationCacheMaxCount: (): number => get('CUBEJS_TOUCH_PRE_AGG_CACHE_MAX_COUNT')
     .default(8192)
     .asInt(),

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -130,7 +130,7 @@ export class QueryCache {
   protected memoryCache: LRUCache<string, CacheEntry>;
 
   public constructor(
-    protected readonly redisPrefix: string,
+    protected readonly cachePrefix: string,
     protected readonly driverFactory: DriverFactoryByDataSource,
     protected readonly logger: any,
     public readonly options: QueryCacheOptions
@@ -165,11 +165,7 @@ export class QueryCache {
   }
 
   public getKey(catalog: string, key: string): string {
-    if (this.cacheDriver instanceof CubeStoreCacheDriver) {
-      return `${this.redisPrefix}#${catalog}:${key}`;
-    } else {
-      return `${catalog}_${this.redisPrefix}_${key}`;
-    }
+    return `${this.cachePrefix}#${catalog}:${key}`;
   }
 
   /**
@@ -469,7 +465,7 @@ export class QueryCache {
       const queueOptions = await this.options.queueOptions(dataSource);
       if (!this.queue[dataSource]) {
         this.queue[dataSource] = QueryCache.createQueue(
-          `SQL_QUERY_${this.redisPrefix}_${dataSource}`,
+          `SQL_QUERY_${this.cachePrefix}_${dataSource}`,
           () => this.driverFactory(dataSource),
           (client, req) => {
             this.logger('Executing SQL', { ...req });
@@ -537,7 +533,7 @@ export class QueryCache {
   public getExternalQueue() {
     if (!this.externalQueue) {
       this.externalQueue = QueryCache.createQueue(
-        `SQL_QUERY_EXT_${this.redisPrefix}`,
+        `SQL_QUERY_EXT_${this.cachePrefix}`,
         this.options.externalDriverFactory,
         (client, q) => {
           this.logger('Executing SQL', {
@@ -931,6 +927,9 @@ export class QueryCache {
     }
 
     if (!res) {
+      console.log('cacheDriver.get', {
+        redisKey
+      });
       res = await this.cacheDriver.get(redisKey);
     }
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -927,9 +927,6 @@ export class QueryCache {
     }
 
     if (!res) {
-      console.log('cacheDriver.get', {
-        redisKey
-      });
       res = await this.cacheDriver.get(redisKey);
     }
 


### PR DESCRIPTION
We use both flags: used and touch. We have already had LRU cache for a long time with the touch flag to reduce the number of updates in the Cache Store, but we didn't do it for the used. 

This leads to a situation where, for a schema with 100 pre-aggs, we will do 200 cache sets per 1 minute because the default refresh interval is set to 30 seconds.