### PR TITLE
feat(query-ocherator): QueryCache - improve usage of in-memory cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Cube is a semantic layer for building data applications. This is a monorepo cont
 
 ## Development Commands
 
-**Note: This project uses Yarn as the package manager.**
+**Note: This project uses Yarn as the package manager. Node.js v22.15.0 is recommended.**
 
 ### Core Build Commands
 ```bash


### PR DESCRIPTION
# before

```
  █ TOTAL RESULTS 

    checks_total.......................: 7824    763.369653/s
    checks_succeeded...................: 100.00% 7824 out of 7824
    checks_failed......................: 0.00%   0 out of 7824

    ✓ status is 200
    ✓ response time < 1000ms
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=195.11ms min=7.42ms med=196.24ms max=407.8ms  p(90)=327.7ms p(95)=354.65ms
      { expected_response:true }............................................: avg=195.11ms min=7.42ms med=196.24ms max=407.8ms  p(90)=327.7ms p(95)=354.65ms
    http_req_failed.........................................................: 0.00%  0 out of 2608
    http_reqs...............................................................: 2608   254.456551/s

    EXECUTION
    iteration_duration......................................................: avg=195.74ms min=7.99ms med=196.93ms max=408.59ms p(90)=328.2ms p(95)=355.15ms
    iterations..............................................................: 2608   254.456551/s
    vus.....................................................................: 99     min=10        max=99 
    vus_max.................................................................: 100    min=100       max=100

    NETWORK
    data_received...........................................................: 127 MB 12 MB/s
    data_sent...............................................................: 1.1 MB 103 kB/s
```

# after

```
  █ TOTAL RESULTS 

    checks_total.......................: 6807    660.71374/s
    checks_succeeded...................: 100.00% 6807 out of 6807
    checks_failed......................: 0.00%   0 out of 6807

    ✓ status is 200
    ✓ response time < 1000ms
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=227.34ms min=7.98ms med=233.06ms max=495.36ms p(90)=389.62ms p(95)=416.05ms
      { expected_response:true }............................................: avg=227.34ms min=7.98ms med=233.06ms max=495.36ms p(90)=389.62ms p(95)=416.05ms
    http_req_failed.........................................................: 0.00%  0 out of 2269
    http_reqs...............................................................: 2269   220.237913/s

    EXECUTION
    iteration_duration......................................................: avg=227.95ms min=8.52ms med=233.57ms max=495.96ms p(90)=390.17ms p(95)=416.96ms
    iterations..............................................................: 2269   220.237913/s
    vus.....................................................................: 99     min=10        max=99 
    vus_max.................................................................: 100    min=100       max=100

    NETWORK
    data_received...........................................................: 111 MB 11 MB/s
    data_sent...............................................................: 914 kB 89 kB/s


```
