### PR TITLE
feat(playground): Use relative paths for assets, playground requests and fonts

### DIFF
--- a/packages/cubejs-playground/src/App.tsx
+++ b/packages/cubejs-playground/src/App.tsx
@@ -63,7 +63,7 @@ class App extends Component<PropsWithChildren<RouteComponentProps>, AppState> {
       });
     });
 
-    const res = await fetch('/playground/context');
+    const res = await fetch('playground/context');
     const context = await res.json();
 
     setTelemetry(context.telemetry);
@@ -112,7 +112,7 @@ class App extends Component<PropsWithChildren<RouteComponentProps>, AppState> {
       <LivePreviewContextProvider
         disabled={!context?.livePreview}
       >
-        <Root styles={ROOT_STYLES}>
+        <Root publicUrl="." styles={ROOT_STYLES}>
           <GlobalStyles />
 
           <Header selectedKeys={[location.pathname]} />

--- a/packages/cubejs-playground/src/components/LivePreviewContext/LivePreviewContextProvider.tsx
+++ b/packages/cubejs-playground/src/components/LivePreviewContext/LivePreviewContextProvider.tsx
@@ -70,7 +70,7 @@ const useLivePreview = (disabled = false) => {
   // }, [status]);
 
   const fetchStatus = () => {
-    return fetch('/playground/live-preview/status')
+    return fetch('playground/live-preview/status')
       .then((res) => res.json())
       .then((status) => {
         setStatus({
@@ -81,7 +81,7 @@ const useLivePreview = (disabled = false) => {
   };
 
   const createTokenWithPayload = async (payload): Promise<any> => {
-    const res = await fetch('/playground/live-preview/token', {
+    const res = await fetch('playground/live-preview/token', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -108,7 +108,7 @@ const useLivePreview = (disabled = false) => {
     statusLivePreview: status,
     createTokenWithPayload,
     stopLivePreview: async (): Promise<Boolean> => {
-      await fetch('/playground/live-preview/stop');
+      await fetch('playground/live-preview/stop');
       await fetchStatus();
       return true;
     },

--- a/packages/cubejs-playground/src/index.tsx
+++ b/packages/cubejs-playground/src/index.tsx
@@ -26,7 +26,7 @@ async function onTokenPayloadChange(payload: Record<string, any>, token) {
     return token;
   }
 
-  const response = await fetch('/playground/token', {
+  const response = await fetch('playground/token', {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/cubejs-playground/src/pages/ConnectionWizard/ConnectionWizardPage.tsx
+++ b/packages/cubejs-playground/src/pages/ConnectionWizard/ConnectionWizardPage.tsx
@@ -63,7 +63,7 @@ async function testConnection(variables: Record<string, string>) {
 }
 
 async function saveConnection(variables: Record<string, string>) {
-  await fetch('/playground/env', {
+  await fetch('playground/env', {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',
@@ -174,7 +174,7 @@ export function ConnectionWizardPage({ history }) {
       }
 
       {
-        const response = await fetch('/playground/driver', {
+        const response = await fetch('playground/driver', {
           method: 'post',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/cubejs-playground/src/pages/Index/IndexPage.tsx
+++ b/packages/cubejs-playground/src/pages/Index/IndexPage.tsx
@@ -12,7 +12,7 @@ export function IndexPage() {
 
   useEffect(() => {
     async function loadFiles() {
-      const res = await fetch('/playground/files');
+      const res = await fetch('playground/files');
       const result = await res.json();
 
       if (result.error?.includes('Model files not found')) {

--- a/packages/cubejs-playground/src/pages/Schema/SchemaPage.tsx
+++ b/packages/cubejs-playground/src/pages/Schema/SchemaPage.tsx
@@ -78,7 +78,7 @@ export class SchemaPage extends Component<SchemaPageProps, any> {
   async loadDBSchema() {
     this.setState({ schemaLoading: true });
     try {
-      const res = await playgroundFetch('/playground/db-schema');
+      const res = await playgroundFetch('playground/db-schema');
       const result = await res.json();
       this.setState({
         tablesSchema: result.tablesSchema,
@@ -91,7 +91,7 @@ export class SchemaPage extends Component<SchemaPageProps, any> {
   }
 
   async loadFiles() {
-    const res = await playgroundFetch('/playground/files');
+    const res = await playgroundFetch('playground/files');
     const result = await res.json();
     this.setState({
       files: result.files,
@@ -106,7 +106,7 @@ export class SchemaPage extends Component<SchemaPageProps, any> {
     const options = { format };
 
     playgroundAction('Generate Schema', options);
-    const res = await playgroundFetch('/playground/generate-schema', {
+    const res = await playgroundFetch('playground/generate-schema', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/cubejs-playground/vite.config.ts
+++ b/packages/cubejs-playground/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import environmentPlugin from 'vite-plugin-environment';
 
 export default defineConfig(({ mode }) => ({
+  base: './',
   build: {
     outDir: 'build',
     target: 'es2018',


### PR DESCRIPTION
Based on the work in PR https://github.com/cube-js/cube/pull/7816

"When attempting to run Cube behind a reverse proxy, it is only possible to set the base path for the API endpoints of Cube. This renders the playground unusable inside a non root base path.

For example when using /cube as a base path behind a reverse proxy, I can get the index.html to load, from /cube/index.html but then requests for assets are made to /some-asset.js instead of /cube/some-asset.js"

In addition to the changes made in that PR the requests to playground were still using the absolute path. 
Fonts were also using an absolute path and the fix for that was forcing a relative path.

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
#3028 #7969 

