### PR TITLE
fix(client-core): Remove default value in table pivot

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.ts
+++ b/packages/cubejs-client-core/src/ResultSet.ts
@@ -784,7 +784,7 @@ export default class ResultSet<T extends Record<string, any> = any> {
       [
         ...(normalizedPivotConfig.x).map((key, index): [string, string | number] => [
           key,
-          xValues[index] ?? ''
+          xValues[index]
         ]),
         ...(isMeasuresPresent
           ? yValuesArray.map(([yValues, measure]): [string, string | number] => [

--- a/packages/cubejs-client-core/test/ResultSet.test.ts
+++ b/packages/cubejs-client-core/test/ResultSet.test.ts
@@ -1807,5 +1807,28 @@ describe('ResultSet', () => {
         ]
       );
     });
+
+    test('keeps null values on non-matching rows', () => {
+      const resultSet = new ResultSet({
+        query: {
+          dimensions: [
+            'User.name',
+            'Friend.name'
+          ],
+        },
+        data: [
+          {
+            'User.name': 'Bob',
+            'Friend.name': null,
+          }
+        ],
+      } as any);
+
+      expect(resultSet.tablePivot()).toEqual(
+        [
+          { 'User.name': 'Bob', 'Friend.name': null },
+        ]
+      );
+    });
   });
 });


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**
Back in May when release 1.3.6 came out, [the client package was migrated to typescript](https://github.com/cube-js/cube/pull/9562). While trying to upgrade from previous versions to the newer releases, i ended up seeing discrepancies when running tests against some cube models. 

After some digging, it seems like the default value was added during the migration process. The previous behaviour being that if you are joining on a table that does not have a matching row for your model, the requested columns were `null` and not `""`.

I'm wondering if that behaviour is expected, and if so why?