### PR TITLE
perf: Debounce information schema queries to Cube Store (1.8x)

### DIFF
--- a/packages/cubejs-backend-shared/src/decorators.ts
+++ b/packages/cubejs-backend-shared/src/decorators.ts
@@ -1,0 +1,36 @@
+import crypto from 'crypto';
+
+/**
+ * Decorator version of asyncDebounce for methods and functions.
+ * Caches promises by method arguments to prevent concurrent execution of the same operation.
+ */
+export function AsyncDebounce() {
+  return function (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor
+  ) {
+    const originalMethod = descriptor.value;
+    const cache = new Map<string, Promise<any>>();
+
+    descriptor.value = async function (...args: any[]) {
+      const key = crypto.createHash('md5')
+        .update(args.map((v) => JSON.stringify(v)).join(','))
+        .digest('hex');
+
+      if (cache.has(key)) {
+        return cache.get(key);
+      }
+
+      try {
+        const promise = originalMethod.apply(this, args);
+        cache.set(key, promise);
+        return await promise;
+      } finally {
+        cache.delete(key);
+      }
+    };
+
+    return descriptor;
+  };
+}

--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -20,3 +20,4 @@ export * from './time';
 export * from './process';
 export * from './platform';
 export * from './FileRepository';
+export * from './decorators';

--- a/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
@@ -14,7 +14,7 @@ import {
   QueryOptions,
   ExternalDriverCompatibilities, TableStructure, TableColumnQueryResult,
 } from '@cubejs-backend/base-driver';
-import { getEnv } from '@cubejs-backend/shared';
+import { AsyncDebounce, getEnv } from '@cubejs-backend/shared';
 import { format as formatSql, escape } from 'sqlstring';
 import fetch from 'node-fetch';
 
@@ -158,6 +158,7 @@ export class CubeStoreDriver extends BaseDriver implements DriverInterface {
     });
   }
 
+  @AsyncDebounce()
   public async getTablesQuery(schemaName) {
     return this.query(
       `SELECT table_name, build_range_end FROM information_schema.tables WHERE table_schema = ${this.param(0)}`,
@@ -165,6 +166,7 @@ export class CubeStoreDriver extends BaseDriver implements DriverInterface {
     );
   }
 
+  @AsyncDebounce()
   public async getPrefixTablesQuery(schemaName, tablePrefixes) {
     const prefixWhere = tablePrefixes.map(_ => 'table_name LIKE CONCAT(?, \'%\')').join(' OR ');
     return this.query(

--- a/packages/cubejs-cubestore-driver/tsconfig.json
+++ b/packages/cubejs-cubestore-driver/tsconfig.json
@@ -10,5 +10,6 @@
     "outDir": "dist",
     "rootDir": ".",
     "baseUrl": ".",
+    "experimentalDecorators": true
   }
 }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -97,9 +97,11 @@ export class PreAggregationLoadCache {
     const client = preAggregation.external ?
       await this.externalDriverFactory() :
       await this.driverFactory();
+
     if (this.tablePrefixes && client.getPrefixTablesQuery && this.preAggregations.options.skipExternalCacheAndQueue) {
       return client.getPrefixTablesQuery(preAggregation.preAggregationsSchema, this.tablePrefixes);
     }
+
     return client.getTablesQuery(preAggregation.preAggregationsSchema);
   }
 


### PR DESCRIPTION
 Introduces @AsyncDebounce decorator to cache promises for getTablesQuery and getPrefixTablesQuery methods,                                                                                                                                                                                          preventing redundant concurrent executions of the same operations. This improves performance by avoiding                                                                                                                                                                                         duplicate database metadata queries.

Before (average across runs)
	•	RPS: ~97–144 req/s (avg ~113)
	•	Avg latency: ~1.0–1.11 s
	•	p95 latency: ~2.05–2.62 s
	•	Fast responses (<1s): ~42–76% (avg ~57%)
	•	Success rate: ~81–92% (avg ~86%)
	•	Min latency: 8.75–24 ms
	•	Max latency: 2.47–4.06 s

⸻

After (average across runs)
	•	RPS: ~130–208 req/s (avg ~175)
	•	Avg latency: ~0.50–0.81 s
	•	p95 latency: ~0.99–1.07 s
	•	Fast responses (<1s): ~89–95% (avg ~92%)
	•	Success rate: ~96–98% (avg ~97%)
	•	Min latency: 10.7–24 ms
	•	Max latency: 1.20–2.05 s

⸻

Improvements
	•	Throughput: +55–80% (avg RPS jumped from ~113 → ~175)
	•	Latency: avg dropped by ~40–55% (1.05 s → 0.60 s)
	•	p95 latency: cut by ~50–60% (≈2.3 s → ≈1.0 s)
	•	Fast responses: from ~57% to ~92% (+35 pp)
	•	Success rate: from ~86% to ~97% (+11 pp)
	•	Max latency: reduced from peaks of 4.06 s to 2.05 s

<details>
  <summary>Before</summary>
  
   ```
  █ TOTAL RESULTS 

    checks_total.......................: 6159   293.066431/s
    checks_succeeded...................: 82.61% 5088 out of 6159
    checks_failed......................: 17.38% 1071 out of 6159

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  47% — ✓ 982 / ✗ 1071
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=1.08s min=24.26ms med=1.17s max=2.58s p(90)=1.76s p(95)=2.06s
      { expected_response:true }............................................: avg=1.08s min=24.26ms med=1.17s max=2.58s p(90)=1.76s p(95)=2.06s
    http_req_failed.........................................................: 0.00%  0 out of 2053
    http_reqs...............................................................: 2053   97.68881/s

    EXECUTION
    iteration_duration......................................................: avg=1.08s min=24.93ms med=1.17s max=2.58s p(90)=1.76s p(95)=2.06s
    iterations..............................................................: 2053   97.68881/s
    vus.....................................................................: 2      min=2         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 102 MB 4.8 MB/s
    data_sent...............................................................: 827 kB 39 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 6945   330.690649/s
    checks_succeeded...................: 88.07% 6117 out of 6945
    checks_failed......................: 11.92% 828 out of 6945

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  64% — ✓ 1487 / ✗ 828
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=1s min=13.1ms  med=738.29ms max=4.06s p(90)=2.44s p(95)=2.62s
      { expected_response:true }............................................: avg=1s min=13.1ms  med=738.29ms max=4.06s p(90)=2.44s p(95)=2.62s
    http_req_failed.........................................................: 0.00%  0 out of 2315
    http_reqs...............................................................: 2315   110.230216/s

    EXECUTION
    iteration_duration......................................................: avg=1s min=13.74ms med=738.76ms max=4.06s p(90)=2.44s p(95)=2.62s
    iterations..............................................................: 2315   110.230216/s
    vus.....................................................................: 1      min=1         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 115 MB 5.5 MB/s
    data_sent...............................................................: 933 kB 44 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 6069   288.962572/s
    checks_succeeded...................: 80.98% 4915 out of 6069
    checks_failed......................: 19.01% 1154 out of 6069

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  42% — ✓ 869 / ✗ 1154
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=1.11s min=8.75ms med=1.04s max=2.73s p(90)=2.03s p(95)=2.2s 
      { expected_response:true }............................................: avg=1.11s min=8.75ms med=1.04s max=2.73s p(90)=2.03s p(95)=2.2s 
    http_req_failed.........................................................: 0.00%  0 out of 2023
    http_reqs...............................................................: 2023   96.320857/s

    EXECUTION
    iteration_duration......................................................: avg=1.11s min=9.27ms med=1.04s max=2.73s p(90)=2.03s p(95)=2.21s
    iterations..............................................................: 2023   96.320857/s
    vus.....................................................................: 1      min=1         max=200
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 100 MB 4.8 MB/s
    data_sent...............................................................: 815 kB 39 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 9066   431.563608/s
    checks_succeeded...................: 92.19% 8358 out of 9066
    checks_failed......................: 7.80%  708 out of 9066

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  76% — ✓ 2314 / ✗ 708
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=743.13ms min=12.78ms med=511.46ms max=2.47s p(90)=1.76s p(95)=1.88s
      { expected_response:true }............................................: avg=743.13ms min=12.78ms med=511.46ms max=2.47s p(90)=1.76s p(95)=1.88s
    http_req_failed.........................................................: 0.00%  0 out of 3022
    http_reqs...............................................................: 3022   143.854536/s

    EXECUTION
    iteration_duration......................................................: avg=744.32ms min=13.5ms  med=512.19ms max=2.48s p(90)=1.76s p(95)=1.88s
    iterations..............................................................: 3022   143.854536/s
    vus.....................................................................: 1      min=1         max=200
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 150 MB 7.1 MB/s
    data_sent...............................................................: 1.2 MB 58 kB/s
```
</details>

<details>
  <summary>After</summary>
  
```

  █ TOTAL RESULTS 

    checks_total.......................: 11961  568.652757/s
    checks_succeeded...................: 98.11% 11736 out of 11961
    checks_failed......................: 1.88%  225 out of 11961

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  94% — ✓ 3762 / ✗ 225
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=556.49ms min=10.71ms med=508.98ms max=2.05s p(90)=920.62ms p(95)=1.06s
      { expected_response:true }............................................: avg=556.49ms min=10.71ms med=508.98ms max=2.05s p(90)=920.62ms p(95)=1.06s
    http_req_failed.........................................................: 0.00%  0 out of 3987
    http_reqs...............................................................: 3987   189.550919/s

    EXECUTION
    iteration_duration......................................................: avg=557.31ms min=11.42ms med=509.55ms max=2.05s p(90)=921.95ms p(95)=1.07s
    iterations..............................................................: 3987   189.550919/s
    vus.....................................................................: 3      min=3         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 198 MB 9.4 MB/s
    data_sent...............................................................: 1.6 MB 76 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 8202   390.377132/s
    checks_succeeded...................: 86.29% 7078 out of 8202
    checks_failed......................: 13.70% 1124 out of 8202

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  58% — ✓ 1610 / ✗ 1124
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=810.09ms min=13.71ms med=798.96ms max=1.62s p(90)=1.41s p(95)=1.5s
      { expected_response:true }............................................: avg=810.09ms min=13.71ms med=798.96ms max=1.62s p(90)=1.41s p(95)=1.5s
    http_req_failed.........................................................: 0.00%  0 out of 2734
    http_reqs...............................................................: 2734   130.125711/s

    EXECUTION
    iteration_duration......................................................: avg=811.42ms min=14.3ms  med=799.91ms max=1.62s p(90)=1.41s p(95)=1.5s
    iterations..............................................................: 2734   130.125711/s
    vus.....................................................................: 1      min=1         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 136 MB 6.5 MB/s
    data_sent...............................................................: 1.1 MB 52 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 13137  624.986768/s
    checks_succeeded...................: 98.37% 12924 out of 13137
    checks_failed......................: 1.62%  213 out of 13137

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  95% — ✓ 4166 / ✗ 213
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=502.48ms min=11.06ms med=477.63ms max=1.36s p(90)=874.7ms p(95)=992.82ms
      { expected_response:true }............................................: avg=502.48ms min=11.06ms med=477.63ms max=1.36s p(90)=874.7ms p(95)=992.82ms
    http_req_failed.........................................................: 0.00%  0 out of 4379
    http_reqs...............................................................: 4379   208.328923/s

    EXECUTION
    iteration_duration......................................................: avg=503.25ms min=11.64ms med=478.59ms max=1.36s p(90)=875.4ms p(95)=993.62ms
    iterations..............................................................: 4379   208.328923/s
    vus.....................................................................: 1      min=1         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 217 MB 10 MB/s
    data_sent...............................................................: 1.8 MB 84 kB/s
```

```
  █ TOTAL RESULTS 

    checks_total.......................: 10569  503.11353/s
    checks_succeeded...................: 96.42% 10191 out of 10569
    checks_failed......................: 3.57%  378 out of 10569

    ✓ status is 200
    ✗ response time < 1000ms
      ↳  89% — ✓ 3145 / ✗ 378
    ✓ has data

    HTTP
    http_req_duration.......................................................: avg=625.04ms min=23.69ms med=627.21ms max=1.2s p(90)=1s p(95)=1.05s
      { expected_response:true }............................................: avg=625.04ms min=23.69ms med=627.21ms max=1.2s p(90)=1s p(95)=1.05s
    http_req_failed.........................................................: 0.00%  0 out of 3523
    http_reqs...............................................................: 3523   167.70451/s

    EXECUTION
    iteration_duration......................................................: avg=626.04ms min=24.5ms  med=628.75ms max=1.2s p(90)=1s p(95)=1.05s
    iterations..............................................................: 3523   167.70451/s
    vus.....................................................................: 1      min=1         max=199
    vus_max.................................................................: 200    min=200       max=200

    NETWORK
    data_received...........................................................: 175 MB 8.3 MB/s
    data_sent...............................................................: 1.4 MB 68 kB/s
```
</details>