### PR TITLE
fix(api-gateway): Handle array format for joins in /meta?extended endpoint

### DIFF
--- a/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
+++ b/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
@@ -79,6 +79,16 @@ function transformJoins(joins: any) {
     return undefined;
   }
 
+  // Handle joins as array (new format after PR #9800)
+  if (Array.isArray(joins)) {
+    return joins.map((join: any) => ({
+      ...join,
+      name: join.name,
+      sql: stringifyMemberSql(join.sql),
+    }));
+  }
+
+  // Fallback for object format (legacy)
   return Object.entries(joins)?.map(([joinName, join]: [joinName: string, join: any]) => ({
     ...join,
     name: joinName,

--- a/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
+++ b/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
@@ -79,21 +79,19 @@ function transformJoins(joins: any) {
     return undefined;
   }
 
+  const transformJoin = (join: any, name: string) => ({
+    ...join,
+    name,
+    sql: stringifyMemberSql(join.sql),
+  });
+
   // Handle joins as array (new format after PR #9800)
   if (Array.isArray(joins)) {
-    return joins.map((join: any) => ({
-      ...join,
-      name: join.name,
-      sql: stringifyMemberSql(join.sql),
-    }));
+    return joins.map((join: any) => transformJoin(join, join.name));
   }
 
   // Fallback for object format (legacy)
-  return Object.entries(joins)?.map(([joinName, join]: [joinName: string, join: any]) => ({
-    ...join,
-    name: joinName,
-    sql: stringifyMemberSql(join.sql),
-  }));
+  return Object.entries(joins)?.map(([joinName, join]: [joinName: string, join: any]) => transformJoin(join, joinName));
 }
 
 function transformPreAggregations(preAggregations: any) {

--- a/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
+++ b/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
@@ -219,6 +219,30 @@ describe('transformMetaExtended helpers', () => {
     expect(handledJoins?.length).toBe(2);
   });
 
+  test('transformJoins - array format', () => {
+    // Test new array format (after PR #9800)
+    const arrayJoins = [
+      {
+        name: 'PlaygroundUsers',
+        relationship: 'belongsTo',
+        sql: () => `{CUBE}.id = {PlaygroundUsers.anonymous}`,
+      },
+      {
+        name: 'IpEnrich',
+        relationship: 'belongsTo',
+        sql: () => `{CUBE.email} = {IpEnrich.email}`,
+      },
+    ];
+    
+    const handledJoins = transformJoins(arrayJoins);
+    expect(handledJoins).toBeDefined();
+    expect(handledJoins?.length).toBe(2);
+    expect(handledJoins?.[0].name).toBe('PlaygroundUsers');
+    expect(handledJoins?.[1].name).toBe('IpEnrich');
+    expect(handledJoins?.[0].sql).toBe('`{CUBE}.id = {PlaygroundUsers.anonymous}`');
+    expect(handledJoins?.[1].sql).toBe('`{CUBE.email} = {IpEnrich.email}`');
+  });
+
   test('transformPreAggregations', () => {
     expect(transformPreAggregations(undefined)).toBeUndefined();
     const handledPreAggregations = transformPreAggregations(MOCK_USERS_CUBE.preAggregations);


### PR DESCRIPTION
After PR #9800, joins are stored as arrays instead of objects in the schema compiler. The transformJoins function in the API gateway was still using Object.entries() which, when applied to arrays, returns numeric indices as keys instead of actual join names.

This fix:
- Checks if joins is an array and preserves the name property
- Maintains backward compatibility with object format
- Adds test coverage for both array and object formats

Fixes the issue where join names appear as "0", "1", "2" instead of their actual names in the /meta?extended endpoint response.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
