### PR TITLE
feat(snowflake-driver): Add queryTag connection parameter

### DIFF
--- a/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
+++ b/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
@@ -165,6 +165,7 @@ interface SnowflakeDriverOptions {
   identIgnoreCase?: boolean,
   application: string,
   readOnly?: boolean,
+  queryTag?: string,
 
   /**
    * The export bucket CSV file escape symbol.
@@ -439,6 +440,10 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
       role: this.config.role,
       resultPrefetch: this.config.resultPrefetch,
     };
+
+    if (this.config.queryTag) {
+      config.queryTag = this.config.queryTag;
+    }
 
     if (this.config.authenticator?.toUpperCase() === 'OAUTH') {
       config.token = this.config.oauthToken || await this.readOAuthToken();


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


Related to [9880](https://github.com/cube-js/cube/pull/9880) 

### Why this change is needed

 While users can pass any parameter in the initial config object to the `SnowflakeDriver` constructor, not all parameters are automatically forwarded to the underlying Snowflake connection. 
The `prepareConnectOptions()` method acts as a filter that explicitly maps only the supported configuration parameters to the final connection options passed to `snowflake.createConnection()`.

 Without this change, even if a user includes `queryTag` in their driver configuration, it would be silently ignored because `prepareConnectOptions()` doesn't include it in the connection options object.

### What this change does

  - Adds `queryTag?:` string to the SnowflakeDriverOptions interface for better type safety
  - Modifies `prepareConnectOptions()` to conditionally include `queryTag` in the connection configuration when provided
  - Enables users to set query tags for better query tracking and monitoring in Snowflake

### Usage

Users can now include queryTag in their Snowflake driver configuration:

```javascript
  const driver = new SnowflakeDriver({
    account: 'myaccount',
    username: 'myuser',
    password: 'mypass',
    queryTag: 'cube-analytics', // This will now be passed to Snowflake
    // ... other options
  });
```

 This allows better query attribution and monitoring in Snowflake's query history and performance monitoring tools.