### PR TITLE
fix(query-orchestrator): QueryCache - propagate error later for streams

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -498,11 +498,27 @@ export class QueryCache {
       if (client.stream) {
         tableData = await client.stream(q.query, q.values, q);
         const errors = [];
-        await pipeline(tableData.rowStream, writer, (err) => {
-          if (err) {
-            errors.push(err);
+
+        const iterator = tableData.rowStream[Symbol.asyncIterator]();
+        try {
+          let result = await iterator.next();
+          while (!result.done) {
+            try {
+              writer.write(result.value);
+            } catch (writeErr) {
+              errors.push(writeErr);
+            }
+            result = await iterator.next();
           }
-        });
+        } catch (streamErr) {
+          errors.push(streamErr);
+        }
+        try {
+          writer.end();
+        } catch (endErr) {
+          errors.push(endErr);
+        }
+
         if (errors.length > 0) {
           throw new Error(`Lambda query errors ${errors.join(', ')}`);
         }


### PR DESCRIPTION
If the source (rowStream) emits an error or closes before all data is read, pipeline will reject.

This manually consumes the async iterator from the stream, catching errors at each step. If the stream ends early or throws, you catch the error and can handle it gracefully. This avoids some of the internal state issues that can occur with pipeline when the source stream is an async generator that may throw.

#9566
