### PR TITLE
perf(schema-compiler): Reduce JS compilation memory usage 3x-5x times.

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -712,7 +712,7 @@ export class DataSchemaCompiler {
 
       // We use AsyncLocalStorage to store the current file context
       // so that it can be accessed in the script execution context even within async functions.
-      // @see https://nodejs.org/api/async_context.html
+      // @see https://nodejs.org/api/async_context.html#class-asynclocalstorage
       ctxFileStorage.run(file, () => {
         script.runInContext(this.compileV8ContextCache!, { timeout: 15000 });
       });

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -238,7 +238,7 @@ export class DataSchemaCompiler {
       let cubeNames: string[] = [];
       let cubeSymbols: Record<string, Record<string, boolean>> = {};
       let transpilerNames: string[] = [];
-      let results;
+      let results: (FileContent | undefined)[];
 
       if (transpilationNative || transpilationWorkerThreads) {
         cubeNames = Object.keys(this.cubeDictionary.byId);
@@ -301,7 +301,7 @@ export class DataSchemaCompiler {
         results = await Promise.all(toCompile.map(f => this.transpileFile(f, errorsReport, {})));
       }
 
-      return results.filter(f => !!f);
+      return results.filter(f => !!f) as FileContent[];
     };
 
     let cubes: CubeDefinition[] = [];

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -391,18 +391,15 @@ export class DataSchemaCompiler {
     });
 
     const compilePhase = async (compilers: CompileCubeFilesCompilers, stage: 0 | 1 | 2 | 3) => {
-      transpiledFiles = await transpile(stage);
-      const res = this.compileCubeFiles(cubes, contexts, compiledFiles, asyncModules, compilers, transpiledFiles, errorsReport);
-
       // clear the objects for the next phase
       cubes = [];
       exports = {};
       contexts = [];
       compiledFiles = {};
       asyncModules = [];
-      transpiledFiles = [];
+      transpiledFiles = await transpile(stage);
 
-      return res;
+      return this.compileCubeFiles(cubes, contexts, compiledFiles, asyncModules, compilers, transpiledFiles, errorsReport);
     };
 
     return compilePhase({ cubeCompilers: this.cubeNameCompilers }, 0)
@@ -415,6 +412,14 @@ export class DataSchemaCompiler {
         contextCompilers: this.contextCompilers,
       }, 3))
       .then(() => {
+        // Free unneeded resources
+        cubes = [];
+        exports = {};
+        contexts = [];
+        compiledFiles = {};
+        asyncModules = [];
+        transpiledFiles = [];
+
         if (transpilationNative) {
           // Clean up cache
           const dummyFile = {

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -688,18 +688,7 @@ export class DataSchemaCompiler {
       return this.compiledScriptCache.get(cacheKey)!;
     }
 
-    // As we run all data model files in the same context,
-    // we need to wrap the code in an IIFE to avoid errors like:
-    // Identifier 'xxx' has already been declared,
-    // avoid polluting and modifying the global scope,
-    // and to provide a controlled environment for the code execution.
-    const wrappedCode = `
-      (function() {
-        ${file.content}
-      })();
-    `;
-
-    const script = new vm.Script(wrappedCode, { filename: file.fileName });
+    const script = new vm.Script(file.content, { filename: file.fileName });
     this.compiledScriptCache.set(cacheKey, script);
     return script;
   }

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -353,7 +353,14 @@ export class DataSchemaCompiler {
         exports[file.fileName] = obj;
       },
       asyncModule: (fn) => {
-        asyncModules.push(fn);
+        const file = ctxFileStorage.getStore();
+        if (!file) {
+          throw new Error('No file stored in context');
+        }
+        // We need to run async module code in the context of the original data model file
+        // where it was defined. So we pass the same file to the async context.
+        // @see https://nodejs.org/api/async_context.html#class-asynclocalstorage
+        asyncModules.push(async () => ctxFileStorage.run(file, () => fn()));
       },
       require: (extensionName: string) => {
         const file = ctxFileStorage.getStore();

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -649,11 +649,9 @@ export class DataSchemaCompiler {
     // avoid polluting and modifying the global scope,
     // and to provide a controlled environment for the code execution.
     const wrappedCode = `
-      (function(globals) {
-        "use strict";
-        const { view, cube, context, addExport, setExport, asyncModule, require, COMPILE_CONTEXT } = globals;
+      (function() {
         ${file.content}
-      })(sandboxLocals);
+      })();
     `;
 
     const script = new vm.Script(wrappedCode, { filename: file.fileName });

--- a/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
@@ -9,6 +9,7 @@ import { DataSchemaCompiler } from './DataSchemaCompiler';
 import {
   CubeCheckDuplicatePropTranspiler,
   CubePropContextTranspiler,
+  IIFETranspiler,
   ImportExportTranspiler,
   TranspilerInterface,
   ValidationTranspiler,
@@ -63,6 +64,7 @@ export const prepareCompiler = (repo: SchemaFileRepository, options: PrepareComp
     new ValidationTranspiler(),
     new ImportExportTranspiler(),
     new CubePropContextTranspiler(cubeSymbols, cubeDictionary, viewCompiler),
+    new IIFETranspiler(),
   ];
 
   if (!options.allowJsDuplicatePropsInSchema) {

--- a/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
@@ -61,10 +61,10 @@ export const prepareCompiler = (repo: SchemaFileRepository, options: PrepareComp
   const compiledScriptCache = options.compiledScriptCache || new LRUCache<string, vm.Script>({ max: 250 });
 
   const transpilers: TranspilerInterface[] = [
-    new IIFETranspiler(),
     new ValidationTranspiler(),
     new ImportExportTranspiler(),
     new CubePropContextTranspiler(cubeSymbols, cubeDictionary, viewCompiler),
+    new IIFETranspiler(),
   ];
 
   if (!options.allowJsDuplicatePropsInSchema) {

--- a/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/PrepareCompiler.ts
@@ -61,10 +61,10 @@ export const prepareCompiler = (repo: SchemaFileRepository, options: PrepareComp
   const compiledScriptCache = options.compiledScriptCache || new LRUCache<string, vm.Script>({ max: 250 });
 
   const transpilers: TranspilerInterface[] = [
+    new IIFETranspiler(),
     new ValidationTranspiler(),
     new ImportExportTranspiler(),
     new CubePropContextTranspiler(cubeSymbols, cubeDictionary, viewCompiler),
-    new IIFETranspiler(),
   ];
 
   if (!options.allowJsDuplicatePropsInSchema) {

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -10,7 +10,7 @@ import type { FileContent } from '@cubejs-backend/shared';
 import { getEnv } from '@cubejs-backend/shared';
 import { CubePropContextTranspiler, transpiledFields, transpiledFieldsPatterns } from './transpilers';
 import { PythonParser } from '../parser/PythonParser';
-import { CubeDefinition, CubeSymbols } from './CubeSymbols';
+import { CubeSymbols } from './CubeSymbols';
 import { DataSchemaCompiler } from './DataSchemaCompiler';
 import { nonStringFields } from './CubeValidator';
 import { CubeDictionary } from './CubeDictionary';

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -10,7 +10,7 @@ import type { FileContent } from '@cubejs-backend/shared';
 import { getEnv } from '@cubejs-backend/shared';
 import { CubePropContextTranspiler, transpiledFields, transpiledFieldsPatterns } from './transpilers';
 import { PythonParser } from '../parser/PythonParser';
-import { CubeSymbols } from './CubeSymbols';
+import { CubeDefinition, CubeSymbols } from './CubeSymbols';
 import { DataSchemaCompiler } from './DataSchemaCompiler';
 import { nonStringFields } from './CubeValidator';
 import { CubeDictionary } from './CubeDictionary';
@@ -66,12 +66,12 @@ export class YamlCompiler {
   public async compileYamlWithJinjaFile(
     file: FileContent,
     errorsReport: ErrorReporter,
-    cubes,
-    contexts,
-    exports,
-    asyncModules,
-    toCompile,
-    compiledFiles,
+    cubes: CubeDefinition[],
+    contexts: Record<string, any>[],
+    exports: Record<string, Record<string, any>>,
+    asyncModules: CallableFunction[],
+    toCompile: FileContent[],
+    compiledFiles: Record<string, boolean>,
     compileContext,
     pythonContext: PythonCtx
   ) {
@@ -89,7 +89,16 @@ export class YamlCompiler {
     );
   }
 
-  public compileYamlFile(file: FileContent, errorsReport: ErrorReporter, cubes, contexts, exports, asyncModules, toCompile, compiledFiles) {
+  public compileYamlFile(
+    file: FileContent,
+    errorsReport: ErrorReporter,
+    cubes: CubeDefinition[],
+    contexts: Record<string, any>[],
+    exports: Record<string, Record<string, any>>,
+    asyncModules: CallableFunction[],
+    toCompile: FileContent[],
+    compiledFiles: Record<string, boolean>
+  ) {
     if (!file.content.trim()) {
       return;
     }

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -66,38 +66,17 @@ export class YamlCompiler {
   public async compileYamlWithJinjaFile(
     file: FileContent,
     errorsReport: ErrorReporter,
-    cubes: CubeDefinition[],
-    contexts: Record<string, any>[],
-    exports: Record<string, Record<string, any>>,
-    asyncModules: CallableFunction[],
-    toCompile: FileContent[],
-    compiledFiles: Record<string, boolean>,
     compileContext,
     pythonContext: PythonCtx
   ) {
     const compiledFile = await this.renderTemplate(file, compileContext, pythonContext);
 
-    return this.compileYamlFile(
-      compiledFile,
-      errorsReport,
-      cubes,
-      contexts,
-      exports,
-      asyncModules,
-      toCompile,
-      compiledFiles
-    );
+    return this.compileYamlFile(compiledFile, errorsReport);
   }
 
   public compileYamlFile(
     file: FileContent,
     errorsReport: ErrorReporter,
-    cubes: CubeDefinition[],
-    contexts: Record<string, any>[],
-    exports: Record<string, Record<string, any>>,
-    asyncModules: CallableFunction[],
-    toCompile: FileContent[],
-    compiledFiles: Record<string, boolean>
   ) {
     if (!file.content.trim()) {
       return;
@@ -112,12 +91,12 @@ export class YamlCompiler {
       if (key === 'cubes') {
         (yamlObj.cubes || []).forEach(({ name, ...cube }) => {
           const transpiledFile = this.transpileAndPrepareJsFile(file, 'cube', { name, ...cube }, errorsReport);
-          this.dataSchemaCompiler?.compileJsFile(transpiledFile, errorsReport, cubes, contexts, exports, asyncModules, toCompile, compiledFiles);
+          this.dataSchemaCompiler?.compileJsFile(transpiledFile, errorsReport);
         });
       } else if (key === 'views') {
         (yamlObj.views || []).forEach(({ name, ...cube }) => {
           const transpiledFile = this.transpileAndPrepareJsFile(file, 'view', { name, ...cube }, errorsReport);
-          this.dataSchemaCompiler?.compileJsFile(transpiledFile, errorsReport, cubes, contexts, exports, asyncModules, toCompile, compiledFiles);
+          this.dataSchemaCompiler?.compileJsFile(transpiledFile, errorsReport);
         });
       } else {
         errorsReport.error(`Unexpected YAML key: ${key}. Only 'cubes' and 'views' are allowed here.`);

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/IIFETranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/IIFETranspiler.ts
@@ -1,0 +1,36 @@
+import * as t from '@babel/types';
+import type { NodePath } from '@babel/traverse';
+import type { TranspilerInterface, TraverseObject } from './transpiler.interface';
+import type { ErrorReporter } from '../ErrorReporter';
+
+/**
+ * IIFETranspiler wraps the entire file content in an Immediately Invoked Function Expression (IIFE).
+ * This prevents:
+ * - Variable redeclaration errors when multiple files define the same variables
+ * - Global scope pollution between data model files
+ * - Provides isolated execution context for each file
+ */
+export class IIFETranspiler implements TranspilerInterface {
+  public traverseObject(_reporter: ErrorReporter): TraverseObject {
+    return {
+      Program: (path: NodePath<t.Program>) => {
+        const { body } = path.node;
+
+        if (body.length > 0) {
+          // Create an IIFE that wraps all the existing statements
+          const iife = t.callExpression(
+            t.functionExpression(
+              null, // anonymous function
+              [],
+              t.blockStatement(body)
+            ),
+            []
+          );
+
+          // Replace the program body with the IIFE
+          path.node.body = [t.expressionStatement(iife)];
+        }
+      }
+    };
+  }
+}

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/ImportExportTranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/ImportExportTranspiler.ts
@@ -69,9 +69,9 @@ export class ImportExportTranspiler implements TranspilerInterface {
 
             path.replaceWithMultiple([
               decl.node,
-              t.callExpression(t.identifier('addExport'), [
+              t.expressionStatement(t.callExpression(t.identifier('addExport'), [
                 t.objectExpression([t.objectProperty(name, name)])
-              ])
+              ]))
             ]);
             return;
           }
@@ -80,12 +80,12 @@ export class ImportExportTranspiler implements TranspilerInterface {
           if (t.isVariableDeclaration(decl.node)) {
             path.replaceWithMultiple([
               decl.node,
-              t.callExpression(t.identifier('addExport'), [
+              t.expressionStatement(t.callExpression(t.identifier('addExport'), [
                 t.objectExpression(
                   // @ts-ignore
                   decl.get('declarations').map(d => t.objectProperty(d.get('id').node, d.get('id').node))
                 )
-              ])
+              ]))
             ]);
             return;
           }
@@ -97,12 +97,12 @@ export class ImportExportTranspiler implements TranspilerInterface {
           return;
         }
 
-        const addExportCall = t.callExpression(t.identifier('addExport'), [t.objectExpression(<t.ObjectProperty[]>declarations)]);
+        const addExportCall = t.expressionStatement(t.callExpression(t.identifier('addExport'), [t.objectExpression(<t.ObjectProperty[]>declarations)]));
         path.replaceWith(addExportCall);
       },
       ExportDefaultDeclaration(path) {
         // @ts-ignore
-        path.replaceWith(t.callExpression(t.identifier('setExport'), [path.get('declaration').node]));
+        path.replaceWith(t.expressionStatement(t.callExpression(t.identifier('setExport'), [path.get('declaration').node])));
       }
     };
   }

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/index.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/index.ts
@@ -2,4 +2,5 @@ export * from './ImportExportTranspiler';
 export * from './CubePropContextTranspiler';
 export * from './CubeCheckDuplicatePropTranspiler';
 export * from './ValidationTranspiler';
+export * from './IIFETranspiler';
 export * from './transpiler.interface';

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/transpiler_worker.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/transpiler_worker.ts
@@ -10,6 +10,7 @@ import { CubePropContextTranspiler } from './CubePropContextTranspiler';
 import { ErrorReporter } from '../ErrorReporter';
 import { LightweightSymbolResolver } from './LightweightSymbolResolver';
 import { LightweightNodeCubeDictionary } from './LightweightNodeCubeDictionary';
+import { IIFETranspiler } from './IIFETranspiler';
 
 type TransferContent = {
   fileName: string;
@@ -28,6 +29,7 @@ const transpilers = {
   ImportExportTranspiler: new ImportExportTranspiler(),
   CubeCheckDuplicatePropTranspiler: new CubeCheckDuplicatePropTranspiler(),
   CubePropContextTranspiler: new CubePropContextTranspiler(cubeSymbols, cubeDictionary, cubeSymbols),
+  IIFETranspiler: new IIFETranspiler(),
 };
 
 const transpile = (data: TransferContent) => {

--- a/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
@@ -77,7 +77,7 @@ describe('Transpilers', () => {
     expect(content).toEqual(`const helperFunction = () => 'hello';
 addExport({
   helperFunction: helperFunction
-})
+});
 addExport({
   alias: helperFunction
 });
@@ -87,11 +87,11 @@ function requireFilterParam() {
 }
 addExport({
   requireFilterParam: requireFilterParam
-})
+});
 const someVar = 42;
 addExport({
   someVar: someVar
-})`);
+});`);
 
     errorsReport.throwIfAny(); // should not throw
   });


### PR DESCRIPTION
This PR brings more memory improvements into the model compilation flow.

Compare the memory usage for 1-time pass of compiling 300 js model files:
```sh
Before:
Memory footprint { rss: '431 MB', heapUsed: '289 MB', heapTotal: '320 MB' }

After this change:
Memory footprint { rss: '254 MB', heapUsed: '120 MB', heapTotal: '154 MB' }
```

And for a 30-times pass of compilation:
```sh
Before:
Memory footprint { rss: '2389 MB', heapUsed: '1937 MB', heapTotal: '2004 MB' }

After this change:
Memory footprint { rss: '895 MB', heapUsed: '523 MB', heapTotal: '565 MB' }
```

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
