### PR TITLE
chore(ci): Disable Vertica tests until vertica docker image will be available

### DIFF
--- a/.github/actions/smoke.sh
+++ b/.github/actions/smoke.sh
@@ -57,9 +57,12 @@ echo "::group::MongoBI"
 yarn lerna run --concurrency 1 --stream --no-prefix smoke:mongobi
 echo "::endgroup::"
 
-echo "::group::Vertica"
-yarn lerna run --concurrency 1 --stream --no-prefix smoke:vertica
-echo "::endgroup::"
+# Vertica tests are disabled because around 20.08.2025 someone
+# totally removed all vertica-ce docker repository from dockerhub.
+# @see https://github.com/vertica/vertica-containers/issues/64
+#echo "::group::Vertica"
+#yarn lerna run --concurrency 1 --stream --no-prefix smoke:vertica
+#echo "::endgroup::"
 
 echo "::group::RBAC"
 yarn lerna run --concurrency 1 --stream --no-prefix smoke:rbac

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -397,10 +397,14 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
+        # Vertica tests are disabled because around 20.08.2025 someone
+        # totally removed all vertica-ce docker repository from dockerhub.
+        # @see https://github.com/vertica/vertica-containers/issues/64
         db: [
             'athena', 'bigquery', 'snowflake', 'trino',
             'clickhouse', 'druid', 'elasticsearch', 'mssql', 'mysql', 'postgres', 'prestodb',
-            'mysql-aurora-serverless', 'crate', 'mongobi', 'firebolt', 'dremio', 'vertica'
+            'mysql-aurora-serverless', 'crate', 'mongobi', 'firebolt', 'dremio'
+#            'vertica'
         ]
         use_tesseract_sql_planner: [ false ]
         include:


### PR DESCRIPTION
Have to disable Vertica tests as vertica-ce docker images are not available.

see https://github.com/vertica/vertica-containers/issues/64