### PR TITLE
chore(cubesql): Disable parquet compression (not used, speedup build)

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -60,21 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,27 +385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,8 +440,6 @@ version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -641,15 +603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +667,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "chrono",
@@ -884,7 +837,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -917,7 +870,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -928,7 +881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "async-trait",
  "chrono",
@@ -941,7 +894,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -952,7 +905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -1118,16 +1071,6 @@ checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1778,15 +1721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,26 +1867,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lz4"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2254,18 +2168,13 @@ source = "git+https://github.com/cube-js/arrow-rs.git?rev=a03d4eef5640e05dddf99f
 dependencies = [
  "arrow",
  "base64 0.13.1",
- "brotli",
  "byteorder",
  "chrono",
- "flate2",
- "lz4",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
- "snap",
  "thrift",
- "zstd",
 ]
 
 [[package]]
@@ -2427,12 +2336,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "postgres"
@@ -3190,12 +3093,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -4368,33 +4265,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/rust/cubenativeutils/Cargo.lock
+++ b/rust/cubenativeutils/Cargo.lock
@@ -50,21 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,27 +316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,8 +371,6 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -556,15 +518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "chrono",
@@ -737,7 +690,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -770,7 +723,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -781,7 +734,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "async-trait",
  "chrono",
@@ -794,7 +747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -805,7 +758,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -943,16 +896,6 @@ dependencies = [
  "bitflags 1.3.2",
  "smallvec",
  "thiserror 1.0.61",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1568,15 +1511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,26 +1646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lz4"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6eab492fe7f8651add23237ea56dbf11b3c4ff762ab83d40a47f11433421f91"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2002,18 +1916,13 @@ source = "git+https://github.com/cube-js/arrow-rs.git?rev=a03d4eef5640e05dddf99f
 dependencies = [
  "arrow",
  "base64 0.13.1",
- "brotli",
  "byteorder",
  "chrono",
- "flate2",
- "lz4",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
- "snap",
  "thrift",
- "zstd",
 ]
 
 [[package]]
@@ -2175,12 +2084,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "postgres-protocol"
@@ -2799,12 +2702,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -3851,33 +3748,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.95",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -50,21 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,27 +299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,8 +350,6 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -588,15 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +697,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "chrono",
@@ -868,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -901,7 +854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -912,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "async-trait",
  "chrono",
@@ -925,7 +878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -936,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -1083,18 +1036,6 @@ dependencies = [
  "bitflags 1.3.2",
  "smallvec",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if",
- "crc32fast",
- "libc",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1749,15 +1690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,26 +1830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lz4"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edcb94251b1c375c459e5abe9fb0168c1c826c3370172684844f8f3f8d1a885"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2189,18 +2101,13 @@ source = "git+https://github.com/cube-js/arrow-rs.git?rev=a03d4eef5640e05dddf99f
 dependencies = [
  "arrow",
  "base64 0.13.0",
- "brotli",
  "byteorder",
  "chrono",
- "flate2",
- "lz4",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
- "snap",
  "thrift",
- "zstd",
 ]
 
 [[package]]
@@ -3015,12 +2922,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snap"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
@@ -4178,33 +4079,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "4f8f7de0617b0580beb5d4140b5f9ce58ef18efc", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e3bb7fe5b16461893234db44950f539c58081bfe", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesqlplanner/Cargo.lock
+++ b/rust/cubesqlplanner/Cargo.lock
@@ -60,21 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,27 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,8 +381,6 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -575,15 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,7 +617,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "chrono",
@@ -777,7 +730,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -810,7 +763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -821,7 +774,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "async-trait",
  "chrono",
@@ -834,7 +787,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -845,7 +798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=4f8f7de0617b0580beb5d4140b5f9ce58ef18efc#4f8f7de0617b0580beb5d4140b5f9ce58ef18efc"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -983,16 +936,6 @@ dependencies = [
  "bitflags 1.3.2",
  "smallvec",
  "thiserror 1.0.61",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1608,15 +1551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,26 +1686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "lz4"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6eab492fe7f8651add23237ea56dbf11b3c4ff762ab83d40a47f11433421f91"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2055,18 +1969,13 @@ source = "git+https://github.com/cube-js/arrow-rs.git?rev=a03d4eef5640e05dddf99f
 dependencies = [
  "arrow",
  "base64 0.13.1",
- "brotli",
  "byteorder",
  "chrono",
- "flate2",
- "lz4",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
- "snap",
  "thrift",
- "zstd",
 ]
 
 [[package]]
@@ -2228,12 +2137,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "postgres-protocol"
@@ -2852,12 +2755,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -3904,33 +3801,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
-dependencies = [
- "cc",
- "pkg-config",
 ]


### PR DESCRIPTION
Compiling brotli, zstd, etc. compression libraries takes a lot of time. We don't use parquet files at all in SQL API, so let's disable them for now to speed up release builds.

It saves ~10 seconds on my M3 Max machine in release builds; it should save ~1 minute on a 4-CPU machine used on CI.

More importantly, it reduces the size of the cache.