### PR TITLE
feat(cubesql): Automatically cast literal strings in binary expressions

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -3610,6 +3610,9 @@ impl FilterRules {
                     let year = match year {
                         ScalarValue::Int64(Some(year)) => year,
                         ScalarValue::Int32(Some(year)) => year as i64,
+                        ScalarValue::Float64(Some(year)) if (1000.0..=9999.0).contains(&year) => {
+                            year.round() as i64
+                        }
                         ScalarValue::Utf8(Some(ref year_str)) if year_str.len() == 4 => {
                             if let Ok(year) = year_str.parse::<i64>() {
                                 year

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -52,7 +52,7 @@ GROUP BY
                 V1LoadRequestQueryFilterItem {
                     member: Some("MultiTypeCube.dim_date0".to_string()),
                     operator: Some("afterDate".to_string()),
-                    values: Some(vec!["2019-01-01 00:00:00".to_string()]),
+                    values: Some(vec!["2019-01-01T00:00:00.000Z".to_string()]),
                     or: None,
                     and: None,
                 },


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

In PostgreSQL, string literals are initially assumed to be of type `unknown`. This allows them to be evaluated to a type they must be automatically casted to. For instance, there's no operator `boolean = text` in PostgreSQL, so expression `bool_column = text_column` or `bool_column = 'FALSE'::text` will always fail. However, an expression `bool_column = 'FALSE'` will automatically cast the literal `FALSE` of `unknown` type to type `boolean`, ending up with `boolean = boolean` operator.

This PR implements the behavior mentioned above, casting and evaluating constant strings in boolean expressions based on the type on the other side of the expression and the operator involved.

Related test is included; other tests are adjusted accordingly.
