### PR TITLE
Make TimeDimension fields nullable

### DIFF
--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -96,31 +96,31 @@ const OrderBy = enumType({
 export const TimeDimension = objectType({
   name: 'TimeDimension',
   definition(t) {
-    t.nonNull.field('value', {
+    t.field('value', {
       type: 'DateTime',
     });
-    t.nonNull.field('second', {
+    t.field('second', {
       type: 'DateTime',
     });
-    t.nonNull.field('minute', {
+    t.field('minute', {
       type: 'DateTime',
     });
-    t.nonNull.field('hour', {
+    t.field('hour', {
       type: 'DateTime',
     });
-    t.nonNull.field('day', {
+    t.field('day', {
       type: 'DateTime',
     });
-    t.nonNull.field('week', {
+    t.field('week', {
       type: 'DateTime',
     });
-    t.nonNull.field('month', {
+    t.field('month', {
       type: 'DateTime',
     });
-    t.nonNull.field('quarter', {
+    t.field('quarter', {
       type: 'DateTime'
     });
-    t.nonNull.field('year', {
+    t.field('year', {
       type: 'DateTime',
     });
   },


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes https://github.com/cube-js/cube/issues/6972

**Description of Changes Made (if issue reference is not provided)**

When querying a null `TimeDimension` through GraphQL, Cube returns a `Cannot return null value for non-nullable field`. When querying through the playground, fetching the `value` of a TimeDimension can return a `null` value if the underlying date column is `null`. The GraphQL tab of the playground also outputs a query that will crash if ran against the GraphQL API that looks like this :
```graphql
query CubeQuery {
  cube {
    my_cube {
      id
      my_date {
        value // <---- will crash with the linked error
      }
    }
  }
}
```

I'm not sure if there are underlying implications of doing this, let me know if it does not makes sense.