### PR TITLE
fix(cubesql): Pass window expressions in SQL push down

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -884,7 +884,7 @@ impl CubeScanWrapperNode {
                     vec![],
                     vec![],
                     vec![],
-                    // TODO
+                    vec![],
                     from_alias.clone().unwrap_or("".to_string()),
                     None,
                     None,
@@ -3579,7 +3579,7 @@ impl WrappedSelectNode {
             aggregate,
             patch_measures,
             filter,
-            window: _,
+            window,
             order,
         } = columns;
 
@@ -3597,7 +3597,7 @@ impl WrappedSelectNode {
                 group_by.into_iter().map(|(m, _)| m).collect(),
                 group_descs,
                 aggregate.into_iter().map(|(m, _)| m).collect(),
-                // TODO
+                window.into_iter().map(|(m, _)| m).collect(),
                 from_alias.unwrap_or("".to_string()),
                 if !filter.is_empty() {
                     Some(filter.iter().map(|(f, _)| f.expr.to_string()).join(" AND "))

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -402,6 +402,7 @@ impl SqlTemplates {
         group_by: Vec<AliasedColumn>,
         group_descs: Vec<Option<GroupingSetDesc>>,
         aggregate: Vec<AliasedColumn>,
+        window: Vec<AliasedColumn>,
         alias: String,
         filter: Option<String>,
         _having: Option<String>,
@@ -412,11 +413,13 @@ impl SqlTemplates {
     ) -> Result<String, CubeError> {
         let group_by = self.to_template_columns(group_by)?;
         let aggregate = self.to_template_columns(aggregate)?;
+        let window = self.to_template_columns(window)?;
         let projection = self.to_template_columns(projection)?;
         let order_by = self.to_template_columns(order_by)?;
         let select_concat = group_by
             .iter()
             .chain(aggregate.iter())
+            .chain(window.iter())
             .chain(projection.iter())
             .cloned()
             .collect::<Vec<_>>();
@@ -437,6 +440,7 @@ impl SqlTemplates {
                 select_concat => select_concat,
                 group_by => group_by_expr,
                 aggregate => aggregate,
+                window => window,
                 projection => projection,
                 order_by => order_by,
                 filter => filter,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with SQL push down where window expressions weren't passed to the SELECT.
