### PR TITLE
feat(cubesql): Print value of the date/time that couldn't be parsed

### DIFF
--- a/rust/cubesql/cubesql/src/compile/date_parser.rs
+++ b/rust/cubesql/cubesql/src/compile/date_parser.rs
@@ -13,6 +13,9 @@ pub fn parse_date_str(s: &str) -> Result<NaiveDateTime, DataFusionError> {
         });
 
     parsed.map_err(|e| {
-        DataFusionError::Internal(format!("Can't parse date/time string literal: {}", e))
+        DataFusionError::Internal(format!(
+            "Can't parse date/time string literal {:?}: {}",
+            s, e
+        ))
     })
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR updates the `parse_date_str` shared function, adding the value that couldn't be parsed to the error message. This will aid in debugging date/time values that could not be parsed.
