### PR TITLE
fix(client-core): Fix time series generation

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.ts
+++ b/packages/cubejs-client-core/src/ResultSet.ts
@@ -549,7 +549,8 @@ export default class ResultSet<T extends Record<string, any> = any> {
         const series = this.loadResponses.map(
           (loadResponse) => this.timeSeries(
             loadResponse.query.timeDimensions![0],
-            resultIndex, loadResponse.annotation.timeDimensions
+            resultIndex,
+            loadResponse.annotation.timeDimensions
           )
         );
 

--- a/packages/cubejs-client-core/src/time.ts
+++ b/packages/cubejs-client-core/src/time.ts
@@ -86,7 +86,7 @@ export const dayRange = (from: any, to: any): DayRange => ({
     let start = internalDayjs(from);
     const end = internalDayjs(to);
 
-    while (start.isBefore(end) || start.isSame(end)) {
+    while (start.startOf(value).isBefore(end) || start.isSame(end)) {
       results.push(start);
       start = start.add(1, value);
     }

--- a/packages/cubejs-client-core/test/granularity.test.ts
+++ b/packages/cubejs-client-core/test/granularity.test.ts
@@ -219,5 +219,285 @@ describe('ResultSet Granularity', () => {
         },
       ]);
     });
+
+    test('hour granularity (end minutes > start minutes)', () => {
+      const result = new ResultSet({
+        queryType: 'regularQuery',
+        results: [
+          {
+            query: {
+              measures: ['LineItems.count'],
+              timeDimensions: [
+                {
+                  dimension: 'LineItems.createdAt',
+                  granularity: 'hour',
+                  dateRange: ['2019-01-08T01:45:25.342', '2019-01-08T07:45:58.399'],
+                },
+              ],
+              filters: [],
+              timezone: 'UTC',
+              order: [],
+              dimensions: [],
+            },
+            data: [
+              {
+                'LineItems.createdAt.hour': '2019-01-08T01:00:00.000',
+                'LineItems.createdAt': '2019-01-08T01:00:00.000',
+                'LineItems.count': '2',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T02:00:00.000',
+                'LineItems.createdAt': '2019-01-08T02:00:00.000',
+                'LineItems.count': '3',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T03:00:00.000',
+                'LineItems.createdAt': '2019-01-08T03:00:00.000',
+                'LineItems.count': '4',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T04:00:00.000',
+                'LineItems.createdAt': '2019-01-08T04:00:00.000',
+                'LineItems.count': '5',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T05:00:00.000',
+                'LineItems.createdAt': '2019-01-08T05:00:00.000',
+                'LineItems.count': '6',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T06:00:00.000',
+                'LineItems.createdAt': '2019-01-08T06:00:00.000',
+                'LineItems.count': '7',
+              },
+            ],
+            lastRefreshTime: '2021-07-07T14:31:30.458Z',
+            annotation: {
+              measures: {
+                'LineItems.count': {
+                  title: 'Line Items Count',
+                  shortTitle: 'Count',
+                  type: 'number',
+                  drillMembers: ['LineItems.id', 'LineItems.createdAt'],
+                  drillMembersGrouped: {
+                    measures: [],
+                    dimensions: ['LineItems.id', 'LineItems.createdAt'],
+                  },
+                },
+              },
+              dimensions: {},
+              segments: {},
+              timeDimensions: {
+                'LineItems.createdAt.week': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+                'LineItems.createdAt': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+              },
+            },
+            slowQuery: false,
+          },
+        ],
+        pivotQuery: {
+          measures: ['LineItems.count'],
+          timeDimensions: [
+            {
+              dimension: 'LineItems.createdAt',
+              granularity: 'hour',
+              dateRange: ['2019-01-08T01:45:25.342', '2019-01-08T07:45:58.399'],
+            },
+          ],
+          filters: [],
+          timezone: 'UTC',
+          order: [],
+          dimensions: [],
+          queryType: 'regularQuery',
+        },
+        slowQuery: false,
+      } as any);
+
+      expect(result.chartPivot()).toStrictEqual([
+        {
+          x: '2019-01-08T01:00:00.000',
+          xValues: ['2019-01-08T01:00:00.000'],
+          'LineItems.count': 2,
+        },
+        {
+          x: '2019-01-08T02:00:00.000',
+          xValues: ['2019-01-08T02:00:00.000'],
+          'LineItems.count': 3,
+        },
+        {
+          x: '2019-01-08T03:00:00.000',
+          xValues: ['2019-01-08T03:00:00.000'],
+          'LineItems.count': 4,
+        },
+        {
+          x: '2019-01-08T04:00:00.000',
+          xValues: ['2019-01-08T04:00:00.000'],
+          'LineItems.count': 5,
+        },
+        {
+          x: '2019-01-08T05:00:00.000',
+          xValues: ['2019-01-08T05:00:00.000'],
+          'LineItems.count': 6,
+        },
+        {
+          x: '2019-01-08T06:00:00.000',
+          xValues: ['2019-01-08T06:00:00.000'],
+          'LineItems.count': 7,
+        },
+        {
+          x: '2019-01-08T07:00:00.000',
+          xValues: ['2019-01-08T07:00:00.000'],
+          'LineItems.count': 0,
+        },
+      ]);
+    });
+
+    test('hour granularity (end minutes < start minutes)', () => {
+      const result = new ResultSet({
+        queryType: 'regularQuery',
+        results: [
+          {
+            query: {
+              measures: ['LineItems.count'],
+              timeDimensions: [
+                {
+                  dimension: 'LineItems.createdAt',
+                  granularity: 'hour',
+                  dateRange: ['2019-01-08T01:45:25.342', '2019-01-08T07:35:58.399'],
+                },
+              ],
+              filters: [],
+              timezone: 'UTC',
+              order: [],
+              dimensions: [],
+            },
+            data: [
+              {
+                'LineItems.createdAt.hour': '2019-01-08T01:00:00.000',
+                'LineItems.createdAt': '2019-01-08T01:00:00.000',
+                'LineItems.count': '2',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T02:00:00.000',
+                'LineItems.createdAt': '2019-01-08T02:00:00.000',
+                'LineItems.count': '3',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T03:00:00.000',
+                'LineItems.createdAt': '2019-01-08T03:00:00.000',
+                'LineItems.count': '4',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T04:00:00.000',
+                'LineItems.createdAt': '2019-01-08T04:00:00.000',
+                'LineItems.count': '5',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T05:00:00.000',
+                'LineItems.createdAt': '2019-01-08T05:00:00.000',
+                'LineItems.count': '6',
+              },
+              {
+                'LineItems.createdAt.hour': '2019-01-08T06:00:00.000',
+                'LineItems.createdAt': '2019-01-08T06:00:00.000',
+                'LineItems.count': '7',
+              },
+            ],
+            lastRefreshTime: '2021-07-07T14:31:30.458Z',
+            annotation: {
+              measures: {
+                'LineItems.count': {
+                  title: 'Line Items Count',
+                  shortTitle: 'Count',
+                  type: 'number',
+                  drillMembers: ['LineItems.id', 'LineItems.createdAt'],
+                  drillMembersGrouped: {
+                    measures: [],
+                    dimensions: ['LineItems.id', 'LineItems.createdAt'],
+                  },
+                },
+              },
+              dimensions: {},
+              segments: {},
+              timeDimensions: {
+                'LineItems.createdAt.week': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+                'LineItems.createdAt': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+              },
+            },
+            slowQuery: false,
+          },
+        ],
+        pivotQuery: {
+          measures: ['LineItems.count'],
+          timeDimensions: [
+            {
+              dimension: 'LineItems.createdAt',
+              granularity: 'hour',
+              dateRange: ['2019-01-08T01:45:25.342', '2019-01-08T07:35:58.399'],
+            },
+          ],
+          filters: [],
+          timezone: 'UTC',
+          order: [],
+          dimensions: [],
+          queryType: 'regularQuery',
+        },
+        slowQuery: false,
+      } as any);
+
+      expect(result.chartPivot()).toStrictEqual([
+        {
+          x: '2019-01-08T01:00:00.000',
+          xValues: ['2019-01-08T01:00:00.000'],
+          'LineItems.count': 2,
+        },
+        {
+          x: '2019-01-08T02:00:00.000',
+          xValues: ['2019-01-08T02:00:00.000'],
+          'LineItems.count': 3,
+        },
+        {
+          x: '2019-01-08T03:00:00.000',
+          xValues: ['2019-01-08T03:00:00.000'],
+          'LineItems.count': 4,
+        },
+        {
+          x: '2019-01-08T04:00:00.000',
+          xValues: ['2019-01-08T04:00:00.000'],
+          'LineItems.count': 5,
+        },
+        {
+          x: '2019-01-08T05:00:00.000',
+          xValues: ['2019-01-08T05:00:00.000'],
+          'LineItems.count': 6,
+        },
+        {
+          x: '2019-01-08T06:00:00.000',
+          xValues: ['2019-01-08T06:00:00.000'],
+          'LineItems.count': 7,
+        },
+        {
+          x: '2019-01-08T07:00:00.000',
+          xValues: ['2019-01-08T07:00:00.000'],
+          'LineItems.count': 0,
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes time series generation for some cases like 
`['2019-01-08T01:45:25.342', '2019-01-08T07:35:58.399'] with hour granularity` - previously, there will be no `'2019-01-08T07:00:00'` entity generated. Now it's fixed.

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
