### PR TITLE
fix(playground): Include lower and upper bound of date range in time dimension filter in Playground

### DIFF
--- a/packages/cubejs-playground/src/QueryBuilderV2/utils/cube-sql-converter.ts
+++ b/packages/cubejs-playground/src/QueryBuilderV2/utils/cube-sql-converter.ts
@@ -318,11 +318,11 @@ export class CubeSQLConverter {
     if (filter.operator === 'inDateRange') {
       return [
         filter.member,
-        '>',
+        '>=',
         this.escapeValue(filter.values[0]),
         'AND',
         filter.member,
-        '<',
+        '<=',
         this.escapeValue(filter.values[1]),
       ].join(' ');
     }


### PR DESCRIPTION


**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
Currently, lower and upper bounds are excluded, which is obviously incorrect:

<img width="1013" height="657" alt="Screenshot 2025-09-19 at 00 40 22" src="https://github.com/user-attachments/assets/1a99f741-a193-40b1-9fdd-a970a64335eb" />
