### PR TITLE
fix(cubesql): Add missing aggregate expressions for `ORDER BY` clause

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "arrow",
  "chrono",
@@ -838,7 +838,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "arrow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=6ac106244a1d4699f36d2bcbf435ca37363d1e21#6ac106244a1d4699f36d2bcbf435ca37363d1e21"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "0ba29ac12e2b13444bd536e1cbe4f73411383521", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "6ac106244a1d4699f36d2bcbf435ca37363d1e21", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@6ac1062, fixing an issue with initial logical plan referencing non-existing aggregate expressions in `Sort` (`ORDER BY`). Related test is included.