### PR TITLE
chore(ci): use Wait.forListeningPorts() in drivers tests

### DIFF
--- a/packages/cubejs-testing-drivers/src/helpers/runEnvironment.ts
+++ b/packages/cubejs-testing-drivers/src/helpers/runEnvironment.ts
@@ -119,6 +119,8 @@ export async function runEnvironment(
   compose.withEnvironment({
     CUBEJS_TELEMETRY: 'false',
   });
+  compose.withWaitStrategy('cube', Wait.forListeningPorts());
+  compose.withWaitStrategy('store', Wait.forListeningPorts());
 
   Object.keys(fixture.cube.environment).forEach((key) => {
     const val = fixture.cube.environment[key];


### PR DESCRIPTION
An attempt to fix occasional errors during drivers tests