### PR TITLE
chore(ci): Switch few packages unit tests to ts-jest

### DIFF
--- a/packages/cubejs-backend-shared/jest.config.js
+++ b/packages/cubejs-backend-shared/jest.config.js
@@ -1,4 +1,4 @@
-const base = require('../../jest.base.config');
+const base = require('../../jest.base-ts.config');
 
 /** @type {import('jest').Config} */
 module.exports = {

--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts",
-    "unit": "jest --coverage dist/test"
+    "unit": "jest --coverage"
   },
   "files": [
     "README.md",
@@ -32,6 +32,7 @@
     "@types/shelljs": "^0.8.5",
     "@types/throttle-debounce": "^2.1.0",
     "jest": "^29",
+    "ts-jest": "^29",
     "typescript": "~5.2.2"
   },
   "dependencies": {

--- a/packages/cubejs-base-driver/jest.config.js
+++ b/packages/cubejs-base-driver/jest.config.js
@@ -1,7 +1,12 @@
-const base = require('../../jest.base.config');
+const base = require('../../jest.base-ts.config');
 
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
   rootDir: '.',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.jest.json'
+    }],
+  },
 };

--- a/packages/cubejs-base-driver/package.json
+++ b/packages/cubejs-base-driver/package.json
@@ -18,7 +18,7 @@
     "tsc": "tsc",
     "watch": "tsc -w",
     "test": "npm run unit && npm run integration",
-    "unit": "jest --runInBand --coverage --verbose dist/test/unit",
+    "unit": "jest --runInBand --coverage --verbose test/unit",
     "lint": "eslint src/* test/* --ext .ts,.js",
     "lint:fix": "eslint --fix src/* test/* --ext .ts,.js"
   },
@@ -41,6 +41,7 @@
     "@types/jest": "^29",
     "@types/node": "^20",
     "jest": "^29",
+    "ts-jest": "^29",
     "typescript": "~5.2.2"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-base-driver/tsconfig.jest.json
+++ b/packages/cubejs-base-driver/tsconfig.jest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "paths": {
+      "@cubejs-backend/shared": ["../cubejs-backend-shared/src"]
+    }
+  }
+}

--- a/packages/cubejs-query-orchestrator/jest.config.js
+++ b/packages/cubejs-query-orchestrator/jest.config.js
@@ -1,7 +1,12 @@
-const base = require('../../jest.base.config');
+const base = require('../../jest.base-ts.config');
 
 /** @type {import('jest').Config} */
 module.exports = {
   ...base,
   rootDir: '.',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.jest.json'
+    }],
+  },
 };

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -18,9 +18,9 @@
     "tsc": "tsc",
     "watch": "tsc -w",
     "test": "npm run unit && npm run integration",
-    "unit": "jest --runInBand --forceExit --coverage --verbose dist/test/unit",
-    "integration": "jest --runInBand --verbose dist/test/integration",
-    "integration:cubestore": "jest --runInBand --verbose dist/test/integration/cubestore",
+    "unit": "jest --runInBand --forceExit --coverage --verbose test/unit",
+    "integration": "jest --runInBand --verbose test/integration",
+    "integration:cubestore": "jest --runInBand --verbose test/integration/cubestore",
     "lint": "eslint src/* test/* --ext .ts,.js",
     "lint:fix": "eslint --fix src/* test/* --ext .ts,.js"
   },
@@ -43,6 +43,7 @@
     "@types/ramda": "^0.27.32",
     "@types/uuid": "^8.3.0",
     "jest": "^29",
+    "ts-jest": "^29",
     "typescript": "~5.2.2"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-query-orchestrator/tsconfig.jest.json
+++ b/packages/cubejs-query-orchestrator/tsconfig.jest.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "paths": {
+      "@cubejs-backend/shared": ["../cubejs-backend-shared/src"],
+      "@cubejs-backend/base-driver": ["../cubejs-base-driver/src"]
+    }
+  }
+}


### PR DESCRIPTION
- **chore(ci): Switch backend-shared unit tests to ts-jest**
- **chore(ci): Switch query-orchestrator unit tests to ts-jest**
- **chore(ci): Switch base-driver unit tests to ts-jest**

Supersedes https://github.com/cube-js/cube/pull/3911
Closes https://github.com/cube-js/cube/pull/3911
