### PR TITLE
fix(cubestore): build with large pagesize support for arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -500,7 +500,9 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: WITH_AVX2=0
+            build-args: |
+              WITH_LG_PAGESIZE=1
+              WITH_AVX2=0
             postfix: "-arm64v8"
             tag: "arm64v8"
           # Non AVX build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -500,9 +500,7 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: |
-              WITH_LG_PAGESIZE=1
-              WITH_AVX2=0
+            build-args: WITH_AVX2=0
             postfix: "-arm64v8"
             tag: "arm64v8"
           # Non AVX build
@@ -649,6 +647,13 @@ jobs:
           key: target-${{ matrix.target }}
       - name: Build with Cargo
         run: |
+          # jemalloc bakes the page size in at build time. This runner has 4 KiB
+          # pages, but arm64 hosts can use up to 64 KiB (Raspberry Pi, Ubuntu
+          # arm64-largemem, Asahi), so build for the largest one there.
+          # TODO: drop once we are on jemalloc 5.3.1+, where this is the default.
+          case "${{ matrix.target }}" in
+            aarch64-*) export JEMALLOC_SYS_WITH_LG_PAGE=16 ;;
+          esac
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }} -p cubestore
       - name: Compress binaries
         uses: svenstaro/upx-action@v3

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -76,7 +76,9 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: WITH_AVX2=0
+            build-args: |
+              WITH_LG_PAGESIZE=1
+              WITH_AVX2=0
             postfix: "-arm64v8"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -76,9 +76,7 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: |
-              WITH_LG_PAGESIZE=1
-              WITH_AVX2=0
+            build-args: WITH_AVX2=0
             postfix: "-arm64v8"
     timeout-minutes: 60
     steps:
@@ -307,6 +305,13 @@ jobs:
           key: target-${{ matrix.target }}
       - name: Build with Cargo
         run: |
+          # jemalloc bakes the page size in at build time. This runner has 4 KiB
+          # pages, but arm64 hosts can use up to 64 KiB (Raspberry Pi, Ubuntu
+          # arm64-largemem, Asahi), so build for the largest one there.
+          # TODO: drop once we are on jemalloc 5.3.1+, where this is the default.
+          case "${{ matrix.target }}" in
+            aarch64-*) export JEMALLOC_SYS_WITH_LG_PAGE=16 ;;
+          esac
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }} -p cubestore
       - name: Compress binaries
         uses: svenstaro/upx-action@v3

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -80,7 +80,9 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: WITH_AVX2=0
+            build-args: |
+              WITH_LG_PAGESIZE=1
+              WITH_AVX2=0
     timeout-minutes: 60
     if: github.ref != 'refs/heads/master'
     steps:

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -80,9 +80,7 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             platforms: linux/arm64
-            build-args: |
-              WITH_LG_PAGESIZE=1
-              WITH_AVX2=0
+            build-args: WITH_AVX2=0
     timeout-minutes: 60
     if: github.ref != 'refs/heads/master'
     steps:
@@ -246,6 +244,13 @@ jobs:
           key: target-${{ matrix.target }}
       - name: Build with Cargo
         run: |
+          # jemalloc bakes the page size in at build time. This runner has 4 KiB
+          # pages, but arm64 hosts can use up to 64 KiB (Raspberry Pi, Ubuntu
+          # arm64-largemem, Asahi), so build for the largest one there.
+          # TODO: drop once we are on jemalloc 5.3.1+, where this is the default.
+          case "${{ matrix.target }}" in
+            aarch64-*) export JEMALLOC_SYS_WITH_LG_PAGE=16 ;;
+          esac
           cd rust/cubestore && cargo build --release --target=${{ matrix.target }} -p cubestore
       - name: Compress binaries
         uses: svenstaro/upx-action@v3

--- a/rust/cubestore/Dockerfile
+++ b/rust/cubestore/Dockerfile
@@ -18,14 +18,17 @@ COPY cubestore/cubestore/Cargo.toml cubestore/Cargo.toml
 RUN mkdir -p cubestore/src/bin && \
     echo "fn main() {print!(\"Dummy main\");} // dummy file" > cubestore/src/bin/cubestored.rs
 
+ARG WITH_LG_PAGESIZE=0
 ARG WITH_AVX2=1
 RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
+    [ "$WITH_LG_PAGESIZE" -eq "1" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
     cargo build --release -p cubestore
 
 # Cube Store get version from his own package
 COPY cubestore/package.json package.json
 COPY cubestore/cubestore cubestore
 RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
+    [ "$WITH_LG_PAGESIZE" -eq "1" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
     cargo build --release -p cubestore
 
 FROM debian:trixie-slim

--- a/rust/cubestore/Dockerfile
+++ b/rust/cubestore/Dockerfile
@@ -18,17 +18,23 @@ COPY cubestore/cubestore/Cargo.toml cubestore/Cargo.toml
 RUN mkdir -p cubestore/src/bin && \
     echo "fn main() {print!(\"Dummy main\");} // dummy file" > cubestore/src/bin/cubestored.rs
 
-ARG WITH_LG_PAGESIZE=0
 ARG WITH_AVX2=1
+ARG TARGETARCH
+# jemalloc bakes the page size in at build time. The arm64 builders use 4 KiB
+# pages, but arm64 hosts can use up to 64 KiB (Raspberry Pi, Ubuntu
+# arm64-largemem, Asahi), so build for the largest one there.
+# TODO: drop once we are on jemalloc 5.3.1+, where this is the default.
 RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
-    [ "$WITH_LG_PAGESIZE" -eq "1" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
+    [ "$TARGETARCH" = "arm64" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
     cargo build --release -p cubestore
 
 # Cube Store get version from his own package
 COPY cubestore/package.json package.json
 COPY cubestore/cubestore cubestore
+# TODO: drop the JEMALLOC_SYS_WITH_LG_PAGE export once we are on jemalloc
+# 5.3.1+, where this is the default.
 RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
-    [ "$WITH_LG_PAGESIZE" -eq "1" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
+    [ "$TARGETARCH" = "arm64" ] && export JEMALLOC_SYS_WITH_LG_PAGE="16"; \
     cargo build --release -p cubestore
 
 FROM debian:trixie-slim


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**
The ARM docker image of cubestore currently fails when running on a kernel with page size >4k. Example of such environments are Ubuntu server [arm64+largemem (64k)](https://documentation.ubuntu.com/server/how-to/installation/choosing-between-the-arm64-and-arm64-largemem-installer-options/index.html#the-arm64-largemem-64k-option), MacOS (16k) and Raspberry Pi (16k). 
An example of the error can be seen in the excerpt below.
```bash
$ docker run -it --rm cubejs/cubestore:v1.5.3-arm64v8
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
memory allocation of 8 bytes failed
```
This is a known issue with jemalloc https://github.com/jemalloc/jemalloc/issues/2639 and the default has been changed in the facebook upstream as of https://github.com/facebook/jemalloc/pull/34. 

To fix it with cubestore, the cargo build can be run with the `JEMALLOC_SYS_WITH_LG_PAGE` env set to 2 log of the page size according to the [jemalloc-sys crate](https://crates.io/crates/jemalloc-sys#:~:text=JEMALLOC%5FSYS%5FWITH%5FLG%5FPAGE). 

This PR addresses the issue by setting the env variable to 16 (support for up to and including 64k page sizes), and configuring the Github actions to build ARM images with large pagesize support. 

I have tested the changes by building the ARM image both with and without the `WITH_LG_PAGESIZE` build argument set. With the argument set the docker image starts up correctly, without it it shows the same error as before. 

If you have ideas of applicable tests to add, I am happy to implement them.
