### PR TITLE
fix(devserver): use tablesSchemaV2 for Generate Data Model to include primary keys

### DIFF
--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -138,7 +138,7 @@ export class DevServer {
         requestId: getRequestIdFromRequest(req),
       });
 
-      const tablesSchema = await driver.tablesSchema();
+      const tablesSchema = await driver.tablesSchemaV2();
 
       this.cubejsServer.event('Dev Server DB Schema Load Success');
       if (Object.keys(tablesSchema || {}).length === 0) {
@@ -176,7 +176,7 @@ export class DevServer {
         securityContext: null,
         requestId: getRequestIdFromRequest(req),
       });
-      const tablesSchema = req.body.tablesSchema || (await driver.tablesSchema());
+      const tablesSchema = req.body.tablesSchema || (await driver.tablesSchemaV2());
 
       if (!Object.values(SchemaFormat).includes(req.body.format)) {
         throw new Error(`Unknown schema format. Must be one of ${Object.values(SchemaFormat)}`);


### PR DESCRIPTION
## Summary

Fixes #10517

When using **Generate Data Model** in Cube Playground, primary key columns are not marked with `primary_key: true` in the generated YAML, causing compile errors for cubes with joins defined.

### Root Cause

`DevServer.ts` calls `driver.tablesSchema()` in both endpoints:

```typescript
// /playground/db-schema
const tablesSchema = await driver.tablesSchema();

// /playground/generate-schema
const tablesSchema = req.body.tablesSchema || (await driver.tablesSchema());
```

`tablesSchema()` queries only `information_schema.columns` — it does **not** fetch primary key constraints. So no column gets `attributes: ['primaryKey']`, meaning `ScaffoldingSchema` never sets `isPrimaryKey: true`, and `BaseSchemaFormatter` never emits `primary_key: true`.

`tablesSchemaV2()` already exists and does the right thing: it calls `primaryKeys()` (implemented per-driver) and merges PK information into column attributes.

### Fix

Replace both calls with `tablesSchemaV2()`:

```diff
- const tablesSchema = await driver.tablesSchema();
+ const tablesSchema = await driver.tablesSchemaV2();
```

```diff
- const tablesSchema = req.body.tablesSchema || (await driver.tablesSchema());
+ const tablesSchema = req.body.tablesSchema || (await driver.tablesSchemaV2());
```

### Impact

- Affects all databases where the PK column is not literally named `id` (the only fallback heuristic in `ScaffoldingSchema`)
- Reproduced with PostgreSQL 14 + AdventureWorks; any real-world schema with named PKs (`salesorderid`, `productid`, `businessentityid`, etc.) is affected

## Test plan

- [ ] Generate Data Model on a PostgreSQL table with a named PK (e.g. `salesorderid`) — generated YAML should include `primary_key: true`
- [ ] Generated YAML compiles without "primary key is required" errors
- [ ] Existing behaviour for tables with no joins is unchanged