### PR TITLE
feat(cubestore): push Sort(fetch=N) to workers for ORDER BY group-by …

### DIFF
--- a/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/inline_aggregate_stream.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/inline_aggregate_stream.rs
@@ -73,7 +73,7 @@ impl InlineAggregateStream {
             aggregate_expressions(&agg.aggr_expr, &agg.mode, agg_group_by.num_group_exprs())?;
 
         let filter_expressions = match agg.mode {
-            InlineAggregateMode::Partial => agg_filter_expr,
+            InlineAggregateMode::Partial | InlineAggregateMode::Single => agg_filter_expr,
             InlineAggregateMode::Final => {
                 vec![None; agg.aggr_expr.len()]
             }
@@ -113,7 +113,7 @@ fn aggregate_expressions(
     col_idx_base: usize,
 ) -> DFResult<Vec<Vec<Arc<dyn PhysicalExpr>>>> {
     match mode {
-        InlineAggregateMode::Partial => Ok(aggr_expr
+        InlineAggregateMode::Partial | InlineAggregateMode::Single => Ok(aggr_expr
             .iter()
             .map(|agg| {
                 let mut result = agg.expressions();
@@ -225,7 +225,6 @@ impl Stream for InlineAggregateStream {
                 ExecutionState::ProducingOutput(batch) => {
                     let batch = batch.clone();
 
-                    // Determine next state
                     self.exec_state = if self.input_done {
                         ExecutionState::Done
                     } else {
@@ -267,7 +266,7 @@ impl InlineAggregateStream {
                     let state = acc.state(emit_to)?;
                     aggr_arrays.extend(state);
                 }
-                InlineAggregateMode::Final => {
+                InlineAggregateMode::Final | InlineAggregateMode::Single => {
                     // Emit final aggregated values
                     aggr_arrays.push(acc.evaluate(emit_to)?);
                 }
@@ -333,7 +332,7 @@ impl InlineAggregateStream {
             // Call the appropriate method on each aggregator with
             // the entire input row and the relevant group indexes
             match self.mode {
-                InlineAggregateMode::Partial => {
+                InlineAggregateMode::Partial | InlineAggregateMode::Single => {
                     acc.update_batch(values, group_indices, opt_filter, total_num_groups)?;
                 }
                 _ => {

--- a/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 pub enum InlineAggregateMode {
     Partial,
     Final,
+    Single,
 }
 
 #[derive(Debug, Clone)]
@@ -66,10 +67,11 @@ impl InlineAggregateExec {
             return None;
         }
 
-        // Only support Partial and Final modes
+        // Only support Partial, Final, and Single modes
         let mode = match aggregate.mode() {
             AggregateMode::Partial => InlineAggregateMode::Partial,
             AggregateMode::Final => InlineAggregateMode::Final,
+            AggregateMode::Single => InlineAggregateMode::Single,
             _ => return None,
         };
 
@@ -109,6 +111,11 @@ impl InlineAggregateExec {
 
     pub fn limit(&self) -> Option<usize> {
         self.limit
+    }
+
+    pub fn with_limit(mut self, limit: Option<usize>) -> Self {
+        self.limit = limit;
+        self
     }
 
     pub fn aggr_expr(&self) -> &[Arc<AggregateFunctionExpr>] {
@@ -151,7 +158,7 @@ impl ExecutionPlan for InlineAggregateExec {
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
         match &self.mode {
-            InlineAggregateMode::Partial => {
+            InlineAggregateMode::Partial | InlineAggregateMode::Single => {
                 vec![Distribution::UnspecifiedDistribution]
             }
             InlineAggregateMode::Final => {
@@ -181,7 +188,7 @@ impl ExecutionPlan for InlineAggregateExec {
             group_by: self.group_by.clone(),
             aggr_expr: self.aggr_expr.clone(),
             filter_expr: self.filter_expr.clone(),
-            limit: self.limit.clone(),
+            limit: self.limit,
             input: children[0].clone(),
             schema: self.schema.clone(),
             input_schema: self.input_schema.clone(),

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
@@ -84,7 +84,7 @@ pub fn push_aggregate_to_workers(
             let worker_input = p_partial.clone().with_new_children(vec![w.input.clone()])?;
 
             // Worker plan, execute partial aggregate inside the worker.
-            Arc::new(WorkerExec::new(
+            let new_worker = WorkerExec::new(
                 worker_input,
                 w.max_batch_rows,
                 // TODO upgrade DF: WorkerExec limit_and_reverse must be wrong here.  Should be
@@ -98,7 +98,9 @@ pub fn push_aggregate_to_workers(
                 WorkerPlanningParams {
                     worker_partition_count: w.properties().output_partitioning().partition_count(),
                 },
-            ))
+                w.worker_sort_and_limit.clone(),
+            );
+            Arc::new(new_worker)
         } else {
             return Ok(p_final);
         };

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
@@ -13,8 +13,11 @@ use crate::queryplanner::optimizations::distributed_partial_aggregate::{
     replace_suboptimal_merge_sorts,
 };
 use crate::queryplanner::optimizations::inline_aggregate_rewriter::replace_with_inline_aggregate;
+use crate::queryplanner::check_memory::CheckMemoryExec;
+use crate::queryplanner::inline_aggregate::{InlineAggregateExec, InlineAggregateMode};
 use crate::queryplanner::planning::CubeExtensionPlanner;
 use crate::queryplanner::pretty_printers::{pp_phys_plan_ext, PPOptions};
+use crate::queryplanner::query_executor::ClusterSendExec;
 use crate::queryplanner::rolling::RollingWindowPlanner;
 use crate::queryplanner::trace_data_loaded::DataLoadedSize;
 use crate::util::memory::MemoryHandler;
@@ -25,7 +28,10 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::context::QueryPlanner;
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_expr::LexOrdering;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use distributed_partial_aggregate::ensure_partition_merge_with_acceptable_parent;
@@ -148,6 +154,10 @@ fn pre_optimize_physical_plan(
     // Replace sorted AggregateExec with InlineAggregateExec for better performance
     let p = rewrite_physical_plan(p, &mut |p| replace_with_inline_aggregate(p))?;
 
+    // Apply worker_sort_and_limit AFTER aggregate restructuring, so the SortExec
+    // wraps the aggregate output (not the raw scan input).
+    let p = rewrite_physical_plan(p, &mut |p| apply_worker_sort_and_limit(p))?;
+
     Ok(p)
 }
 
@@ -177,10 +187,190 @@ fn finalize_physical_plan(
         "Rewrote physical plan by add_limit_to_workers:\n{}",
         pp_phys_plan_ext(p.as_ref(), &PPOptions::show_nonmeta())
     );
+    let p = push_sort_to_workers(p)?;
+    log::trace!(
+        "Rewrote physical plan by push_sort_to_workers:\n{}",
+        pp_phys_plan_ext(p.as_ref(), &PPOptions::show_nonmeta())
+    );
     let p = rewrite_physical_plan(p, &mut |p| replace_suboptimal_merge_sorts(p))?;
     log::trace!(
         "Rewrote physical plan by replace_suboptimal_merge_sorts:\n{}",
         pp_phys_plan_ext(p.as_ref(), &PPOptions::show_nonmeta())
     );
     Ok(p)
+}
+
+/// When the router plan has `SortExec(fetch=N)` sorting by GROUP BY columns,
+/// and the worker uses `InlineAggregateExec` (streaming aggregate where groups don't overlap),
+/// push a matching `SortExec(fetch=N)` to the worker. DataFusion's SortExec with fetch uses
+/// a bounded heap, so this limits worker output to N rows with O(N) memory.
+fn push_sort_to_workers(
+    p: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let Some(sort) = p.as_any().downcast_ref::<SortExec>() else {
+        return Ok(p);
+    };
+    let Some(fetch) = sort.fetch() else {
+        return Ok(p);
+    };
+
+    let sort_exprs = sort.expr().clone();
+
+    // Walk down through Projection → InlineAggregate(Final) → ClusterSend
+    let sort_input = sort.input();
+    let (below_proj, col_mapping) = if let Some(proj) = sort_input.as_any().downcast_ref::<ProjectionExec>() {
+        // Map sort column indices through the projection
+        let mapping: Vec<Option<usize>> = proj.expr().iter().map(|(expr, _name)| {
+            expr.as_any()
+                .downcast_ref::<datafusion::physical_plan::expressions::Column>()
+                .map(|c| c.index())
+        }).collect();
+        (proj.input().clone(), Some(mapping))
+    } else {
+        (sort_input.clone(), None)
+    };
+
+    let Some(inline_final) = below_proj.as_any().downcast_ref::<InlineAggregateExec>() else {
+        return Ok(p);
+    };
+    if *inline_final.mode() != InlineAggregateMode::Final {
+        return Ok(p);
+    }
+    let group_key_len = inline_final.group_expr().expr().len();
+
+    // Translate sort expressions to pre-projection column indices
+    let translated_sort_exprs: Vec<_> = sort_exprs.iter().map(|se| {
+        if let Some(col) = se.expr.as_any().downcast_ref::<datafusion::physical_plan::expressions::Column>() {
+            let actual_idx = if let Some(ref mapping) = col_mapping {
+                mapping.get(col.index()).copied().flatten()
+            } else {
+                Some(col.index())
+            };
+            actual_idx.filter(|&idx| idx < group_key_len)
+        } else {
+            None
+        }
+    }).collect();
+
+    // All sort columns must be GROUP BY columns
+    if translated_sort_exprs.iter().any(|x| x.is_none()) {
+        return Ok(p);
+    }
+
+    // Find ClusterSendExec below InlineAggregate(Final), possibly through CheckMemoryExec
+    let final_input = inline_final.input();
+    let (cluster_send, through_check_memory) =
+        if let Some(cs) = final_input.as_any().downcast_ref::<ClusterSendExec>() {
+            (cs, false)
+        } else if let Some(cm) = final_input.as_any().downcast_ref::<CheckMemoryExec>() {
+            if let Some(cs) = cm.input.as_any().downcast_ref::<ClusterSendExec>() {
+                (cs, true)
+            } else {
+                return Ok(p);
+            }
+        } else {
+            return Ok(p);
+        };
+
+    // Don't override if limit_and_reverse is already set
+    if cluster_send.limit_and_reverse.is_some() {
+        return Ok(p);
+    }
+
+    let worker_input = &cluster_send.input_for_optimizations;
+
+    // Verify the worker has InlineAggregateExec(Partial) - confirms groups don't overlap
+    let has_inline_partial = worker_input
+        .as_any()
+        .downcast_ref::<InlineAggregateExec>()
+        .map_or(false, |ia| *ia.mode() == InlineAggregateMode::Partial);
+    if !has_inline_partial {
+        return Ok(p);
+    }
+
+    // Build sort expressions for the worker (same column indices, same options)
+    let worker_schema = worker_input.schema();
+    let worker_sort_exprs: Vec<_> = sort_exprs.iter().zip(translated_sort_exprs.iter()).map(|(se, &mapped_idx)| {
+        let idx = mapped_idx.unwrap();
+        datafusion::physical_expr::PhysicalSortExpr {
+            expr: Arc::new(datafusion::physical_plan::expressions::Column::new(
+                worker_schema.field(idx).name(),
+                idx,
+            )),
+            options: se.options,
+        }
+    }).collect();
+
+    // Wrap the worker plan: SortExec(fetch=N) → InlinePartialAggregate
+    let new_worker_input: Arc<dyn ExecutionPlan> = Arc::new(
+        SortExec::new(LexOrdering::new(worker_sort_exprs), worker_input.clone())
+            .with_fetch(Some(fetch)),
+    );
+
+    // Rebuild ClusterSendExec with the new worker input
+    let new_cluster_send: Arc<dyn ExecutionPlan> = Arc::new(
+        cluster_send.with_changed_schema(new_worker_input, cluster_send.required_input_ordering.clone()),
+    );
+
+    // Re-wrap with CheckMemoryExec if it was present
+    let new_final_child: Arc<dyn ExecutionPlan> = if through_check_memory {
+        final_input.clone().with_new_children(vec![new_cluster_send])?
+    } else {
+        new_cluster_send
+    };
+
+    // Rebuild InlineAggregate(Final) with new child
+    let new_inline_final: Arc<dyn ExecutionPlan> =
+        Arc::clone(&below_proj).with_new_children(vec![new_final_child])?;
+
+    // Rebuild Projection if present
+    let new_sort_input = if sort_input.as_any().downcast_ref::<ProjectionExec>().is_some() {
+        sort_input.clone().with_new_children(vec![new_inline_final])?
+    } else {
+        new_inline_final
+    };
+
+    // Rebuild SortExec with the new subtree
+    p.with_new_children(vec![new_sort_input])
+}
+
+/// Apply worker_sort_and_limit on a WorkerExec by wrapping its child
+/// (the partial aggregate) with SortExec(fetch=N). Must run AFTER
+/// push_aggregate_to_workers and replace_with_inline_aggregate.
+fn apply_worker_sort_and_limit(
+    p: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    use crate::queryplanner::planning::WorkerExec;
+
+    let Some(w) = p.as_any().downcast_ref::<WorkerExec>() else {
+        return Ok(p);
+    };
+    let Some((sort_cols, limit)) = w.worker_sort_and_limit.as_ref() else {
+        return Ok(p);
+    };
+
+    let input = &w.input;
+    let schema = input.schema();
+    let sort_exprs: Vec<_> = sort_cols
+        .iter()
+        .map(|(col_idx, asc, nulls_first)| {
+            datafusion::physical_expr::PhysicalSortExpr {
+                expr: Arc::new(
+                    datafusion::physical_plan::expressions::Column::new(
+                        schema.field(*col_idx).name(),
+                        *col_idx,
+                    ),
+                ),
+                options: datafusion::arrow::compute::SortOptions {
+                    descending: !asc,
+                    nulls_first: *nulls_first,
+                },
+            }
+        })
+        .collect();
+    let sort_exec: Arc<dyn ExecutionPlan> = Arc::new(
+        SortExec::new(LexOrdering::new(sort_exprs), input.clone())
+            .with_fetch(Some(*limit)),
+    );
+    p.with_new_children(vec![sort_exec])
 }

--- a/rust/cubestore/cubestore/src/queryplanner/panic.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/panic.rs
@@ -186,5 +186,6 @@ pub fn plan_panic_worker() -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         WorkerPlanningParams {
             worker_partition_count: 1,
         },
+        /* worker_sort_and_limit */ None,
     )))
 }

--- a/rust/cubestore/cubestore/src/queryplanner/planning.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/planning.rs
@@ -976,18 +976,53 @@ impl ChooseIndex<'_> {
                         assert_eq!(table_schema, index_schema);
                         let limit = self.get_limit_for_pushdown(snapshot.sort_on(), ctx);
                         let limit_and_reverse = if let Some(limit) = limit {
-                            Some((limit, !ctx.sort_is_asc))
+                            let reverse = if ctx.sort.is_some()
+                                && !ctx.sort.as_ref().unwrap().is_empty()
+                            {
+                                !ctx.sort_is_asc
+                            } else {
+                                false
+                            };
+                            Some((limit, reverse))
                         } else {
                             None
                         };
 
-                        return Ok(ClusterSendNode::new(
+                        // When ORDER BY is on GROUP BY columns but doesn't match the index
+                        // prefix (so limit_and_reverse is None), we can still push a bounded
+                        // sort to the worker using DataFusion's SortExec(fetch=N).
+                        let worker_sort_and_limit = if limit_and_reverse.is_none()
+                            && self.can_pushdown_limit
+                            && ctx.limit.is_some()
+                            && ctx.sort.is_some()
+                            && !ctx.sort.as_ref().unwrap().is_empty()
+                        {
+                            let sort_cols = ctx.sort.as_ref().unwrap();
+                            let output_schema = p.schema();
+                            // Map each sort column to its position in the worker output schema
+                            let mapped: Option<Vec<(usize, bool, bool)>> = sort_cols
+                                .iter()
+                                .map(|col_name| {
+                                    output_schema
+                                        .fields()
+                                        .iter()
+                                        .position(|f| f.name() == col_name)
+                                        .map(|pos| (pos, ctx.sort_is_asc, !ctx.sort_is_asc))
+                                })
+                                .collect();
+                            mapped.map(|cols| (cols, ctx.limit.unwrap()))
+                        } else {
+                            None
+                        };
+
+                        let mut node = ClusterSendNode::new(
                             self.get_cluster_send_next_id(),
                             Arc::new(p),
                             vec![vec![Snapshot::Index(snapshot)]],
                             limit_and_reverse,
-                        )
-                        .into_plan());
+                        );
+                        node.worker_sort_and_limit = worker_sort_and_limit;
+                        return Ok(node.into_plan());
                     } else if let Some(table) = table_provider
                         .as_any()
                         .downcast_ref::<InlineTableProvider>()
@@ -1044,15 +1079,22 @@ impl ChooseIndex<'_> {
             || !self.can_pushdown_limit
             || index_sort_on.is_none()
             || index_sort_on.unwrap().is_empty()
-            || ctx.sort.is_none()
-            || ctx.sort.as_ref().unwrap().is_empty()
         {
             return None;
         }
 
         let limit = ctx.limit.unwrap();
-        let sort_columns = ctx.sort.as_ref().unwrap();
         let index_sort_on = index_sort_on.unwrap();
+
+        // When there's no ORDER BY, we can still push down the limit if the index has a sort
+        // order. The InlineAggregateExec will produce groups in the index's natural order,
+        // so taking the first N groups is valid (though the result order is arbitrary from
+        // the user's perspective).
+        if ctx.sort.is_none() || ctx.sort.as_ref().unwrap().is_empty() {
+            return Some(limit);
+        }
+
+        let sort_columns = ctx.sort.as_ref().unwrap();
 
         //We exclude from order by and index sort_on strictly restricted columns (aka `a = 10`)
         let works_ind_sort_cols = index_sort_on
@@ -1468,6 +1510,9 @@ pub struct ClusterSendNode {
     pub input: Arc<LogicalPlan>,
     pub snapshots: Vec<Snapshots>,
     pub limit_and_reverse: Option<(usize, bool)>,
+    /// Sort expressions + limit for worker-side top-K when ORDER BY is on GROUP BY columns.
+    /// Format: (vec of (column_index, ascending, nulls_first), limit)
+    pub worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -1475,6 +1520,16 @@ pub struct ClusterSendSerialized {
     pub id: usize,
     pub snapshots: Vec<Snapshots>,
     pub limit_and_reverse: Option<(usize, bool)>,
+    #[serde(default)]
+    pub worker_sort_and_limit: Option<WorkerSortAndLimitSerialized>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct WorkerSortAndLimitSerialized {
+    pub sort_col_indices: Vec<usize>,
+    pub sort_col_ascending: Vec<bool>,
+    pub sort_col_nulls_first: Vec<bool>,
+    pub limit: usize,
 }
 
 impl ClusterSendNode {
@@ -1489,6 +1544,7 @@ impl ClusterSendNode {
             input,
             snapshots,
             limit_and_reverse,
+            worker_sort_and_limit: None,
         }
     }
 
@@ -1504,6 +1560,16 @@ impl ClusterSendNode {
             input: Arc::new(inputs[0].clone()),
             snapshots: serialized.snapshots,
             limit_and_reverse: serialized.limit_and_reverse,
+            worker_sort_and_limit: serialized.worker_sort_and_limit.map(|s| {
+                let cols: Vec<(usize, bool, bool)> = s
+                    .sort_col_indices
+                    .iter()
+                    .zip(s.sort_col_ascending.iter())
+                    .zip(s.sort_col_nulls_first.iter())
+                    .map(|((idx, asc), nf)| (*idx, *asc, *nf))
+                    .collect();
+                (cols, s.limit)
+            }),
         }
     }
 
@@ -1512,6 +1578,14 @@ impl ClusterSendNode {
             id: self.id,
             snapshots: self.snapshots.clone(),
             limit_and_reverse: self.limit_and_reverse.clone(),
+            worker_sort_and_limit: self.worker_sort_and_limit.as_ref().map(|(cols, limit)| {
+                WorkerSortAndLimitSerialized {
+                    sort_col_indices: cols.iter().map(|(idx, _, _)| *idx).collect(),
+                    sort_col_ascending: cols.iter().map(|(_, asc, _)| *asc).collect(),
+                    sort_col_nulls_first: cols.iter().map(|(_, _, nf)| *nf).collect(),
+                    limit: *limit,
+                }
+            }),
         }
     }
 }
@@ -1562,6 +1636,7 @@ impl UserDefinedLogicalNode for ClusterSendNode {
             input: Arc::new(inputs[0].clone()),
             snapshots: self.snapshots.clone(),
             limit_and_reverse: self.limit_and_reverse.clone(),
+            worker_sort_and_limit: self.worker_sort_and_limit.clone(),
         }))
     }
 
@@ -1785,6 +1860,7 @@ impl ExtensionPlanner for CubeExtensionPlanner {
                     CubeError::internal("ClusterSend cut point not found".to_string())
                 })?),
                 /* required input ordering */ None,
+                cs.worker_sort_and_limit.clone(),
             )?))
         } else if let Some(topk_lower) = node.as_any().downcast_ref::<ClusterAggregateTopKLower>() {
             assert_eq!(inputs.len(), 1);
@@ -1842,13 +1918,14 @@ impl CubeExtensionPlanner {
         limit_and_reverse: Option<(usize, bool)>,
         logical_plan_to_send: Option<&LogicalPlan>,
         required_input_ordering: Option<LexRequirement>,
+        worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         if snapshots.is_empty() {
             return Ok(Arc::new(EmptyExec::new(input.schema())));
         }
         // Note that MergeExecs are added automatically when needed.
         if let Some(c) = self.cluster.as_ref() {
-            Ok(Arc::new(ClusterSendExec::new(
+            let cs = ClusterSendExec::new(
                 c.clone(),
                 if let Some(logical_plan_to_send) = logical_plan_to_send {
                     Arc::new(
@@ -1863,16 +1940,20 @@ impl CubeExtensionPlanner {
                 use_streaming,
                 limit_and_reverse,
                 required_input_ordering,
-            )?))
+                worker_sort_and_limit,
+            )?;
+            Ok(Arc::new(cs))
         } else {
             let worker_planning_params = self.worker_planning_params.expect("cluster_send_partition_count must be set when CubeExtensionPlanner::cluster is None");
-            Ok(Arc::new(WorkerExec::new(
+            let we = WorkerExec::new(
                 input,
                 max_batch_rows,
                 limit_and_reverse,
                 required_input_ordering,
                 worker_planning_params,
-            )))
+                worker_sort_and_limit,
+            );
+            Ok(Arc::new(we))
         }
     }
 }
@@ -1885,6 +1966,7 @@ pub struct WorkerExec {
     pub max_batch_rows: usize,
     pub limit_and_reverse: Option<(usize, bool)>,
     pub required_input_ordering: Option<LexRequirement>,
+    pub worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
     properties: PlanProperties,
 }
 
@@ -1895,6 +1977,7 @@ impl WorkerExec {
         limit_and_reverse: Option<(usize, bool)>,
         required_input_ordering: Option<LexRequirement>,
         worker_planning_params: WorkerPlanningParams,
+        worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
     ) -> WorkerExec {
         // This, importantly, gives us the same PlanProperties as ClusterSendExec.
         let properties = ClusterSendExec::compute_properties(
@@ -1906,6 +1989,7 @@ impl WorkerExec {
             max_batch_rows,
             limit_and_reverse,
             required_input_ordering,
+            worker_sort_and_limit,
             properties,
         }
     }
@@ -1942,6 +2026,7 @@ impl ExecutionPlan for WorkerExec {
             max_batch_rows: self.max_batch_rows,
             limit_and_reverse: self.limit_and_reverse.clone(),
             required_input_ordering: self.required_input_ordering.clone(),
+            worker_sort_and_limit: self.worker_sort_and_limit.clone(),
             properties,
         }))
     }

--- a/rust/cubestore/cubestore/src/queryplanner/pretty_printers.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/pretty_printers.rs
@@ -609,6 +609,7 @@ fn pp_phys_plan_indented(p: &dyn ExecutionPlan, indent: usize, o: &PPOptions, ou
             let mode = match agg.mode() {
                 InlineAggregateMode::Partial => "Partial",
                 InlineAggregateMode::Final => "Final",
+                InlineAggregateMode::Single => "Single",
             };
             *out += &format!("Inline{}Aggregate", mode);
             if o.show_aggregations {

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -1296,6 +1296,8 @@ pub struct ClusterSendExec {
     pub limit_and_reverse: Option<(usize, bool)>,
     // Used to prevent SortExec on workers (e.g. with ClusterAggregateTopK) from being optimized away.
     pub required_input_ordering: Option<LexRequirement>,
+    /// Sort + limit for worker-side bounded sort when ORDER BY is on GROUP BY columns.
+    pub worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
 }
 
 pub type PartitionWithFilters = (u64, RowRange);
@@ -1319,6 +1321,7 @@ impl ClusterSendExec {
         use_streaming: bool,
         limit_and_reverse: Option<(usize, bool)>,
         required_input_ordering: Option<LexRequirement>,
+        worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
     ) -> Result<Self, CubeError> {
         let partitions = Self::distribute_to_workers(
             cluster.config().as_ref(),
@@ -1337,6 +1340,7 @@ impl ClusterSendExec {
             use_streaming,
             limit_and_reverse,
             required_input_ordering,
+            worker_sort_and_limit,
         })
     }
 
@@ -1658,6 +1662,7 @@ impl ClusterSendExec {
             // the bug.
             limit_and_reverse: self.limit_and_reverse,
             required_input_ordering: new_required_input_ordering,
+            worker_sort_and_limit: self.worker_sort_and_limit.clone(),
         }
     }
 
@@ -1725,6 +1730,7 @@ impl ExecutionPlan for ClusterSendExec {
             use_streaming: self.use_streaming,
             limit_and_reverse: self.limit_and_reverse,
             required_input_ordering: self.required_input_ordering.clone(),
+            worker_sort_and_limit: self.worker_sort_and_limit.clone(),
         }))
     }
 

--- a/rust/cubestore/cubestore/src/queryplanner/serialized_plan.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/serialized_plan.rs
@@ -637,6 +637,7 @@ impl PreSerializedPlan {
                         input,
                         snapshots,
                         limit_and_reverse,
+                        worker_sort_and_limit,
                     } = cluster_send;
                     let input = PreSerializedPlan::remove_unused_tables(
                         &input,
@@ -649,6 +650,7 @@ impl PreSerializedPlan {
                             input: Arc::new(input),
                             snapshots: snapshots.clone(),
                             limit_and_reverse: *limit_and_reverse,
+                            worker_sort_and_limit: worker_sort_and_limit.clone(),
                         }),
                     })
                 } else if let Some(panic_worker) = node.as_any().downcast_ref::<PanicWorkerNode>() {

--- a/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
@@ -645,6 +645,7 @@ pub fn plan_topk(
         None,
         None,
         Some(sort_requirement.clone()),
+        None,
     )?;
 
     let having = if let Some(predicate) = &upper_node.having_expr {

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -5170,6 +5170,214 @@ mod tests {
         }).await;
         Ok(())
     }
+
+    #[tokio::test]
+    async fn worker_sort_and_limit_cluster() -> Result<(), CubeError> {
+        Config::test("worker_sort_limit_router")
+            .update_config(|mut config| {
+                config.select_workers = vec![
+                    "127.0.0.1:24106".to_string(),
+                    "127.0.0.1:24107".to_string(),
+                ];
+                config.metastore_bind_address = Some("127.0.0.1:25106".to_string());
+                config.compaction_chunks_count_threshold = 0;
+                config
+            })
+            .start_test(async move |services| {
+                let service = services.sql_service;
+
+                Config::test("worker_sort_limit_worker_1")
+                    .update_config(|mut config| {
+                        config.worker_bind_address = Some("127.0.0.1:24106".to_string());
+                        config.server_name = "127.0.0.1:24106".to_string();
+                        config.metastore_remote_address =
+                            Some("127.0.0.1:25106".to_string());
+                        config.store_provider = FileStoreProvider::Filesystem {
+                            remote_dir: Some(
+                                env::current_dir()
+                                    .unwrap()
+                                    .join("worker_sort_limit_router-upstream".to_string()),
+                            ),
+                        };
+                        config.compaction_chunks_count_threshold = 0;
+                        config
+                    })
+                    .start_test_worker(async move |_| {
+                        Config::test("worker_sort_limit_worker_2")
+                            .update_config(|mut config| {
+                                config.worker_bind_address =
+                                    Some("127.0.0.1:24107".to_string());
+                                config.server_name = "127.0.0.1:24107".to_string();
+                                config.metastore_remote_address =
+                                    Some("127.0.0.1:25106".to_string());
+                                config.store_provider = FileStoreProvider::Filesystem {
+                                    remote_dir: Some(
+                                        env::current_dir().unwrap().join(
+                                            "worker_sort_limit_router-upstream".to_string(),
+                                        ),
+                                    ),
+                                };
+                                config.compaction_chunks_count_threshold = 0;
+                                config
+                            })
+                            .start_test_worker(async move |_| {
+                                service
+                                    .exec_query("CREATE SCHEMA foo")
+                                    .await?
+                                    .collect()
+                                    .await?;
+
+                                service
+                                    .exec_query(
+                                        "CREATE TABLE foo.data (category text, region text, amount int) \
+                                         INDEX idx1 (category, region)",
+                                    )
+                                    .await?
+                                    .collect()
+                                    .await?;
+
+                                service
+                                    .exec_query(
+                                        "INSERT INTO foo.data (category, region, amount) VALUES \
+                                         ('A', 'East', 10), ('A', 'West', 20), ('B', 'East', 30), ('B', 'West', 40), \
+                                         ('C', 'East', 50), ('C', 'West', 60), ('D', 'East', 70), ('D', 'West', 80), \
+                                         ('A', 'North', 15), ('B', 'North', 25), ('C', 'North', 35), ('D', 'North', 45), \
+                                         ('A', 'South', 55), ('B', 'South', 65), ('C', 'South', 75), ('D', 'South', 85)",
+                                    )
+                                    .await?
+                                    .collect()
+                                    .await?;
+
+                                // Test 1: ORDER BY group-by column (matches index prefix) with LIMIT
+                                // Should use limit_and_reverse on the worker
+                                {
+                                    let result = service
+                                        .exec_query(
+                                            "EXPLAIN ANALYZE SELECT category, sum(amount) \
+                                             FROM foo.data GROUP BY 1 ORDER BY 1 LIMIT 2",
+                                        )
+                                        .await?
+                                        .collect()
+                                        .await?;
+
+                                    let worker_row = &result.get_rows()[1];
+                                    let worker_plan = match &worker_row.values()[2] {
+                                        TableValue::String(s) => s.clone(),
+                                        _ => panic!("expected string"),
+                                    };
+                                    assert!(
+                                        !worker_plan.contains("Sort"),
+                                        "When ORDER BY matches index prefix, worker should use \
+                                         limit scan instead of Sort. Plan: {}",
+                                        worker_plan
+                                    );
+                                }
+
+                                // Test 2: ORDER BY non-prefix group-by column with LIMIT
+                                // Should push Sort(fetch=N) to the worker
+                                {
+                                    let result = service
+                                        .exec_query(
+                                            "EXPLAIN ANALYZE SELECT category, region, sum(amount) \
+                                             FROM foo.data GROUP BY 1, 2 ORDER BY 2 LIMIT 3",
+                                        )
+                                        .await?
+                                        .collect()
+                                        .await?;
+
+                                    let worker_row = &result.get_rows()[1];
+                                    let worker_plan = match &worker_row.values()[2] {
+                                        TableValue::String(s) => s.clone(),
+                                        _ => panic!("expected string"),
+                                    };
+                                    assert!(
+                                        worker_plan.contains("Sort, fetch: 3"),
+                                        "Worker should have Sort with fetch=3. Plan: {}",
+                                        worker_plan
+                                    );
+                                }
+
+                                // Test 3: Verify correctness of ORDER BY 2 LIMIT 3
+                                {
+                                    let result = service
+                                        .exec_query(
+                                            "SELECT category, region, sum(amount) \
+                                             FROM foo.data GROUP BY 1, 2 ORDER BY 2 LIMIT 3",
+                                        )
+                                        .await?
+                                        .collect()
+                                        .await?;
+
+                                    assert_eq!(result.len(), 3);
+                                    // ORDER BY region ASC: East comes first
+                                    for row in result.get_rows() {
+                                        match &row.values()[1] {
+                                            TableValue::String(region) => {
+                                                assert_eq!(region, "East");
+                                            }
+                                            _ => panic!("expected string"),
+                                        }
+                                    }
+                                }
+
+                                // Test 4: ORDER BY 1 DESC with LIMIT on non-prefix column
+                                {
+                                    let result = service
+                                        .exec_query(
+                                            "EXPLAIN ANALYZE SELECT region, sum(amount) \
+                                             FROM foo.data GROUP BY 1 ORDER BY 1 DESC LIMIT 2",
+                                        )
+                                        .await?
+                                        .collect()
+                                        .await?;
+
+                                    let worker_row = &result.get_rows()[1];
+                                    let worker_plan = match &worker_row.values()[2] {
+                                        TableValue::String(s) => s.clone(),
+                                        _ => panic!("expected string"),
+                                    };
+                                    assert!(
+                                        worker_plan.contains("Sort, fetch: 2"),
+                                        "Worker should have Sort with fetch=2 for DESC. Plan: {}",
+                                        worker_plan
+                                    );
+                                }
+
+                                // Test 5: Verify correctness of ORDER BY 1 DESC LIMIT 2
+                                {
+                                    let result = service
+                                        .exec_query(
+                                            "SELECT region, sum(amount) \
+                                             FROM foo.data GROUP BY 1 ORDER BY 1 DESC LIMIT 2",
+                                        )
+                                        .await?
+                                        .collect()
+                                        .await?;
+
+                                    assert_eq!(result.len(), 2);
+                                    let regions: Vec<&str> = result
+                                        .get_rows()
+                                        .iter()
+                                        .map(|r| match &r.values()[0] {
+                                            TableValue::String(s) => s.as_str(),
+                                            _ => panic!("expected string"),
+                                        })
+                                        .collect();
+                                    assert_eq!(regions, vec!["West", "South"]);
+                                }
+
+                                Ok::<(), CubeError>(())
+                            })
+                            .await;
+                        Ok::<(), CubeError>(())
+                    })
+                    .await;
+                Ok::<(), CubeError>(())
+            })
+            .await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn create_aggr_index() -> Result<(), CubeError> {
         assert!(true);


### PR DESCRIPTION
…column LIMIT queries

When a query has ORDER BY on GROUP BY columns with a LIMIT but doesn't match the index sort prefix (so the existing limit_and_reverse optimization cannot apply), propagate a worker_sort_and_limit through ClusterSendNode serialization to workers. Workers wrap their aggregate output with SortExec(fetch=N), bounding memory to O(limit) via DataFusion's heap-based sort instead of materializing all groups.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
