### PR TITLE
fix(schema-compiler): use ClickHouse String type in Tesseract casts (#10316)

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -274,6 +274,10 @@ export class ClickHouseQuery extends BaseQuery {
     templates.quotes.escape = '\\`';
     templates.types.boolean = 'BOOL';
     templates.types.timestamp = 'DATETIME';
+    // ClickHouse's string type is `String` (case-sensitive); the base `STRING` is invalid.
+    // The legacy planner avoids this via castToString(), but Tesseract renders the types.string
+    // template directly, so it must be overridden here. See cube-js/cube#10316.
+    templates.types.string = 'String';
     delete templates.types.time;
     // ClickHouse intervals have a distinct type for each granularity
     delete templates.types.interval;


### PR DESCRIPTION
## Issue
Fixes the ClickHouse string-cast casing bug reported in #10316.

When the Tesseract SQL planner (`CUBEJS_TESSERACT_SQL_PLANNER=true`) renders a string cast on ClickHouse — e.g. the composite-primary-key concatenation behind a `count` measure queried through a join — it emits `CAST(x AS STRING)`. `STRING` is not a valid ClickHouse type name (ClickHouse uses `String`, case-sensitive), so the query is rejected.

```sql
-- Tesseract (buggy):
count(CAST(order_id AS STRING) || CAST(product_id AS STRING))
-- Legacy planner (correct):
count(toString(CAST(`order_id` as String)) || toString(CAST(`product_id` as String)))
```

## Root cause
`BaseQuery` defines `types.string = 'STRING'`. The legacy ClickHouse path never hits it because `ClickHouseQuery.castToString()` is overridden to emit `String`. Tesseract, however, renders the `types.string` template directly, and `ClickHouseQuery.sqlTemplates()` overrides `boolean`/`timestamp` but not `string` — so the base `STRING` leaks through.

## Fix
Override `templates.types.string = 'String'` in `ClickHouseQuery.sqlTemplates()`, mirroring the existing `boolean`/`timestamp` overrides.

Note: #10316 also reported a null-safe `IS NULL` join-key bug, which was already fixed in v1.6.24 (#10494). This PR addresses the remaining string-cast-casing symptom.
