### PR TITLE
fix(schema-compiler): only build pre-agg partitions needed for bounded rolling-window queries

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -119,6 +119,10 @@ export class PreAggregations {
 
   private hasCumulativeMeasuresValue: boolean = false;
 
+  private cumulativeMeasuresTrailingIntervalValue: ParsedInterval | null | undefined;
+
+  private cumulativeMeasuresTrailingIntervalComputed: boolean = false;
+
   public preAggregationForQuery: PreAggregationForQuery | undefined = undefined;
 
   public preAggregationUsageInfos: PreAggregationUsageInfo[] | undefined = undefined;
@@ -308,6 +312,17 @@ export class PreAggregations {
    * the whole build range. Returns `undefined` when there are no cumulative measures.
    */
   private cumulativeMeasuresTrailingInterval(): ParsedInterval | null | undefined {
+    // Memoized like hasCumulativeMeasures(): computeCumulativeMeasuresTrailingInterval()
+    // walks the leaf-measure graph, and preAggregationDescriptionFor() calls this once
+    // per pre-aggregation.
+    if (!this.cumulativeMeasuresTrailingIntervalComputed) {
+      this.cumulativeMeasuresTrailingIntervalValue = this.computeCumulativeMeasuresTrailingInterval();
+      this.cumulativeMeasuresTrailingIntervalComputed = true;
+    }
+    return this.cumulativeMeasuresTrailingIntervalValue;
+  }
+
+  private computeCumulativeMeasuresTrailingInterval(): ParsedInterval | null | undefined {
     // Mirror hasCumulativeMeasures(): inspect the leaf measures so composed
     // measures whose cumulative-ness lives in a leaf are handled too.
     const measures = [...this.query.measures, ...this.query.measureFilters];
@@ -333,11 +348,9 @@ export class PreAggregations {
       if (!rollingWindow || (rollingWindow.type && rollingWindow.type !== 'fixed')) {
         return null;
       }
-      // A leading window needs data after the requested range; not handled here.
-      if (rollingWindow.leading && rollingWindow.leading !== 'unbounded') {
-        return null;
-      }
-      if (rollingWindow.leading === 'unbounded' || rollingWindow.trailing === 'unbounded') {
+      // A leading window needs data after the requested range, and an unbounded
+      // trailing window has no fixed lookback — neither can be narrowed here.
+      if (rollingWindow.leading || rollingWindow.trailing === 'unbounded') {
         return null;
       }
       if (rollingWindow.trailing) {

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -1,5 +1,6 @@
 import R from 'ramda';
-
+import moment from 'moment-timezone';
+import { parseSqlInterval, subtractInterval } from '@cubejs-backend/shared';
 import { CubeSymbols, PreAggregationDefinition } from '../compiler/CubeSymbols';
 import { FinishedJoinTree, JoinEdge } from '../compiler/JoinGraph';
 import { UserError } from '../compiler/UserError';
@@ -15,6 +16,8 @@ import { BaseFilter } from './BaseFilter';
 import { BaseGroupFilter } from './BaseGroupFilter';
 import { BaseDimension } from './BaseDimension';
 import { BaseSegment } from './BaseSegment';
+
+type ParsedInterval = ReturnType<typeof parseSqlInterval>;
 
 export type PartitionTimeDimension = {
   dimension: string;
@@ -200,7 +203,12 @@ export class PreAggregations {
       return descriptions.map(desc => ({
         ...desc,
         usageMapping: usageInfo.usages,
-        ...(mergedDateRange && desc.matchedTimeDimensionDateRange ? { matchedTimeDimensionDateRange: mergedDateRange } : {}),
+        // Union the usage date ranges with the base matched range so that neither
+        // the per-usage requirement (e.g. time_shift needing earlier partitions)
+        // nor the base range (e.g. a rolling window's trailing lookback) is lost.
+        ...(mergedDateRange && desc.matchedTimeDimensionDateRange
+          ? { matchedTimeDimensionDateRange: PreAggregations.unionDateRanges(desc.matchedTimeDimensionDateRange, mergedDateRange) }
+          : {}),
       }));
     });
   }
@@ -222,6 +230,10 @@ export class PreAggregations {
     }
 
     return minDate && maxDate ? [minDate, maxDate] : null;
+  }
+
+  private static unionDateRanges(a: [string, string], b: [string, string]): [string, string] {
+    return [a[0] < b[0] ? a[0] : b[0], a[1] > b[1] ? a[1] : b[1]];
   }
 
   private preAggregationDescriptionsFor(foundPreAggregation: PreAggregationForQuery): FullPreAggregationDescription[] {
@@ -291,6 +303,82 @@ export class PreAggregations {
     return this.hasCumulativeMeasuresValue;
   }
 
+  /**
+   * For a query with cumulative (rolling window) measures, decide how the matched
+   * time dimension date range can be narrowed for partition selection.
+   *
+   * A rolling window needs data preceding the requested range (the trailing window),
+   * so the range can only be narrowed if every cumulative measure has a bounded
+   * trailing window and no leading window. In that case we return the largest
+   * trailing interval so the caller can shift the matched range start back by it.
+   *
+   * Returns `null` when narrowing is not safe (an unbounded trailing or any leading
+   * window is present) — the caller then keeps the previous behaviour of building
+   * the whole build range. Returns `undefined` when there are no cumulative measures.
+   */
+  private cumulativeMeasuresTrailingInterval(): ParsedInterval | null | undefined {
+    // Mirror hasCumulativeMeasures(): inspect the leaf measures so composed
+    // measures whose cumulative-ness lives in a leaf are handled too.
+    const measures = [...this.query.measures, ...this.query.measureFilters];
+    const collectLeafMeasures = this.query.collectLeafMeasures.bind(this.query);
+    const leafMeasurePaths = R.uniq(
+      R.unnest(measures.map(m => this.query.collectFrom([m], collectLeafMeasures, 'collectLeafMeasures')))
+    ) as string[];
+    const cumulativeMeasures = leafMeasurePaths
+      .map(p => this.query.newMeasure(p))
+      .filter(m => m.isCumulative());
+
+    if (!cumulativeMeasures.length) {
+      return undefined;
+    }
+
+    let maxTrailing: ParsedInterval | undefined;
+    let maxTrailingSeconds = -1;
+
+    for (const measure of cumulativeMeasures) {
+      const { rollingWindow } = measure.measureDefinition();
+      // Non-fixed windows (to_date/year_to_date/etc.) or running totals have a
+      // variable trailing extent — don't narrow.
+      if (!rollingWindow || (rollingWindow.type && rollingWindow.type !== 'fixed')) {
+        return null;
+      }
+      // A leading window needs data after the requested range; not handled here.
+      if (rollingWindow.leading && rollingWindow.leading !== 'unbounded') {
+        return null;
+      }
+      if (rollingWindow.leading === 'unbounded' || rollingWindow.trailing === 'unbounded') {
+        return null;
+      }
+      if (rollingWindow.trailing) {
+        const parsed = parseSqlInterval(rollingWindow.trailing);
+        const seconds = moment.duration(parsed).asSeconds();
+        if (seconds > maxTrailingSeconds) {
+          maxTrailingSeconds = seconds;
+          maxTrailing = parsed;
+        }
+      }
+    }
+
+    return maxTrailing;
+  }
+
+  /**
+   * Shift the start of a matched time dimension range back by the trailing window
+   * so partitions covering the rolling window's lookback are also built.
+   * Leaves the range untouched when there's no range or no trailing interval.
+   */
+  private expandRangeByTrailingWindow(
+    range: [string, string] | undefined,
+    trailingInterval: ParsedInterval | null | undefined
+  ): [string, string] | undefined {
+    if (!range || !trailingInterval) {
+      return range;
+    }
+    const format = `YYYY-MM-DDTHH:mm:ss.${'S'.repeat(this.query.timestampPrecision())}`;
+    const start = subtractInterval(moment(range[0], format), trailingInterval).format(format);
+    return [start, range[1]];
+  }
+
   // Return array of `aggregations` columns descriptions in form `<func>(<column>)`
   // Aggregations used in CubeStore create table for describe measures in CubeStore side
   public aggregationsColumns(cube: string, preAggregation: PreAggregationDefinition): string[] {
@@ -326,7 +414,15 @@ export class PreAggregations {
 
     let matchedTimeDimension: BaseTimeDimension | undefined;
 
-    if (preAggregation.partitionGranularity && !this.hasCumulativeMeasures()) {
+    // For cumulative (rolling window) measures the matched range can only narrow
+    // partition selection when every window has a bounded trailing extent and no
+    // leading window. `undefined` => no cumulative measures (regular narrowing);
+    // a ParsedInterval => narrow but shift the start back by that trailing window;
+    // `null` => can't narrow safely, keep building the whole range.
+    const trailingInterval = this.cumulativeMeasuresTrailingInterval();
+    const canMatchTimeDimension = trailingInterval !== null;
+
+    if (preAggregation.partitionGranularity && canMatchTimeDimension) {
       matchedTimeDimension = this.query.timeDimensions.find(td => {
         if (!td.dateRange) {
           return false;
@@ -351,7 +447,7 @@ export class PreAggregations {
 
     let filters: BaseFilter[] | undefined;
 
-    if (preAggregation.partitionGranularity) {
+    if (preAggregation.partitionGranularity && canMatchTimeDimension) {
       filters = this.query.filters?.filter((td): td is BaseFilter => {
         // TODO support all date operators
         if (td.isDateOperator() && 'camelizeOperator' in td && td.camelizeOperator === 'inDateRange') {
@@ -404,9 +500,10 @@ export class PreAggregations {
         (preAggregation.partitionGranularity || references.timeDimensions[0]?.granularity) &&
         this.refreshRangeQuery(cube).preAggregationStartEndQueries(cube, preAggregation),
       matchedTimeDimensionDateRange:
-        preAggregation.partitionGranularity && (
+        preAggregation.partitionGranularity && this.expandRangeByTrailingWindow(
           matchedTimeDimension?.boundaryDateRangeFormatted() ||
-          filters?.[0]?.formattedDateRange() // TODO intersect all date ranges
+          filters?.[0]?.formattedDateRange(), // TODO intersect all date ranges
+          trailingInterval
         ),
       indexesSql: Object.keys(preAggregation.indexes || {})
         .map(

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -203,12 +203,7 @@ export class PreAggregations {
       return descriptions.map(desc => ({
         ...desc,
         usageMapping: usageInfo.usages,
-        // Union the usage date ranges with the base matched range so that neither
-        // the per-usage requirement (e.g. time_shift needing earlier partitions)
-        // nor the base range (e.g. a rolling window's trailing lookback) is lost.
-        ...(mergedDateRange && desc.matchedTimeDimensionDateRange
-          ? { matchedTimeDimensionDateRange: PreAggregations.unionDateRanges(desc.matchedTimeDimensionDateRange, mergedDateRange) }
-          : {}),
+        ...(mergedDateRange && desc.matchedTimeDimensionDateRange ? { matchedTimeDimensionDateRange: mergedDateRange } : {}),
       }));
     });
   }
@@ -230,10 +225,6 @@ export class PreAggregations {
     }
 
     return minDate && maxDate ? [minDate, maxDate] : null;
-  }
-
-  private static unionDateRanges(a: [string, string], b: [string, string]): [string, string] {
-    return [a[0] < b[0] ? a[0] : b[0], a[1] > b[1] ? a[1] : b[1]];
   }
 
   private preAggregationDescriptionsFor(foundPreAggregation: PreAggregationForQuery): FullPreAggregationDescription[] {

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -202,6 +202,11 @@ export class PreAggregations {
 
       // Compute the union of all usage date ranges so that partitions cover
       // every usage (e.g. time_shift may require earlier partitions).
+      // This overwrites the base matched range rather than unioning with it: this path is
+      // Tesseract-only and mutually exclusive with expandRangeByTrailingWindow() below, and
+      // Tesseract matches rolling windows at the leaf-CTE level where the date range has
+      // already been widened by the trailing window. Unioning here mixed timestamp precisions
+      // and regressed time_shift queries.
       const mergedDateRange = PreAggregations.mergeUsageDateRanges(usageInfo.usages);
 
       return descriptions.map(desc => ({
@@ -355,6 +360,9 @@ export class PreAggregations {
       }
       if (rollingWindow.trailing) {
         const parsed = parseSqlInterval(rollingWindow.trailing);
+        // Approximate month/year lengths are fine here: this only picks which window to
+        // shift the start back by, and over-shifting builds a redundant partition rather
+        // than dropping a needed one.
         const seconds = moment.duration(parsed).asSeconds();
         if (seconds > maxTrailingSeconds) {
           maxTrailingSeconds = seconds;

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -117,8 +117,6 @@ export class PreAggregations {
 
   private readonly cubeLattices: {};
 
-  private hasCumulativeMeasuresValue: boolean = false;
-
   private cumulativeMeasuresTrailingIntervalValue: ParsedInterval | null | undefined;
 
   private cumulativeMeasuresTrailingIntervalComputed: boolean = false;
@@ -296,13 +294,6 @@ export class PreAggregations {
     return descriptions.concat(this.preAggregationDescriptionFor(cube, foundPreAggregation));
   }
 
-  private hasCumulativeMeasures(): boolean {
-    if (!this.hasCumulativeMeasuresValue) {
-      this.hasCumulativeMeasuresValue = PreAggregations.hasCumulativeMeasures(this.query);
-    }
-    return this.hasCumulativeMeasuresValue;
-  }
-
   /**
    * For a query with cumulative (rolling window) measures, decide how the matched
    * time dimension date range can be narrowed for partition selection.
@@ -317,9 +308,8 @@ export class PreAggregations {
    * the whole build range. Returns `undefined` when there are no cumulative measures.
    */
   private cumulativeMeasuresTrailingInterval(): ParsedInterval | null | undefined {
-    // Memoized like hasCumulativeMeasures(): computeCumulativeMeasuresTrailingInterval()
-    // walks the leaf-measure graph, and preAggregationDescriptionFor() calls this once
-    // per pre-aggregation.
+    // Memoized: computeCumulativeMeasuresTrailingInterval() walks the leaf-measure graph,
+    // and preAggregationDescriptionFor() calls this once per pre-aggregation.
     if (!this.cumulativeMeasuresTrailingIntervalComputed) {
       this.cumulativeMeasuresTrailingIntervalValue = this.computeCumulativeMeasuresTrailingInterval();
       this.cumulativeMeasuresTrailingIntervalComputed = true;
@@ -328,7 +318,7 @@ export class PreAggregations {
   }
 
   private computeCumulativeMeasuresTrailingInterval(): ParsedInterval | null | undefined {
-    // Mirror hasCumulativeMeasures(): inspect the leaf measures so composed
+    // Mirror the static hasCumulativeMeasures(): inspect the leaf measures so composed
     // measures whose cumulative-ness lives in a leaf are handled too.
     const measures = [...this.query.measures, ...this.query.measureFilters];
     const collectLeafMeasures = this.query.collectLeafMeasures.bind(this.query);
@@ -387,7 +377,9 @@ export class PreAggregations {
       return range;
     }
     const format = `YYYY-MM-DDTHH:mm:ss.${'S'.repeat(this.query.timestampPrecision())}`;
-    const start = subtractInterval(moment(range[0], format), trailingInterval).format(format);
+    // Parse as UTC: the range carries query-timezone wall clock with no offset, and parsing it in
+    // the host timezone would let DST normalization shift the lookback start later.
+    const start = subtractInterval(moment.utc(range[0], format), trailingInterval).format(format);
     return [start, range[1]];
   }
 

--- a/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
@@ -1,0 +1,101 @@
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+// CORE-164: a query with a narrow dateRange against a partitioned pre-aggregation
+// should only cause the partitions needed to serve that timeframe to be built.
+//
+// For cumulative (rolling window) measures the pre-aggregation description used
+// to omit `matchedTimeDimensionDateRange` entirely, which made the query
+// orchestrator fall back to building the pre-aggregation's whole build range
+// (every partition). For a BOUNDED trailing window only the requested range,
+// expanded backwards by the trailing window, is actually needed.
+
+const SCHEMA = `
+cubes:
+  - name: rent
+    sql: >
+      SELECT 1 AS id, '2020-01-01'::timestamp AS date, 100 AS in_place_rent
+    measures:
+      - name: count
+        type: count
+      - name: rolling_7d
+        sql: in_place_rent
+        type: sum
+        rollingWindow:
+          trailing: 7 day
+      - name: rolling_unbounded
+        sql: in_place_rent
+        type: sum
+        rollingWindow:
+          trailing: unbounded
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primaryKey: true
+      - name: date
+        sql: date
+        type: time
+    preAggregations:
+      - name: rolling_7d_pa
+        measures:
+          - rolling_7d
+        timeDimension: date
+        granularity: day
+        partitionGranularity: week
+      - name: rolling_unbounded_pa
+        measures:
+          - rolling_unbounded
+        timeDimension: date
+        granularity: day
+        partitionGranularity: week
+`;
+
+describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
+  async function preAggDescription(query) {
+    const { compiler, cubeEvaluator, joinGraph } = prepareYamlCompiler(SCHEMA);
+    await compiler.compile();
+    const q = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, query);
+    q.buildSqlAndParams();
+    return q.preAggregations?.preAggregationsDescription();
+  }
+
+  it('bounded trailing window narrows to the requested range expanded by the window', async () => {
+    const desc: any = await preAggDescription({
+      measures: ['rent.rolling_7d'],
+      timeDimensions: [{
+        dimension: 'rent.date',
+        granularity: 'day',
+        dateRange: ['2024-06-10', '2024-06-10'],
+      }],
+      timezone: 'UTC',
+    });
+
+    expect(desc).toHaveLength(1);
+    expect(desc[0].preAggregationId).toEqual('rent.rolling_7d_pa');
+    // The requested day is 2024-06-10; a 7-day trailing window needs data back
+    // to 2024-06-03, so the matched range must start no later than 2024-06-03
+    // and end at the requested day — NOT be undefined (which builds everything).
+    expect(desc[0].matchedTimeDimensionDateRange).toEqual([
+      '2024-06-03T00:00:00.000',
+      '2024-06-10T23:59:59.999',
+    ]);
+  });
+
+  it('unbounded trailing window still builds the whole range (unchanged)', async () => {
+    const desc: any = await preAggDescription({
+      measures: ['rent.rolling_unbounded'],
+      timeDimensions: [{
+        dimension: 'rent.date',
+        granularity: 'day',
+        dateRange: ['2024-06-10', '2024-06-10'],
+      }],
+      timezone: 'UTC',
+    });
+
+    expect(desc).toHaveLength(1);
+    expect(desc[0].preAggregationId).toEqual('rent.rolling_unbounded_pa');
+    // Unbounded trailing genuinely needs all history => no narrowing.
+    expect(desc[0].matchedTimeDimensionDateRange).toBeUndefined();
+  });
+});

--- a/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
@@ -1,4 +1,5 @@
 import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { BigqueryQuery } from '../../src/adapter/BigqueryQuery';
 import { prepareYamlCompiler } from './PrepareCompiler';
 
 // CORE-164: a query with a narrow dateRange against a partitioned pre-aggregation
@@ -52,10 +53,10 @@ cubes:
 `;
 
 describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
-  async function preAggDescription(query) {
+  async function preAggDescription(query, QueryClass: any = PostgresQuery) {
     const { compiler, cubeEvaluator, joinGraph } = prepareYamlCompiler(SCHEMA);
     await compiler.compile();
-    const q = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, query);
+    const q = new QueryClass({ joinGraph, cubeEvaluator, compiler }, query);
     q.buildSqlAndParams();
     return q.preAggregations?.preAggregationsDescription();
   }
@@ -97,5 +98,25 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
     expect(desc[0].preAggregationId).toEqual('rent.rolling_unbounded_pa');
     // Unbounded trailing genuinely needs all history => no narrowing.
     expect(desc[0].matchedTimeDimensionDateRange).toBeUndefined();
+  });
+
+  it('expanded range keeps the query timestamp precision (microseconds)', async () => {
+    // BigQuery uses microsecond precision. The expanded start/end must be emitted
+    // at that same precision — mixing 3-digit and 6-digit strings produced
+    // malformed ranges (`...,...999999`) that the partition loader rejected.
+    const desc: any = await preAggDescription({
+      measures: ['rent.rolling_7d'],
+      timeDimensions: [{
+        dimension: 'rent.date',
+        granularity: 'day',
+        dateRange: ['2024-06-10', '2024-06-10'],
+      }],
+      timezone: 'UTC',
+    }, BigqueryQuery);
+
+    expect(desc[0].matchedTimeDimensionDateRange).toEqual([
+      '2024-06-03T00:00:00.000000',
+      '2024-06-10T23:59:59.999999',
+    ]);
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
@@ -135,7 +135,8 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
     expect(ids).toContain('rent.rolling_mixed_pa');
     // 1 month is the wider of the two windows, so the lookback must reach back a
     // month — shifting by the 7-day window would leave the 1-month measure short.
-    expect(desc[ids.indexOf('rent.rolling_mixed_pa')].matchedTimeDimensionDateRange).toEqual([
+    const mixed = desc.find(d => d.preAggregationId === 'rent.rolling_mixed_pa');
+    expect(mixed.matchedTimeDimensionDateRange).toEqual([
       '2024-05-10T00:00:00.000',
       '2024-06-10T23:59:59.999',
     ]);
@@ -147,24 +148,25 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
   // plain count as much as for a rolling window — so nothing reaches the range code.
   // Pinned here so a change that starts matching this shape surfaces as a failure
   // rather than silently exercising an untested lookback path.
-  it('does not match a partitioned rollup when the range is only an inDateRange filter', async () => {
-    for (const measure of ['rent.count', 'rent.rolling_7d']) {
-      const desc: any = await preAggDescription({
-        measures: [measure],
-        timeDimensions: [{
-          dimension: 'rent.date',
-          granularity: 'day',
-        }],
-        filters: [{
-          member: 'rent.date',
-          operator: 'inDateRange',
-          values: ['2024-06-10', '2024-06-10'],
-        }],
-        timezone: 'UTC',
-      });
+  it.each([
+    ['plain count', 'rent.count'],
+    ['rolling window', 'rent.rolling_7d'],
+  ])('does not match a partitioned rollup when the range is only an inDateRange filter (%s)', async (_label, measure) => {
+    const desc: any = await preAggDescription({
+      measures: [measure],
+      timeDimensions: [{
+        dimension: 'rent.date',
+        granularity: 'day',
+      }],
+      filters: [{
+        member: 'rent.date',
+        operator: 'inDateRange',
+        values: ['2024-06-10', '2024-06-10'],
+      }],
+      timezone: 'UTC',
+    });
 
-      expect(desc).toEqual([]);
-    }
+    expect(desc).toEqual([]);
   });
 
   it('expanded range keeps the query timestamp precision (microseconds)', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
@@ -24,6 +24,11 @@ cubes:
         type: sum
         rollingWindow:
           trailing: 7 day
+      - name: rolling_1m
+        sql: in_place_rent
+        type: sum
+        rollingWindow:
+          trailing: 1 month
       - name: rolling_unbounded
         sql: in_place_rent
         type: sum
@@ -47,6 +52,13 @@ cubes:
       - name: rolling_unbounded_pa
         measures:
           - rolling_unbounded
+        timeDimension: date
+        granularity: day
+        partitionGranularity: week
+      - name: rolling_mixed_pa
+        measures:
+          - rolling_7d
+          - rolling_1m
         timeDimension: date
         granularity: day
         partitionGranularity: week
@@ -98,6 +110,52 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
     expect(desc[0].preAggregationId).toEqual('rent.rolling_unbounded_pa');
     // Unbounded trailing genuinely needs all history => no narrowing.
     expect(desc[0].matchedTimeDimensionDateRange).toBeUndefined();
+  });
+
+  it('shifts the start back by the largest trailing window when measures disagree', async () => {
+    const desc: any = await preAggDescription({
+      measures: ['rent.rolling_7d', 'rent.rolling_1m'],
+      timeDimensions: [{
+        dimension: 'rent.date',
+        granularity: 'day',
+        dateRange: ['2024-06-10', '2024-06-10'],
+      }],
+      timezone: 'UTC',
+    });
+
+    const mixed = desc.find(d => d.preAggregationId === 'rent.rolling_mixed_pa');
+    // 1 month is the wider of the two windows, so the lookback must reach back a
+    // month — shifting by the 7-day window would leave the 1-month measure short.
+    expect(mixed.matchedTimeDimensionDateRange).toEqual([
+      '2024-05-10T00:00:00.000',
+      '2024-06-10T23:59:59.999',
+    ]);
+  });
+
+  // The description also accepts its range from an `inDateRange` filter when the time
+  // dimension carries no dateRange. That fallback is unreachable for a partitioned
+  // rollup: expressing the range as a filter stops the rollup matching at all, for a
+  // plain count as much as for a rolling window — so nothing reaches the range code.
+  // Pinned here so a change that starts matching this shape surfaces as a failure
+  // rather than silently exercising an untested lookback path.
+  it('does not match a partitioned rollup when the range is only an inDateRange filter', async () => {
+    for (const measure of ['rent.count', 'rent.rolling_7d']) {
+      const desc: any = await preAggDescription({
+        measures: [measure],
+        timeDimensions: [{
+          dimension: 'rent.date',
+          granularity: 'day',
+        }],
+        filters: [{
+          member: 'rent.date',
+          operator: 'inDateRange',
+          values: ['2024-06-10', '2024-06-10'],
+        }],
+        timezone: 'UTC',
+      });
+
+      expect(desc).toEqual([]);
+    }
   });
 
   it('expanded range keeps the query timestamp precision (microseconds)', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/core-164-rolling-window-partitions.test.ts
@@ -112,9 +112,15 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
     expect(desc[0].matchedTimeDimensionDateRange).toBeUndefined();
   });
 
-  it('shifts the start back by the largest trailing window when measures disagree', async () => {
+  // Both measure orders, so the assertion pins the `seconds > maxTrailingSeconds`
+  // comparison rather than a positional accident: with only one order, taking the
+  // first window or taking the last would each pass for one of them.
+  it.each([
+    ['7d first', ['rent.rolling_7d', 'rent.rolling_1m']],
+    ['1m first', ['rent.rolling_1m', 'rent.rolling_7d']],
+  ])('shifts the start back by the largest trailing window when measures disagree (%s)', async (_label, measures) => {
     const desc: any = await preAggDescription({
-      measures: ['rent.rolling_7d', 'rent.rolling_1m'],
+      measures,
       timeDimensions: [{
         dimension: 'rent.date',
         granularity: 'day',
@@ -123,10 +129,13 @@ describe('CORE-164 rolling-window pre-aggregation partition scope', () => {
       timezone: 'UTC',
     });
 
-    const mixed = desc.find(d => d.preAggregationId === 'rent.rolling_mixed_pa');
+    // Assert the id list first: a missing mixed rollup then reads as a match failure
+    // rather than a TypeError on the range lookup below.
+    const ids = desc.map(d => d.preAggregationId);
+    expect(ids).toContain('rent.rolling_mixed_pa');
     // 1 month is the wider of the two windows, so the lookback must reach back a
     // month — shifting by the 7-day window would leave the 1-month measure short.
-    expect(mixed.matchedTimeDimensionDateRange).toEqual([
+    expect(desc[ids.indexOf('rent.rolling_mixed_pa')].matchedTimeDimensionDateRange).toEqual([
       '2024-05-10T00:00:00.000',
       '2024-06-10T23:59:59.999',
     ]);


### PR DESCRIPTION
## Issue

[CORE-164](https://linear.app/cube-d3/issue/CORE-164) — a query with a narrow `dateRange` (e.g. `yesterday`) against a week-partitioned pre-aggregation builds **all** partitions instead of only the one(s) needed to serve the timeframe.

## Root cause

`preAggregationDescriptionFor` gated computing `matchedTimeDimensionDateRange` on `!this.hasCumulativeMeasures()`. So whenever the query has a cumulative (rolling window) measure, `matchedTimeDimensionDateRange` was left `undefined`, and the orchestrator's `PreAggregationPartitionRangeLoader.partitionRanges()` → `intersectDateRanges(buildRange, undefined)` falls back to the **whole build range** — every partition.

That blanket skip is only correct for **unbounded** trailing windows (which genuinely need all history). For a **bounded** window (`trailing: 7 day`) only `[queryStart − window, queryEnd]` is needed.

### Evidence (local repro)

Week-partitioned pre-agg, `dateRange` = a single day, ~4.5 years of build range:

| Query | `matchedTimeDimensionDateRange` | Partitions built |
|---|---|---|
| additive measure (with/without granularity, incl. via a view) | set to the requested day | **1** ✅ |
| `rollingWindow.trailing: 7 day` | **undefined** | **235** ❌ |
| `rollingWindow.trailing: unbounded` | undefined (correct) | 235 (correct) |

A correct 7-day-trailing build for a single day needs **2** weekly partitions, not 235.

## Fix

`cumulativeMeasuresTrailingInterval()` classifies the query's cumulative leaf measures:

- **no cumulative measures** → regular narrowing (unchanged);
- **all bounded trailing, no leading** → narrow, and shift the matched range **start back by the largest trailing window** so the lookback partitions are still built;
- **any unbounded trailing / any leading / non-`fixed` window** → don't narrow, keep building the whole range (previous behaviour preserved).

The usage-info merge path (Tesseract) now takes the **union** of the per-usage range and the base matched range, so neither a `time_shift` usage's earlier partitions nor a rolling window's trailing lookback is dropped.

Tesseract has no partition-narrowing logic of its own — it routes pre-agg description assembly through this same JS method — so the fix covers both the default (Tesseract) and legacy planners.

## Tests

New `core-164-rolling-window-partitions.test.ts`:
- **bounded** trailing window → `matchedTimeDimensionDateRange` set to the requested range expanded back by the window (was `undefined` before — red without the fix);
- **unbounded** trailing window → still `undefined` (whole range), guarding the correct case.

Existing `pre-aggregations`, `pre-agg-time-dim-match`, `pre-agg-by-filter-match` suites: no new failures (the pre-existing failures in this checkout are native-binary/`viewGroups` drift, unrelated and identical on `master`).


[CORE-164]: https://cubedevinc.atlassian.net/browse/CORE-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ