### PR TITLE
feat(cubesql): Support joining ungrouped queries with SQL push down

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_stays_above_filter_over_join.snap
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/snapshots/cubesql__compile__engine__df__optimizers__sort_push_down__tests__sort_stays_above_filter_over_join.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+expression: optimize(&plan)
+---
+Sort: #j1.c1 ASC NULLS LAST
+  Filter: #j1.c1 >= #j2.c2
+    Inner Join: #j1.key = #j2.key
+      Projection: #j1.key, #j1.c1
+        TableScan: j1 projection=None
+      Projection: #j2.key, #j2.c2
+        TableScan: j2 projection=None

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
@@ -112,15 +112,29 @@ fn sort_push_down(
             // Sort can be pushed down Filter, and while it may seem weird to do that
             // after doing the exact opposite in `FilterPushDown`, this may allow the sort
             // to push through some complex filters, ultimately reaching CubeScan.
-            Ok(LogicalPlan::Filter(Filter {
-                predicate: predicate.clone(),
-                input: Arc::new(sort_push_down(
-                    optimizer,
-                    input,
+            // Only do that when the sort can actually reach a scan: when it would get
+            // stuck above a barrier like Join or Aggregate instead, a sort in a subquery
+            // under a filter does not guarantee result order once the query is pushed
+            // down to SQL, so the sort must stay above the filter.
+            if sort_expr.is_none() || sort_can_reach_scan(input) {
+                Ok(LogicalPlan::Filter(Filter {
+                    predicate: predicate.clone(),
+                    input: Arc::new(sort_push_down(
+                        optimizer,
+                        input,
+                        sort_expr,
+                        optimizer_config,
+                    )?),
+                }))
+            } else {
+                issue_sort(
                     sort_expr,
-                    optimizer_config,
-                )?),
-            }))
+                    LogicalPlan::Filter(Filter {
+                        predicate: predicate.clone(),
+                        input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    }),
+                )
+            }
         }
         LogicalPlan::Window(Window {
             input,
@@ -269,6 +283,30 @@ fn rewrite_map_for_projection(
             ]
         })
         .collect()
+}
+
+/// Whether pushing a sort expression down this plan is useful: the sort must not
+/// get stuck above a Join. A sort in a subquery under a filter does not guarantee
+/// result order once the query is pushed down to SQL, and a sort above a Join —
+/// including a Join buried under Aggregate, Window, Limit or similar nodes — can't
+/// be absorbed into a CubeScan. Plans without a Join on their input spine keep the
+/// pre-existing behavior: the sort is pushed down and later absorbed into a CubeScan
+/// (grouped CubeScans absorb ORDER BY even through Aggregate).
+fn sort_can_reach_scan(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Projection(Projection { input, .. })
+        | LogicalPlan::Filter(Filter { input, .. })
+        | LogicalPlan::Sort(Sort { input, .. })
+        | LogicalPlan::Aggregate(Aggregate { input, .. })
+        | LogicalPlan::Window(Window { input, .. })
+        | LogicalPlan::Limit(Limit { input, .. })
+        | LogicalPlan::Distinct(Distinct { input }) => sort_can_reach_scan(input),
+        LogicalPlan::Union(Union { inputs, .. }) => {
+            inputs.iter().all(|input| sort_can_reach_scan(input))
+        }
+        LogicalPlan::Join(_) | LogicalPlan::CrossJoin(_) => false,
+        _ => true,
+    }
 }
 
 /// Issues a Sort containing the provided input if the provided `sort_expr` is `Some`;

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
@@ -112,15 +112,28 @@ fn sort_push_down(
             // Sort can be pushed down Filter, and while it may seem weird to do that
             // after doing the exact opposite in `FilterPushDown`, this may allow the sort
             // to push through some complex filters, ultimately reaching CubeScan.
-            Ok(LogicalPlan::Filter(Filter {
-                predicate: predicate.clone(),
-                input: Arc::new(sort_push_down(
-                    optimizer,
-                    input,
+            // Only do that when the sort can actually reach a scan: a sort stuck above
+            // a Join does not guarantee result order once pushed down to SQL, so it
+            // must stay above the filter instead.
+            if sort_expr.is_none() || sort_can_reach_scan(input) {
+                Ok(LogicalPlan::Filter(Filter {
+                    predicate: predicate.clone(),
+                    input: Arc::new(sort_push_down(
+                        optimizer,
+                        input,
+                        sort_expr,
+                        optimizer_config,
+                    )?),
+                }))
+            } else {
+                issue_sort(
                     sort_expr,
-                    optimizer_config,
-                )?),
-            }))
+                    LogicalPlan::Filter(Filter {
+                        predicate: predicate.clone(),
+                        input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    }),
+                )
+            }
         }
         LogicalPlan::Window(Window {
             input,
@@ -269,6 +282,36 @@ fn rewrite_map_for_projection(
             ]
         })
         .collect()
+}
+
+/// Whether pushing a sort expression down this plan is useful: the sort must not
+/// get stuck above a Join. A sort in a subquery under a filter does not guarantee
+/// result order once the query is pushed down to SQL, and a sort above a Join -
+/// including a Join buried under Aggregate, Window, Limit or similar nodes - can't
+/// be absorbed into a CubeScan. Plans without a Join on their input spine keep the
+/// pre-existing behavior: the sort is pushed down and later absorbed into a CubeScan
+/// (grouped CubeScans absorb ORDER BY even through Aggregate). In grouped join shapes
+/// like Sort(Filter(Aggregate(Join(..)))) both placements preserve order;
+/// above-the-filter is the safer one.
+fn sort_can_reach_scan(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Projection(Projection { input, .. })
+        | LogicalPlan::Filter(Filter { input, .. })
+        | LogicalPlan::Sort(Sort { input, .. })
+        | LogicalPlan::Aggregate(Aggregate { input, .. })
+        | LogicalPlan::Window(Window { input, .. })
+        | LogicalPlan::Limit(Limit { input, .. })
+        | LogicalPlan::Distinct(Distinct { input }) => sort_can_reach_scan(input),
+        LogicalPlan::Union(Union { inputs, .. }) => {
+            // Vacuously true for a unionless Union; such plans don't survive planning
+            inputs.iter().all(|input| sort_can_reach_scan(input))
+        }
+        LogicalPlan::Join(_) | LogicalPlan::CrossJoin(_) => false,
+        // Optimistic by design: a stricter allow-list demonstrably loses push down
+        // (grouped scans regress to post-processing plans), while over-permitting
+        // costs at most a pushed sort that is not absorbed
+        _ => true,
+    }
 }
 
 /// Issues a Sort containing the provided input if the provided `sort_expr` is `Some`;
@@ -421,6 +464,34 @@ mod tests {
         )?
         .project(vec![col("j1.c1"), col("j2.c2")])?
         .sort(vec![sort(col("j2.c2"), true, false)])?
+        .build()?;
+
+        insta::assert_debug_snapshot!(optimize(&plan));
+        Ok(())
+    }
+
+    #[test]
+    fn test_sort_stays_above_filter_over_join() -> Result<()> {
+        // Sort must not be pushed below a Filter when it would get stuck above a Join:
+        // a sort in a subquery under a filter does not guarantee result order once the
+        // query is pushed down to SQL.
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"], vec![])?)
+                .project(vec![col("key"), col("c1")])?
+                .build()?,
+        )
+        .join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"], vec![])?)
+                .project(vec![col("key"), col("c2")])?
+                .build()?,
+            JoinType::Inner,
+            (
+                vec![Column::from_name("key")],
+                vec![Column::from_name("key")],
+            ),
+        )?
+        .filter(col("j1.c1").gt_eq(col("j2.c2")))?
+        .sort(vec![sort(col("j1.c1"), true, false)])?
         .build()?;
 
         insta::assert_debug_snapshot!(optimize(&plan));

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
@@ -11,9 +11,9 @@ use crate::{
         wrapper_pullup_replacer, wrapper_pushdown_replacer, wrapper_replacer_context, BinaryExprOp,
         ColumnExprColumn, CubeEGraph, JoinLeftOn, JoinRightOn, LogicalPlanLanguage,
         WrappedSelectJoinJoinType, WrappedSelectPushToCube, WrapperReplacerContextAliasToCube,
-        WrapperReplacerContextGroupedSubqueries,
+        WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextUngroupedScan,
     },
-    transport::MetaContext,
+    transport::{DataSource, MetaContext},
     var, var_iter, var_list_iter,
 };
 
@@ -490,6 +490,238 @@ impl WrapperRules {
                     "?out_push_to_cube",
                 ),
             ),
+            // Join where at least one side is an ungrouped (raw) query.
+            // Both sides are rendered as standalone subqueries and joined with plain SQL,
+            // so the result is not push-to-Cube. Grouped-grouped joins are covered by
+            // wrapper-push-down-grouped-join-grouped above.
+            // The result is marked UngroupedScan:true ("raw rows, may contain duplicate
+            // join keys"): it must never become the grouped RHS of the push-to-Cube
+            // subquery join path. Cube renders subqueryJoins as a plain join for simple
+            // measures but as a SELECT DISTINCT keys semi-join for multiplied measures -
+            // those two only agree when the subquery is unique on the join keys, which
+            // raw join output is not. An aggregation above this join produces
+            // UngroupedScan:false again, legitimately: its output is unique on its
+            // GROUP BY keys.
+            transforming_rewrite(
+                "wrapper-push-down-ungrouped-join-ungrouped",
+                join(
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?left_input",
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "?left_push_to_cube",
+                                "?left_in_projection",
+                                "?left_cube_members",
+                                "?left_grouped_subqueries",
+                                "?left_ungrouped_scan",
+                                // Data sources must match for both sides
+                                // TODO support unrestricted data source on one side
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?right_input",
+                            wrapper_replacer_context(
+                                // Going to ignore this
+                                "?right_alias_to_cube",
+                                "?right_push_to_cube",
+                                "?right_in_projection",
+                                // Used to reject joins on virtual members (__cubeJoinField)
+                                "?right_cube_members",
+                                "?right_grouped_subqueries",
+                                "?right_ungrouped_scan",
+                                // Data sources must match for both sides
+                                // TODO support unrestricted data source on one side
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    "?left_on",
+                    "?right_on",
+                    "?in_join_type",
+                    "?join_constraint",
+                    "JoinNullEqualsNull:false",
+                ),
+                // Both sides are standalone subqueries, so the result is plain SQL over them:
+                // PushToCube:false everywhere, and join condition columns are just columns
+                cube_scan_wrapper(
+                    wrapped_select(
+                        "WrappedSelectSelectType:Projection",
+                        wrapper_pullup_replacer(
+                            wrapped_select_projection_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_subqueries_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_group_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_aggr_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_window_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            // Standalone subquery: SQL for it is generated in isolation,
+                            // no need to check what exactly is inside
+                            "?left_input",
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        // We don't want to use list rules here, because ?right_input is already done
+                        wrapped_select_joins(
+                            wrapped_select_join(
+                                wrapper_pullup_replacer(
+                                    "?right_input",
+                                    wrapper_replacer_context(
+                                        "?left_alias_to_cube",
+                                        "WrapperReplacerContextPushToCube:false",
+                                        "WrapperReplacerContextInProjection:false",
+                                        "?left_cube_members",
+                                        "?out_grouped_subqueries",
+                                        "WrapperReplacerContextUngroupedScan:true",
+                                        "?input_data_source",
+                                    ),
+                                ),
+                                wrapper_pushdown_replacer(
+                                    "?out_join_expr",
+                                    wrapper_replacer_context(
+                                        "?left_alias_to_cube",
+                                        // PushToCube:false, so every column in join condition
+                                        // is rewritten as a plain column
+                                        "WrapperReplacerContextPushToCube:false",
+                                        "WrapperReplacerContextInProjection:false",
+                                        "?left_cube_members",
+                                        "?out_grouped_subqueries",
+                                        "WrapperReplacerContextUngroupedScan:true",
+                                        "?input_data_source",
+                                    ),
+                                ),
+                                "?out_join_type",
+                            ),
+                            // pullup(tail) just so it could be easily picked up by pullup rules
+                            wrapper_pullup_replacer(
+                                wrapped_select_joins_empty_tail(),
+                                wrapper_replacer_context(
+                                    "?left_alias_to_cube",
+                                    "WrapperReplacerContextPushToCube:false",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?left_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:true",
+                                    "?input_data_source",
+                                ),
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_filter_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapped_select_having_expr_empty_tail(),
+                        "WrappedSelectLimit:None",
+                        "WrappedSelectOffset:None",
+                        wrapper_pullup_replacer(
+                            wrapped_select_order_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        "WrappedSelectAlias:None",
+                        "WrappedSelectDistinct:false",
+                        // Both sides are standalone subqueries, nothing to push to Cube
+                        "WrappedSelectPushToCube:false",
+                        // Raw rows with possibly duplicated join keys: must not be
+                        // consumed as a grouped subquery by other join rules
+                        "WrappedSelectUngroupedScan:true",
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+                self.transform_ungrouped_join_ungrouped(
+                    "?left_cube_members",
+                    "?left_ungrouped_scan",
+                    "?left_on",
+                    "?right_cube_members",
+                    "?right_ungrouped_scan",
+                    "?right_on",
+                    "?in_join_type",
+                    "?input_data_source",
+                    "?out_join_expr",
+                    "?out_join_type",
+                    "?out_grouped_subqueries",
+                ),
+            ),
         ]);
 
         // DataFusion plans complex join conditions as Filter(?join_condition, CrossJoin(...))
@@ -913,6 +1145,30 @@ impl WrapperRules {
         binary_expr(left_expr, "IS_NOT_DISTINCT_FROM", right_expr)
     }
 
+    /// Whether every member of the list can materialize as a plain column of a raw
+    /// (ungrouped) subquery. Measures can't: per-row materialization is not defined
+    /// for every measure (e.g. a multi-stage measure has no meaningful value for a
+    /// single raw row). Virtual fields (`__cubeJoinField`, `__user`) and change-user
+    /// members aren't real columns in the generated subquery SQL either. Segments are
+    /// deliberately admitted: a segment is a row filter shipped in the side's own load
+    /// query, not a column that needs materializing. When the members can't be
+    /// inspected, assume the worst.
+    fn are_members_raw_materializable(egraph: &CubeEGraph, members: Id) -> bool {
+        let Some(members_data) = &egraph[members].data.member_name_to_expr else {
+            log::trace!(
+                "wrapper-push-down-ungrouped-join-ungrouped: \
+                no member data for a join side, assuming it can't be materialized raw"
+            );
+            return false;
+        };
+        members_data.list.iter().all(|(_, member, _)| {
+            !matches!(
+                member,
+                Member::Measure { .. } | Member::VirtualField { .. } | Member::ChangeUser { .. }
+            )
+        })
+    }
+
     fn are_join_members_supported<'egraph, 'columns>(
         egraph: &'egraph mut CubeEGraph,
         members: Id,
@@ -1011,7 +1267,15 @@ impl WrapperRules {
         let Ok(data_source) = Self::get_data_source(egraph, subst, data_source_var) else {
             return false;
         };
-        Self::can_rewrite_template(&data_source, meta, template)
+        match data_source {
+            DataSource::Specific(_) => Self::can_rewrite_template(&data_source, meta, template),
+            // The join type is committed into the rewritten plan, so when the data source
+            // is not pinned down yet, whichever generator the plan resolves to must be
+            // able to render it: require the template on every registered generator
+            DataSource::Unrestricted => {
+                Self::is_template_available_on_every_data_source(meta, template)
+            }
+        }
     }
 
     fn transform_ungrouped_join_grouped(
@@ -1257,6 +1521,154 @@ impl WrapperRules {
             }
 
             return false;
+        }
+    }
+
+    fn transform_ungrouped_join_ungrouped(
+        &self,
+        left_members_var: &'static str,
+        left_ungrouped_scan_var: &'static str,
+        left_on_var: &'static str,
+        right_members_var: &'static str,
+        right_ungrouped_scan_var: &'static str,
+        right_on_var: &'static str,
+        in_join_type_var: &'static str,
+        input_data_source_var: &'static str,
+        out_join_expr_var: &'static str,
+        out_join_type_var: &'static str,
+        out_grouped_subqueries_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let left_members_var = var!(left_members_var);
+        let left_ungrouped_scan_var = var!(left_ungrouped_scan_var);
+        let left_on_var = var!(left_on_var);
+
+        let right_members_var = var!(right_members_var);
+        let right_ungrouped_scan_var = var!(right_ungrouped_scan_var);
+        let right_on_var = var!(right_on_var);
+
+        let in_join_type_var = var!(in_join_type_var);
+        let input_data_source_var = var!(input_data_source_var);
+
+        let out_join_expr_var = var!(out_join_expr_var);
+        let out_join_type_var = var!(out_join_type_var);
+        let out_grouped_subqueries_var = var!(out_grouped_subqueries_var);
+
+        let meta = self.meta_context.clone();
+
+        move |egraph, subst| {
+            // At least one side must be an ungrouped scan: grouped-grouped joins are
+            // covered by wrapper-push-down-grouped-join-grouped
+            let left_ungrouped = var_iter!(
+                egraph[subst[left_ungrouped_scan_var]],
+                WrapperReplacerContextUngroupedScan
+            )
+            .any(|ungrouped_scan| *ungrouped_scan);
+            let right_ungrouped = var_iter!(
+                egraph[subst[right_ungrouped_scan_var]],
+                WrapperReplacerContextUngroupedScan
+            )
+            .any(|ungrouped_scan| *ungrouped_scan);
+            if !left_ungrouped && !right_ungrouped {
+                return false;
+            }
+
+            // An ungrouped (raw) side may only carry dimension-like columns.
+            // A measure column in a raw subquery requires per-row materialization,
+            // which is not defined for every measure: e.g. a multi-stage measure
+            // like a percentage of total has no meaningful value for a single raw
+            // row. Virtual members aren't real columns at all. Grouped sides keep
+            // their measures: those are aggregated inside their own subquery, where
+            // full measure semantics apply.
+            if left_ungrouped
+                && !Self::are_members_raw_materializable(egraph, subst[left_members_var])
+            {
+                return false;
+            }
+            if right_ungrouped
+                && !Self::are_members_raw_materializable(egraph, subst[right_members_var])
+            {
+                return false;
+            }
+
+            // Output contexts are PushToCube:false, so grouped subqueries are not
+            // consulted when rewriting columns; the value doesn't depend on the
+            // join keys or the join type
+            let out_grouped_subqueries = egraph.add(
+                LogicalPlanLanguage::WrapperReplacerContextGroupedSubqueries(
+                    WrapperReplacerContextGroupedSubqueries(vec![]),
+                ),
+            );
+
+            // Unlike transform_grouped_join_grouped, which `continue`s on a failed check
+            // to give its other output variant a chance, this rule builds exactly one
+            // output variant: any failed check refuses outright with `return false`
+            for in_join_type in
+                var_list_iter!(egraph[subst[in_join_type_var]], JoinJoinType).cloned()
+            {
+                // Both sides are standalone subqueries, so this is the
+                // non-push-to-Cube path
+                if !Self::is_subquery_join_type_supported(
+                    egraph,
+                    subst,
+                    &meta,
+                    input_data_source_var,
+                    &in_join_type.0,
+                    false,
+                ) {
+                    return false;
+                }
+
+                for left_join_on in var_iter!(egraph[subst[left_on_var]], JoinLeftOn).cloned() {
+                    for right_join_on in
+                        var_iter!(egraph[subst[right_on_var]], JoinRightOn).cloned()
+                    {
+                        // Reject joins on virtual members like __cubeJoinField:
+                        // they don't exist as columns in the generated subquery SQL.
+                        // Member lookup can miss when the column qualifier does not match
+                        // (e.g. a CTE alias), so also reject __cubeJoinField by name
+                        if left_join_on
+                            .iter()
+                            .chain(right_join_on.iter())
+                            .any(|column| column.name == "__cubeJoinField")
+                        {
+                            return false;
+                        }
+                        if !Self::are_join_members_supported(
+                            egraph,
+                            subst[left_members_var],
+                            &left_join_on,
+                        ) {
+                            return false;
+                        }
+                        if !Self::are_join_members_supported(
+                            egraph,
+                            subst[right_members_var],
+                            &right_join_on,
+                        ) {
+                            return false;
+                        }
+
+                        let Some(out_join_expr) =
+                            Self::build_join_expr(egraph, left_join_on, right_join_on)
+                        else {
+                            return false;
+                        };
+
+                        subst.insert(out_join_expr_var, out_join_expr);
+                        subst.insert(
+                            out_join_type_var,
+                            egraph.add(LogicalPlanLanguage::WrappedSelectJoinJoinType(
+                                WrappedSelectJoinJoinType(in_join_type.0),
+                            )),
+                        );
+                        subst.insert(out_grouped_subqueries_var, out_grouped_subqueries);
+
+                        return true;
+                    }
+                }
+            }
+
+            false
         }
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
@@ -11,7 +11,7 @@ use crate::{
         wrapper_pullup_replacer, wrapper_pushdown_replacer, wrapper_replacer_context, BinaryExprOp,
         ColumnExprColumn, CubeEGraph, JoinLeftOn, JoinRightOn, LogicalPlanLanguage,
         WrappedSelectJoinJoinType, WrappedSelectPushToCube, WrapperReplacerContextAliasToCube,
-        WrapperReplacerContextGroupedSubqueries,
+        WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextUngroupedScan,
     },
     transport::MetaContext,
     var, var_iter, var_list_iter,
@@ -488,6 +488,238 @@ impl WrapperRules {
                     "?out_join_type",
                     "?out_grouped_subqueries",
                     "?out_push_to_cube",
+                ),
+            ),
+            // Join where at least one side is an ungrouped (raw) query.
+            // Both sides are rendered as standalone subqueries and joined with plain SQL,
+            // so the result is not push-to-Cube. Grouped-grouped joins are covered by
+            // wrapper-push-down-grouped-join-grouped above.
+            // The result is marked UngroupedScan:true ("raw rows, may contain duplicate
+            // join keys"): it must never become the grouped RHS of the push-to-Cube
+            // subquery join path. Cube renders subqueryJoins as a plain join for simple
+            // measures but as a SELECT DISTINCT keys semi-join for multiplied measures —
+            // those two only agree when the subquery is unique on the join keys, which
+            // raw join output is not. An aggregation above this join produces
+            // UngroupedScan:false again, legitimately: its output is unique on its
+            // GROUP BY keys.
+            transforming_rewrite(
+                "wrapper-push-down-ungrouped-join-ungrouped",
+                join(
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?left_input",
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "?left_push_to_cube",
+                                "?left_in_projection",
+                                "?left_cube_members",
+                                "?left_grouped_subqueries",
+                                "?left_ungrouped_scan",
+                                // Data sources must match for both sides
+                                // TODO support unrestricted data source on one side
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?right_input",
+                            wrapper_replacer_context(
+                                // Going to ignore this
+                                "?right_alias_to_cube",
+                                "?right_push_to_cube",
+                                "?right_in_projection",
+                                // Used to reject joins on virtual members (__cubeJoinField)
+                                "?right_cube_members",
+                                "?right_grouped_subqueries",
+                                "?right_ungrouped_scan",
+                                // Data sources must match for both sides
+                                // TODO support unrestricted data source on one side
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    "?left_on",
+                    "?right_on",
+                    "?in_join_type",
+                    "?join_constraint",
+                    "JoinNullEqualsNull:false",
+                ),
+                // Both sides are standalone subqueries, so the result is plain SQL over them:
+                // PushToCube:false everywhere, and join condition columns are just columns
+                cube_scan_wrapper(
+                    wrapped_select(
+                        "WrappedSelectSelectType:Projection",
+                        wrapper_pullup_replacer(
+                            wrapped_select_projection_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_subqueries_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_group_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_aggr_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_window_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            // Standalone subquery: SQL for it is generated in isolation,
+                            // no need to check what exactly is inside
+                            "?left_input",
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        // We don't want to use list rules here, because ?right_input is already done
+                        wrapped_select_joins(
+                            wrapped_select_join(
+                                wrapper_pullup_replacer(
+                                    "?right_input",
+                                    wrapper_replacer_context(
+                                        "?left_alias_to_cube",
+                                        "WrapperReplacerContextPushToCube:false",
+                                        "WrapperReplacerContextInProjection:false",
+                                        "?left_cube_members",
+                                        "?out_grouped_subqueries",
+                                        "WrapperReplacerContextUngroupedScan:true",
+                                        "?input_data_source",
+                                    ),
+                                ),
+                                wrapper_pushdown_replacer(
+                                    "?out_join_expr",
+                                    wrapper_replacer_context(
+                                        "?left_alias_to_cube",
+                                        // PushToCube:false, so every column in join condition
+                                        // is rewritten as a plain column
+                                        "WrapperReplacerContextPushToCube:false",
+                                        "WrapperReplacerContextInProjection:false",
+                                        "?left_cube_members",
+                                        "?out_grouped_subqueries",
+                                        "WrapperReplacerContextUngroupedScan:true",
+                                        "?input_data_source",
+                                    ),
+                                ),
+                                "?out_join_type",
+                            ),
+                            // pullup(tail) just so it could be easily picked up by pullup rules
+                            wrapper_pullup_replacer(
+                                wrapped_select_joins_empty_tail(),
+                                wrapper_replacer_context(
+                                    "?left_alias_to_cube",
+                                    "WrapperReplacerContextPushToCube:false",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?left_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:true",
+                                    "?input_data_source",
+                                ),
+                            ),
+                        ),
+                        wrapper_pullup_replacer(
+                            wrapped_select_filter_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        wrapped_select_having_expr_empty_tail(),
+                        "WrappedSelectLimit:None",
+                        "WrappedSelectOffset:None",
+                        wrapper_pullup_replacer(
+                            wrapped_select_order_expr_empty_tail(),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                "WrapperReplacerContextPushToCube:false",
+                                "WrapperReplacerContextInProjection:false",
+                                "?left_cube_members",
+                                "?out_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:true",
+                                "?input_data_source",
+                            ),
+                        ),
+                        "WrappedSelectAlias:None",
+                        "WrappedSelectDistinct:false",
+                        // Both sides are standalone subqueries, nothing to push to Cube
+                        "WrappedSelectPushToCube:false",
+                        // Raw rows with possibly duplicated join keys: must not be
+                        // consumed as a grouped subquery by other join rules
+                        "WrappedSelectUngroupedScan:true",
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+                self.transform_ungrouped_join_ungrouped(
+                    "?left_cube_members",
+                    "?left_ungrouped_scan",
+                    "?left_on",
+                    "?right_cube_members",
+                    "?right_ungrouped_scan",
+                    "?right_on",
+                    "?in_join_type",
+                    "?input_data_source",
+                    "?out_join_expr",
+                    "?out_join_type",
+                    "?out_grouped_subqueries",
                 ),
             ),
         ]);
@@ -1257,6 +1489,133 @@ impl WrapperRules {
             }
 
             return false;
+        }
+    }
+
+    fn transform_ungrouped_join_ungrouped(
+        &self,
+        left_members_var: &'static str,
+        left_ungrouped_scan_var: &'static str,
+        left_on_var: &'static str,
+        right_members_var: &'static str,
+        right_ungrouped_scan_var: &'static str,
+        right_on_var: &'static str,
+        in_join_type_var: &'static str,
+        input_data_source_var: &'static str,
+        out_join_expr_var: &'static str,
+        out_join_type_var: &'static str,
+        out_grouped_subqueries_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let left_members_var = var!(left_members_var);
+        let left_ungrouped_scan_var = var!(left_ungrouped_scan_var);
+        let left_on_var = var!(left_on_var);
+
+        let right_members_var = var!(right_members_var);
+        let right_ungrouped_scan_var = var!(right_ungrouped_scan_var);
+        let right_on_var = var!(right_on_var);
+
+        let in_join_type_var = var!(in_join_type_var);
+        let input_data_source_var = var!(input_data_source_var);
+
+        let out_join_expr_var = var!(out_join_expr_var);
+        let out_join_type_var = var!(out_join_type_var);
+        let out_grouped_subqueries_var = var!(out_grouped_subqueries_var);
+
+        let meta = self.meta_context.clone();
+
+        move |egraph, subst| {
+            // At least one side must be an ungrouped scan: grouped-grouped joins are
+            // covered by wrapper-push-down-grouped-join-grouped
+            let left_ungrouped = var_iter!(
+                egraph[subst[left_ungrouped_scan_var]],
+                WrapperReplacerContextUngroupedScan
+            )
+            .any(|ungrouped_scan| *ungrouped_scan);
+            let right_ungrouped = var_iter!(
+                egraph[subst[right_ungrouped_scan_var]],
+                WrapperReplacerContextUngroupedScan
+            )
+            .any(|ungrouped_scan| *ungrouped_scan);
+            if !left_ungrouped && !right_ungrouped {
+                return false;
+            }
+
+            for left_join_on in var_iter!(egraph[subst[left_on_var]], JoinLeftOn).cloned() {
+                for right_join_on in var_iter!(egraph[subst[right_on_var]], JoinRightOn).cloned() {
+                    for in_join_type in
+                        var_list_iter!(egraph[subst[in_join_type_var]], JoinJoinType).cloned()
+                    {
+                        // Both sides are standalone subqueries, so this is the
+                        // non-push-to-Cube path
+                        if !Self::is_subquery_join_type_supported(
+                            egraph,
+                            subst,
+                            &meta,
+                            input_data_source_var,
+                            &in_join_type.0,
+                            false,
+                        ) {
+                            return false;
+                        }
+
+                        // Reject joins on virtual members like __cubeJoinField:
+                        // they don't exist as columns in the generated subquery SQL.
+                        // Member lookup can miss when the column qualifier does not match
+                        // (e.g. a CTE alias), so also reject __cubeJoinField by name
+                        if left_join_on
+                            .iter()
+                            .chain(right_join_on.iter())
+                            .any(|column| column.name.eq_ignore_ascii_case("__cubeJoinField"))
+                        {
+                            return false;
+                        }
+                        if !Self::are_join_members_supported(
+                            egraph,
+                            subst[left_members_var],
+                            &left_join_on,
+                        ) {
+                            return false;
+                        }
+                        if !Self::are_join_members_supported(
+                            egraph,
+                            subst[right_members_var],
+                            &right_join_on,
+                        ) {
+                            return false;
+                        }
+
+                        let Some(out_join_expr) =
+                            Self::build_join_expr(egraph, left_join_on, right_join_on)
+                        else {
+                            return false;
+                        };
+
+                        // Output contexts are PushToCube:false, so grouped subqueries
+                        // are not consulted when rewriting columns
+                        let out_grouped_subqueries: Vec<String> = vec![];
+
+                        subst.insert(out_join_expr_var, out_join_expr);
+                        subst.insert(
+                            out_join_type_var,
+                            egraph.add(LogicalPlanLanguage::WrappedSelectJoinJoinType(
+                                WrappedSelectJoinJoinType(in_join_type.0),
+                            )),
+                        );
+                        subst.insert(
+                            out_grouped_subqueries_var,
+                            egraph.add(
+                                LogicalPlanLanguage::WrapperReplacerContextGroupedSubqueries(
+                                    WrapperReplacerContextGroupedSubqueries(out_grouped_subqueries),
+                                ),
+                            ),
+                        );
+
+                        return true;
+                    }
+                }
+            }
+
+            false
         }
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -218,8 +218,22 @@ impl WrapperRules {
                 };
                 sql_generator
             }
-            // TODO is it correct?
-            DataSource::Unrestricted => return true,
+            // Data source is not pinned down at rewrite time, but SQL generation will
+            // resolve a specific one. Admit the template only when every registered
+            // generator supports it, so the rewrite can't commit to a shape the
+            // resolved generator is unable to render.
+            DataSource::Unrestricted => {
+                return !meta.data_source_to_sql_generator.is_empty()
+                    && meta
+                        .data_source_to_sql_generator
+                        .values()
+                        .all(|sql_generator| {
+                            sql_generator
+                                .get_sql_templates()
+                                .templates
+                                .contains_key(template)
+                        });
+            }
         };
 
         sql_generator

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -220,7 +220,11 @@ impl WrapperRules {
                 };
                 sql_generator
             }
-            // TODO is it correct?
+            // Data source is not pinned down at rewrite time, but SQL generation will
+            // resolve a specific one. Optimistically assume the resolved generator will
+            // support the template: a miss surfaces as a generation-time error, never
+            // broken SQL. Callers that must not commit to an unrenderable shape should
+            // use `is_template_available_on_every_data_source` instead.
             DataSource::Unrestricted => return true,
         };
 
@@ -228,5 +232,75 @@ impl WrapperRules {
             .get_sql_templates()
             .templates
             .contains_key(template)
+    }
+
+    /// Whether every registered SQL generator supports `template`. Used for template
+    /// checks on plans whose data source is not pinned down at rewrite time
+    /// ([`DataSource::Unrestricted`]): whichever generator the plan resolves to must be
+    /// able to render the committed shape. An empty generator registry refuses: there
+    /// is nothing that could render the template.
+    fn is_template_available_on_every_data_source(meta: &MetaContext, template: &str) -> bool {
+        !meta.data_source_to_sql_generator.is_empty()
+            && meta
+                .data_source_to_sql_generator
+                .values()
+                .all(|sql_generator| {
+                    sql_generator
+                        .get_sql_templates()
+                        .templates
+                        .contains_key(template)
+                })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WrapperRules;
+    use crate::{compile::test::sql_generator, transport::MetaContext};
+    use std::{collections::HashMap, sync::Arc};
+    use uuid::Uuid;
+
+    fn meta_with_generators(generators: Vec<(&str, Vec<(String, String)>)>) -> Arc<MetaContext> {
+        Arc::new(MetaContext::new(
+            vec![],
+            HashMap::new(),
+            generators
+                .into_iter()
+                .map(|(data_source, custom_templates)| {
+                    (data_source.to_string(), sql_generator(custom_templates))
+                })
+                .collect(),
+            Uuid::new_v4(),
+        ))
+    }
+
+    /// A template counts as available for an unrestricted data source only when every
+    /// registered generator supports it: whichever generator the plan resolves to must
+    /// be able to render the committed shape.
+    #[test]
+    fn test_template_available_on_every_data_source() {
+        // Custom template with an empty value removes the base template
+        let meta = meta_with_generators(vec![
+            ("default", vec![]),
+            (
+                "no_full_join",
+                vec![("join_types/full".to_string(), "".to_string())],
+            ),
+        ]);
+        assert!(WrapperRules::is_template_available_on_every_data_source(
+            &meta,
+            "join_types/inner"
+        ));
+        assert!(!WrapperRules::is_template_available_on_every_data_source(
+            &meta,
+            "join_types/full"
+        ));
+
+        // An empty generator registry refuses: nothing could render the template
+        let empty_meta = meta_with_generators(vec![]);
+        assert!(!WrapperRules::is_template_available_on_every_data_source(
+            &empty_meta,
+            "join_types/inner"
+        ));
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
@@ -5,8 +5,8 @@ use crate::{
         rules::{members::MemberRules, wrapper::WrapperRules},
         transforming_rewrite, wrapped_select, wrapped_select_having_expr_empty_tail,
         wrapped_select_joins_empty_tail, wrapper_pullup_replacer, wrapper_replacer_context,
-        LogicalPlanLanguage, WrappedSelectAlias, WrappedSelectSelectType, WrappedSelectType,
-        WrapperReplacerContextAliasToCube,
+        LogicalPlanLanguage, WrappedSelectAlias, WrappedSelectLimit, WrappedSelectOffset,
+        WrappedSelectSelectType, WrappedSelectType, WrapperReplacerContextAliasToCube,
     },
     var, var_iter, var_list_iter,
 };
@@ -381,10 +381,19 @@ impl WrapperRules {
                     "?projection_expr",
                     "?group_expr",
                     "?aggr_expr",
+                    "?window_expr",
+                    "?filter_expr",
+                    "?order_expr",
                     "?inner_select_type",
                     "?inner_projection_expr",
                     "?inner_group_expr",
                     "?inner_aggr_expr",
+                    "?inner_window_expr",
+                    "?inner_filter_expr",
+                    "?inner_order_expr",
+                    "?inner_joins",
+                    "?inner_limit",
+                    "?inner_offset",
                     "?alias_to_cube",
                     "?select_alias",
                     "?alias_to_cube_out",
@@ -455,18 +464,36 @@ impl WrapperRules {
         projection_expr_var: &'static str,
         _group_expr_var: &'static str,
         _aggr_expr_var: &'static str,
+        window_expr_var: &'static str,
+        filter_expr_var: &'static str,
+        order_expr_var: &'static str,
         inner_select_type_var: &'static str,
         inner_projection_expr_var: &'static str,
         _inner_group_expr_var: &'static str,
         _inner_aggr_expr_var: &'static str,
+        inner_window_expr_var: &'static str,
+        inner_filter_expr_var: &'static str,
+        inner_order_expr_var: &'static str,
+        inner_joins_var: &'static str,
+        inner_limit_var: &'static str,
+        inner_offset_var: &'static str,
         alias_to_cube_var: &'static str,
         select_alias_var: &'static str,
         alias_to_cube_out_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let select_type_var = var!(select_type_var);
         let projection_expr_var = var!(projection_expr_var);
+        let window_expr_var = var!(window_expr_var);
+        let filter_expr_var = var!(filter_expr_var);
+        let order_expr_var = var!(order_expr_var);
         let inner_select_type_var = var!(inner_select_type_var);
         let inner_projection_expr_var = var!(inner_projection_expr_var);
+        let inner_window_expr_var = var!(inner_window_expr_var);
+        let inner_filter_expr_var = var!(inner_filter_expr_var);
+        let inner_order_expr_var = var!(inner_order_expr_var);
+        let inner_joins_var = var!(inner_joins_var);
+        let inner_limit_var = var!(inner_limit_var);
+        let inner_offset_var = var!(inner_offset_var);
         let alias_to_cube_var = var!(alias_to_cube_var);
         let select_alias_var = var!(select_alias_var);
         let alias_to_cube_out_var = var!(alias_to_cube_out_var);
@@ -497,7 +524,39 @@ impl WrapperRules {
                     return match select_type {
                         WrappedSelectType::Projection => {
                             // TODO changes of alias can be non-trivial
-                            subst[projection_expr_var] != subst[inner_projection_expr_var]
+                            if subst[projection_expr_var] != subst[inner_projection_expr_var] {
+                                return true;
+                            }
+
+                            // Identical projections can still be a non-trivial nesting:
+                            // outer select can filter, order or window over an inner select
+                            // that can't be merged into (it has joins, limit or offset).
+                            // Comparing same-purpose eclasses converges: repeated rule
+                            // applications produce equal components, and get rejected here.
+                            if subst[filter_expr_var] != subst[inner_filter_expr_var] {
+                                return true;
+                            }
+                            if subst[order_expr_var] != subst[inner_order_expr_var] {
+                                return true;
+                            }
+                            if subst[window_expr_var] != subst[inner_window_expr_var] {
+                                return true;
+                            }
+
+                            let inner_has_joins =
+                                var_list_iter!(egraph[subst[inner_joins_var]], WrappedSelectJoins)
+                                    .any(|joins| !joins.is_empty());
+                            if inner_has_joins {
+                                return true;
+                            }
+
+                            let inner_has_limit =
+                                var_iter!(egraph[subst[inner_limit_var]], WrappedSelectLimit)
+                                    .any(|limit| limit.is_some());
+                            let inner_has_offset =
+                                var_iter!(egraph[subst[inner_offset_var]], WrappedSelectOffset)
+                                    .any(|offset| offset.is_some());
+                            inner_has_limit || inner_has_offset
                         }
                         WrappedSelectType::Aggregate => {
                             // TODO write rules for non trivial wrapped aggregate

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -827,6 +827,43 @@ pub fn get_test_tenant_ctx_with_meta(meta: Vec<CubeMeta>) -> Arc<MetaContext> {
     get_test_tenant_ctx_with_meta_and_templates(meta, vec![])
 }
 
+/// Standard test tenant context, except `Logs` members live on a separate data
+/// source from the rest of the cubes. Both data sources use the default mock
+/// templates. Used to check that rewrites requiring a single data source do not
+/// fire across data sources.
+pub fn get_test_tenant_ctx_with_split_data_sources() -> Arc<MetaContext> {
+    let meta = get_test_meta();
+    let member_to_data_source = meta
+        .iter()
+        .flat_map(|cube| {
+            cube.dimensions
+                .iter()
+                .map(|d| &d.name)
+                .chain(cube.measures.iter().map(|m| &m.name))
+                .chain(cube.segments.iter().map(|s| &s.name))
+        })
+        .map(|member| {
+            let data_source = if member.starts_with("Logs.") {
+                "logs"
+            } else {
+                "default"
+            };
+            (member.clone(), data_source.to_string())
+        })
+        .collect();
+    Arc::new(MetaContext::new(
+        meta,
+        member_to_data_source,
+        vec![
+            ("default".to_string(), sql_generator(vec![])),
+            ("logs".to_string(), sql_generator(vec![])),
+        ]
+        .into_iter()
+        .collect(),
+        Uuid::new_v4(),
+    ))
+}
+
 pub async fn get_test_session(
     protocol: DatabaseProtocol,
     meta_context: Arc<MetaContext>,

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -889,6 +889,43 @@ pub fn get_test_tenant_ctx_with_cube_data_sources(
     ))
 }
 
+/// Standard test tenant context, except `Logs` members live on a separate data
+/// source from the rest of the cubes. Both data sources use the default mock
+/// templates. Used to check that rewrites requiring a single data source do not
+/// fire across data sources.
+pub fn get_test_tenant_ctx_with_split_data_sources() -> Arc<MetaContext> {
+    let meta = get_test_meta();
+    let member_to_data_source = meta
+        .iter()
+        .flat_map(|cube| {
+            cube.dimensions
+                .iter()
+                .map(|d| &d.name)
+                .chain(cube.measures.iter().map(|m| &m.name))
+                .chain(cube.segments.iter().map(|s| &s.name))
+        })
+        .map(|member| {
+            let data_source = if member.starts_with("Logs.") {
+                "logs"
+            } else {
+                "default"
+            };
+            (member.clone(), data_source.to_string())
+        })
+        .collect();
+    Arc::new(MetaContext::new(
+        meta,
+        member_to_data_source,
+        vec![
+            ("default".to_string(), sql_generator(vec![])),
+            ("logs".to_string(), sql_generator(vec![])),
+        ]
+        .into_iter()
+        .collect(),
+        Uuid::new_v4(),
+    ))
+}
+
 pub async fn get_test_session(
     protocol: DatabaseProtocol,
     meta_context: Arc<MetaContext>,

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
@@ -520,8 +520,72 @@ async fn test_join_two_subqueries_filter_push_down() {
     )
 }
 
+/// A `__cubeJoinField` join where one side has a LIMIT can be neither merged into
+/// a single CubeScan nor planned as a join of standalone subqueries:
+/// `__cubeJoinField` is virtual and does not exist as a column in generated
+/// subquery SQL. This must stay a compilation error — not broken SQL.
 #[tokio::test]
-async fn test_join_cubes_on_wrong_field_error() {
+async fn test_join_cubes_on_cube_join_field_with_limit_error() {
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx();
+    let query = convert_sql_to_cube_query(
+        &r#"
+            SELECT *
+            FROM (SELECT customer_gender, __cubeJoinField FROM KibanaSampleDataEcommerce LIMIT 10) kibana
+            LEFT JOIN (SELECT read, __cubeJoinField FROM Logs) logs
+                ON (kibana.__cubeJoinField = logs.__cubeJoinField)
+            "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
+/// Same shape as [`test_join_cubes_on_cube_join_field_with_limit_error`] but without
+/// the LIMIT: a proper `__cubeJoinField` join must still merge into a single
+/// CubeScan with join hints - the standalone-subquery join rule must not hijack it
+/// (defense in depth: both the member-based and the name-based rejections cover it).
+#[tokio::test]
+async fn test_join_cubes_on_cube_join_field_no_limit_merged() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan(
+        r#"
+            SELECT *
+            FROM (SELECT customer_gender, __cubeJoinField FROM KibanaSampleDataEcommerce) kibana
+            LEFT JOIN (SELECT read, __cubeJoinField FROM Logs) logs
+                ON (kibana.__cubeJoinField = logs.__cubeJoinField)
+            "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .as_logical_plan();
+
+    // Single merged CubeScan, not a join of standalone subqueries
+    let request = logical_plan.find_cube_scan().request;
+    assert_eq!(
+        request.join_hints,
+        Some(vec![vec![
+            "KibanaSampleDataEcommerce".to_string(),
+            "Logs".to_string(),
+        ]])
+    );
+}
+
+/// Joining cubes on a regular field (not `__cubeJoinField`) is not a cube join:
+/// with SQL push down it is planned as a plain SQL join of two standalone
+/// ungrouped subqueries.
+#[tokio::test]
+async fn test_join_cubes_on_regular_field_pushdown() {
     init_testing_logger();
 
     let meta = get_test_tenant_ctx();
@@ -537,11 +601,22 @@ async fn test_join_cubes_on_wrong_field_error() {
     )
     .await;
 
-    let error = query.unwrap_err();
-    assert!(matches!(error, CompilationError::Rewrite(..)));
-    assert_eq!(
-        error.message(),
-        "Use __cubeJoinField to join Cubes".to_string()
+    if !Rewriter::sql_push_down_enabled() {
+        let error = query.unwrap_err();
+        assert!(matches!(error, CompilationError::Rewrite(..)));
+        assert_eq!(
+            error.message(),
+            "Use __cubeJoinField to join Cubes".to_string()
+        );
+        return;
+    }
+
+    let logical_plan = query.unwrap().as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
     );
 }
 

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
@@ -520,8 +520,72 @@ async fn test_join_two_subqueries_filter_push_down() {
     )
 }
 
+/// A `__cubeJoinField` join where one side has a LIMIT can be neither merged into
+/// a single CubeScan nor planned as a join of standalone subqueries:
+/// `__cubeJoinField` is virtual and does not exist as a column in generated
+/// subquery SQL. This must stay a compilation error - not broken SQL.
 #[tokio::test]
-async fn test_join_cubes_on_wrong_field_error() {
+async fn test_join_cubes_on_cube_join_field_with_limit_error() {
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx();
+    let query = convert_sql_to_cube_query(
+        &r#"
+            SELECT *
+            FROM (SELECT customer_gender, __cubeJoinField FROM KibanaSampleDataEcommerce LIMIT 10) kibana
+            LEFT JOIN (SELECT read, __cubeJoinField FROM Logs) logs
+                ON (kibana.__cubeJoinField = logs.__cubeJoinField)
+            "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
+/// Same shape as [`test_join_cubes_on_cube_join_field_with_limit_error`] but without
+/// the LIMIT: a proper `__cubeJoinField` join must still merge into a single
+/// CubeScan with join hints - the standalone-subquery join rule must not hijack it
+/// (defense in depth: both the member-based and the name-based rejections cover it).
+#[tokio::test]
+async fn test_join_cubes_on_cube_join_field_no_limit_merged() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan(
+        r#"
+            SELECT *
+            FROM (SELECT customer_gender, __cubeJoinField FROM KibanaSampleDataEcommerce) kibana
+            LEFT JOIN (SELECT read, __cubeJoinField FROM Logs) logs
+                ON (kibana.__cubeJoinField = logs.__cubeJoinField)
+            "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .as_logical_plan();
+
+    // Single merged CubeScan, not a join of standalone subqueries
+    let request = logical_plan.find_cube_scan().request;
+    assert_eq!(
+        request.join_hints,
+        Some(vec![vec![
+            "KibanaSampleDataEcommerce".to_string(),
+            "Logs".to_string(),
+        ]])
+    );
+}
+
+/// Joining cubes on a regular field (not `__cubeJoinField`) is not a cube join:
+/// with SQL push down it is planned as a plain SQL join of two standalone
+/// ungrouped subqueries.
+#[tokio::test]
+async fn test_join_cubes_on_regular_field_pushdown() {
     init_testing_logger();
 
     let meta = get_test_tenant_ctx();
@@ -537,11 +601,22 @@ async fn test_join_cubes_on_wrong_field_error() {
     )
     .await;
 
-    let error = query.unwrap_err();
-    assert!(matches!(error, CompilationError::Rewrite(..)));
-    assert_eq!(
-        error.message(),
-        "Use __cubeJoinField to join Cubes".to_string()
+    if !Rewriter::sql_push_down_enabled() {
+        let error = query.unwrap_err();
+        assert!(matches!(error, CompilationError::Rewrite(..)));
+        assert_eq!(
+            error.message(),
+            "Use __cubeJoinField to join Cubes".to_string()
+        );
+        return;
+    }
+
+    let logical_plan = query.unwrap().as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
     );
 }
 

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join_grouped.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join_grouped.rs
@@ -959,3 +959,79 @@ LIMIT 1
     assert_eq!(request.segments.as_ref().unwrap().len(), 1);
     assert!(request.segments.as_ref().unwrap()[0].contains(r#"\"t0\".\"measure\" IS NULL"#));
 }
+
+/// Ungrouped query with LIMIT joined with grouped query can not be pushed to Cube:
+/// limit must apply before join, and it does not commute with it.
+/// Instead it should plan as a plain SQL join of two standalone subqueries,
+/// keeping the limit inside the ungrouped subquery
+#[tokio::test]
+async fn test_join_limited_ungrouped_with_grouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+WITH category_averages AS (
+  SELECT
+    KibanaSampleDataEcommerce.customer_gender,
+    MEASURE(KibanaSampleDataEcommerce.avgPrice) AS avg_amount
+  FROM KibanaSampleDataEcommerce
+  WHERE KibanaSampleDataEcommerce.customer_gender IN ('male', 'female')
+    AND KibanaSampleDataEcommerce.order_date >= '2026-01-01'
+  GROUP BY 1
+  LIMIT 5000
+), transactions AS (
+  SELECT
+    KibanaSampleDataEcommerce.customer_gender,
+    KibanaSampleDataEcommerce.notes,
+    KibanaSampleDataEcommerce.taxful_total_price,
+    KibanaSampleDataEcommerce.order_date
+  FROM KibanaSampleDataEcommerce
+  WHERE KibanaSampleDataEcommerce.customer_gender IN ('male', 'female')
+    AND KibanaSampleDataEcommerce.order_date >= '2026-01-01'
+  LIMIT 5000
+)
+SELECT
+  t.customer_gender,
+  t.notes,
+  t.taxful_total_price AS transaction_amount,
+  ca.avg_amount AS category_average,
+  t.taxful_total_price - ca.avg_amount AS amount_above_average,
+  t.order_date
+FROM transactions t
+JOIN category_averages ca ON t.customer_gender = ca.customer_gender
+WHERE t.taxful_total_price > ca.avg_amount
+ORDER BY 5 DESC
+LIMIT 100
+;
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    let physical_plan_string = displayable(physical_plan.as_ref()).indent().to_string();
+    println!("Physical plan: {}", physical_plan_string);
+
+    let cube_scans = query_plan.as_logical_plan().find_cube_scans();
+    assert_eq!(cube_scans.len(), 2);
+
+    // Ungrouped side keeps its limit inside its own subquery
+    assert!(cube_scans
+        .iter()
+        .any(|scan| scan.request.ungrouped == Some(true) && scan.request.limit == Some(5000)));
+    // Grouped side is a regular grouped subquery
+    assert!(cube_scans.iter().any(|scan| {
+        scan.request.ungrouped.is_none()
+            && scan.request.limit == Some(5000)
+            && scan.request.measures == Some(vec!["KibanaSampleDataEcommerce.avgPrice".to_string()])
+    }));
+
+    // Join is pushed down to the data source as a plain SQL join
+    assert!(physical_plan_string.contains(r#"INNER JOIN (SELECT * FROM {"#));
+    assert!(physical_plan_string.contains(r#"ON ("t"."customer_gender" = "ca"."customer_gender")"#));
+}

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join_views.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join_views.rs
@@ -155,6 +155,23 @@ async fn plan_view_join(sql: &str, tesseract: bool) -> Result<QueryPlan, Compila
     convert_sql_to_cube_query(&sql.to_string(), meta, session).await
 }
 
+/// Asserts that the view join was NOT merged into a single multi-fact CubeScan:
+/// the plan must contain two separate ungrouped CubeScans (one per view),
+/// joined as standalone subqueries in the pushed-down SQL.
+fn assert_not_merged_subquery_join(logical_plan: &datafusion::logical_plan::LogicalPlan) {
+    let scans = logical_plan.find_cube_scans();
+    assert_eq!(
+        scans.len(),
+        2,
+        "expected two separate view scans, got: {:?}",
+        scans.iter().map(|scan| &scan.request).collect::<Vec<_>>()
+    );
+    for scan in &scans {
+        assert_eq!(scan.request.ungrouped, Some(true));
+        assert_eq!(scan.request.join_hints, None);
+    }
+}
+
 const GROUPED_LEFT_JOIN: &str = r#"
     SELECT c.customer_city, measure(o.revenue), measure(c.avg_age)
     FROM customers_view c
@@ -245,7 +262,9 @@ async fn test_group_by_inner_join_two_views_on_shared_member() {
 }
 
 /// The merge relies on the Tesseract SQL planner; with it disabled the join is
-/// not merged and the query is rejected like any other unsupported cube join.
+/// not merged: it is planned as a join of two standalone ungrouped subqueries
+/// instead, with MEASURE() staying outside the pushed-down SQL (and failing at
+/// execution).
 #[tokio::test]
 async fn test_grouped_view_join_not_merged_without_tesseract() {
     if !Rewriter::sql_push_down_enabled() {
@@ -253,13 +272,17 @@ async fn test_grouped_view_join_not_merged_without_tesseract() {
     }
     init_testing_logger();
 
-    let error = plan_view_join(GROUPED_LEFT_JOIN, false).await.unwrap_err();
-    assert!(matches!(error, CompilationError::Rewrite(..)));
+    let logical_plan = plan_view_join(GROUPED_LEFT_JOIN, false)
+        .await
+        .unwrap()
+        .as_logical_plan();
+    assert_not_merged_subquery_join(&logical_plan);
 }
 
 /// Ungrouped query (`SELECT *`): the shared-member merge only applies to
-/// grouped queries, so an ungrouped join is not merged and is rejected even
-/// when Tesseract is enabled.
+/// grouped queries, so an ungrouped join is not merged even when Tesseract is
+/// enabled. It is planned as a plain SQL join of two standalone ungrouped
+/// subqueries instead.
 #[tokio::test]
 async fn test_ungrouped_join_two_views_on_shared_member_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -267,7 +290,7 @@ async fn test_ungrouped_join_two_views_on_shared_member_is_not_merged() {
     }
     init_testing_logger();
 
-    let error = plan_view_join(
+    let logical_plan = plan_view_join(
         r#"
             SELECT *
             FROM customers_view
@@ -277,13 +300,22 @@ async fn test_ungrouped_join_two_views_on_shared_member_is_not_merged() {
         true,
     )
     .await
-    .unwrap_err();
-    assert!(matches!(error, CompilationError::Rewrite(..)));
+    .unwrap()
+    .as_logical_plan();
+
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    assert_not_merged_subquery_join(&logical_plan);
 }
 
 /// The join is over a dimension (`customer_city`) that is not in the GROUP BY
 /// (the query groups by `status` instead). The merge requires the join key to
-/// be the group-by key, so this is not merged and is rejected.
+/// be the group-by key, so this is not merged: it is planned as a join of two
+/// standalone ungrouped subqueries instead.
 #[tokio::test]
 async fn test_group_by_join_dimension_not_in_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -291,7 +323,7 @@ async fn test_group_by_join_dimension_not_in_group_by_is_not_merged() {
     }
     init_testing_logger();
 
-    let error = plan_view_join(
+    let logical_plan = plan_view_join(
         r#"
             SELECT c.status, measure(o.revenue), measure(c.avg_age)
             FROM customers_view c
@@ -301,8 +333,9 @@ async fn test_group_by_join_dimension_not_in_group_by_is_not_merged() {
         true,
     )
     .await
-    .unwrap_err();
-    assert!(matches!(error, CompilationError::Rewrite(..)));
+    .unwrap()
+    .as_logical_plan();
+    assert_not_merged_subquery_join(&logical_plan);
 }
 
 /// The merge only fires when the join key is fully within dimensions. Joining
@@ -784,7 +817,7 @@ async fn test_left_join_on_multiple_dimensions_group_by_both() {
 
 /// Grouping by only part of a composite join key must not merge: the GROUP BY
 /// must cover the full join key, so this falls back to standard join handling
-/// (which errors for ungrouped-style cube joins).
+/// (a join of two standalone ungrouped subqueries).
 #[tokio::test]
 async fn test_join_on_multiple_dimensions_partial_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -805,11 +838,8 @@ async fn test_join_on_multiple_dimensions_partial_group_by_is_not_merged() {
     )
     .await;
 
-    assert!(
-        result.is_err(),
-        "expected partial-group-by composite join not to merge, got: {:?}",
-        result.map(|p| p.as_logical_plan().find_cube_scan().request)
-    );
+    let logical_plan = result.unwrap().as_logical_plan();
+    assert_not_merged_subquery_join(&logical_plan);
 }
 
 /// Joining on a mix of a `DATE_TRUNC` equality and a plain dimension equality.
@@ -870,7 +900,8 @@ async fn test_inner_join_on_date_trunc_and_dimension() {
 /// A join on the raw time column (exact-timestamp equality, "no grain") does not
 /// match a truncated `DATE_TRUNC('day', ...)` GROUP BY, so it is not merged: the
 /// multi-fact stitch happens at the GROUP BY grain, which must be the grain the
-/// user joined on. Truncate the join key to the grain you group by instead.
+/// user joined on. It is planned as a join of two standalone ungrouped
+/// subqueries instead.
 #[tokio::test]
 async fn test_raw_time_join_with_date_trunc_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -889,9 +920,6 @@ async fn test_raw_time_join_with_date_trunc_group_by_is_not_merged() {
     )
     .await;
 
-    assert!(
-        result.is_err(),
-        "expected raw-time-column join with a DATE_TRUNC GROUP BY not to merge, got: {:?}",
-        result.map(|p| p.as_logical_plan().find_cube_scan().request)
-    );
+    let logical_plan = result.unwrap().as_logical_plan();
+    assert_not_merged_subquery_join(&logical_plan);
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join_views.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join_views.rs
@@ -155,6 +155,23 @@ async fn plan_view_join(sql: &str, tesseract: bool) -> Result<QueryPlan, Compila
     convert_sql_to_cube_query(&sql.to_string(), meta, session).await
 }
 
+/// Asserts that the view join was NOT merged into a single multi-fact CubeScan:
+/// the plan must contain two separate ungrouped CubeScans (one per view),
+/// joined as standalone subqueries in the pushed-down SQL.
+fn assert_not_merged_subquery_join(logical_plan: &datafusion::logical_plan::LogicalPlan) {
+    let scans = logical_plan.find_cube_scans();
+    assert_eq!(
+        scans.len(),
+        2,
+        "expected two separate view scans, got: {:?}",
+        scans.iter().map(|scan| &scan.request).collect::<Vec<_>>()
+    );
+    for scan in &scans {
+        assert_eq!(scan.request.ungrouped, Some(true));
+        assert_eq!(scan.request.join_hints, None);
+    }
+}
+
 const GROUPED_LEFT_JOIN: &str = r#"
     SELECT c.customer_city, measure(o.revenue), measure(c.avg_age)
     FROM customers_view c
@@ -244,8 +261,12 @@ async fn test_group_by_inner_join_two_views_on_shared_member() {
     )
 }
 
-/// The merge relies on the Tesseract SQL planner; with it disabled the join is
-/// not merged and the query is rejected like any other unsupported cube join.
+/// The merge relies on the Tesseract SQL planner; with it disabled the join
+/// can't be planned at all: the fallback would be a join of standalone raw
+/// subqueries, but those would have to carry measure columns (`revenue`,
+/// `avg_age`), and measure columns have no defined per-row materialization
+/// (e.g. multi-stage measures), so the raw-join path refuses and the query is
+/// rejected at compile time.
 #[tokio::test]
 async fn test_grouped_view_join_not_merged_without_tesseract() {
     if !Rewriter::sql_push_down_enabled() {
@@ -257,11 +278,48 @@ async fn test_grouped_view_join_not_merged_without_tesseract() {
     assert!(matches!(error, CompilationError::Rewrite(..)));
 }
 
-/// Ungrouped query (`SELECT *`): the shared-member merge only applies to
-/// grouped queries, so an ungrouped join is not merged and is rejected even
-/// when Tesseract is enabled.
+/// Ungrouped join of two views over dimension columns only: the shared-member
+/// merge only applies to grouped queries, so this is not merged even when
+/// Tesseract is enabled. It is planned as a plain SQL join of two standalone
+/// ungrouped subqueries instead. The per-side subselects narrow each scan to
+/// its dimension columns, which is what makes the sides valid raw subqueries.
 #[tokio::test]
 async fn test_ungrouped_join_two_views_on_shared_member_is_not_merged() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = plan_view_join(
+        r#"
+            SELECT c.customer_city, o.customer_city
+            FROM (SELECT customer_city FROM customers_view) c
+            LEFT JOIN (SELECT customer_city FROM orders_view) o
+                ON (o.customer_city = c.customer_city)
+            "#,
+        true,
+    )
+    .await
+    .unwrap()
+    .as_logical_plan();
+
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    assert_not_merged_subquery_join(&logical_plan);
+}
+
+/// An ungrouped join of bare views (`SELECT *`, or any shape that leaves the
+/// sides unnarrowed) puts the views' measure columns on the raw join sides. A
+/// raw join side carrying a measure column can't be pushed down: a measure has
+/// no defined per-row materialization (e.g. a multi-stage measure like a
+/// percentage of total has no meaning for a single raw row), so the query is
+/// rejected instead of returning meaningless values.
+#[tokio::test]
+async fn test_ungrouped_join_views_with_measures_is_rejected() {
     if !Rewriter::sql_push_down_enabled() {
         return;
     }
@@ -283,7 +341,9 @@ async fn test_ungrouped_join_two_views_on_shared_member_is_not_merged() {
 
 /// The join is over a dimension (`customer_city`) that is not in the GROUP BY
 /// (the query groups by `status` instead). The merge requires the join key to
-/// be the group-by key, so this is not merged and is rejected.
+/// be the group-by key, so this is not merged; the raw-join fallback would
+/// need the sides to carry measure columns, which have no defined per-row
+/// materialization, so the query is rejected at compile time.
 #[tokio::test]
 async fn test_group_by_join_dimension_not_in_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -783,8 +843,9 @@ async fn test_left_join_on_multiple_dimensions_group_by_both() {
 }
 
 /// Grouping by only part of a composite join key must not merge: the GROUP BY
-/// must cover the full join key, so this falls back to standard join handling
-/// (which errors for ungrouped-style cube joins).
+/// must cover the full join key. The raw-join fallback would need the orders
+/// side to carry the `revenue` measure column, which has no defined per-row
+/// materialization, so the query is rejected at compile time.
 #[tokio::test]
 async fn test_join_on_multiple_dimensions_partial_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -792,7 +853,7 @@ async fn test_join_on_multiple_dimensions_partial_group_by_is_not_merged() {
     }
     init_testing_logger();
 
-    let result = plan_view_join(
+    let error = plan_view_join(
         r#"
             SELECT c.customer_city, measure(o.revenue)
             FROM customers_view c
@@ -803,13 +864,9 @@ async fn test_join_on_multiple_dimensions_partial_group_by_is_not_merged() {
             "#,
         true,
     )
-    .await;
-
-    assert!(
-        result.is_err(),
-        "expected partial-group-by composite join not to merge, got: {:?}",
-        result.map(|p| p.as_logical_plan().find_cube_scan().request)
-    );
+    .await
+    .unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
 }
 
 /// Joining on a mix of a `DATE_TRUNC` equality and a plain dimension equality.
@@ -870,7 +927,9 @@ async fn test_inner_join_on_date_trunc_and_dimension() {
 /// A join on the raw time column (exact-timestamp equality, "no grain") does not
 /// match a truncated `DATE_TRUNC('day', ...)` GROUP BY, so it is not merged: the
 /// multi-fact stitch happens at the GROUP BY grain, which must be the grain the
-/// user joined on. Truncate the join key to the grain you group by instead.
+/// user joined on. The raw-join fallback would need the orders side to carry the
+/// `revenue` measure column, which has no defined per-row materialization, so
+/// the query is rejected at compile time.
 #[tokio::test]
 async fn test_raw_time_join_with_date_trunc_group_by_is_not_merged() {
     if !Rewriter::sql_push_down_enabled() {
@@ -878,7 +937,7 @@ async fn test_raw_time_join_with_date_trunc_group_by_is_not_merged() {
     }
     init_testing_logger();
 
-    let result = plan_view_join(
+    let error = plan_view_join(
         r#"
             SELECT DATE_TRUNC('day', c.created_at), measure(o.revenue)
             FROM customers_view c
@@ -887,11 +946,7 @@ async fn test_raw_time_join_with_date_trunc_group_by_is_not_merged() {
             "#,
         true,
     )
-    .await;
-
-    assert!(
-        result.is_err(),
-        "expected raw-time-column join with a DATE_TRUNC GROUP BY not to merge, got: {:?}",
-        result.map(|p| p.as_logical_plan().find_cube_scan().request)
-    );
+    .await
+    .unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -15,9 +15,11 @@ use crate::{
         rewrite::rewriter::Rewriter,
         test::{
             convert_select_to_query_plan, convert_select_to_query_plan_customized,
-            convert_select_to_query_plan_with_config, init_testing_logger, LogicalPlanTestUtils,
+            convert_select_to_query_plan_with_config, convert_sql_to_cube_query, get_test_session,
+            get_test_tenant_ctx_customized, get_test_tenant_ctx_with_split_data_sources,
+            init_testing_logger, LogicalPlanTestUtils,
         },
-        DatabaseProtocol,
+        CompilationError, DatabaseProtocol,
     },
     config::ConfigObjImpl,
     transport::TransportLoadRequestQuery,
@@ -1762,6 +1764,340 @@ GROUP BY 1
     );
 }
 
+/// Regression test for self-join of an ungrouped (raw) CTE under SQL push down.
+/// Both join sides are ungrouped queries, so they must be rendered as standalone
+/// subqueries joined with plain SQL. Before wrapper-push-down-ungrouped-join-ungrouped
+/// this failed with `Use __cubeJoinField to join Cubes`.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT
+                customer_gender,
+                taxful_total_price AS amount,
+                order_date
+            FROM KibanaSampleDataEcommerce
+            WHERE customer_gender ILIKE '%male%'
+            LIMIT 5000
+        )
+        SELECT
+            a.customer_gender,
+            a.amount,
+            a.order_date AS txn1_date,
+            b.order_date AS txn2_date
+        FROM txns a
+        JOIN txns b ON a.customer_gender = b.customer_gender
+            AND a.amount = b.amount
+            AND a.order_date < b.order_date
+        ORDER BY a.customer_gender, a.order_date
+        LIMIT 100
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("INNER JOIN ("),
+        "wrapped SQL is missing INNER JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    // Both sides are ungrouped load queries
+    assert_eq!(
+        sql.matches(r#""ungrouped": true"#).count(),
+        2,
+        "expected both join sides to be standalone ungrouped load queries:\n{}",
+        sql
+    );
+}
+
+/// Same as [`test_wrapper_ungrouped_join_ungrouped`], but the CTE has only an
+/// OFFSET (no LIMIT): the offset must stay inside each standalone subquery.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped_offset() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT
+                customer_gender,
+                taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            OFFSET 10
+        )
+        SELECT a.customer_gender, a.amount
+        FROM txns a
+        JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("INNER JOIN ("),
+        "wrapped SQL is missing INNER JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    assert_eq!(
+        sql.matches(r#""offset": 10"#).count(),
+        2,
+        "expected both join sides to keep their offset:\n{}",
+        sql
+    );
+}
+
+/// LEFT JOIN with the ungrouped side on the outer (left) side.
+#[tokio::test]
+async fn test_wrapper_ungrouped_left_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        LEFT JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// RIGHT JOIN with the ungrouped side on the left and a grouped subquery on the
+/// right. Right/Full join subqueries are only supported on the non-push-to-Cube
+/// path, which is exactly what a join with an ungrouped side produces.
+#[tokio::test]
+async fn test_wrapper_ungrouped_right_join_grouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        ),
+        averages AS (
+            SELECT customer_gender, AVG(avgPrice) AS avg_amount
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        )
+        SELECT t.amount, ca.avg_amount
+        FROM txns t
+        RIGHT JOIN averages ca ON t.customer_gender = ca.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("RIGHT JOIN ("),
+        "wrapped SQL is missing RIGHT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// FULL JOIN of two ungrouped sides.
+#[tokio::test]
+async fn test_wrapper_ungrouped_full_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        FULL JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("FULL JOIN ("),
+        "wrapped SQL is missing FULL JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// When the data source has no `join_types/full` template, a FULL JOIN of two
+/// ungrouped sides must not be pushed down as broken SQL: the rule must not fire.
+#[tokio::test]
+async fn test_wrapper_ungrouped_full_join_without_template() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_customized(vec![
+        // Emulate a data source without FULL JOIN support: empty value removes the template
+        ("join_types/full".to_string(), "".to_string()),
+    ]);
+    let query = convert_sql_to_cube_query(
+        &r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        FULL JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
+/// The output of an ungrouped join is raw rows with possibly duplicated join keys
+/// (UngroupedScan:true). It must never be consumed as the grouped RHS of the
+/// push-to-Cube subquery join path: Cube renders subqueryJoins as a plain join for
+/// simple measures but as a SELECT DISTINCT keys semi-join for multiplied measures,
+/// and with duplicated join keys those disagree — same query, different numbers.
+/// MEASURE() over such a join must stay outside the pushed-down SQL (and fail at
+/// execution) instead of producing contract-dependent results.
+#[tokio::test]
+async fn test_wrapper_no_measure_over_raw_join_subquery() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH t AS (
+            SELECT customer_gender, order_date
+            FROM KibanaSampleDataEcommerce
+            LIMIT 100
+        ),
+        pairs AS (
+            SELECT a.customer_gender AS g
+            FROM t a
+            JOIN t b ON a.customer_gender = b.customer_gender
+                AND a.order_date < b.order_date
+        )
+        SELECT k.customer_gender, MEASURE(k.count)
+        FROM KibanaSampleDataEcommerce k
+        JOIN pairs p ON k.customer_gender = p.g
+        GROUP BY 1
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    // Query is plannable, but MEASURE() must not be pushed into a load query
+    // joined to the raw pairs subquery
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    let physical_plan_string = displayable(physical_plan.as_ref()).indent().to_string();
+    assert!(
+        !physical_plan_string.contains("subqueryJoins"),
+        "raw join output leaked into a push-to-Cube subquery join:\n{}",
+        physical_plan_string
+    );
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert!(
+        !matches!(logical_plan, LogicalPlan::Extension(_)),
+        "MEASURE() over a raw join must stay outside the pushed-down SQL, got:\n{}",
+        logical_plan.display_indent()
+    );
+}
+
+/// Both join sides must live on the same data source: an ungrouped join across
+/// two data sources can't be pushed down as one SQL query and must stay an error.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped_different_data_sources() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_split_data_sources();
+    let query = convert_sql_to_cube_query(
+        &r#"
+        SELECT k.customer_gender, l.content
+        FROM (SELECT customer_gender, has_subscription FROM KibanaSampleDataEcommerce LIMIT 100) k
+        JOIN (SELECT read, content FROM Logs LIMIT 100) l ON (k.has_subscription = l.read)
+        "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
 /// Regression test for window expression on top of a grouped join subquery
 /// (Sigma-style query). Window expr rebase in converter must keep field names
 /// consistent with column references in plans above.
@@ -2809,3 +3145,4 @@ async fn test_case_wrapper_sum_case_date_only_string() {
         displayable(physical_plan.as_ref()).indent()
     );
 }
+

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -16,11 +16,12 @@ use crate::{
         test::{
             convert_select_to_query_plan, convert_select_to_query_plan_customized,
             convert_select_to_query_plan_with_config, convert_sql_to_cube_query, get_test_session,
-            get_test_session_with_config, get_test_tenant_ctx,
-            get_test_tenant_ctx_with_cube_data_sources, init_testing_logger, member_expression_sql,
-            LogicalPlanTestUtils, TestContext,
+            get_test_session_with_config, get_test_tenant_ctx, get_test_tenant_ctx_customized,
+            get_test_tenant_ctx_with_cube_data_sources,
+            get_test_tenant_ctx_with_split_data_sources, init_testing_logger,
+            member_expression_sql, LogicalPlanTestUtils, TestContext,
         },
-        DatabaseProtocol,
+        CompilationError, DatabaseProtocol,
     },
     config::ConfigObjImpl,
     transport::TransportLoadRequestQuery,
@@ -1763,6 +1764,331 @@ GROUP BY 1
         "join condition leaked original column name instead of remapped alias:\n{}",
         sql
     );
+}
+
+/// Regression test for self-join of an ungrouped (raw) CTE under SQL push down.
+/// Both join sides are ungrouped queries, so they must be rendered as standalone
+/// subqueries joined with plain SQL. Before wrapper-push-down-ungrouped-join-ungrouped
+/// this failed with `Use __cubeJoinField to join Cubes`.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT
+                customer_gender,
+                taxful_total_price AS amount,
+                order_date
+            FROM KibanaSampleDataEcommerce
+            WHERE customer_gender ILIKE '%male%'
+            LIMIT 5000
+        )
+        SELECT
+            a.customer_gender,
+            a.amount,
+            a.order_date AS txn1_date,
+            b.order_date AS txn2_date
+        FROM txns a
+        JOIN txns b ON a.customer_gender = b.customer_gender
+            AND a.amount = b.amount
+            AND a.order_date < b.order_date
+        ORDER BY a.customer_gender, a.order_date
+        LIMIT 100
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("INNER JOIN ("),
+        "wrapped SQL is missing INNER JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    // Both sides are ungrouped load queries
+    assert_eq!(
+        sql.matches(r#""ungrouped": true"#).count(),
+        2,
+        "expected both join sides to be standalone ungrouped load queries:\n{}",
+        sql
+    );
+}
+
+/// Same as [`test_wrapper_ungrouped_join_ungrouped`], but the CTE has only an
+/// OFFSET (no LIMIT): the offset must stay inside each standalone subquery.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped_offset() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT
+                customer_gender,
+                taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            OFFSET 10
+        )
+        SELECT a.customer_gender, a.amount
+        FROM txns a
+        JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("INNER JOIN ("),
+        "wrapped SQL is missing INNER JOIN of standalone subqueries:\n{}",
+        sql
+    );
+    assert_eq!(
+        sql.matches(r#""offset": 10"#).count(),
+        2,
+        "expected both join sides to keep their offset:\n{}",
+        sql
+    );
+}
+
+/// LEFT JOIN with the ungrouped side on the outer (left) side.
+#[tokio::test]
+async fn test_wrapper_ungrouped_left_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        LEFT JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("LEFT JOIN ("),
+        "wrapped SQL is missing LEFT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// RIGHT JOIN with the ungrouped side on the left and a grouped subquery on the
+/// right. Right/Full join subqueries are only supported on the non-push-to-Cube
+/// path, which is exactly what a join with an ungrouped side produces.
+#[tokio::test]
+async fn test_wrapper_ungrouped_right_join_grouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        ),
+        averages AS (
+            SELECT customer_gender, AVG(avgPrice) AS avg_amount
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        )
+        SELECT t.amount, ca.avg_amount
+        FROM txns t
+        RIGHT JOIN averages ca ON t.customer_gender = ca.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("RIGHT JOIN ("),
+        "wrapped SQL is missing RIGHT JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// FULL JOIN of two ungrouped sides.
+#[tokio::test]
+async fn test_wrapper_ungrouped_full_join_ungrouped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        FULL JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("FULL JOIN ("),
+        "wrapped SQL is missing FULL JOIN of standalone subqueries:\n{}",
+        sql
+    );
+}
+
+/// When the data source has no `join_types/full` template, a FULL JOIN of two
+/// ungrouped sides must not be pushed down as broken SQL: the rule must not fire.
+#[tokio::test]
+async fn test_wrapper_ungrouped_full_join_without_template() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_customized(vec![
+        // Emulate a data source without FULL JOIN support: empty value removes the template
+        ("join_types/full".to_string(), "".to_string()),
+    ]);
+    let query = convert_sql_to_cube_query(
+        &r#"
+        WITH txns AS (
+            SELECT customer_gender, taxful_total_price AS amount
+            FROM KibanaSampleDataEcommerce
+            LIMIT 5000
+        )
+        SELECT a.customer_gender, b.amount
+        FROM txns a
+        FULL JOIN txns b ON a.customer_gender = b.customer_gender
+        "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
+/// The output of an ungrouped join is raw rows with possibly duplicated join keys
+/// (UngroupedScan:true). It must never be consumed as the grouped RHS of the
+/// push-to-Cube subquery join path: Cube renders subqueryJoins as a plain join for
+/// simple measures but as a SELECT DISTINCT keys semi-join for multiplied measures,
+/// and with duplicated join keys those disagree - same query, different numbers.
+/// MEASURE() over such a join can't be answered at all: the measure side would have
+/// to become a raw subquery carrying a measure column (no defined per-row
+/// materialization), so the whole query is rejected at compile time instead of
+/// producing contract-dependent results.
+#[tokio::test]
+async fn test_wrapper_no_measure_over_raw_join_subquery() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx();
+    let query = convert_sql_to_cube_query(
+        // language=PostgreSQL
+        &r#"
+        WITH t AS (
+            SELECT customer_gender, order_date
+            FROM KibanaSampleDataEcommerce
+            LIMIT 100
+        ),
+        pairs AS (
+            SELECT a.customer_gender AS g
+            FROM t a
+            JOIN t b ON a.customer_gender = b.customer_gender
+                AND a.order_date < b.order_date
+        )
+        SELECT k.customer_gender, MEASURE(k.count)
+        FROM KibanaSampleDataEcommerce k
+        JOIN pairs p ON k.customer_gender = p.g
+        GROUP BY 1
+        "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    // Must be a compile error: never a subqueryJoins load query over the raw join
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
+}
+
+/// Both join sides must live on the same data source: an ungrouped join across
+/// two data sources can't be pushed down as one SQL query and must stay an error.
+#[tokio::test]
+async fn test_wrapper_ungrouped_join_ungrouped_different_data_sources() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_split_data_sources();
+    let query = convert_sql_to_cube_query(
+        &r#"
+        SELECT k.customer_gender, l.content
+        FROM (SELECT customer_gender, has_subscription FROM KibanaSampleDataEcommerce LIMIT 100) k
+        JOIN (SELECT read, content FROM Logs LIMIT 100) l ON (k.has_subscription = l.read)
+        "#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
 }
 
 /// Regression test for window expression on top of a grouped join subquery


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR supports SQL push down for joins where either side is an ungrouped (raw) query, e.g. a self-join of a CTE selecting dimensions, by planning them as plain SQL joins of standalone subqueries instead of failing with `Use __cubeJoinField to join Cubes`. Related tests are included.
