### PR TITLE
fix(tesseract): carry add_group_by grain through rolling-window rollup CTE

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/member_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/member_query_planner.rs
@@ -171,8 +171,8 @@ impl MultiStageMemberQueryPlanner {
         };
 
         let schema = LogicalSchema::default()
-            .set_dimensions(self.query_properties.dimensions().clone())
-            .set_time_dimensions(self.query_properties.time_dimensions().clone())
+            .set_dimensions(self.description.state().dimensions().clone())
+            .set_time_dimensions(self.description.state().time_dimensions().clone())
             .set_measures(vec![self.description.member().evaluation_node().clone()])
             .into_rc();
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -462,13 +462,11 @@ cubes:
                 type: to_date
                 granularity: year
 
-          # Real-model shape (mirrors valid_license_seats.licensed_seats_*):
-          # the rolling-window leaf declares `add_group_by` AND the parent
-          # calc re-declares it. `orders.category` must be carried through the
-          # leaf's rollup CTE. NB: the leaf's own `add_group_by` is inert on
-          # the rolling-window path — `try_plan_rolling_window` builds the leaf
-          # before the inode `grain.include` is applied — so it is the parent
-          # calc's pushed-down grain that actually reaches the rollup here.
+          # rolling-window leaf declaring `add_group_by`, with the parent calc
+          # re-declaring it. The leaf's own `add_group_by` is inert on the
+          # rolling path — `try_plan_rolling_window` builds the leaf before the
+          # inode `grain.include` is applied — so it is the parent's pushed-down
+          # grain that reaches the rollup CTE.
           - name: rolling_leaf_own_category
             type: sum
             sql: "{CUBE.total_amount}"
@@ -493,10 +491,8 @@ cubes:
             reduce_by:
                 - orders.category
 
-          # Parent-pushed grain: the rolling-window leaf declares NO grain of
-          # its own; the parent multi-stage calc pushes `orders.category` down
-          # into the leaf, which must still reach the leaf's rollup CTE. This
-          # isolates the parent-push propagation the fix targets.
+          # Same shape with no grain declared on the leaf, so only the parent's
+          # pushed-down `add_group_by` reaches the rollup CTE.
           - name: rolling_leaf_plain
             type: sum
             sql: "{CUBE.total_amount}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -462,6 +462,63 @@ cubes:
                 type: to_date
                 granularity: year
 
+          # Real-model shape (mirrors valid_license_seats.licensed_seats_*):
+          # the rolling-window leaf declares `add_group_by` AND the parent
+          # calc re-declares it. `orders.category` must be carried through the
+          # leaf's rollup CTE. NB: the leaf's own `add_group_by` is inert on
+          # the rolling-window path — `try_plan_rolling_window` builds the leaf
+          # before the inode `grain.include` is applied — so it is the parent
+          # calc's pushed-down grain that actually reaches the rollup here.
+          - name: rolling_leaf_own_category
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            rolling_window:
+                trailing: unbounded
+                offset: end
+            add_group_by:
+                - orders.category
+
+          - name: rolling_leaf_own_calc
+            type: number
+            sql: "{CUBE.rolling_leaf_own_category}"
+            multi_stage: true
+            add_group_by:
+                - orders.category
+
+          - name: rolling_leaf_own_reduce
+            type: sum
+            sql: "{CUBE.rolling_leaf_own_calc}"
+            multi_stage: true
+            reduce_by:
+                - orders.category
+
+          # Parent-pushed grain: the rolling-window leaf declares NO grain of
+          # its own; the parent multi-stage calc pushes `orders.category` down
+          # into the leaf, which must still reach the leaf's rollup CTE. This
+          # isolates the parent-push propagation the fix targets.
+          - name: rolling_leaf_plain
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            rolling_window:
+                trailing: unbounded
+                offset: end
+
+          - name: rolling_parent_pushes_category
+            type: number
+            sql: "{CUBE.rolling_leaf_plain}"
+            multi_stage: true
+            add_group_by:
+                - orders.category
+
+          - name: rolling_parent_pushed_reduce
+            type: sum
+            sql: "{CUBE.rolling_parent_pushes_category}"
+            multi_stage: true
+            reduce_by:
+                - orders.category
+
           # ── filter: directive variants ────────────────────────────────────
           - name: amount_exclude_status
             type: sum

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__with_rolling_window__rolling_multi_stage_add_group_by_leaf_and_parent.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__with_rolling_window__rolling_multi_stage_add_group_by_leaf_and_parent.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
+expression: result
+---
+orders__created_at_month | orders__rolling_leaf_own_reduce
+-------------------------+--------------------------------
+2024-01-01 00:00:00      | 500.00                         
+2024-02-01 00:00:00      | 1250.00                        
+2024-03-01 00:00:00      | 2250.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__with_rolling_window__rolling_multi_stage_add_group_by_pushed_from_parent.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__with_rolling_window__rolling_multi_stage_add_group_by_pushed_from_parent.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
+expression: result
+---
+orders__created_at_month | orders__rolling_parent_pushed_reduce
+-------------------------+-------------------------------------
+2024-01-01 00:00:00      | 500.00                              
+2024-02-01 00:00:00      | 1250.00                             
+2024-03-01 00:00:00      | 2250.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
@@ -9,53 +9,9 @@ fn create_context() -> TestContext {
 
 const SEED: &str = "integration_multi_stage_tables.sql";
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_rolling_and_add_group_by() {
-    let ctx = create_context();
-
-    let query = indoc! {r#"
-        measures:
-          - orders.rolling_sum_7d
-          - orders.amount_by_id
-        time_dimensions:
-          - dimension: orders.created_at
-            granularity: day
-            dateRange:
-              - "2024-01-01"
-              - "2024-01-31"
-    "#};
-
-    ctx.build_sql(query).unwrap();
-
-    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
-        insta::assert_snapshot!(result);
-    }
-}
-
-/// Splits `s` on commas that are not nested inside parentheses.
-fn split_top_level_commas(s: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut depth = 0i32;
-    let mut start = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '(' => depth += 1,
-            ')' => depth -= 1,
-            ',' if depth == 0 => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    parts.push(&s[start..]);
-    parts
-}
-
-/// Returns the body of the CTE that assembles the rolling window: the one whose
-/// `FROM` reaches the base rollup through the `rolling_source` alias. CTE bodies
-/// are `<name> AS ( ... )`; each `AS (` opener is paren-matched so the returned
-/// slice is exactly that CTE and never spills into an adjacent one.
+/// Body of the CTE that assembles the rolling window — the one reaching the base
+/// rollup through the `rolling_source` alias. Each `AS (` opener is paren-matched
+/// so the returned slice never spills into an adjacent CTE.
 fn rolling_rollup_cte(sql: &str) -> &str {
     let bytes = sql.as_bytes();
     for (open, _) in sql.match_indices(" AS (") {
@@ -78,107 +34,39 @@ fn rolling_rollup_cte(sql: &str) -> &str {
     panic!("no rolling-window rollup CTE (`rolling_source` alias) found in SQL:\n{sql}");
 }
 
-/// Asserts that `dim_alias` is carried through the rolling-window rollup CTE:
-/// it must be BOTH projected in that CTE's SELECT list AND present in its
-/// GROUP BY (matched either by its 1-based ordinal position or by name). This
-/// is the exact shape that regressed — the buggy planner dropped the added
-/// dimension from the rollup, so it was neither selected nor grouped.
-fn assert_dim_carried_through_rollup(sql: &str, dim_alias: &str) {
+/// Asserts `dim_alias` is projected by the rolling-window rollup CTE. The buggy
+/// planner built that CTE's grain from the top-level query dimensions, so an
+/// added dimension was dropped there while downstream CTEs still referenced it.
+fn assert_dim_projected_in_rollup(sql: &str, dim_alias: &str) {
     let cte = rolling_rollup_cte(sql);
-    let quoted = format!("\"{dim_alias}\"");
-
     let select_start = cte.find("SELECT").expect("rollup CTE without SELECT") + "SELECT".len();
     let from_pos = select_start
         + cte[select_start..]
             .find(" FROM")
             .expect("rollup CTE without FROM");
-    let projection = &cte[select_start..from_pos];
-
-    let projections = split_top_level_commas(projection);
-    let dim_index = projections
-        .iter()
-        .position(|p| p.trim_end().ends_with(&quoted))
-        .unwrap_or_else(|| {
-            panic!("`{dim_alias}` not projected in rolling-window rollup CTE:\n{cte}")
-        });
-
-    let gb_start = cte
-        .find("GROUP BY")
-        .unwrap_or_else(|| panic!("rolling-window rollup CTE without GROUP BY:\n{cte}"))
-        + "GROUP BY".len();
-    let gb_end = cte[gb_start..]
-        .find("ORDER BY")
-        .map(|p| gb_start + p)
-        .unwrap_or(cte.len());
-    let group_by = &cte[gb_start..gb_end];
-
-    let ordinal = (dim_index + 1).to_string();
-    let grouped =
-        group_by.contains(dim_alias) || group_by.split(',').map(str::trim).any(|t| t == ordinal);
     assert!(
-        grouped,
-        "`{dim_alias}` (projection #{}) is projected but missing from GROUP BY `{}` \
-         of the rolling-window rollup CTE:\n{cte}",
-        dim_index + 1,
-        group_by.trim(),
+        cte[select_start..from_pos].contains(&format!("\"{dim_alias}\"")),
+        "`{dim_alias}` not projected in rolling-window rollup CTE:\n{cte}",
     );
 }
 
-// Real-model regression (mirrors valid_license_seats.licensed_seats_*): a
-// rolling-window leaf declares `add_group_by` and the parent calc re-declares
-// it. The rolling-window rollup CTE used to source its grain from the
-// top-level query dimensions, dropping the added dimension and emitting SQL
-// that referenced a column absent from the rollup CTE. `orders__category` must
-// now be projected and grouped in the rollup CTE feeding `rolling_source`.
-// (The leaf's own `add_group_by` is inert on the rolling path — see fixture
-// note — so it is the parent calc's pushed-down grain that reaches the rollup;
-// this shape guards that the redundant leaf declaration stays harmless.)
 #[tokio::test(flavor = "multi_thread")]
-async fn test_rolling_multi_stage_add_group_by_leaf_and_parent() {
+async fn test_rolling_and_add_group_by() {
     let ctx = create_context();
 
     let query = indoc! {r#"
         measures:
-          - orders.rolling_leaf_own_reduce
+          - orders.rolling_sum_7d
+          - orders.amount_by_id
         time_dimensions:
           - dimension: orders.created_at
-            granularity: month
+            granularity: day
             dateRange:
               - "2024-01-01"
-              - "2024-03-31"
+              - "2024-01-31"
     "#};
 
-    let sql = ctx.build_sql(query).unwrap();
-    assert_dim_carried_through_rollup(&sql, "orders__category");
-
-    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
-        insta::assert_snapshot!(result);
-    }
-}
-
-// Same regression via the parent-push path in isolation: the rolling-window
-// leaf `rolling_leaf_plain` declares NO grain of its own, and the parent
-// multi-stage calc `rolling_parent_pushes_category` pushes
-// `add_group_by: [orders.category]` down into it. The pushed-down dimension
-// must reach the leaf's rollup CTE (projected and grouped), which the bug
-// prevented because the rollup read the top-level (category-less) query grain.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_rolling_multi_stage_add_group_by_pushed_from_parent() {
-    let ctx = create_context();
-
-    let query = indoc! {r#"
-        measures:
-          - orders.rolling_parent_pushed_reduce
-        time_dimensions:
-          - dimension: orders.created_at
-            granularity: month
-            dateRange:
-              - "2024-01-01"
-              - "2024-03-31"
-    "#};
-
-    let sql = ctx.build_sql(query).unwrap();
-    assert_dim_carried_through_rollup(&sql, "orders__category");
+    ctx.build_sql(query).unwrap();
 
     if let Some(result) = ctx.try_execute_pg(query, SEED).await {
         insta::assert_snapshot!(result);
@@ -299,6 +187,60 @@ async fn test_rolling_and_calculated() {
     "#};
 
     ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// A rolling-window leaf under an `add_group_by` calc, queried without the added
+// dimension. The rollup CTE used to take its grain from the top-level query
+// dimensions, dropping `orders.category` while a downstream CTE still joined on
+// it, so the planner emitted SQL naming a column the rollup never selected.
+// Grain is declared on both the leaf and the parent calc here; only the parent's
+// push reaches the rollup (see fixture note), so this also guards that the
+// redundant leaf declaration stays harmless.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_multi_stage_add_group_by_leaf_and_parent() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_leaf_own_reduce
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_dim_projected_in_rollup(&sql, "orders__category");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// Same regression with the grain declared only on the parent calc.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_multi_stage_add_group_by_pushed_from_parent() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_parent_pushed_reduce
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_dim_projected_in_rollup(&sql, "orders__category");
 
     if let Some(result) = ctx.try_execute_pg(query, SEED).await {
         insta::assert_snapshot!(result);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/with_rolling_window.rs
@@ -32,6 +32,159 @@ async fn test_rolling_and_add_group_by() {
     }
 }
 
+/// Splits `s` on commas that are not nested inside parentheses.
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
+/// Returns the body of the CTE that assembles the rolling window: the one whose
+/// `FROM` reaches the base rollup through the `rolling_source` alias. CTE bodies
+/// are `<name> AS ( ... )`; each `AS (` opener is paren-matched so the returned
+/// slice is exactly that CTE and never spills into an adjacent one.
+fn rolling_rollup_cte(sql: &str) -> &str {
+    let bytes = sql.as_bytes();
+    for (open, _) in sql.match_indices(" AS (") {
+        let body_start = open + " AS (".len();
+        let mut depth = 1usize;
+        let mut i = body_start;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        let body = &sql[body_start..i - 1];
+        if body.contains("rolling_source") {
+            return body;
+        }
+    }
+    panic!("no rolling-window rollup CTE (`rolling_source` alias) found in SQL:\n{sql}");
+}
+
+/// Asserts that `dim_alias` is carried through the rolling-window rollup CTE:
+/// it must be BOTH projected in that CTE's SELECT list AND present in its
+/// GROUP BY (matched either by its 1-based ordinal position or by name). This
+/// is the exact shape that regressed — the buggy planner dropped the added
+/// dimension from the rollup, so it was neither selected nor grouped.
+fn assert_dim_carried_through_rollup(sql: &str, dim_alias: &str) {
+    let cte = rolling_rollup_cte(sql);
+    let quoted = format!("\"{dim_alias}\"");
+
+    let select_start = cte.find("SELECT").expect("rollup CTE without SELECT") + "SELECT".len();
+    let from_pos = select_start
+        + cte[select_start..]
+            .find(" FROM")
+            .expect("rollup CTE without FROM");
+    let projection = &cte[select_start..from_pos];
+
+    let projections = split_top_level_commas(projection);
+    let dim_index = projections
+        .iter()
+        .position(|p| p.trim_end().ends_with(&quoted))
+        .unwrap_or_else(|| {
+            panic!("`{dim_alias}` not projected in rolling-window rollup CTE:\n{cte}")
+        });
+
+    let gb_start = cte
+        .find("GROUP BY")
+        .unwrap_or_else(|| panic!("rolling-window rollup CTE without GROUP BY:\n{cte}"))
+        + "GROUP BY".len();
+    let gb_end = cte[gb_start..]
+        .find("ORDER BY")
+        .map(|p| gb_start + p)
+        .unwrap_or(cte.len());
+    let group_by = &cte[gb_start..gb_end];
+
+    let ordinal = (dim_index + 1).to_string();
+    let grouped =
+        group_by.contains(dim_alias) || group_by.split(',').map(str::trim).any(|t| t == ordinal);
+    assert!(
+        grouped,
+        "`{dim_alias}` (projection #{}) is projected but missing from GROUP BY `{}` \
+         of the rolling-window rollup CTE:\n{cte}",
+        dim_index + 1,
+        group_by.trim(),
+    );
+}
+
+// Real-model regression (mirrors valid_license_seats.licensed_seats_*): a
+// rolling-window leaf declares `add_group_by` and the parent calc re-declares
+// it. The rolling-window rollup CTE used to source its grain from the
+// top-level query dimensions, dropping the added dimension and emitting SQL
+// that referenced a column absent from the rollup CTE. `orders__category` must
+// now be projected and grouped in the rollup CTE feeding `rolling_source`.
+// (The leaf's own `add_group_by` is inert on the rolling path — see fixture
+// note — so it is the parent calc's pushed-down grain that reaches the rollup;
+// this shape guards that the redundant leaf declaration stays harmless.)
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_multi_stage_add_group_by_leaf_and_parent() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_leaf_own_reduce
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_dim_carried_through_rollup(&sql, "orders__category");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// Same regression via the parent-push path in isolation: the rolling-window
+// leaf `rolling_leaf_plain` declares NO grain of its own, and the parent
+// multi-stage calc `rolling_parent_pushes_category` pushes
+// `add_group_by: [orders.category]` down into it. The pushed-down dimension
+// must reach the leaf's rollup CTE (projected and grouped), which the bug
+// prevented because the rollup read the top-level (category-less) query grain.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_multi_stage_add_group_by_pushed_from_parent() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_parent_pushed_reduce
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_dim_carried_through_rollup(&sql, "orders__category");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rolling_and_time_shift() {
     let ctx = create_context();


### PR DESCRIPTION
## Description

A multi-stage measure that combines a `rolling_window` with an `add_group_by`
dimension generates **invalid SQL** when that dimension is not part of the query:
the rolling-window rollup CTE drops the added dimension, so a later CTE references
a column the rollup never projected.

Related to #10864 and #11327 — the same multi-stage `add_group_by` family in the Tesseract
planner (those are the *missing-`GROUP BY`* variant; distinct root cause, but adjacent).

### Reproduction

Multi-stage chain — rolling-window leaf → `add_group_by` calc → `reduce_by` sum:

```yaml
measures:
  - name: rolling_leaf
    type: sum
    sql: amount
    multi_stage: true
    rolling_window: { trailing: unbounded, offset: end }
  - name: per_group                 # pushes the grain down
    type: number
    sql: "{CUBE.rolling_leaf}"
    multi_stage: true
    add_group_by: [orders.category]
  - name: total                     # sums back over the group
    type: sum
    sql: "{CUBE.per_group}"
    multi_stage: true
    reduce_by: [orders.category]
```

Querying `total` grouped by time only (no `category` dimension) fails:

```
column "orders__category" does not exist in cte_1
```

The rolling window's stage-1 aggregation CTE groups by `category` correctly, but the
rollup CTE (`time_series LEFT JOIN … ON … <= DATEADD(…)`) omits it, while the
downstream full-key aggregate joins on it.

### Root cause

In `plan_rolling_window_query`, the rollup CTE's `LogicalSchema` grain was built from
`self.query_properties` (top-level query dimensions) instead of `self.description.state()`
(the member's own grain, which carries the `add_group_by` dimension). The sibling builders
(`plan_for_cte_query`, `plan_for_cte_dimension_query`, `plan_for_leaf_cte_query`) all use
`self.description.state()` — this one had drifted.

### Fix

Source the rollup grain from `self.description.state()`, matching the siblings (2 lines).
For plain rolling windows `state() == query_properties`, so existing behaviour and snapshots
are unchanged; where the grain is extended (`add_group_by`) or reduced (`reduce_by`), the
rollup now agrees with the base-measure leaf CTE by construction.

### Tests

Integration tests + fixtures under `multi_stage/with_rolling_window` covering both
propagation shapes — a leaf-declared `add_group_by` and a parent-pushed grain — asserting the
added dimension is projected by the rollup CTE, with committed snapshots pinning the
aggregated values. Existing snapshots are unchanged.

Projection is the assertion that fails on the bug: the rollup never selected the column,
while a downstream CTE still referenced it. Grouping is covered by the executed snapshots
rather than structurally — the rollup emits ordinal `GROUP BY 1, 2`, so asserting it by name
would mean resolving the projection index in the test, which seemed like more machinery than
this directory's helpers carry. Happy to add it back if you'd rather have it.

## Check List

- [x] Tests have been run
- [x] Linter has been run (`cargo fmt --check`, `cargo clippy -- -D warnings`)
- [x] Tests for the changes have been added
- [ ] Docs updated (N/A — internal planner fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

