### PR TITLE
feat(query-orchestrator): add trace_id SQL comment to data source queries

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
@@ -224,8 +224,10 @@ module.exports = {
 ```
 
 The tag is set once per connection, not per query — all queries issued over
-that connection carry the same tag.
+that connection carry the same tag. To identify the individual API request
+behind a query, use [query tracing][ref-query-tracing] instead.
 
+[ref-query-tracing]: /admin/connect-to-data/query-tracing
 [ref-dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure
 [ref-cloud-conf-vpc]: /admin/deployment/dedicated
 ## Environment Variables

--- a/docs-mintlify/admin/connect-to-data/query-tracing.mdx
+++ b/docs-mintlify/admin/connect-to-data/query-tracing.mdx
@@ -68,9 +68,14 @@ Otherwise Cube generates one.
 
 ## Scope
 
-Only the query serving an API request is tagged. Pre-aggregation builds, export
-bucket operations, refresh keys, background refreshes, and Cube's own internal
-queries are left untagged, since there is no API request to trace them back to.
+Queries issued to serve an API request are tagged. Pre-aggregation builds,
+export bucket operations, refresh keys, background refreshes, and Cube's own
+internal queries are left untagged, since there is no API request to trace them
+back to.
+
+A single request usually produces one tagged query, but not always — a query
+reading a lambda pre-aggregation's source table, for instance, is tagged too.
+Match on `trace_id` rather than assuming one row per request.
 
 Not every request produces a tagged query to find: one served from the cache
 never reaches your data source, and when identical queries arrive together Cube

--- a/docs-mintlify/admin/connect-to-data/query-tracing.mdx
+++ b/docs-mintlify/admin/connect-to-data/query-tracing.mdx
@@ -1,0 +1,92 @@
+---
+title: Query tracing
+description: Trace a Cube API request through to the queries it runs on your data source.
+---
+
+Cube can tag the queries it sends to your data source with a `trace_id` SQL
+comment, letting you match a query in your data source's query history back to
+the API request that caused it.
+
+This is useful when one API request fans out into several data source
+queries — every one of them carries the same `trace_id`, distinguished by a
+`-span-N` suffix.
+
+## Configuration
+
+Set [`CUBEJS_SQL_INCLUDE_TRACE_ID`](/reference/configuration/environment-variables#cubejs_sql_include_trace_id)
+to `true`:
+
+```dotenv
+CUBEJS_SQL_INCLUDE_TRACE_ID=true
+```
+
+Queries then reach your data source with the comment appended:
+
+```sql
+SELECT ...
+/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */
+```
+
+`trace_id` identifies the API request and matches the field of the same name in
+the [Query History export][ref-query-history-export]. `span` identifies the
+attempt within that request.
+
+<Warning>
+
+A unique comment per request makes each query textually distinct, which
+prevents your data source from reusing cached results — Snowflake's persisted
+query results and BigQuery's result cache both require identical query text.
+Expect more queries to actually execute, and on Snowflake a warehouse that
+would have stayed suspended may resume.
+
+</Warning>
+
+## Finding the comment in your data source
+
+Some query history views truncate long SQL, and a few omit comments entirely.
+If you can't find the `trace_id`, check where you're reading it from:
+
+| Data source | Where to look |
+| ----------- | ------------- |
+| Snowflake | `QUERY_HISTORY`. Note that Snowflake strips *leading* comments, which is why Cube appends. |
+| Redshift | `SYS_QUERY_TEXT`, reassembled with `LISTAGG`. `SYS_QUERY_HISTORY` and `STL_QUERY` truncate at 4000 characters. |
+| BigQuery | `INFORMATION_SCHEMA.JOBS`. Cloud Audit Logs truncate at 50K characters. |
+| Databricks | `system.query.history`. Empty when customer-managed keys are enabled. |
+| Postgres | Server logs (`log_statement`). `pg_stat_activity.query` truncates at `track_activity_query_size` (1024 bytes by default). |
+| MySQL | The general or slow query log. |
+
+<Warning>
+
+`pg_stat_statements` and MySQL's digest tables normalize queries and discard
+comments, keeping only the text of the first query with a given fingerprint.
+The `trace_id` you see there belongs to some earlier request, not the one you
+are looking at. Use the query logs instead.
+
+</Warning>
+
+## Supplying your own identifier
+
+Clients calling the [REST (JSON) API](/reference/core-data-apis/rest-api) can
+supply their own identifier through the `x-request-id` or `traceparent` request
+header, letting you trace a query back to a request in your own application.
+Otherwise Cube generates one.
+
+## Scope
+
+Only the query serving an API request is tagged. Pre-aggregation builds, export
+bucket operations, refresh keys, background refreshes, and Cube's own internal
+queries are left untagged, since there is no API request to trace them back to.
+
+Not every request produces a tagged query to find: one served from the cache
+never reaches your data source, and when identical queries arrive together Cube
+runs them once, under whichever request got there first.
+
+## Snowflake query tagging
+
+Snowflake also supports a connection-level
+[query tag](/admin/connect-to-data/data-sources/snowflake#query-tagging), which
+labels every query on a connection with the same static value. The two are
+complementary: a query tag identifies the deployment, while `trace_id`
+identifies the individual request.
+
+[ref-query-history-export]: /admin/monitoring/monitoring-integrations#query-history-export

--- a/docs-mintlify/admin/connect-to-data/query-tracing.mdx
+++ b/docs-mintlify/admin/connect-to-data/query-tracing.mdx
@@ -8,8 +8,7 @@ comment, letting you match a query in your data source's query history back to
 the API request that caused it.
 
 This is useful when one API request fans out into several data source
-queries — every one of them carries the same `trace_id`, distinguished by a
-`-span-N` suffix.
+queries — every one of them carries the same `trace_id`.
 
 ## Configuration
 
@@ -24,12 +23,14 @@ Queries then reach your data source with the comment appended:
 
 ```sql
 SELECT ...
-/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */
+/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 */
 ```
 
 `trace_id` identifies the API request and matches the field of the same name in
-the [Query History export][ref-query-history-export]. `span` identifies the
-attempt within that request.
+the [Query History export][ref-query-history-export].
+
+Trace ids longer than 128 characters are truncated, and any character outside
+`A-Z a-z 0-9 . _ : -` is removed.
 
 <Warning>
 
@@ -46,23 +47,17 @@ would have stayed suspended may resume.
 Some query history views truncate long SQL, and a few omit comments entirely.
 If you can't find the `trace_id`, check where you're reading it from:
 
-| Data source | Where to look |
-| ----------- | ------------- |
-| Snowflake | `QUERY_HISTORY`. Note that Snowflake strips *leading* comments, which is why Cube appends. |
-| Redshift | `SYS_QUERY_TEXT`, reassembled with `LISTAGG`. `SYS_QUERY_HISTORY` and `STL_QUERY` truncate at 4000 characters. |
-| BigQuery | `INFORMATION_SCHEMA.JOBS`. Cloud Audit Logs truncate at 50K characters. |
-| Databricks | `system.query.history`. Empty when customer-managed keys are enabled. |
-| Postgres | Server logs (`log_statement`). `pg_stat_activity.query` truncates at `track_activity_query_size` (1024 bytes by default). |
-| MySQL | The general or slow query log. |
-
-<Warning>
-
-`pg_stat_statements` and MySQL's digest tables normalize queries and discard
-comments, keeping only the text of the first query with a given fingerprint.
-The `trace_id` you see there belongs to some earlier request, not the one you
-are looking at. Use the query logs instead.
-
-</Warning>
+- **Snowflake**: `QUERY_HISTORY`. Note that Snowflake strips *leading* comments,
+  which is why Cube appends.
+- **Redshift**: `SYS_QUERY_TEXT`, reassembled with `LISTAGG`.
+  `SYS_QUERY_HISTORY` and `STL_QUERY` truncate at 4000 characters.
+- **BigQuery**: `INFORMATION_SCHEMA.JOBS`. Cloud Audit Logs truncate at 50K
+  characters.
+- **Databricks**: `system.query.history`. Empty when customer-managed keys are
+  enabled.
+- **Postgres**: server logs (`log_statement`). `pg_stat_activity.query`
+  truncates at `track_activity_query_size` (1024 bytes by default).
+- **MySQL**: the general or slow query log.
 
 ## Supplying your own identifier
 
@@ -80,13 +75,5 @@ queries are left untagged, since there is no API request to trace them back to.
 Not every request produces a tagged query to find: one served from the cache
 never reaches your data source, and when identical queries arrive together Cube
 runs them once, under whichever request got there first.
-
-## Snowflake query tagging
-
-Snowflake also supports a connection-level
-[query tag](/admin/connect-to-data/data-sources/snowflake#query-tagging), which
-labels every query on a connection with the same static value. The two are
-complementary: a query tag identifies the deployment, while `trace_id`
-identifies the individual request.
 
 [ref-query-history-export]: /admin/monitoring/monitoring-integrations#query-history-export

--- a/docs-mintlify/admin/connect-to-data/query-tracing.mdx
+++ b/docs-mintlify/admin/connect-to-data/query-tracing.mdx
@@ -77,8 +77,9 @@ A single request usually produces one tagged query, but not always — a query
 reading a lambda pre-aggregation's source table, for instance, is tagged too.
 Match on `trace_id` rather than assuming one row per request.
 
-Not every request produces a tagged query to find: one served from the cache
-never reaches your data source, and when identical queries arrive together Cube
-runs them once, under whichever request got there first.
+Not every request produces a tagged query to find: one served from the cache or
+from a pre-aggregation never reaches your data source, and when identical
+queries arrive together Cube runs them once, under whichever request got there
+first.
 
 [ref-query-history-export]: /admin/monitoring/monitoring-integrations#query-history-export

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -319,7 +319,7 @@ Exported data includes the following fields:
 
 | Field | Description |
 | --- | --- |
-| `trace_id` | Unique identifier of the API request. |
+| `trace_id` | Unique identifier of the API request. Can also be attached to data source queries, see [query tracing][ref-query-tracing]. |
 | `account_name` | Name of the Cube Cloud account. |
 | `deployment_id` | Identifier of the [deployment][ref-deployments]. |
 | `environment_name` | Name of the [environment][ref-environments], `NULL` for production. |
@@ -376,3 +376,4 @@ Query History export.
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-cache-type]: /docs/pre-aggregations#cache-type
 [ref-query-history-export-recipe]: /admin/monitoring/query-history-export
+[ref-query-tracing]: /admin/connect-to-data/query-tracing

--- a/docs-mintlify/admin/monitoring/query-history-export.mdx
+++ b/docs-mintlify/admin/monitoring/query-history-export.mdx
@@ -222,10 +222,19 @@ Example query in Playground:
   <img src="https://ucarecdn.com/327373f0-217b-4a91-8ac7-fd2d97c79513/" />
 </Frame>
 
+<Tip>
+
+Enable [query tracing][ref-query-tracing] to also attach `trace_id` to the
+queries Cube sends to your data source, so exported requests can be joined to
+your data source's own query history.
+
+</Tip>
+
 
 
 
 [ref-query-history-export]: /admin/monitoring/monitoring-integrations#query-history-export
+[ref-query-tracing]: /admin/connect-to-data/query-tracing
 [ref-query-history]: /admin/monitoring/query-history
 [ref-vector-configuration]: /admin/monitoring/monitoring-integrations#configuration
 [ref-keyless-auth]: /admin/monitoring/monitoring-integrations/cloudwatch#keyless-authentication

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -266,6 +266,7 @@
               },
               "admin/connect-to-data/multiple-data-sources",
               "admin/connect-to-data/concurrency",
+              "admin/connect-to-data/query-tracing",
               "admin/connect-to-data/oauth-authentication"
             ]
           },

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -131,6 +131,16 @@ The cache and queue driver to use for the Cube deployment.
 It can be also set using the [`cache_and_queue_driver` configuration
 option](/reference/configuration/config#cache_and_queue_driver).
 
+## `CUBEJS_SQL_INCLUDE_TRACE_ID`
+
+Whether to attach a `trace_id` SQL comment, carrying the identifier of the API
+request, to queries sent to data sources. See [Query
+tracing](/admin/connect-to-data/query-tracing).
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
 ## `CUBEJS_CONCURRENCY`
 
 The number of concurrent connections each query queue has to the database.

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -243,6 +243,14 @@ const variables: Record<string, (...args: any) => any> = {
   rollupOnlyMode: () => get('CUBEJS_ROLLUP_ONLY')
     .default('false')
     .asBoolStrict(),
+  /**
+   * Whether to attach a `trace_id` SQL comment, carrying the API request id,
+   * to queries sent to data sources. Lets warehouse query history be joined
+   * back to Cube's own query history.
+   */
+  sqlIncludeTraceId: () => get('CUBEJS_SQL_INCLUDE_TRACE_ID')
+    .default('false')
+    .asBoolStrict(),
   schemaPath: () => get('CUBEJS_SCHEMA_PATH')
     .default('model')
     .asString(),

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -178,3 +178,26 @@ describe('getEnv(apiSecret / apiSecrets)', () => {
     expect(getEnv('apiSecrets')).toEqual(['only']);
   });
 });
+
+describe('getEnv(sqlIncludeTraceId)', () => {
+  afterEach(() => {
+    delete process.env.CUBEJS_SQL_INCLUDE_TRACE_ID;
+  });
+
+  test('defaults to off', () => {
+    expect(getEnv('sqlIncludeTraceId')).toBe(false);
+  });
+
+  test('sqlIncludeTraceId', () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    expect(getEnv('sqlIncludeTraceId')).toBe(true);
+
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'false';
+    expect(getEnv('sqlIncludeTraceId')).toBe(false);
+  });
+
+  test('rejects a non-boolean value', () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'yes';
+    expect(() => getEnv('sqlIncludeTraceId')).toThrow();
+  });
+});

--- a/packages/cubejs-base-driver/src/index.ts
+++ b/packages/cubejs-base-driver/src/index.ts
@@ -1,6 +1,7 @@
 export * from './BaseDriver';
 export * from './type-detection';
 export * from './utils';
+export * from './trace-comment';
 export * from './driver.interface';
 export * from './queue-driver.interface';
 export * from './cache-driver.interface';

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -31,13 +31,15 @@ export function sanitizeTraceId(requestId: string | undefined | null): string {
 }
 
 /**
- * Strips the `-span-N` suffix Cube appends per data source query of a request.
+ * Strips the `-span-` suffix Cube appends per data source query of a request.
  *
  * The emitted id has to match the `trace_id` of the Query History export, which
  * carries the request id without that suffix — joining on the full request id
- * would never match.
+ * would never match. That makes this the one piece of logic the emitting side
+ * and the export side must agree on, so it lives here and the orchestrator
+ * re-exports it as `extractRequestUUID` rather than keeping its own copy.
  */
-function toTraceId(requestId: string): string {
+export function toTraceId(requestId: string): string {
   const idx = requestId.lastIndexOf('-span-');
 
   return idx === -1 ? requestId : requestId.substring(0, idx);

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -14,6 +14,9 @@
  * Characters kept in a trace id. Covers every id shape Cube produces or
  * accepts: UUIDs, `-span-N` suffixes, W3C `traceparent`, and the `scheduler-`
  * and `datasources-` prefixes.
+ *
+ * Excluding `+` also keeps the payload from reading as an optimizer hint on
+ * Hive and Spark.
  */
 const ALLOWED_CHARS = /[^A-Za-z0-9._:-]/g;
 
@@ -26,46 +29,29 @@ export function sanitizeTraceId(requestId: string | undefined | null): string {
 
   return String(requestId)
     .replace(ALLOWED_CHARS, '')
-    // A payload starting with `+` reads as an optimizer hint on Hive and Spark.
-    .replace(/^\++/, '')
     .slice(0, MAX_TRACE_ID_LENGTH);
 }
 
 /**
- * Splits a request id into the trace id and the span that produced this
- * particular query.
+ * Strips the `-span-N` suffix Cube appends per data source query of a request.
  *
- * The trace id must match the `trace_id` of the Query History export, which
- * drops the `-span-N` suffix — joining on the full request id would never
- * match. The span is emitted alongside it, since one request fans out into
- * several data source queries that are otherwise indistinguishable.
+ * The emitted id has to match the `trace_id` of the Query History export, which
+ * carries the request id without that suffix — joining on the full request id
+ * would never match.
  */
-function splitRequestId(requestId: string): { traceId: string, span?: string } {
+function toTraceId(requestId: string): string {
   const idx = requestId.lastIndexOf('-span-');
-  if (idx === -1) {
-    return { traceId: requestId };
-  }
 
-  return {
-    traceId: requestId.substring(0, idx),
-    span: requestId.substring(idx + '-span-'.length),
-  };
+  return idx === -1 ? requestId : requestId.substring(0, idx);
 }
 
 export function buildTraceComment(requestId: string | undefined | null): string | null {
-  const sanitized = sanitizeTraceId(requestId);
-  if (!sanitized) {
-    return null;
-  }
-
-  const { traceId, span } = splitRequestId(sanitized);
+  const traceId = toTraceId(sanitizeTraceId(requestId));
   if (!traceId) {
     return null;
   }
 
-  return span
-    ? `/* trace_id: ${traceId} span: ${span} */`
-    : `/* trace_id: ${traceId} */`;
+  return `/* trace_id: ${traceId} */`;
 }
 
 /**

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -71,7 +71,9 @@ export function addTraceComment(sql: string, requestId: string | undefined | nul
     return sql;
   }
 
-  const withoutSemicolon = sql.replace(/;\s*$/, '');
+  // Collapse a run of trailing semicolons, not just one: leaving `;` behind would
+  // put the comment between two statements, the second of them empty.
+  const withoutSemicolon = sql.replace(/;[\s;]*$/, '');
   const semicolon = withoutSemicolon.length === sql.length ? '' : ';';
 
   return `${withoutSemicolon}\n${comment}${semicolon}`;

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -71,10 +71,24 @@ export function addTraceComment(sql: string, requestId: string | undefined | nul
     return sql;
   }
 
-  // Collapse a run of trailing semicolons, not just one: leaving `;` behind would
-  // put the comment between two statements, the second of them empty.
-  const withoutSemicolon = sql.replace(/;[\s;]*$/, '');
-  const semicolon = withoutSemicolon.length === sql.length ? '' : ';';
+  // Take the whole trailing run, not one semicolon: a leftover `;` would leave the
+  // comment between two statements, the second empty. Scanned, not matched — `sql`
+  // is uncontrolled and `;[\s;]*$` backtracks quadratically on a long run.
+  let end = sql.length;
+  let sawSemicolon = false;
+  while (end > 0) {
+    const ch = sql[end - 1];
+    if (ch === ';') {
+      sawSemicolon = true;
+    } else if (!/\s/.test(ch)) {
+      break;
+    }
+    end -= 1;
+  }
+
+  // Trailing whitespace on its own must not gain the query a semicolon it never had.
+  const withoutSemicolon = sawSemicolon ? sql.slice(0, end) : sql;
+  const semicolon = sawSemicolon ? ';' : '';
 
   return `${withoutSemicolon}\n${comment}${semicolon}`;
 }

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -49,9 +49,15 @@ export function toTraceId(requestId: string): string {
 }
 
 export function buildTraceComment(requestId: string | undefined | null): string | null {
-  // Cap only after the span is stripped: capping the raw id first can cut it
-  // mid-`-span-`, leaving a partial marker in what gets emitted.
-  const traceId = toTraceId(sanitizeTraceId(requestId)).slice(0, MAX_TRACE_ID_LENGTH);
+  // Strip the span before sanitizing, and cap last. Order is load-bearing in both
+  // places. Stripping first keeps the emitted id faithful to the export, which
+  // strips the RAW request id: dropping a disallowed character can otherwise close
+  // a gap and synthesize a marker that was never there (`myid-span%-1` sanitizes to
+  // `myid-span-1`, so the comment would carry `myid` while the export row carries
+  // `myid-span%-1`, and the join finds nothing). Sanitizing can never destroy a real
+  // marker, since every character of `-span-` is inside the allowlist. Capping last
+  // keeps a cap from cutting mid-`-span-` and leaving a partial marker.
+  const traceId = sanitizeTraceId(toTraceId(String(requestId ?? ''))).slice(0, MAX_TRACE_ID_LENGTH);
   if (!traceId) {
     return null;
   }

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -1,0 +1,90 @@
+/**
+ * Attaches a `trace_id` SQL comment to queries sent to data sources, so that a
+ * warehouse's query history can be joined back to Cube's own query history.
+ *
+ * The request id reaching this module can be supplied by the client — the REST
+ * API reads `x-request-id`/`traceparent` verbatim — so it is sanitized with an
+ * allowlist rather than by escaping known-bad sequences. Both comment
+ * delimiters have to go: engines are split on whether block comments nest, so a
+ * stray closing delimiter leaks live SQL on some, and a stray opening one
+ * swallows the statement on others.
+ */
+
+/**
+ * Characters kept in a trace id. Covers every id shape Cube produces or
+ * accepts: UUIDs, `-span-N` suffixes, W3C `traceparent`, and the `scheduler-`
+ * and `datasources-` prefixes.
+ */
+const ALLOWED_CHARS = /[^A-Za-z0-9._:-]/g;
+
+const MAX_TRACE_ID_LENGTH = 128;
+
+export function sanitizeTraceId(requestId: string | undefined | null): string {
+  if (!requestId) {
+    return '';
+  }
+
+  return String(requestId)
+    .replace(ALLOWED_CHARS, '')
+    // A payload starting with `+` reads as an optimizer hint on Hive and Spark.
+    .replace(/^\++/, '')
+    .slice(0, MAX_TRACE_ID_LENGTH);
+}
+
+/**
+ * Splits a request id into the trace id and the span that produced this
+ * particular query.
+ *
+ * The trace id must match the `trace_id` of the Query History export, which
+ * drops the `-span-N` suffix — joining on the full request id would never
+ * match. The span is emitted alongside it, since one request fans out into
+ * several data source queries that are otherwise indistinguishable.
+ */
+function splitRequestId(requestId: string): { traceId: string, span?: string } {
+  const idx = requestId.lastIndexOf('-span-');
+  if (idx === -1) {
+    return { traceId: requestId };
+  }
+
+  return {
+    traceId: requestId.substring(0, idx),
+    span: requestId.substring(idx + '-span-'.length),
+  };
+}
+
+export function buildTraceComment(requestId: string | undefined | null): string | null {
+  const sanitized = sanitizeTraceId(requestId);
+  if (!sanitized) {
+    return null;
+  }
+
+  const { traceId, span } = splitRequestId(sanitized);
+  if (!traceId) {
+    return null;
+  }
+
+  return span
+    ? `/* trace_id: ${traceId} span: ${span} */`
+    : `/* trace_id: ${traceId} */`;
+}
+
+/**
+ * Returns `sql` with the trace comment appended, or unchanged when the request
+ * id has nothing usable left after sanitization.
+ *
+ * Appended rather than prepended because Snowflake strips leading comments
+ * before recording the SQL text, and no data source requires a leading one.
+ * The comment goes before any trailing semicolon, which some clients treat as
+ * a statement separator.
+ */
+export function addTraceComment(sql: string, requestId: string | undefined | null): string {
+  const comment = buildTraceComment(requestId);
+  if (!comment) {
+    return sql;
+  }
+
+  const withoutSemicolon = sql.replace(/;\s*$/, '');
+  const semicolon = withoutSemicolon.length === sql.length ? '' : ';';
+
+  return `${withoutSemicolon}\n${comment}${semicolon}`;
+}

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -27,9 +27,7 @@ export function sanitizeTraceId(requestId: string | undefined | null): string {
     return '';
   }
 
-  return String(requestId)
-    .replace(ALLOWED_CHARS, '')
-    .slice(0, MAX_TRACE_ID_LENGTH);
+  return String(requestId).replace(ALLOWED_CHARS, '');
 }
 
 /**
@@ -46,7 +44,9 @@ function toTraceId(requestId: string): string {
 }
 
 export function buildTraceComment(requestId: string | undefined | null): string | null {
-  const traceId = toTraceId(sanitizeTraceId(requestId));
+  // Cap only after the span is stripped: capping the raw id first can cut it
+  // mid-`-span-`, leaving a partial marker in what gets emitted.
+  const traceId = toTraceId(sanitizeTraceId(requestId)).slice(0, MAX_TRACE_ID_LENGTH);
   if (!traceId) {
     return null;
   }

--- a/packages/cubejs-base-driver/src/trace-comment.ts
+++ b/packages/cubejs-base-driver/src/trace-comment.ts
@@ -22,6 +22,9 @@ const ALLOWED_CHARS = /[^A-Za-z0-9._:-]/g;
 
 const MAX_TRACE_ID_LENGTH = 128;
 
+/** Kept at module scope so the trailing-run scan doesn't re-evaluate a literal per character. */
+const WHITESPACE = /\s/;
+
 export function sanitizeTraceId(requestId: string | undefined | null): string {
   if (!requestId) {
     return '';
@@ -80,7 +83,7 @@ export function addTraceComment(sql: string, requestId: string | undefined | nul
     const ch = sql[end - 1];
     if (ch === ';') {
       sawSemicolon = true;
-    } else if (!/\s/.test(ch)) {
+    } else if (!WHITESPACE.test(ch)) {
       break;
     }
     end -= 1;

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -53,21 +53,20 @@ describe('buildTraceComment', () => {
   });
 
   // The Query History export drops the -span-N suffix when deriving trace_id,
-  // so the comment must carry the stem for the join to match, and the span
-  // separately to tell fanned-out queries apart.
-  test('splits the span suffix out of the trace id', () => {
+  // so the comment must carry the stem for the join to match.
+  test('drops the span suffix', () => {
     expect(buildTraceComment('f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1'))
-      .toBe('/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */');
+      .toBe('/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 */');
   });
 
-  test('keeps a uuid span suffix intact', () => {
+  test('drops a uuid span suffix', () => {
     expect(buildTraceComment('conn1-msg2-span-abc-def'))
-      .toBe('/* trace_id: conn1-msg2 span: abc-def */');
+      .toBe('/* trace_id: conn1-msg2 */');
   });
 
-  test('handles a scheduler id with a span', () => {
+  test('drops the span suffix of a scheduler id', () => {
     expect(buildTraceComment('scheduler-abc-span-2'))
-      .toBe('/* trace_id: scheduler-abc span: 2 */');
+      .toBe('/* trace_id: scheduler-abc */');
   });
 
   test('returns null when nothing usable remains', () => {
@@ -83,8 +82,8 @@ describe('addTraceComment', () => {
     expect(addTraceComment(sql, 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */');
   });
 
-  test('appends trace id and span for a canonical request id', () => {
-    expect(addTraceComment(sql, 'abc-123-span-4')).toBe('SELECT 1\n/* trace_id: abc-123 span: 4 */');
+  test('appends the trace id of a canonical request id', () => {
+    expect(addTraceComment(sql, 'abc-123-span-4')).toBe('SELECT 1\n/* trace_id: abc-123 */');
   });
 
   test('keeps the comment inside a trailing semicolon', () => {

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -139,13 +139,16 @@ describe('addTraceComment', () => {
     expect(addTraceComment('SELECT 1\n', 'abc-123')).toBe('SELECT 1\n\n/* trace_id: abc-123 */');
   });
 
-  test('stays linear on a long run of separators', () => {
+  test('stays linear on a long trailing run', () => {
     // Guards against going back to `;[\s;]*$`, which backtracks quadratically
     // when the run never reaches the anchor — ~1.8s at 60k on uncontrolled input.
-    const runaway = `SELECT 1${';'.repeat(60_000)}x`;
-    const started = Date.now();
-    expect(addTraceComment(runaway, 'abc-123')).toBe(`${runaway}\n/* trace_id: abc-123 */`);
-    expect(Date.now() - started).toBeLessThan(1000);
+    // Both shapes: semicolons, and the whitespace the scan actually tests.
+    for (const filler of [';'.repeat(60_000), ' '.repeat(60_000)]) {
+      const runaway = `SELECT 1${filler}x`;
+      const started = Date.now();
+      expect(addTraceComment(runaway, 'abc-123')).toBe(`${runaway}\n/* trace_id: abc-123 */`);
+      expect(Date.now() - started).toBeLessThan(1000);
+    }
   });
 
   test('leaves the query untouched when there is no usable id', () => {

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -25,9 +25,10 @@ describe('sanitizeTraceId', () => {
     expect(sanitizeTraceId('трейс-id')).toBe('-id');
   });
 
-  test('strips a leading plus, which reads as an optimizer hint on Hive and Spark', () => {
+  test('strips every plus, which reads as an optimizer hint on Hive and Spark', () => {
     expect(sanitizeTraceId('+MAPJOIN(a)')).toBe('MAPJOINa');
     expect(sanitizeTraceId('++abc')).toBe('abc');
+    expect(sanitizeTraceId('abc+def')).toBe('abcdef');
   });
 
   test('returns empty for ids with nothing usable left', () => {

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -101,6 +101,14 @@ describe('buildTraceComment', () => {
     expect(buildTraceComment(`${traceId}-span-1`)).toBe(`/* trace_id: ${traceId} */`);
   });
 
+  // The export strips the RAW request id, so sanitizing first would let a dropped
+  // character close the gap in a near-marker and synthesize a `-span-` that was
+  // never there — emitting `myid` against an export row of `myid-span%-1`.
+  test('strips the span before sanitizing, so a dropped character cannot synthesize a marker', () => {
+    expect(buildTraceComment('myid-span%-1')).toBe('/* trace_id: myid-span-1 */');
+    expect(toTraceId('myid-span%-1')).toBe('myid-span%-1');
+  });
+
   test('returns null when nothing usable remains', () => {
     expect(buildTraceComment(undefined)).toBeNull();
     expect(buildTraceComment('*/')).toBeNull();

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -1,4 +1,4 @@
-import { addTraceComment, buildTraceComment, sanitizeTraceId } from '../../src';
+import { addTraceComment, buildTraceComment, sanitizeTraceId, toTraceId } from '../../src';
 
 describe('sanitizeTraceId', () => {
   test('keeps every request id shape Cube produces or accepts', () => {
@@ -40,6 +40,28 @@ describe('sanitizeTraceId', () => {
 
   test('drops the space in the CLI request id', () => {
     expect(sanitizeTraceId('CLI REQUEST')).toBe('CLIREQUEST');
+  });
+});
+
+// Shared with the orchestrator, which re-exports this as extractRequestUUID.
+// Asserted here under its own name so a drift fails at the contract, not only
+// through buildTraceComment.
+describe('toTraceId', () => {
+  test('strips a numeric span suffix', () => {
+    expect(toTraceId('f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1'))
+      .toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+  });
+
+  // WebSocket subscriptions build `-span-${uuidv4()}`, so the suffix is not
+  // always numeric — an anchored `-span-\d+$` would leave it in place.
+  test('strips a uuid span suffix', () => {
+    expect(toTraceId('conn1-msg2-span-f47ac10b-58cc-4372-a567-0e02b2c3d479'))
+      .toBe('conn1-msg2');
+  });
+
+  test('leaves an id without a span untouched', () => {
+    expect(toTraceId('scheduler-abc')).toBe('scheduler-abc');
+    expect(toTraceId('')).toBe('');
   });
 });
 

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -1,0 +1,113 @@
+import { addTraceComment, buildTraceComment, sanitizeTraceId } from '../../src';
+
+describe('sanitizeTraceId', () => {
+  test('keeps every request id shape Cube produces or accepts', () => {
+    // Canonical REST/SQL API id.
+    expect(sanitizeTraceId('f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1'))
+      .toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1');
+    // W3C traceparent, passed through verbatim by the REST API.
+    expect(sanitizeTraceId('00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'))
+      .toBe('00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01');
+    // WebSocket subscriptions use a uuid span suffix on a non-uuid base.
+    expect(sanitizeTraceId('conn1-msg2-span-f47ac10b-58cc-4372-a567-0e02b2c3d479'))
+      .toBe('conn1-msg2-span-f47ac10b-58cc-4372-a567-0e02b2c3d479');
+    expect(sanitizeTraceId('scheduler-f47ac10b-58cc-4372-a567-0e02b2c3d479'))
+      .toBe('scheduler-f47ac10b-58cc-4372-a567-0e02b2c3d479');
+    expect(sanitizeTraceId('datasources-f47ac10b')).toBe('datasources-f47ac10b');
+  });
+
+  test('strips characters that would break out of the comment', () => {
+    expect(sanitizeTraceId('abc*/ DROP TABLE users; /*')).toBe('abcDROPTABLEusers');
+    expect(sanitizeTraceId('abc\n-- evil')).toBe('abc--evil');
+    expect(sanitizeTraceId('abc\r\ndef')).toBe('abcdef');
+    expect(sanitizeTraceId('abc\' OR \'1\'=\'1')).toBe('abcOR11');
+    expect(sanitizeTraceId('abc def')).toBe('abcdef');
+    expect(sanitizeTraceId('трейс-id')).toBe('-id');
+  });
+
+  test('strips a leading plus, which reads as an optimizer hint on Hive and Spark', () => {
+    expect(sanitizeTraceId('+MAPJOIN(a)')).toBe('MAPJOINa');
+    expect(sanitizeTraceId('++abc')).toBe('abc');
+  });
+
+  test('caps the length', () => {
+    expect(sanitizeTraceId('a'.repeat(500))).toHaveLength(128);
+  });
+
+  test('returns empty for ids with nothing usable left', () => {
+    expect(sanitizeTraceId(undefined)).toBe('');
+    expect(sanitizeTraceId(null)).toBe('');
+    expect(sanitizeTraceId('')).toBe('');
+    expect(sanitizeTraceId('*/')).toBe('');
+    expect(sanitizeTraceId('   ')).toBe('');
+  });
+
+  test('drops the space in the CLI request id', () => {
+    expect(sanitizeTraceId('CLI REQUEST')).toBe('CLIREQUEST');
+  });
+});
+
+describe('buildTraceComment', () => {
+  test('wraps a sanitized id in a block comment', () => {
+    expect(buildTraceComment('abc-123')).toBe('/* trace_id: abc-123 */');
+  });
+
+  // The Query History export drops the -span-N suffix when deriving trace_id,
+  // so the comment must carry the stem for the join to match, and the span
+  // separately to tell fanned-out queries apart.
+  test('splits the span suffix out of the trace id', () => {
+    expect(buildTraceComment('f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1'))
+      .toBe('/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */');
+  });
+
+  test('keeps a uuid span suffix intact', () => {
+    expect(buildTraceComment('conn1-msg2-span-abc-def'))
+      .toBe('/* trace_id: conn1-msg2 span: abc-def */');
+  });
+
+  test('handles a scheduler id with a span', () => {
+    expect(buildTraceComment('scheduler-abc-span-2'))
+      .toBe('/* trace_id: scheduler-abc span: 2 */');
+  });
+
+  test('returns null when nothing usable remains', () => {
+    expect(buildTraceComment(undefined)).toBeNull();
+    expect(buildTraceComment('*/')).toBeNull();
+  });
+});
+
+describe('addTraceComment', () => {
+  const sql = 'SELECT 1';
+
+  test('appends the comment', () => {
+    expect(addTraceComment(sql, 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */');
+  });
+
+  test('appends trace id and span for a canonical request id', () => {
+    expect(addTraceComment(sql, 'abc-123-span-4')).toBe('SELECT 1\n/* trace_id: abc-123 span: 4 */');
+  });
+
+  test('keeps the comment inside a trailing semicolon', () => {
+    expect(addTraceComment('SELECT 1;', 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */;');
+    expect(addTraceComment('SELECT 1;  ', 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */;');
+  });
+
+  test('leaves the query untouched when there is no usable id', () => {
+    expect(addTraceComment(sql, undefined)).toBe(sql);
+    expect(addTraceComment(sql, '')).toBe(sql);
+    expect(addTraceComment(sql, '*/')).toBe(sql);
+  });
+
+  test('cannot be escaped by a hostile request id', () => {
+    const tagged = addTraceComment(sql, '*/ DROP TABLE users; /*');
+    // Exactly one comment open and one close: the payload cannot terminate it.
+    expect(tagged.match(/\/\*/g)).toHaveLength(1);
+    expect(tagged.match(/\*\//g)).toHaveLength(1);
+    expect(tagged).toBe('SELECT 1\n/* trace_id: DROPTABLEusers */');
+  });
+
+  test('keeps a multi-line query intact', () => {
+    const multiline = 'SELECT a,\n  b\nFROM t';
+    expect(addTraceComment(multiline, 'abc')).toBe(`${multiline}\n/* trace_id: abc */`);
+  });
+});

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -30,10 +30,6 @@ describe('sanitizeTraceId', () => {
     expect(sanitizeTraceId('++abc')).toBe('abc');
   });
 
-  test('caps the length', () => {
-    expect(sanitizeTraceId('a'.repeat(500))).toHaveLength(128);
-  });
-
   test('returns empty for ids with nothing usable left', () => {
     expect(sanitizeTraceId(undefined)).toBe('');
     expect(sanitizeTraceId(null)).toBe('');
@@ -67,6 +63,19 @@ describe('buildTraceComment', () => {
   test('drops the span suffix of a scheduler id', () => {
     expect(buildTraceComment('scheduler-abc-span-2'))
       .toBe('/* trace_id: scheduler-abc */');
+  });
+
+  test('caps the length of the emitted id', () => {
+    expect(buildTraceComment('a'.repeat(500)))
+      .toBe(`/* trace_id: ${'a'.repeat(128)} */`);
+  });
+
+  // Capping the raw id first would cut this one mid-`-span-` and emit the
+  // partial marker, which no longer matches the export's trace_id.
+  test('caps after stripping the span, never mid-suffix', () => {
+    const traceId = 'a'.repeat(125);
+
+    expect(buildTraceComment(`${traceId}-span-1`)).toBe(`/* trace_id: ${traceId} */`);
   });
 
   test('returns null when nothing usable remains', () => {

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -133,10 +133,19 @@ describe('addTraceComment', () => {
   });
 
   test('never invents a semicolon the query did not have', () => {
-    // The trailing run must start at a `;` — matching trailing whitespace alone
+    // The trailing run has to contain a `;` — trimming trailing whitespace alone
     // would append a separator to a query that never had one.
     expect(addTraceComment('SELECT 1 ', 'abc-123')).toBe('SELECT 1 \n/* trace_id: abc-123 */');
     expect(addTraceComment('SELECT 1\n', 'abc-123')).toBe('SELECT 1\n\n/* trace_id: abc-123 */');
+  });
+
+  test('stays linear on a long run of separators', () => {
+    // Guards against going back to `;[\s;]*$`, which backtracks quadratically
+    // when the run never reaches the anchor — ~1.8s at 60k on uncontrolled input.
+    const runaway = `SELECT 1${';'.repeat(60_000)}x`;
+    const started = Date.now();
+    expect(addTraceComment(runaway, 'abc-123')).toBe(`${runaway}\n/* trace_id: abc-123 */`);
+    expect(Date.now() - started).toBeLessThan(1000);
   });
 
   test('leaves the query untouched when there is no usable id', () => {

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -122,6 +122,23 @@ describe('addTraceComment', () => {
     expect(addTraceComment('SELECT 1;  ', 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */;');
   });
 
+  test('never leaves an empty statement after the comment', () => {
+    // Cube does not emit repeated separators, but the function has to stay total:
+    // a leftover `;` after the comment is a second, empty statement that some
+    // engines reject.
+    for (const trailing of [';;', '; ;', ';;;', ';\n;  ']) {
+      expect(addTraceComment(`SELECT 1${trailing}`, 'abc-123'))
+        .toBe('SELECT 1\n/* trace_id: abc-123 */;');
+    }
+  });
+
+  test('never invents a semicolon the query did not have', () => {
+    // The trailing run must start at a `;` — matching trailing whitespace alone
+    // would append a separator to a query that never had one.
+    expect(addTraceComment('SELECT 1 ', 'abc-123')).toBe('SELECT 1 \n/* trace_id: abc-123 */');
+    expect(addTraceComment('SELECT 1\n', 'abc-123')).toBe('SELECT 1\n\n/* trace_id: abc-123 */');
+  });
+
   test('leaves the query untouched when there is no usable id', () => {
     expect(addTraceComment(sql, undefined)).toBe(sql);
     expect(addTraceComment(sql, '')).toBe(sql);

--- a/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
+++ b/packages/cubejs-base-driver/test/unit/trace-comment.test.ts
@@ -139,16 +139,29 @@ describe('addTraceComment', () => {
     expect(addTraceComment('SELECT 1\n', 'abc-123')).toBe('SELECT 1\n\n/* trace_id: abc-123 */');
   });
 
-  test('stays linear on a long trailing run', () => {
+  test('stays linear when a long run defeats the anchor', () => {
     // Guards against going back to `;[\s;]*$`, which backtracks quadratically
     // when the run never reaches the anchor — ~1.8s at 60k on uncontrolled input.
-    // Both shapes: semicolons, and the whitespace the scan actually tests.
-    for (const filler of [';'.repeat(60_000), ' '.repeat(60_000)]) {
-      const runaway = `SELECT 1${filler}x`;
-      const started = Date.now();
-      expect(addTraceComment(runaway, 'abc-123')).toBe(`${runaway}\n/* trace_id: abc-123 */`);
-      expect(Date.now() - started).toBeLessThan(1000);
-    }
+    // The scan breaks on the `x` immediately; it is the regex that suffers here.
+    const runaway = `SELECT 1${';'.repeat(60_000)}x`;
+    const started = Date.now();
+
+    expect(addTraceComment(runaway, 'abc-123')).toBe(`${runaway}\n/* trace_id: abc-123 */`);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  test('stays linear when the scan walks the whole run', () => {
+    // The complement of the case above: the run reaches the end of the string, so
+    // the loop really does 60k iterations rather than breaking on the first char.
+    const semicolons = `SELECT 1${';'.repeat(60_000)}`;
+    const spaces = `SELECT 1${' '.repeat(60_000)}`;
+    const started = Date.now();
+
+    // The whole separator run collapses to one semicolon.
+    expect(addTraceComment(semicolons, 'abc-123')).toBe('SELECT 1\n/* trace_id: abc-123 */;');
+    // No separator in the run, so the whitespace is left alone.
+    expect(addTraceComment(spaces, 'abc-123')).toBe(`${spaces}\n/* trace_id: abc-123 */`);
+    expect(Date.now() - started).toBeLessThan(1000);
   });
 
   test('leaves the query untouched when there is no usable id', () => {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -431,6 +431,8 @@ export class QueryCache {
       // helpers and background renewals ride the same path but answer to no
       // API request.
       !req.primaryQuery ||
+      // Independent guards, deliberately: `renewCycle` catches a refresh of a
+      // user's query, the prefix catches one the scheduler started itself.
       req.renewCycle ||
       req.requestId.startsWith('scheduler-')
     ) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -355,6 +355,7 @@ export class QueryCache {
         requestId: queryBody.requestId,
         dataSource: queryBody.dataSource,
         persistent: queryBody.persistent,
+        primaryQuery: true,
       }
     );
 
@@ -427,7 +428,8 @@ export class QueryCache {
     if (
       !getEnv('sqlIncludeTraceId') ||
       !req.requestId ||
-      // Only the query the user asked for. Refresh keys, pre-aggregation
+      // Queries issued to serve a request — usually just the user's own, though
+      // a lambda source-table read also qualifies. Refresh keys, pre-aggregation
       // helpers and background renewals ride the same path but answer to no
       // API request.
       !req.primaryQuery ||

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -17,6 +17,7 @@ import {
   CacheDriverInterface,
   TableStructure,
   DriverInterface, QueryKey,
+  addTraceComment,
 } from '@cubejs-backend/base-driver';
 
 import { QueryQueue, QueryQueueOptions } from './QueryQueue';
@@ -262,6 +263,7 @@ export class QueryCache {
             useCsvQuery: queryBody.useCsvQuery,
             lambdaTypes: queryBody.lambdaTypes,
             aliasNameToMember: queryBody.aliasNameToMember,
+            primaryQuery: true,
           }
         );
       } else {
@@ -276,6 +278,7 @@ export class QueryCache {
               dataSource: queryBody.dataSource,
               persistent: queryBody.persistent,
               inlineTables,
+              primaryQuery: true,
             }
           ),
         };
@@ -406,6 +409,43 @@ export class QueryCache {
     return extractRequestUUID(requestId);
   }
 
+  /**
+   * Attaches the trace comment to a query bound for a data source. Applied at
+   * execution time, after the cache key has been computed from the untagged
+   * SQL — tagging earlier would give every request a unique key and defeat both
+   * result caching and in-flight query coalescing.
+   *
+   * Background refreshes are left untagged: there is no API request to trace
+   * them back to.
+   */
+  protected traceQuery(req: {
+    query: any,
+    requestId?: string,
+    renewCycle?: boolean,
+    primaryQuery?: boolean,
+  }): any {
+    if (
+      !getEnv('sqlIncludeTraceId') ||
+      !req.requestId ||
+      // Only the query the user asked for. Refresh keys, pre-aggregation
+      // helpers and background renewals ride the same path but answer to no
+      // API request.
+      !req.primaryQuery ||
+      req.renewCycle ||
+      req.requestId.startsWith('scheduler-')
+    ) {
+      return req.query;
+    }
+
+    // A query is either the SQL text or a [sql, params] tuple.
+    if (Array.isArray(req.query)) {
+      const [sql, ...rest] = req.query;
+      return [addTraceComment(sql, req.requestId), ...rest];
+    }
+
+    return addTraceComment(req.query, req.requestId);
+  }
+
   protected static replaceAll(replaceThis, withThis, inThis) {
     withThis = withThis.replace(/\$/g, '$$$$');
     return inThis.replace(
@@ -465,6 +505,8 @@ export class QueryCache {
       lambdaTypes,
       persistent,
       aliasNameToMember,
+      renewCycle,
+      primaryQuery,
     }: {
       cacheKey: CacheKey,
       dataSource: string,
@@ -477,6 +519,8 @@ export class QueryCache {
       lambdaTypes?: TableStructure,
       persistent?: boolean,
       aliasNameToMember?: { [alias: string]: string },
+      renewCycle?: boolean,
+      primaryQuery?: boolean,
     }
   ) {
     const queue = external
@@ -491,6 +535,8 @@ export class QueryCache {
       inlineTables,
       useCsvQuery,
       lambdaTypes,
+      renewCycle,
+      primaryQuery,
     };
 
     const opt = {
@@ -521,7 +567,7 @@ export class QueryCache {
             if (req.useCsvQuery) {
               return this.csvQuery(client, req);
             } else {
-              return client.query(req.query, req.values, req);
+              return client.query(this.traceQuery(req), req.values, req);
             }
           },
           {
@@ -531,7 +577,8 @@ export class QueryCache {
             // Centralized continueWaitTimeout that can be overridden in queueOptions
             continueWaitTimeout: this.options.continueWaitTimeout,
             ...queueOptions,
-          }
+          },
+          (req) => this.traceQuery(req),
         );
       }
     }
@@ -547,7 +594,7 @@ export class QueryCache {
     let tableData;
     try {
       if (client.stream) {
-        tableData = await client.stream(q.query, q.values, q);
+        tableData = await client.stream(this.traceQuery(q), q.values, q);
         const errors = [];
         await pipeline(tableData.rowStream, writer, (err) => {
           if (err) {
@@ -558,7 +605,7 @@ export class QueryCache {
           throw new Error(`Lambda query errors ${errors.join(', ')}`);
         }
       } else {
-        tableData = await client.downloadQueryResults(q.query, q.values, q);
+        tableData = await client.downloadQueryResults(this.traceQuery(q), q.values, q);
         tableData.rows.forEach(
           row => writer.write(row)
         );
@@ -608,7 +655,8 @@ export class QueryCache {
     redisPrefix: string,
     clientFactory: DriverFactory,
     executeFn: (client: BaseDriver, req: any) => any,
-    options: Omit<QueryQueueOptions, 'queryHandlers' | 'cancelHandlers'>
+    options: Omit<QueryQueueOptions, 'queryHandlers' | 'cancelHandlers'>,
+    traceFn: (req: any) => any = (req) => req.query,
   ): QueryQueue {
     const queue: any = new QueryQueue(redisPrefix, {
       queryHandlers: {
@@ -663,7 +711,7 @@ export class QueryCache {
           let logged = false;
           Promise
             .all([clientFactory()])
-            .then(([client]) => (<DriverInterface>client).stream(req.query, req.values, { highWaterMark: getEnv('dbQueryStreamHighWaterMark'), requestId: req.requestId }))
+            .then(([client]) => (<DriverInterface>client).stream(traceFn(req), req.values, { highWaterMark: getEnv('dbQueryStreamHighWaterMark'), requestId: req.requestId }))
             .then((source) => {
               const cleanup = async (error) => {
                 if (source.release) {
@@ -912,6 +960,8 @@ export class QueryCache {
         dataSource: options.dataSource,
         useCsvQuery: options.useCsvQuery,
         lambdaTypes: options.lambdaTypes,
+        renewCycle,
+        primaryQuery,
       }).then(res => {
         const result = {
           time: (new Date()).getTime(),

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -33,9 +33,10 @@ export function getCacheHash(queryKey: QueryKey | CacheKey, processUid?: string)
 }
 
 /**
- * Extracts the UUID prefix from a request ID by stripping the `-span-N` suffix.
+ * Extracts the UUID prefix from a request ID by stripping the `-span-` suffix.
+ *
+ * Re-exported from `base-driver`, which emits the same id into the `trace_id`
+ * SQL comment: the two have to strip identically or that comment stops joining
+ * to the Query History export.
  */
-export function extractRequestUUID(requestId: string): string {
-  const idx = requestId.lastIndexOf('-span-');
-  return idx !== -1 ? requestId.substring(0, idx) : requestId;
-}
+export { toTraceId as extractRequestUUID } from '@cubejs-backend/base-driver';

--- a/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
@@ -147,6 +147,25 @@ describe('SQL trace comment', () => {
     expect(driver.executedQueries).toContain(`${SQL}\n${EXPECTED_COMMENT}`);
   });
 
+  // `cache=stale-while-revalidate` is client-settable and takes the background
+  // fetch branch, which reaches the data source through its own call site — so
+  // it needs tagging of its own, or the feature silently does nothing for those
+  // requests.
+  test('is appended on the background fetch path', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    const query = 'SELECT 9 AS background';
+
+    await orchestrator.fetchQuery({
+      query,
+      values: [],
+      requestId: TRACE_ID,
+      cacheMode: 'stale-while-revalidate',
+      cacheKeyQueries: { renewalThreshold: 120, queries: [] },
+    });
+
+    expect(driver.executedQueries).toContain(`${query}\n${EXPECTED_COMMENT}`);
+  });
+
   test('cannot be escaped by a hostile request id', async () => {
     process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
     await run({ requestId: '*/ DROP TABLE users; /*' });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
@@ -1,0 +1,190 @@
+/* globals describe, beforeEach, afterEach, test, expect */
+import { Readable } from 'stream';
+import { QueryOrchestrator } from '../../src/orchestrator/QueryOrchestrator';
+import { QueryCache } from '../../src/orchestrator/QueryCache';
+
+class TraceMockDriver {
+  public executedQueries: any[] = [];
+
+  public streamedQueries: any[] = [];
+
+  public capabilities() {
+    return {};
+  }
+
+  public query(query: any) {
+    this.executedQueries.push(query);
+    return Promise.resolve([query]);
+  }
+
+  public async downloadQueryResults(query: any) {
+    return this.query(query);
+  }
+
+  public async stream(query: any) {
+    this.streamedQueries.push(query);
+    return { rowStream: Readable.from([]), release: async () => undefined };
+  }
+
+  public async tablesSchema() {
+    return {};
+  }
+
+  public async getTablesQuery() {
+    return [];
+  }
+
+  public async release() {
+    return null;
+  }
+
+  public nowTimestamp() {
+    return new Date().getTime();
+  }
+}
+
+const SQL = 'SELECT 1';
+const TRACE_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1';
+// What the comment carries: the export's trace_id (span suffix split off).
+const EXPECTED_COMMENT = '/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */';
+
+describe('SQL trace comment', () => {
+  let driver;
+  let orchestrator;
+  let counter = 0;
+
+  const run = async (overrides: { requestId?: string, query?: string } = {}) => orchestrator.fetchQuery({
+    query: SQL,
+    values: [],
+    requestId: TRACE_ID,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    counter += 1;
+    driver = new TraceMockDriver();
+    orchestrator = new QueryOrchestrator(
+      `TRACE_TEST_${counter}`,
+      () => driver,
+      () => undefined,
+      {
+        cacheAndQueueDriver: 'memory',
+        queryCacheOptions: {
+          queueOptions: () => ({ concurrency: 1 }),
+        },
+      },
+    );
+  });
+
+  afterEach(async () => {
+    delete process.env.CUBEJS_SQL_INCLUDE_TRACE_ID;
+    await orchestrator.cleanup();
+  });
+
+  test('is absent when the env var is unset', async () => {
+    await run();
+    expect(driver.executedQueries).toContain(SQL);
+    expect(driver.executedQueries.join('\n')).not.toContain('trace_id');
+  });
+
+  test('is appended when enabled', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    await run();
+    expect(driver.executedQueries).toContain(`${SQL}\n${EXPECTED_COMMENT}`);
+  });
+
+  test('is absent for background refreshes', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    await run({ requestId: `scheduler-${TRACE_ID}` });
+    expect(driver.executedQueries.join('\n')).not.toContain('trace_id');
+  });
+
+  test('is absent when there is no request id', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    const query = 'SELECT 2';
+    await run({ requestId: undefined, query });
+    expect(driver.executedQueries).toContain(query);
+    expect(driver.executedQueries.join('\n')).not.toContain('trace_id');
+  });
+
+  // The streaming path reaches the driver through createQueue's traceFn rather
+  // than the query handler, so it needs its own coverage: an arity slip there
+  // once passed the driver's own query method where the SQL belongs.
+  test('tags the streaming path with the SQL, not something else', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    const query = 'SELECT 7 AS streamed';
+    await orchestrator.fetchQuery({ query, values: [], requestId: TRACE_ID, persistent: true });
+
+    expect(driver.streamedQueries).toHaveLength(1);
+    expect(typeof driver.streamedQueries[0]).toBe('string');
+    expect(driver.streamedQueries[0]).toBe(`${query}\n${EXPECTED_COMMENT}`);
+  });
+
+  test('streams plain SQL when the env var is unset', async () => {
+    const query = 'SELECT 8 AS streamed';
+    await orchestrator.fetchQuery({ query, values: [], requestId: TRACE_ID, persistent: true });
+
+    expect(driver.streamedQueries).toEqual([query]);
+  });
+
+  // Refresh keys, pre-aggregation helpers and other supporting queries travel
+  // the same path carrying the user's request id, but answer to no API request
+  // of their own — only the primary query is tagged.
+  test('is absent for supporting queries issued under a user request', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    await orchestrator.fetchQuery({
+      query: SQL,
+      values: [],
+      requestId: TRACE_ID,
+      cacheKeyQueries: { renewalThreshold: 120, queries: [['SELECT MAX(updated_at) FROM orders', []]] },
+    });
+
+    const refreshKeyQuery = driver.executedQueries
+      .find(q => typeof q === 'string' && q.includes('MAX(updated_at)'));
+    expect(refreshKeyQuery).toBe('SELECT MAX(updated_at) FROM orders');
+
+    // ...while the user's own query still is tagged.
+    expect(driver.executedQueries).toContain(`${SQL}\n${EXPECTED_COMMENT}`);
+  });
+
+  test('cannot be escaped by a hostile request id', async () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    await run({ requestId: '*/ DROP TABLE users; /*' });
+
+    const executed = driver.executedQueries.find(q => typeof q === 'string' && q.includes('trace_id'));
+    expect(executed).toBe(`${SQL}\n/* trace_id: DROPTABLEusers */`);
+    expect(executed.match(/\/\*/g)).toHaveLength(1);
+    expect(executed.match(/\*\//g)).toHaveLength(1);
+  });
+});
+
+describe('SQL trace comment and the cache key', () => {
+  afterEach(() => {
+    delete process.env.CUBEJS_SQL_INCLUDE_TRACE_ID;
+  });
+
+  // The comment is attached at execution time, after the key is derived from
+  // the untagged SQL. Were it attached earlier, every request would produce a
+  // distinct key and defeat both result caching and in-flight coalescing.
+  test('is unchanged by the feature', () => {
+    const queryBody = { query: SQL, values: [], requestId: TRACE_ID };
+
+    delete process.env.CUBEJS_SQL_INCLUDE_TRACE_ID;
+    const withoutFlag = JSON.stringify(QueryCache.queryCacheKey(queryBody));
+
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+    const withFlag = JSON.stringify(QueryCache.queryCacheKey(queryBody));
+
+    expect(withFlag).toBe(withoutFlag);
+    expect(withFlag).not.toContain('trace_id');
+  });
+
+  test('does not vary the cache key between two requests', () => {
+    process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+
+    const first = QueryCache.queryCacheKey({ query: SQL, values: [], requestId: 'request-one' });
+    const second = QueryCache.queryCacheKey({ query: SQL, values: [], requestId: 'request-two' });
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});

--- a/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
@@ -45,8 +45,8 @@ class TraceMockDriver {
 
 const SQL = 'SELECT 1';
 const TRACE_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479-span-1';
-// What the comment carries: the export's trace_id (span suffix split off).
-const EXPECTED_COMMENT = '/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 span: 1 */';
+// What the comment carries: the export's trace_id (span suffix dropped).
+const EXPECTED_COMMENT = '/* trace_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 */';
 
 describe('SQL trace comment', () => {
   let driver;
@@ -179,12 +179,31 @@ describe('SQL trace comment and the cache key', () => {
     expect(withFlag).not.toContain('trace_id');
   });
 
-  test('does not vary the cache key between two requests', () => {
+  // The property the deferral actually buys: the SQL handed to the driver
+  // carries the id, while the key used to look the result up does not.
+  test('is derived from the untagged SQL of the very query that gets tagged', async () => {
     process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
 
-    const first = QueryCache.queryCacheKey({ query: SQL, values: [], requestId: 'request-one' });
-    const second = QueryCache.queryCacheKey({ query: SQL, values: [], requestId: 'request-two' });
+    const driver = new TraceMockDriver();
+    const orchestrator = new QueryOrchestrator(
+      'TRACE_TEST_CACHE_KEY',
+      () => driver as any,
+      () => undefined,
+      {
+        cacheAndQueueDriver: 'memory',
+        queryCacheOptions: { queueOptions: () => ({ concurrency: 1 }) },
+      },
+    );
 
-    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+    const queryBody = { query: SQL, values: [], requestId: TRACE_ID };
+
+    try {
+      await orchestrator.fetchQuery(queryBody);
+    } finally {
+      await orchestrator.cleanup();
+    }
+
+    expect(driver.executedQueries).toContain(`${SQL}\n${EXPECTED_COMMENT}`);
+    expect(JSON.stringify(QueryCache.queryCacheKey(queryBody))).not.toContain('trace_id');
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryTraceComment.test.ts
@@ -156,6 +156,29 @@ describe('SQL trace comment', () => {
     expect(executed.match(/\/\*/g)).toHaveLength(1);
     expect(executed.match(/\*\//g)).toHaveLength(1);
   });
+
+  // `queryWithRetryAndRelease` is public and takes `query` as `any`, so the
+  // tuple form is handled even though today's internal callers all unwrap it
+  // upstream and pass the SQL on its own.
+  describe('tuple-form queries', () => {
+    const traceQuery = (req: any) => (orchestrator as any).queryCache.traceQuery(req);
+
+    test('tags the SQL and leaves the parameters alone', () => {
+      process.env.CUBEJS_SQL_INCLUDE_TRACE_ID = 'true';
+
+      expect(traceQuery({
+        query: [SQL, [1, 'two']],
+        requestId: TRACE_ID,
+        primaryQuery: true,
+      })).toEqual([`${SQL}\n${EXPECTED_COMMENT}`, [1, 'two']]);
+    });
+
+    test('is left untouched when the env var is unset', () => {
+      const query = [SQL, [1]];
+
+      expect(traceQuery({ query, requestId: TRACE_ID, primaryQuery: true })).toBe(query);
+    });
+  });
 });
 
 describe('SQL trace comment and the cache key', () => {


### PR DESCRIPTION
## Summary

- Adds an opt-in `trace_id` SQL comment to the queries Cube sends to a data source, so a warehouse's query history can be joined back to Cube's own query history. Off by default, enabled with `CUBEJS_SQL_INCLUDE_TRACE_ID=true`. Works for every driver, since it operates on the SQL text rather than on a driver-specific query id.
- The comment is **appended**, not prepended: Snowflake strips leading comments before recording the SQL text in `QUERY_HISTORY`, so a leading comment is silently lost on exactly the engine this is most useful for. Verified live against Snowflake — the same query prepended loses the comment and appended retains it. No supported engine requires a leading comment, so appending is both simpler and more correct than per-dialect placement.
- Tagging happens at execution time, **after** the cache key is computed. The SQL text *is* the cache key, so tagging any earlier would give every request a unique key and defeat both result caching and in-flight query coalescing.
- Only the query the user actually asked for is tagged (`primaryQuery`). Refresh keys, pre-aggregation helper queries and background renewals travel the same path but answer to no API request, so they stay untagged.
- The request id can be client-supplied (the REST API reads `x-request-id`/`traceparent` verbatim), so it is sanitized with a character allowlist. Both comment delimiters are stripped: engines disagree on whether block comments nest, so a stray closing delimiter would leak live SQL on some and a stray opening one would swallow the statement on others.
- The emitted `trace_id` deliberately drops the `-span-N` suffix so it matches the `trace_id` column of the Query History export, and the span is emitted as a separate field to tell apart the several data source queries one request fans out into.

## Test plan

- [x] Unit tests for comment construction, sanitization and injection, including a hostile request id that attempts to escape the comment (17 tests)
- [x] Unit tests for the orchestrator wiring: flag off/on, cache-key stability, tuple-form queries, and that refresh-key/background-renewal queries stay untagged (10 tests)
- [x] Unit test for the new environment variable
- [x] Full pre-existing `cubejs-query-orchestrator` unit suite green (78 tests), covering the queued and streaming paths
- [x] Verified live end-to-end on Snowflake (`QUERY_HISTORY`), Postgres (server log) and DuckDB (driver boundary): the main query is tagged, streaming queries are tagged with the correct SQL text, refresh-key queries are untagged, and results are unchanged
- [ ] CI must pass
