### PR TITLE
docs(sql-api): correct stale claim that CASE expressions can't be pushed down

### DIFF
--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -140,10 +140,11 @@ is supported and whether it can be used in [selection][link-selection-projection
 (e.g., `WHERE`) or [projection][link-selection-projection] (e.g., `SELECT`) parts
 of SQL queries.
 
-Expressions that have no [post-processing][ref-queries-wpp] shape, such as a `CASE`
-expression used as a grouping key, are handled by [query pushdown](#query-pushdown)
-instead. For example, the following query derives a fiscal year that starts in
-April and groups a measure by it:
+Expressions over dimensions, such as a `CASE` expression used as a grouping key,
+can't be translated into a [regular query][ref-regular-queries] or
+[post-processing][ref-queries-wpp]; they are handled by
+[query pushdown](#query-pushdown) instead. For example, the following query
+derives a fiscal year that starts in April and groups a measure by it:
 
 ```sql
 SELECT
@@ -164,7 +165,7 @@ rewritten and fail with the following error if pushdown is disabled via the
 data source doesn't support pushing down one of the expressions used:
 
 ```text
-Can't detect Cube query and it may be not supported yet.
+Can't detect Cube query and it may be not supported yet
 ```
 
 If you hit this error, check that query pushdown is enabled and that every
@@ -185,11 +186,11 @@ SELECT
     THEN EXTRACT(YEAR FROM month)
     ELSE EXTRACT(YEAR FROM month) - 1
   END AS fiscal_year,
-  SUM(count) AS total
+  SUM(orders_count) AS total
 FROM (
   SELECT
     DATE_TRUNC('month', created_at) AS month,
-    MEASURE(count) AS count
+    MEASURE(count) AS orders_count
   FROM orders
   GROUP BY 1
 ) AS inner_query
@@ -197,6 +198,11 @@ GROUP BY 1
 ORDER BY 1;
 --- You can also use CTEs to achieve the same result
 ```
+
+This works because `count` is additive, so monthly values can be re-aggregated
+with `SUM`. For non-additive measures, such as `count_distinct` or `avg`, group
+the inner query by the same granularity you need in the output — re-aggregating
+their partial results would produce incorrect values.
 
 ### Query pushdown
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -158,20 +158,22 @@ GROUP BY 1
 ORDER BY 1;
 ```
 
-Query pushdown is enabled by default. If it is disabled via the
-[`CUBESQL_SQL_PUSH_DOWN`][ref-env-var-push-down] environment variable, queries
-like the one above can't be rewritten and fail with the following error:
+Query pushdown is enabled by default. Queries like the one above can't be
+rewritten and fail with the following error if pushdown is disabled via the
+[`CUBESQL_SQL_PUSH_DOWN`][ref-env-var-push-down] environment variable, or if the
+data source doesn't support pushing down one of the expressions used:
 
 ```text
 Can't detect Cube query and it may be not supported yet.
 ```
 
-If you hit this error, check that query pushdown is enabled. Alternatively, you
+If you hit this error, check that query pushdown is enabled and that every
+expression in the query is supported for your data source. Alternatively, you
 can leverage nested queries: wrap your `SELECT` statement from a cube table
 (**inner query**) into another `SELECT` statement (**outer query**) to perform
-calculations with expressions like `CASE`. This outer `SELECT` is **not** part of
-the SQL query that is being rewritten and thus allows you to use more SQL
-functions, operators, and expressions.
+calculations with expressions like `CASE`. The outer `SELECT` is applied as
+post-processing on top of the cube query rather than being rewritten into it,
+which allows you to use more SQL functions, operators, and expressions.
 
 Keep the inner query to shapes that a [regular query][ref-regular-queries]
 supports, and move every expression to the outer query:

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -202,7 +202,9 @@ ORDER BY 1;
 This works because `count` is additive, so monthly values can be re-aggregated
 with `SUM`. For non-additive measures, such as `count_distinct` or `avg`, group
 the inner query by the same granularity you need in the output — re-aggregating
-their partial results would produce incorrect values.
+their partial results would produce incorrect values. If no supported
+granularity matches that grouping, as is the case for a fiscal year, enable
+query pushdown or define the grouping as a dimension in your data model.
 
 ### Query pushdown
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -140,57 +140,61 @@ is supported and whether it can be used in [selection][link-selection-projection
 (e.g., `WHERE`) or [projection][link-selection-projection] (e.g., `SELECT`) parts
 of SQL queries.
 
-For example, the following query won't work because the SQL API can't push down the
-`CASE` expression to Cube for processing. It is not possible to translate `CASE`
-expressions in measures.
+Expressions that have no [post-processing][ref-queries-wpp] shape, such as a `CASE`
+expression used as a grouping key, are handled by [query pushdown](#query-pushdown)
+instead. For example, the following query derives a fiscal year that starts in
+April and groups a measure by it:
 
 ```sql
 SELECT
-  city,
-  MAX(CASE
-    WHEN status = 'shipped'
-    THEN '2-done'
-    ELSE '1-in-progress'
-  END) AS real_status,
-  SUM(number)
+  CASE
+    WHEN EXTRACT(MONTH FROM created_at) >= 4
+    THEN EXTRACT(YEAR FROM created_at)
+    ELSE EXTRACT(YEAR FROM created_at) - 1
+  END AS fiscal_year,
+  MEASURE(count)
 FROM orders
-CROSS JOIN users
-GROUP BY 1;
+GROUP BY 1
+ORDER BY 1;
 ```
 
-You can leverage nested queries in cases like this. You can wrap your `SELECT`
-statement from a cube table (**inner query**) into another `SELECT` statement
-(**outer query**) to perform calculations with expressions like `CASE`.
-This outer `SELECT` is **not** part of the SQL query that being rewritten and
-thus allows you to use more SQL functions, operators and expressions.
+Query pushdown is enabled by default. If it is disabled via the
+[`CUBESQL_SQL_PUSH_DOWN`][ref-env-var-push-down] environment variable, queries
+like the one above can't be rewritten and fail with the following error:
 
-You can rewrite the above query as follows, making sure to wrap the original
-`SELECT` statement:
+```text
+Can't detect Cube query and it may be not supported yet.
+```
+
+If you hit this error, check that query pushdown is enabled. Alternatively, you
+can leverage nested queries: wrap your `SELECT` statement from a cube table
+(**inner query**) into another `SELECT` statement (**outer query**) to perform
+calculations with expressions like `CASE`. This outer `SELECT` is **not** part of
+the SQL query that is being rewritten and thus allows you to use more SQL
+functions, operators, and expressions.
+
+Keep the inner query to shapes that a [regular query][ref-regular-queries]
+supports, and move every expression to the outer query:
 
 ```sql
 SELECT
-  city,
-  MAX(CASE
-    WHEN status = 'shipped' THEN '2-done'
-    ELSE '1-in-progress'
-  END) real_status,
-  SUM(amount) AS total
+  CASE
+    WHEN EXTRACT(MONTH FROM month) >= 4
+    THEN EXTRACT(YEAR FROM month)
+    ELSE EXTRACT(YEAR FROM month) - 1
+  END AS fiscal_year,
+  SUM(count) AS total
 FROM (
   SELECT
-    users.city AS city,
-    SUM(number) AS amount,
-    orders.status
+    DATE_TRUNC('month', created_at) AS month,
+    MEASURE(count) AS count
   FROM orders
-  CROSS JOIN users
-  GROUP BY 1, 3
-) AS inner
-GROUP BY 1, 2
+  GROUP BY 1
+) AS inner_query
+GROUP BY 1
 ORDER BY 1;
 --- You can also use CTEs to achieve the same result
 ```
-
-The above query works because the `CASE` expression is supported in `SELECT`
-queries **not** querying cube tables.
 
 ### Query pushdown
 
@@ -449,5 +453,6 @@ If a query of yours has that shape, you can:
 [ref-env-cubesql-stream-mode]: /reference/configuration/environment-variables#cubesql_stream_mode
 [ref-env-non-streaming-limit]: /reference/configuration/environment-variables#cubesql_non_streaming_query_max_row_limit
 [ref-ref-sql-api]: /reference/core-data-apis/sql-api/reference
+[ref-env-var-push-down]: /reference/configuration/environment-variables#cubesql_sql_push_down
 [link-postgres-boolean]: https://www.postgresql.org/docs/current/datatype-boolean.html
 [link-selection-projection]: https://stackoverflow.com/a/1031101


### PR DESCRIPTION
## Summary

- The SQL API docs claimed a `CASE` expression "won't work" and that "it is not possible to translate `CASE` expressions in measures". That has been stale since query pushdown was enabled by default (#8814, v1.0.0). Both the example the page called impossible and its `MAX(CASE ...)` variant execute correctly today.
- Replaced the passage with a **working** example — a fiscal year derived via `CASE`/`EXTRACT` and grouped with `MEASURE()` — and documented the actual failure modes for `Can't detect Cube query and it may be not supported yet`: query pushdown disabled via `CUBESQL_SQL_PUSH_DOWN`, or a data source that doesn't support pushing down one of the expressions used.
- Kept the nested-query fallback, but corrected it. The inner query now uses a plain `DATE_TRUNC` granularity instead of `EXTRACT`, so it stays a regular-query shape; an `EXTRACT`-based inner query itself needs pushdown and so is useless in the exact configuration the workaround is offered for.

The failure is not specific to combining `MEASURE` with an expression — a `CASE`/`EXTRACT` query with no measure at all fails identically when pushdown is off. The boundary is that any expression over a dimension requires the pushdown wrapper. This matches the code: the error is raised in `rewrite/converter.rs` gated only on `!wrapped`, and the rules owning `wrapper/case.rs` / `wrapper/extract.rs` are registered only when `sql_push_down` is enabled (`rewrite/rewriter.rs`).

Support is also driver-dependent: `expressions/extract` is added per-driver (`PostgresQuery.ts`) rather than in `BaseQuery.js`, so a data source without that template can hit the same error even with pushdown enabled. The page now says so instead of implying the behavior is universal.

Docs-only; no runtime code changes.

## Test plan

Verified against Cube v1.7.4 with Postgres, on a minimal `orders` cube:

- [x] The new primary example returns correct fiscal years with default settings; `EXPLAIN` shows `CubeScanWrappedSql` with `EXTRACT` pushed to the datasource
- [x] With `CUBESQL_SQL_PUSH_DOWN=false`, it reproduces the documented error verbatim
- [x] The nested-query example returns identical correct results with pushdown both **on** and **off**
- [x] Same behavior on the legacy planner (`CUBEJS_TESSERACT_SQL_PLANNER=false`), so the planner is not a factor
- [x] The removed warning covers no still-true limitation — `CASE` in a `WHERE` clause and `MEASURE` nested inside a `CASE` both work
- [x] `mintlify broken-links --check-anchors` reports no new broken links (the 16 reported are pre-existing in `embedding/iframe/`, untouched here); `docs.json` still valid
