### PR TITLE
docs: correct HTML chart Handlebars bindings and sandbox limitations

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -1,9 +1,9 @@
 ---
 title: HTML
-description: Build fully custom layouts using HTML templates with Handlebars and JavaScript.
+description: Build fully custom layouts using HTML templates with Handlebars.
 ---
 
-HTML charts let you render any layout that Vega-Lite cannot produce — custom scorecards, branded cards, rich tables, or any structure built with HTML, CSS, and JavaScript. Query results are available inside the template via [Handlebars](https://handlebarsjs.com/) expressions.
+HTML charts let you render any layout that Vega-Lite cannot produce — custom scorecards, branded cards, or rich tables built with HTML and CSS. Query results are available inside the template via [Handlebars](https://handlebarsjs.com/) expressions, which are evaluated before the chart is rendered.
 
 ## Variant
 
@@ -15,40 +15,81 @@ A free-form HTML document with Handlebars expressions. Write any markup and bind
 
 ## Template structure
 
-Query results are available in the template context under `result`.
+Query result rows are available as a flat `data` array. Each row is keyed by member name, e.g. `order_items.status`.
 
-**Access the first row** with `result._first`:
+**Access a row by index** with `data.<index>`:
 
 ```html
 <div class="scorecard">
-  <h2>{{result._first.order_items.status}}</h2>
-  <p>{{result._first.order_items.count}} orders</p>
+  <h2>{{data.0.order_items.status}}</h2>
+  <p>{{data.0.order_items.count}} orders</p>
 </div>
 ```
 
-**Iterate over all rows** with `{{#each result.data}}`:
+**Iterate over all rows** with `{{#each data}}`:
 
 ```html
 <ul>
-  {{#each result.data}}
+  {{#each data}}
     <li>{{this.order_items.status}}: {{this.order_items.count}}</li>
   {{/each}}
 </ul>
 ```
 
-## Using JavaScript
+Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. If a chart fails to render, check that every path in the template matches a member of the current query.
 
-Standard `<script>` tags are supported, enabling the use of charting libraries (D3, Chart.js, etc.) or any JavaScript that manipulates the rendered DOM.
+<Tip>
+The chart editor includes a **Handlebars reference** panel listing the bindings for your current query. Add `{{json data}}` to a template to inspect the full context.
+</Tip>
+
+### Context
+
+Alongside `data`, the following are available:
+
+| Binding | Description |
+| --- | --- |
+| `data` | Array of result rows, each keyed by member name |
+| `columns` | Array of columns in the result, each with `name` and `title` |
+| `rowCount` | Number of rows in `data` |
+| `columnCount` | Number of columns |
+| `pivot` | Pivot table structure and totals, when the report is pivoted |
+
+## Helpers
+
+In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/builtin-helpers.html), these are available:
+
+| Helper | Description |
+| --- | --- |
+| `formatNumber value "format"` | Format a number using a [d3-format](https://d3js.org/d3-format) string, e.g. `",.2f"` |
+| `formatDate value "format"` | Format a date, e.g. `"yyyy-LL-dd"` |
+| `formatMonth value "format"` | Format a date as a month, e.g. `"LLL yyyy"` |
+| `json value` | Serialize a value as JSON — useful for inspecting the context |
+| `get object "path"` | Read a nested value by dotted path |
+| `entries object` | Turn an object into `key`/`value` pairs for iteration |
+| `concat a b …` | Join values into a single string |
+| `coalesce value fallback` | Use `fallback` when `value` is null or undefined |
+| `eq`, `ne`, `and`, `or` | Comparison and boolean logic for `{{#if}}` blocks |
+| `now` | The current date |
 
 ```html
-<canvas id="myChart"></canvas>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script>
-  const labels = [{{#each result.data}}"{{this.order_items.status}}"{{#unless @last}},{{/unless}}{{/each}}];
-  const data = [{{#each result.data}}{{this.order_items.count}}{{#unless @last}},{{/unless}}{{/each}}];
-  new Chart(document.getElementById('myChart'), {
-    type: 'bar',
-    data: { labels, datasets: [{ data }] }
-  });
-</script>
+<p>{{formatNumber data.0.order_items.count ",.0f"}} orders</p>
+<p>as of {{formatDate now "yyyy-LL-dd"}}</p>
 ```
+
+## Sandboxing
+
+HTML charts render inside a sandboxed iframe with a restrictive [content security policy](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP). This is intentional: a chart is authored by one user and viewed by others, so templates are not allowed to execute code or reach the network.
+
+Supported:
+
+- HTML markup and inline `<style>` blocks
+- Images and fonts embedded as [`data:` URLs](https://developer.mozilla.org/docs/Web/URI/Reference/Schemes/data)
+- Handlebars expressions, which are evaluated before the iframe is rendered
+
+Not supported:
+
+- `<script>` tags, inline event handlers, and any other JavaScript
+- Stylesheets, scripts, images, and fonts loaded from an external URL, including CDNs
+- Network requests from the template, such as `fetch`
+
+Charting libraries like D3 or Chart.js therefore can't be used in an HTML chart. To visualize data, use one of the [built-in chart types](/docs/explore-analyze/charts/chart-types) or a [custom visualization](/docs/explore-analyze/charts/custom), which lets you edit the Vega-Lite spec directly without custom code.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -36,7 +36,7 @@ Query result rows are available as a flat `data` array. Each row is keyed by the
 </ul>
 ```
 
-Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. If a chart fails to render, check that every path in the template matches a column of the current query.
+Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. Helper arguments are the one exception — a path that misses there is passed to the helper as `undefined`. If a chart fails to render, check that every path in the template matches a column of the current query.
 
 <Warning>
 A qualified column name must be wrapped in square brackets: `{{data.0.[order_items.count]}}`, and `{{this.[order_items.count]}}` inside a loop. Rows are keyed by literal strings, so without brackets Handlebars reads the dot as a path and looks for a `count` property on a non-existent `order_items` object, which fails in strict mode. Unqualified names never need brackets.
@@ -80,7 +80,7 @@ In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/
 <p>as of {{formatDate (now) "yyyy-LL-dd"}}</p>
 ```
 
-A helper used as an argument to another helper has to be a parenthesized [subexpression](https://handlebarsjs.com/guide/expressions.html#subexpressions). A bare `{{formatDate now "yyyy-LL-dd"}}` reads `now` as a context lookup rather than the helper, so it passes nothing to `formatDate` and renders an empty string.
+A helper used as an argument to another helper has to be a parenthesized [subexpression](https://handlebarsjs.com/guide/expressions.html#subexpressions). A bare `{{formatDate now "yyyy-LL-dd"}}` reads `now` as a context lookup rather than the helper, so `formatDate` never receives the current date.
 
 ## Sandboxing
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -15,14 +15,14 @@ A free-form HTML document with Handlebars expressions. Write any markup and bind
 
 ## Template structure
 
-Query result rows are available as a flat `data` array. Each row is keyed by member name, e.g. `order_items.status`.
+Query result rows are available as a flat `data` array. Each row is keyed by column name, e.g. `status` or `count`.
 
 **Access a row by index** with `data.<index>`:
 
 ```html
 <div class="scorecard">
-  <h2>{{data.0.order_items.status}}</h2>
-  <p>{{data.0.order_items.count}} orders</p>
+  <h2>{{data.0.status}}</h2>
+  <p>{{data.0.count}} orders</p>
 </div>
 ```
 
@@ -31,12 +31,16 @@ Query result rows are available as a flat `data` array. Each row is keyed by mem
 ```html
 <ul>
   {{#each data}}
-    <li>{{this.order_items.status}}: {{this.order_items.count}}</li>
+    <li>{{this.status}}: {{this.count}}</li>
   {{/each}}
 </ul>
 ```
 
-Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. If a chart fails to render, check that every path in the template matches a member of the current query.
+Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. If a chart fails to render, check that every path in the template matches a column of the current query.
+
+<Warning>
+Rows are keyed by literal strings, so a qualified name like `order_items.count` must be wrapped in square brackets: `{{data.0.[order_items.count]}}`. Without them, Handlebars reads the dot as a path and looks for a `count` property on a non-existent `order_items` object, which fails in strict mode. The unqualified column name never needs brackets.
+</Warning>
 
 <Tip>
 The chart editor includes a **Handlebars reference** panel listing the bindings for your current query. Add `{{json data}}` to a template to inspect the full context.
@@ -48,7 +52,7 @@ Alongside `data`, the following are available:
 
 | Binding | Description |
 | --- | --- |
-| `data` | Array of result rows, each keyed by member name |
+| `data` | Array of result rows, each keyed by column name |
 | `columns` | Array of columns in the result, each with `name` and `title` |
 | `rowCount` | Number of rows in `data` |
 | `columnCount` | Number of columns |
@@ -72,7 +76,7 @@ In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/
 | `now` | The current date |
 
 ```html
-<p>{{formatNumber data.0.order_items.count ",.0f"}} orders</p>
+<p>{{formatNumber data.0.count ",.0f"}} orders</p>
 <p>as of {{formatDate now "yyyy-LL-dd"}}</p>
 ```
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -66,7 +66,7 @@ In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/
 | --- | --- |
 | `formatNumber value "format"` | Format a number using a [d3-format](https://d3js.org/d3-format) string, e.g. `",.2f"` |
 | `formatDate value "format"` | Format a date using a [date-fns](https://date-fns.org/docs/format) pattern, e.g. `"yyyy-LL-dd"` |
-| `formatMonth value "format"` | Format a date as a month, e.g. `"LLL yyyy"` |
+| `formatMonth value "format"` | Format a date as a month using the same [date-fns](https://date-fns.org/docs/format) patterns, e.g. `"LLL yyyy"` |
 | `json value` | Serialize a value as JSON — useful for inspecting the context |
 | `get object "path"` | Read a nested value by dotted path |
 | `entries object` | Turn an object into `key`/`value` pairs for iteration |

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -48,7 +48,7 @@ The chart editor includes a **Handlebars reference** panel listing the bindings 
 
 ### Context
 
-Alongside `data`, the following are available:
+The following bindings are available:
 
 | Binding | Description |
 | --- | --- |

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -15,7 +15,7 @@ A free-form HTML document with Handlebars expressions. Write any markup and bind
 
 ## Template structure
 
-Query result rows are available as a flat `data` array. Each row is keyed by column name, e.g. `status` or `count`.
+Query result rows are available as a flat `data` array. Each row is keyed by the column name of the current query, which may be unqualified (`count`) or qualified with its cube or view (`order_items.count`) depending on how the query selects its members. Read the exact binding for each column from the **Handlebars reference** panel in the chart editor.
 
 **Access a row by index** with `data.<index>`:
 
@@ -39,11 +39,11 @@ Query result rows are available as a flat `data` array. Each row is keyed by col
 Templates are compiled in strict mode, so referencing a property that doesn't exist raises an error instead of rendering an empty string. If a chart fails to render, check that every path in the template matches a column of the current query.
 
 <Warning>
-Rows are keyed by literal strings, so a qualified name like `order_items.count` must be wrapped in square brackets: `{{data.0.[order_items.count]}}`. Without them, Handlebars reads the dot as a path and looks for a `count` property on a non-existent `order_items` object, which fails in strict mode. The unqualified column name never needs brackets.
+A qualified column name must be wrapped in square brackets: `{{data.0.[order_items.count]}}`, and `{{this.[order_items.count]}}` inside a loop. Rows are keyed by literal strings, so without brackets Handlebars reads the dot as a path and looks for a `count` property on a non-existent `order_items` object, which fails in strict mode. Unqualified names never need brackets.
 </Warning>
 
 <Tip>
-The chart editor includes a **Handlebars reference** panel listing the bindings for your current query. Add `{{json data}}` to a template to inspect the full context.
+The chart editor includes a **Handlebars reference** panel listing the bindings for your current query. Add `{{json data}}` to a template to inspect the full context — see the [`json` helper](#helpers).
 </Tip>
 
 ### Context
@@ -56,7 +56,7 @@ Alongside `data`, the following are available:
 | `columns` | Array of columns in the result, each with `name` and `title` |
 | `rowCount` | Number of rows in `data` |
 | `columnCount` | Number of columns |
-| `pivot` | Pivot table structure and totals, when the report is pivoted |
+| `pivot` | Pivot structure, when the report is pivoted, with `rows`, `columns`, `cellMap`, `grandTotals`, and `config`. Inspect it with `{{json pivot}}` |
 
 ## Helpers
 
@@ -65,7 +65,7 @@ In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/
 | Helper | Description |
 | --- | --- |
 | `formatNumber value "format"` | Format a number using a [d3-format](https://d3js.org/d3-format) string, e.g. `",.2f"` |
-| `formatDate value "format"` | Format a date, e.g. `"yyyy-LL-dd"` |
+| `formatDate value "format"` | Format a date using a [date-fns](https://date-fns.org/docs/format) pattern, e.g. `"yyyy-LL-dd"` |
 | `formatMonth value "format"` | Format a date as a month, e.g. `"LLL yyyy"` |
 | `json value` | Serialize a value as JSON — useful for inspecting the context |
 | `get object "path"` | Read a nested value by dotted path |
@@ -88,7 +88,7 @@ Supported:
 
 - HTML markup and inline `<style>` blocks
 - Images and fonts embedded as [`data:` URLs](https://developer.mozilla.org/docs/Web/URI/Reference/Schemes/data)
-- Handlebars expressions, which are evaluated before the iframe is rendered
+- Handlebars expressions
 
 Not supported:
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/html.mdx
@@ -73,12 +73,14 @@ In addition to the [built-in Handlebars helpers](https://handlebarsjs.com/guide/
 | `concat a b …` | Join values into a single string |
 | `coalesce value fallback` | Use `fallback` when `value` is null or undefined |
 | `eq`, `ne`, `and`, `or` | Comparison and boolean logic for `{{#if}}` blocks |
-| `now` | The current date |
+| `now` | The current date. Wrap it in parentheses when passing it to another helper: `(now)` |
 
 ```html
 <p>{{formatNumber data.0.count ",.0f"}} orders</p>
-<p>as of {{formatDate now "yyyy-LL-dd"}}</p>
+<p>as of {{formatDate (now) "yyyy-LL-dd"}}</p>
 ```
+
+A helper used as an argument to another helper has to be a parenthesized [subexpression](https://handlebarsjs.com/guide/expressions.html#subexpressions). A bare `{{formatDate now "yyyy-LL-dd"}}` reads `now` as a context lookup rather than the helper, so it passes nothing to `formatDate` and renders an empty string.
 
 ## Sandboxing
 


### PR DESCRIPTION
The HTML chart docs page describes a template context and a JavaScript capability that don't match what the product does. Every code example on the page currently fails if copy-pasted.

**Handlebars bindings.** The page documents `result._first` and `{{#each result.data}}`. There's no `result` key in the template context — rows are a flat `data` array. Templates compile in strict mode, so these don't render blank, they throw and break the chart. Corrected to `data.0.<member>` and `{{#each data}}`, matching the Handlebars reference panel in the chart editor.

**JavaScript.** The page says `<script>` tags are supported and shows a Chart.js CDN example. HTML charts render in a sandboxed iframe under a restrictive CSP, so scripts don't execute and external resources don't load. Replaced that section with an accurate description of what the sandbox allows, and pointed readers at built-in chart types or custom Vega-Lite specs for visualizations.

Also documents the rest of the template context (`columns`, `rowCount`, `columnCount`, `pivot`) and the available helpers, which previously only existed in the in-app panel.
