### PR TITLE
docs: document country name matching in region maps

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
@@ -58,7 +58,7 @@ Clustering groups nearby points into a single circle that expands on zoom. It is
 
 A region map requires:
 
-- **Source** — the GeoJSON to render: `World countries`, `US states`, or `Custom`.
+- **Source** — the GeoJSON to render: `World Countries`, `US States`, or `Custom`.
 - **Property** — which property in each GeoJSON feature acts as the join key (e.g. `name`, `ISO3166-1-Alpha-2`, `ISO3166-1-Alpha-3`, `state_code`).
 - **Dimension** — which column from your query joins to **Property**.
 - **Measure** — the numeric measure that drives the choropleth fill.
@@ -71,11 +71,11 @@ The choropleth gradient comes from the active palette — pick from the built-in
 
 ### Country name matching
 
-With **World countries**, country names do not have to be spelled the way the boundary data spells them. Long forms, endonyms, and common abbreviations all resolve to the same country, so `United States`, `United States of America`, and `USA` are interchangeable, as are `Brasil` and `Brazil`, or `Deutschland` and `Germany`. The same applies to the 2- and 3-letter ISO code properties, and it works in either direction — a name in your data still matches when **Property** is set to a code.
+With **World Countries**, country names do not have to be spelled the way the boundary data spells them. Long forms, endonyms, and common abbreviations all resolve to the same country, so `United States`, `United States of America`, and `USA` are interchangeable, as are `Brasil` and `Brazil`, or `Deutschland` and `Germany`. The same applies to the 2- and 3-letter ISO code properties, and it works in either direction — a name in your data still matches when **Property** is set to a code.
 
 Matching is exact, never approximate: `United States` resolves to the United States and never to `United States Minor Outlying Islands`. Bare 2-letter codes such as `US` are only treated as country codes when **Property** is set to one of the ISO code properties, so a column of US state codes joined against country names stays unmatched rather than coloring `DE` as Germany.
 
-This applies to **World countries** only. With **US states** or **Custom**, values must match the chosen **Property** exactly (ignoring case and surrounding whitespace).
+This applies to **World Countries** only. With **US States** or **Custom**, values must match the chosen **Property** exactly (ignoring case and surrounding whitespace).
 
 ### Custom GeoJSON
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
@@ -58,7 +58,7 @@ Clustering groups nearby points into a single circle that expands on zoom. It is
 
 A region map requires:
 
-- **Source** — the GeoJSON to render: `World Countries`, `US States`, or `Custom`.
+- **Source** — the GeoJSON to render: **World Countries**, **US States**, or **Custom**.
 - **Property** — which property in each GeoJSON feature acts as the join key (e.g. `name`, `ISO3166-1-Alpha-2`, `ISO3166-1-Alpha-3`, `state_code`).
 - **Dimension** — which column from your query joins to **Property**.
 - **Measure** — the numeric measure that drives the choropleth fill.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
@@ -59,7 +59,7 @@ Clustering groups nearby points into a single circle that expands on zoom. It is
 A region map requires:
 
 - **Source** — the GeoJSON to render: `World countries`, `US states`, or `Custom`.
-- **Property** — which property in each GeoJSON feature acts as the join key (e.g. `name`, `ISO3166-1-Alpha-2`, `state_code`).
+- **Property** — which property in each GeoJSON feature acts as the join key (e.g. `name`, `ISO3166-1-Alpha-2`, `ISO3166-1-Alpha-3`, `state_code`).
 - **Dimension** — which column from your query joins to **Property**.
 - **Measure** — the numeric measure that drives the choropleth fill.
 
@@ -67,15 +67,15 @@ Built-in sources expose a fixed list of allowed properties. **Custom** lets you 
 
 When the chart enters Region mode, the join dimension and measure are auto-picked when an unambiguous match exists in your query.
 
+The choropleth gradient comes from the active palette — pick from the built-in palettes or supply a custom one, see [Color and stacking](/docs/explore-analyze/charts/configuration/color-and-stacking).
+
 ### Country name matching
 
-With **World countries**, country names do not have to be spelled the way the boundary data spells them. Long forms, endonyms, and common abbreviations all resolve to the same country, so `United States`, `United States of America`, `USA`, and `US` are interchangeable, as are `Brasil` and `Brazil`, or `Deutschland` and `Germany`. The same applies to the 2- and 3-letter ISO code properties, and it works in either direction — a name in your data still matches when **Property** is set to a code.
+With **World countries**, country names do not have to be spelled the way the boundary data spells them. Long forms, endonyms, and common abbreviations all resolve to the same country, so `United States`, `United States of America`, and `USA` are interchangeable, as are `Brasil` and `Brazil`, or `Deutschland` and `Germany`. The same applies to the 2- and 3-letter ISO code properties, and it works in either direction — a name in your data still matches when **Property** is set to a code.
 
-Matching is exact, never approximate: `United States` resolves to the United States and never to `United States Minor Outlying Islands`. Bare 2-letter codes are only treated as country codes when **Property** is set to one of the ISO code properties, so a column of US state codes joined against country names stays unmatched rather than colouring `DE` as Germany.
+Matching is exact, never approximate: `United States` resolves to the United States and never to `United States Minor Outlying Islands`. Bare 2-letter codes such as `US` are only treated as country codes when **Property** is set to one of the ISO code properties, so a column of US state codes joined against country names stays unmatched rather than coloring `DE` as Germany.
 
 This applies to **World countries** only. With **US states** or **Custom**, values must match the chosen **Property** exactly (ignoring case and surrounding whitespace).
-
-The choropleth gradient comes from the active palette — pick from the built-in palettes or supply a custom one, see [Color and stacking](/docs/explore-analyze/charts/configuration/color-and-stacking).
 
 ### Custom GeoJSON
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
@@ -67,6 +67,14 @@ Built-in sources expose a fixed list of allowed properties. **Custom** lets you 
 
 When the chart enters Region mode, the join dimension and measure are auto-picked when an unambiguous match exists in your query.
 
+### Country name matching
+
+With **World countries**, country names do not have to be spelled the way the boundary data spells them. Long forms, endonyms, and common abbreviations all resolve to the same country, so `United States`, `United States of America`, `USA`, and `US` are interchangeable, as are `Brasil` and `Brazil`, or `Deutschland` and `Germany`. The same applies to the 2- and 3-letter ISO code properties, and it works in either direction — a name in your data still matches when **Property** is set to a code.
+
+Matching is exact, never approximate: `United States` resolves to the United States and never to `United States Minor Outlying Islands`. Bare 2-letter codes are only treated as country codes when **Property** is set to one of the ISO code properties, so a column of US state codes joined against country names stays unmatched rather than colouring `DE` as Germany.
+
+This applies to **World countries** only. With **US states** or **Custom**, values must match the chosen **Property** exactly (ignoring case and surrounding whitespace).
+
 The choropleth gradient comes from the active palette — pick from the built-in palettes or supply a custom one, see [Color and stacking](/docs/explore-analyze/charts/configuration/color-and-stacking).
 
 ### Custom GeoJSON


### PR DESCRIPTION
## Summary

Region maps join a query dimension to the boundary data by name or ISO code, and the World Countries boundaries use long-form names — so `United States` in a user's data did not match the `United States of America` polygon. That join is now tolerant of alternate spellings, and this documents the behavior.

Added a **Country name matching** section under Region map covering what resolves (long forms, endonyms, abbreviations, both ISO code properties, in either direction), the two guarantees worth knowing — matching is exact rather than approximate, and bare 2-letter codes only count as country codes when **Property** is set to an ISO code property — and that this applies to World countries only, not US states or Custom.

## Test plan

- [x] Prose-only change to an existing page; no new files, links, or frontmatter
- [ ] CI must pass