### PR TITLE
Retry CLI release asset uploads and verify the release has every platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -831,14 +831,57 @@ jobs:
           bin=cube
           [ "${{ runner.os }}" = "Windows" ] && bin=cube.exe
           tar -C "$bindir" -czf "cube-${{ matrix.target }}.tar.gz" "$bin"
+      # A single API timeout here used to drop one platform's binary from the
+      # release while the job's build steps still passed, so the release
+      # shipped incomplete and `install-cli.sh` 404'd for that platform.
       - name: Upload Binary to Release
-        uses: svenstaro/upload-release-action@v2
+        uses: nick-fields/retry@v3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: cube-${{ matrix.target }}.tar.gz
-          asset_name: cube-${{ matrix.target }}.tar.gz
-          tag: ${{ github.ref }}
-          overwrite: true
+          max_attempts: 5
+          retry_on: error
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          # Defaults to powershell on Windows, where ${VAR} does not expand.
+          shell: bash
+          command: gh release upload "${GITHUB_REF_NAME}" "cube-${{ matrix.target }}.tar.gz" --clobber --repo "${GITHUB_REPOSITORY}"
+
+  # Guards against a release that is missing a platform: every target built by
+  # the cube-cli matrix must be attached before the release is considered good.
+  cube-cli-assets-complete:
+    name: Cube CLI release assets complete
+    runs-on: ubuntu-24.04
+    needs: [cube-cli]
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Verify every CLI target is attached to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          targets="
+          x86_64-unknown-linux-musl
+          aarch64-unknown-linux-musl
+          x86_64-apple-darwin
+          aarch64-apple-darwin
+          x86_64-pc-windows-msvc
+          "
+          assets=$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')
+          missing=""
+          for t in $targets; do
+            if ! printf '%s\n' "$assets" | grep -qx "cube-${t}.tar.gz"; then
+              missing="${missing} cube-${t}.tar.gz"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "release ${GITHUB_REF_NAME} is missing CLI assets:${missing}" >&2
+            exit 1
+          fi
+          echo "all CLI assets present on ${GITHUB_REF_NAME}"
 
   trigger-test-suites:
     name: Trigger test suites run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -896,7 +896,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          expected=$(cat expected/* | sort -u)
+          # download-artifact succeeds without creating anything when its
+          # pattern matches nothing, so treat "no markers" as a failure of its
+          # own rather than letting an unmatched glob report it.
+          expected=$(find expected -type f -exec cat {} + 2>/dev/null | sort -u || true)
           if [ -z "$expected" ]; then
             echo "no cube-cli leg reported an expected asset — the matrix did not run" >&2
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -865,10 +865,17 @@ jobs:
           echo "cube-${{ matrix.target }}.tar.gz" > "expected/${{ matrix.target }}"
       - name: Upload expected asset marker
         if: ${{ !cancelled() }}
+        # A marker carries no release payload, so it must never be the thing
+        # that reddens a release: overwrite so re-running a failed leg isn't
+        # blocked by its own earlier marker (the recovery path that restored
+        # the v1.7.14 asset), and continue-on-error so an artifact-service blip
+        # leaves that target merely unverified rather than failing the release.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: cube-cli-expected-${{ matrix.target }}
           path: expected/
+          overwrite: true
           retention-days: 1
 
   # Guards against a release that is missing a platform: every target built by
@@ -911,7 +918,7 @@ jobs:
             --jq '.assets[] | select(.state == "uploaded" and .size > 0) | .name')
           missing=""
           while IFS= read -r asset; do
-            if ! printf '%s\n' "$assets" | grep -qx "$asset"; then
+            if ! printf '%s\n' "$assets" | grep -qxF "$asset"; then
               missing="${missing} ${asset}"
             fi
           done <<< "$expected"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -834,6 +834,11 @@ jobs:
       # A single API timeout here used to drop one platform's binary from the
       # release while the job's build steps still passed, so the release
       # shipped incomplete and `install-cli.sh` 404'd for that platform.
+      #
+      # Unlike upload-release-action, `gh release upload` does not create the
+      # release. That is fine here: the release is always published before the
+      # tag push that starts this workflow, so it exists by the time any job
+      # runs.
       - name: Upload Binary to Release
         uses: nick-fields/retry@v3
         env:
@@ -846,6 +851,25 @@ jobs:
           # Defaults to powershell on Windows, where ${VAR} does not expand.
           shell: bash
           command: gh release upload "${GITHUB_REF_NAME}" "cube-${{ matrix.target }}.tar.gz" --clobber --repo "${GITHUB_REPOSITORY}"
+      # Each leg records the target it is responsible for, so the completeness
+      # guard below checks the matrix as it actually ran instead of a copy of
+      # the target list that could drift out of sync with it. This runs even
+      # when the upload failed — a leg that dropped its asset is precisely what
+      # the guard must still hear about.
+      - name: Record expected asset
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p expected
+          echo "cube-${{ matrix.target }}.tar.gz" > "expected/${{ matrix.target }}"
+      - name: Upload expected asset marker
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cube-cli-expected-${{ matrix.target }}
+          path: expected/
+          retention-days: 1
 
   # Guards against a release that is missing a platform: every target built by
   # the cube-cli matrix must be attached before the release is considered good.
@@ -853,35 +877,47 @@ jobs:
     name: Cube CLI release assets complete
     runs-on: ubuntu-24.04
     needs: [cube-cli]
+    # A failed matrix leg is the exact case this guard exists for, and a plain
+    # `needs:` would skip it there — so it runs whenever the matrix did.
+    if: ${{ !cancelled() }}
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      - name: Collect expected assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cube-cli-expected-*
+          merge-multiple: true
+          path: expected/
       - name: Verify every CLI target is attached to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          targets="
-          x86_64-unknown-linux-musl
-          aarch64-unknown-linux-musl
-          x86_64-apple-darwin
-          aarch64-apple-darwin
-          x86_64-pc-windows-msvc
-          "
-          assets=$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')
+          expected=$(cat expected/* | sort -u)
+          if [ -z "$expected" ]; then
+            echo "no cube-cli leg reported an expected asset — the matrix did not run" >&2
+            exit 1
+          fi
+          # `state` is starting/new until an upload completes, so an interrupted
+          # upload can leave a name-only match behind; require it uploaded and
+          # non-empty.
+          assets=$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json assets \
+            --jq '.assets[] | select(.state == "uploaded" and .size > 0) | .name')
           missing=""
-          for t in $targets; do
-            if ! printf '%s\n' "$assets" | grep -qx "cube-${t}.tar.gz"; then
-              missing="${missing} cube-${t}.tar.gz"
+          while IFS= read -r asset; do
+            if ! printf '%s\n' "$assets" | grep -qx "$asset"; then
+              missing="${missing} ${asset}"
             fi
-          done
+          done <<< "$expected"
           if [ -n "$missing" ]; then
             echo "release ${GITHUB_REF_NAME} is missing CLI assets:${missing}" >&2
             exit 1
           fi
-          echo "all CLI assets present on ${GITHUB_REF_NAME}"
+          echo "all CLI assets present on ${GITHUB_REF_NAME}:"
+          printf '%s\n' "$expected"
 
   trigger-test-suites:
     name: Trigger test suites run


### PR DESCRIPTION
The v1.7.14 release shipped without `cube-aarch64-apple-darwin.tar.gz`, so the documented install command

```
curl -fsSL https://raw.githubusercontent.com/cube-js/cube/master/install-cli.sh | sh
```

404'd on every Apple Silicon Mac. The binary built fine — only the upload step failed, with a one-off `Connect Timeout Error (attempted address: api.github.com:443, timeout: 10000ms)`. Because `cube-cli` runs `fail-fast: false` and nothing depends on it, the rest of the release published normally and the gap was invisible until someone tried to install.

Two changes:

- The upload is wrapped in `nick-fields/retry@v3` (the convention already used elsewhere in this workflow), 5 attempts with a 30s wait, so a single API blip no longer drops a platform. It now shells out to `gh release upload --clobber` rather than `svenstaro/upload-release-action`, since that action has no retry input of its own. `shell: bash` is set explicitly — the retry action defaults to powershell on Windows, where `${GITHUB_REF_NAME}` would not expand.
- A new `cube-cli-assets-complete` job runs after the matrix and fails the release if any of the five targets is missing from the release. A release that is missing a platform is now a red run instead of a silent 404.

The missing v1.7.14 asset has been re-uploaded separately by re-running the failed job, so the install works on Apple Silicon again.

Only the `cube-cli` upload path is touched here; the other five `svenstaro/upload-release-action` call sites (cubestored, native) have the same exposure but are left alone to keep this reviewable.

CORE-694