### PR TITLE
docs: add GPT-5.6 Sol and Terra to the predefined agent LLM models

### DIFF
--- a/docs-mintlify/admin/ai/index.mdx
+++ b/docs-mintlify/admin/ai/index.mdx
@@ -90,6 +90,8 @@ To pin a specific model, set the `llm` property to one of the predefined models:
 - `gpt_5_mini`
 - `gpt_5_3`
 - `gpt_5_4`
+- `gpt_5_6_sol`
+- `gpt_5_6_terra`
 - `o3`
 - `o4_mini`
 


### PR DESCRIPTION
Adds GPT-5.6 Sol and Terra to the list of predefined models for an agent's `llm` property.
