### PR TITLE
fix(jdbc-driver): actually run connection queries on the query and stream paths

### DIFF
--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -253,7 +253,9 @@ export class JDBCDriver extends BaseDriver {
   public async query<R = unknown>(query: string, values: unknown[]): Promise<R[]> {
     const queryWithParams = this.prepareQueryWithParams(query, values);
     const cancelObj: {cancel?: Function} = {};
-    const promise = this.queryPromised(queryWithParams, cancelObj, this.prepareConnectionQueries());
+    const promise = this.queryPromised(queryWithParams, cancelObj, {
+      prepareConnectionQueries: this.prepareConnectionQueries(),
+    });
     (promise as CancelablePromise<any>).cancel =
       () => cancelObj.cancel && cancelObj.cancel() ||
       Promise.reject(new Error('Statement is not ready'));
@@ -299,6 +301,12 @@ export class JDBCDriver extends BaseDriver {
     try {
       const query = this.prepareQueryWithParams(sql, values);
       const cancelObj: {cancel?: Function} = {};
+
+      // A streamed query runs on its own connection, so it needs the same
+      // connection queries the query path replays.
+      for (const connectionQuery of this.prepareConnectionQueries()) {
+        await this.executeStatement(conn, connectionQuery);
+      }
 
       const createStatement = promisify(conn.createStatement.bind(conn));
       const statement = await createStatement();

--- a/packages/cubejs-jdbc-driver/test/unit/connection-queries.test.ts
+++ b/packages/cubejs-jdbc-driver/test/unit/connection-queries.test.ts
@@ -86,18 +86,24 @@ describe('JDBC connection queries', () => {
   // `stream()` acquires its own connection, so the replay the query path does
   // buys it nothing — it has to run them itself.
   describe('stream()', () => {
+    // The primary query runs through createStatement -> statement.execute, not
+    // executeStatement, so it has to land in the same array — otherwise the
+    // ordering assertions below would hold with the replay moved after it.
     const streamDriverFor = (config: Record<string, any>) => {
       const built = driverFor(config);
       const statement = {
         cancel: (cb: Function) => cb(null),
-        execute: (_sql: string, cb: Function) => cb(null, {
-          _types: { 12: 'string' },
-          toObjectIter: (cb2: Function) => cb2(null, {
-            labels: ['a'],
-            types: [12],
-            rows: { next: () => { /* no rows */ } },
-          }),
-        }),
+        execute: (sql: string, cb: Function) => {
+          built.executed.push(sql);
+          cb(null, {
+            _types: { 12: 'string' },
+            toObjectIter: (cb2: Function) => cb2(null, {
+              labels: ['a'],
+              types: [12],
+              rows: { next: () => { /* no rows */ } },
+            }),
+          });
+        },
       };
       built.conn.createStatement = (cb: Function) => cb(null, statement);
       return built;
@@ -108,7 +114,7 @@ describe('JDBC connection queries', () => {
 
       await driver.stream('SELECT 1', [], { highWaterMark: 1 });
 
-      expect(executed).toEqual([MYSQL_TIME_ZONE]);
+      expect(executed).toEqual([MYSQL_TIME_ZONE, 'SELECT 1']);
     });
 
     it('replays connection queries passed explicitly in the driver config', async () => {
@@ -119,7 +125,7 @@ describe('JDBC connection queries', () => {
 
       await driver.stream('SELECT 1', [], { highWaterMark: 1 });
 
-      expect(executed).toEqual(['SET a = 1', 'SET b = 2']);
+      expect(executed).toEqual(['SET a = 1', 'SET b = 2', 'SELECT 1']);
     });
 
     it('runs no connection queries for a dbType that declares none', async () => {
@@ -127,7 +133,7 @@ describe('JDBC connection queries', () => {
 
       await driver.stream('SELECT 1', [], { highWaterMark: 1 });
 
-      expect(executed).toEqual([]);
+      expect(executed).toEqual(['SELECT 1']);
     });
 
     it('releases the connection when a connection query fails', async () => {

--- a/packages/cubejs-jdbc-driver/test/unit/connection-queries.test.ts
+++ b/packages/cubejs-jdbc-driver/test/unit/connection-queries.test.ts
@@ -1,0 +1,142 @@
+// Keep the JVM out of the unit test: the connection-query replay is pure logic
+// over a pooled connection.
+jest.mock('@cubejs-backend/jdbc/lib/drivermanager', () => ({
+  getConnection: () => { /* stub */ },
+}), { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/connection', () => class Connection {
+  public getMetaData() { /* stub */ }
+}, { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/databasemetadata', () => class DatabaseMetaData {
+  public getSchemas() { /* stub */ }
+
+  public getTables() { /* stub */ }
+}, { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/jinst', () => ({ isJvmCreated: () => true }), { virtual: true });
+jest.mock('@cubejs-backend/node-java-maven', () => () => { /* stub */ }, { virtual: true });
+
+// eslint-disable-next-line import/first
+import { JDBCDriver } from '../../src/JDBCDriver';
+
+const MYSQL_TIME_ZONE = 'SET time_zone = \'+00:00\'';
+
+/**
+ * The constructor needs a JVM-backed pool, while the replay only needs a
+ * connection to hand out and a record of what was executed on it.
+ *
+ * `executed` collects every statement in order, so a test can assert both that
+ * the connection queries ran and that they ran before the primary query.
+ */
+const driverFor = (config: Record<string, any>) => {
+  const executed: string[] = [];
+  const released: unknown[] = [];
+  const conn: Record<string, any> = { id: 'conn' };
+
+  const driver: any = Object.create(JDBCDriver.prototype);
+  driver.config = config;
+  driver.pool = {
+    acquire: async () => conn,
+    release: async (c: unknown) => { released.push(c); },
+  };
+  driver.executeStatement = async (_conn: unknown, sql: string) => {
+    executed.push(sql);
+    return [];
+  };
+
+  return { driver, executed, released, conn };
+};
+
+describe('JDBC connection queries', () => {
+  describe('query()', () => {
+    it('replays the dbType connection queries before the primary query', async () => {
+      const { driver, executed } = driverFor({ dbType: 'mysql' });
+
+      await driver.query('SELECT 1', []);
+
+      expect(executed).toEqual([MYSQL_TIME_ZONE, 'SELECT 1']);
+    });
+
+    it('replays connection queries passed explicitly in the driver config', async () => {
+      const { driver, executed } = driverFor({
+        dbType: 'athena',
+        prepareConnectionQueries: ['SET a = 1', 'SET b = 2'],
+      });
+
+      await driver.query('SELECT 1', []);
+
+      expect(executed).toEqual(['SET a = 1', 'SET b = 2', 'SELECT 1']);
+    });
+
+    it('runs only the primary query for a dbType with no connection queries', async () => {
+      const { driver, executed } = driverFor({ dbType: 'athena' });
+
+      await driver.query('SELECT 1', []);
+
+      expect(executed).toEqual(['SELECT 1']);
+    });
+
+    it('releases the connection when a connection query fails', async () => {
+      const { driver, released, conn } = driverFor({ dbType: 'mysql' });
+      driver.executeStatement = async () => { throw new Error('connection query failed'); };
+
+      await expect(driver.query('SELECT 1', [])).rejects.toThrow('connection query failed');
+      expect(released).toEqual([conn]);
+    });
+  });
+
+  // `stream()` acquires its own connection, so the replay the query path does
+  // buys it nothing — it has to run them itself.
+  describe('stream()', () => {
+    const streamDriverFor = (config: Record<string, any>) => {
+      const built = driverFor(config);
+      const statement = {
+        cancel: (cb: Function) => cb(null),
+        execute: (_sql: string, cb: Function) => cb(null, {
+          _types: { 12: 'string' },
+          toObjectIter: (cb2: Function) => cb2(null, {
+            labels: ['a'],
+            types: [12],
+            rows: { next: () => { /* no rows */ } },
+          }),
+        }),
+      };
+      built.conn.createStatement = (cb: Function) => cb(null, statement);
+      return built;
+    };
+
+    it('replays the dbType connection queries before opening the stream', async () => {
+      const { driver, executed } = streamDriverFor({ dbType: 'mysql' });
+
+      await driver.stream('SELECT 1', [], { highWaterMark: 1 });
+
+      expect(executed).toEqual([MYSQL_TIME_ZONE]);
+    });
+
+    it('replays connection queries passed explicitly in the driver config', async () => {
+      const { driver, executed } = streamDriverFor({
+        dbType: 'athena',
+        prepareConnectionQueries: ['SET a = 1', 'SET b = 2'],
+      });
+
+      await driver.stream('SELECT 1', [], { highWaterMark: 1 });
+
+      expect(executed).toEqual(['SET a = 1', 'SET b = 2']);
+    });
+
+    it('runs no connection queries for a dbType that declares none', async () => {
+      const { driver, executed } = streamDriverFor({ dbType: 'athena' });
+
+      await driver.stream('SELECT 1', [], { highWaterMark: 1 });
+
+      expect(executed).toEqual([]);
+    });
+
+    it('releases the connection when a connection query fails', async () => {
+      const { driver, released, conn } = streamDriverFor({ dbType: 'mysql' });
+      driver.executeStatement = async () => { throw new Error('connection query failed'); };
+
+      await expect(driver.stream('SELECT 1', [], { highWaterMark: 1 }))
+        .rejects.toThrow('connection query failed');
+      expect(released).toEqual([conn]);
+    });
+  });
+});


### PR DESCRIPTION
## Issue

`JDBCDriver.query()` passed the *array* returned by `prepareConnectionQueries()` as `queryPromised`'s `options` argument, but `queryPromised` reads `options.prepareConnectionQueries` off it — which on an array is `undefined`. The replay loop therefore ran zero times, and no connection query was ever executed on the query path.

```ts
// query()
const promise = this.queryPromised(queryWithParams, cancelObj, this.prepareConnectionQueries());

// queryPromised()
const prepareConnectionQueries = options.prepareConnectionQueries || [];  // undefined -> []
```

`stream()` was separately missing the replay entirely, so neither path applied it. The defect dates back to the driver's original commit.

`supported-drivers.ts` ships `prepareConnectionQueries: ["SET time_zone = '+00:00'"]` for MySQL, so MySQL accessed through this driver has never applied it — timestamps are read in the server's local timezone rather than UTC. Any driver config passing `prepareConnectionQueries` explicitly was silently ignored too.

## Fix

- `query()` passes a proper options object so `queryPromised` reads the statements. Fixing the caller rather than widening `queryPromised`'s contract keeps that method's `options` shape intact — it is `protected` with this as its only call site.
- `stream()` replays the same statements before opening the stream, inside the existing `try` so a failing connection query still releases the pooled connection through the `catch`.

`prepareConnectionQueries()` itself is unchanged, as is every driver's statement list.

## Blast radius

`mysql` is the only dbType in `supported-drivers.ts` with a non-empty list — `athena`, `sparksql` and `hive` all ship `[]`, and `DatabricksDriver` resolves to `[]` because its dbType is absent from `SupportedDrivers` (and it overrides none of `query`/`stream`/`queryPromised`/`prepareConnectionQueries`). Reaching the non-empty case requires `CUBEJS_DB_TYPE=jdbc`; a plain `CUBEJS_DB_TYPE=mysql` routes to the native MySQL driver, not this one.

So the change is confined to MySQL-over-JDBC and to configs that set `prepareConnectionQueries` explicitly. In both cases the behaviour moves from "silently ignored" to "does what it says" — but it does mean MySQL-over-JDBC starts returning UTC timestamps where it previously returned local-time ones. Worth a release note for anyone who compensated for the old behaviour downstream.

## Tests

`test/unit/connection-queries.test.ts` — 8 tests over both paths, following the existing `escape-dialect.test.ts` pattern (JVM mocked out, driver built via `Object.create` with a stub pool). Per path: dbType built-ins replay before the primary query, explicit config replays, an empty-array dbType runs none, and a failing connection query still releases the connection exactly once.

Each was verified to fail on the unfixed code: reverting the fix turns the 5 replay-asserting tests red while the 3 negative controls stay green.

## Out of scope

Two pre-existing issues this touches but does not change:

- `executeStatement()` never closes the JDBC `Statement` it creates. The query path already leaks these; the stream path now creates one more per connection query, held for the stream's lifetime. Fixing it means changing the shared query path.
- `withConnection()` (used for metadata/schema queries) does not replay connection queries, so it stays asymmetric with `query()`/`stream()`.
