### PR TITLE
fix(server-core): release and connection-test dedicated pre-aggregation drivers

### DIFF
--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -2,6 +2,7 @@
 import * as stream from 'stream';
 import pt from 'promise-timeout';
 import {
+  BaseDriver,
   ContinueWaitError,
   DriverFactoryByDataSource,
   DriverType,
@@ -18,26 +19,75 @@ export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
   redisPrefix?: string;
 }
 
+/** A driver the factory has been asked for, and the promise it returned. */
+type RequestedDriver = {
+  dataSource: string;
+  preAggregations: boolean;
+  driver: Promise<BaseDriver>;
+};
+
 export class OrchestratorApi {
   private seenDataSources: Record<string, boolean> = {};
+
+  /**
+   * Every driver the factory has been asked to build. `seenDataSources` cannot
+   * serve this purpose: it holds plain data source names only, so a dedicated
+   * pre-aggregation driver — which the factory caches separately — was never
+   * released or connection-tested. Only the pre-aggregation subsystem requests
+   * those, and it does so lazily, so nothing but the factory itself knows they
+   * exist.
+   *
+   * Keyed by what was *asked for*, which the schema bounds, rather than by the
+   * promise handed back: an `async` factory returns a new promise per call, so
+   * promise keys would grow one entry per query. Whether two requests share one
+   * connection is then settled by the resolved instance, not by this key.
+   */
+  private requestedDrivers: Map<string, RequestedDriver> = new Map();
 
   protected orchestrator: QueryOrchestrator;
 
   protected readonly continueWaitTimeout: number;
 
+  /**
+   * Wraps the factory the orchestrator was built with, so every driver resolved
+   * anywhere in the process is recorded. Kept in the `driverFactory` field, and
+   * passed down to `QueryOrchestrator`, so the query path, the pre-aggregation
+   * subsystem and `CompilerApi`'s data source probe all record through it.
+   */
+  protected readonly driverFactory: DriverFactoryByDataSource;
+
   public constructor(
-    protected readonly driverFactory: DriverFactoryByDataSource,
+    driverFactory: DriverFactoryByDataSource,
     protected readonly logger,
     protected readonly options: OrchestratorApiOptions
   ) {
     this.continueWaitTimeout = this.options.continueWaitTimeout || 10;
 
+    this.driverFactory = this.recordingDriverFactory(driverFactory);
+
     this.orchestrator = new QueryOrchestrator(
       options.redisPrefix || 'STANDALONE',
-      driverFactory,
+      this.driverFactory,
       logger,
       options
     );
+  }
+
+  private recordingDriverFactory(driverFactory: DriverFactoryByDataSource): DriverFactoryByDataSource {
+    return (dataSource = 'default', preAggregations = false) => {
+      const driver = driverFactory(dataSource, preAggregations);
+
+      // One entry per distinct request, overwriting the previous promise for the
+      // same one: a re-request returns the same connection, and the factory owns
+      // its cache, so the latest promise is the one worth holding.
+      this.requestedDrivers.set(`${dataSource}${preAggregations ? '@pre_agg' : ''}`, {
+        dataSource,
+        preAggregations,
+        driver: Promise.resolve(driver),
+      });
+
+      return driver;
+    };
   }
 
   /**
@@ -183,13 +233,56 @@ export class OrchestratorApi {
     if (this.options.rollupOnlyMode) {
       return this.testDriverConnection(this.options.externalDriverFactory, DriverType.External);
     } else {
+      // Requests that share a connection must not each cost a round-trip, and
+      // only the resolved driver reveals which those are — the factory answers
+      // a shared connection with one instance, whatever it was asked for.
+      const tested = new Set<BaseDriver>();
+
       return Promise.all([
-        ...Object.keys(this.seenDataSources).map(
-          ds => this.testDriverConnection(this.driverFactory, DriverType.Internal, ds),
+        ...this.connectionsToTest().map(
+          ({ dataSource, preAggregations }) => this.testDriverConnection(
+            this.driverFactory,
+            DriverType.Internal,
+            dataSource,
+            preAggregations,
+            tested,
+          ),
         ),
         this.testDriverConnection(this.options.externalDriverFactory, DriverType.External),
       ]);
     }
+  }
+
+  /**
+   * The data sources a connection test should cover: everything a driver has
+   * been built for, plus anything announced through `addDataSeenSource` that
+   * has not been built yet. The latter matters for the readiness probe, which
+   * announces a data source and then tests it precisely to force the first
+   * connection — on a fresh server nothing has been requested yet, so testing
+   * only what was requested would report healthy without touching the database.
+   */
+  private connectionsToTest(): { dataSource: string, preAggregations: boolean }[] {
+    const connections = [...this.requestedDrivers.values()].map(
+      ({ dataSource, preAggregations }) => ({ dataSource, preAggregations })
+    );
+
+    Object.keys(this.seenDataSources).forEach((dataSource) => {
+      // Matched against the query request specifically. A data source whose
+      // pre-aggregation driver was built first has a record, but on dedicated
+      // credentials that record is a different database — treating it as cover
+      // would let the probe pass while the primary connection is unreachable.
+      // When the two do share a connection, they resolve to one driver and the
+      // duplicate costs nothing.
+      const queryConnectionCovered = connections.some(
+        connection => connection.dataSource === dataSource && !connection.preAggregations
+      );
+
+      if (!queryConnectionCovered) {
+        connections.push({ dataSource, preAggregations: false });
+      }
+    });
+
+    return connections;
   }
 
   /**
@@ -200,14 +293,25 @@ export class OrchestratorApi {
     driverFn?: DriverFactoryByDataSource,
     driverType?: DriverType,
     dataSource: string = 'default',
+    preAggregations: boolean = false,
+    tested?: Set<BaseDriver>,
   ) {
     if (driverFn) {
       try {
-        const driver = await driverFn(dataSource);
+        const driver = await driverFn(dataSource, preAggregations);
+
+        if (tested) {
+          if (tested.has(driver)) {
+            return;
+          }
+          tested.add(driver);
+        }
+
         await driver.testConnection();
         this.logger('Connection test completed successfully', {
           driverType,
           dataSource,
+          preAggregations,
         });
       } catch (e: any) {
         e.driverType = driverType;
@@ -240,19 +344,73 @@ export class OrchestratorApi {
   }
 
   public async release() {
-    return Promise.all([
-      ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
+    const requested = [...this.requestedDrivers.values()];
+
+    // The api is spent once released, so stop tracking immediately; holding
+    // closed drivers would keep their captured scope alive for as long as
+    // anything references the api.
+    this.requestedDrivers.clear();
+
+    // Each driver is released as soon as it resolves, so one whose connection
+    // never settles cannot hold up the others, the external driver, or the
+    // orchestrator's own cleanup.
+    //
+    // Deliberately released through the recorded promise rather than the
+    // factory: asking a factory for something you intend to destroy builds a
+    // driver — and opens a connection — whenever the cached one is gone, which
+    // is exactly the state a failed resolution leaves behind. A resolution that
+    // failed has no driver to close, so it is skipped.
+    const released = new Set<BaseDriver>();
+
+    const results = await Promise.allSettled([
+      ...requested.map(async ({ driver }) => {
+        // A driver that never resolved was never built, so there is nothing to
+        // close and nothing leaked — whatever failed the resolution was already
+        // reported to whoever requested it.
+        const resolved = await driver.catch(() => null);
+
+        // A data source and its pre-aggregation request resolve to one driver
+        // unless a dedicated connection is configured; close it once.
+        if (!resolved || released.has(resolved)) {
+          return;
+        }
+        released.add(resolved);
+
+        await this.releaseDriverInstance(resolved);
+      }),
       this.releaseDriver(this.options.externalDriverFactory),
       this.orchestrator.cleanup()
     ]);
+
+    // Teardown runs to completion before anything is reported: one driver
+    // refusing to close must not strand the rest. But the failure still has to
+    // reach the caller — shutdown exits non-zero on it, and a reset must not
+    // reload over state it could not release.
+    const errors = results
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map(result => result.reason);
+
+    if (errors.length) {
+      errors.forEach((error) => {
+        this.logger('Error during release', {
+          error: (error as Error)?.stack || error,
+        });
+      });
+
+      throw errors[0];
+    }
   }
 
   protected async releaseDriver(driverFn?: DriverFactoryByDataSource, dataSource: string = 'default') {
     if (driverFn) {
       const driver = await driverFn(dataSource);
-      if (driver.release) {
-        await driver.release();
-      }
+      await this.releaseDriverInstance(driver);
+    }
+  }
+
+  private async releaseDriverInstance(driver: BaseDriver) {
+    if (driver.release) {
+      await driver.release();
     }
   }
 

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -4,6 +4,7 @@ import pt from 'promise-timeout';
 import {
   BaseDriver,
   ContinueWaitError,
+  DriverFactory,
   DriverFactoryByDataSource,
   DriverType,
   QueryBody,
@@ -12,6 +13,7 @@ import {
 } from '@cubejs-backend/query-orchestrator';
 
 import { DatabaseType, RequestContext } from './types';
+import { driverCacheKey } from './utils';
 
 export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
   contextToDbType: (dataSource: string) => Promise<DatabaseType>;
@@ -56,20 +58,51 @@ export class OrchestratorApi {
    */
   protected readonly driverFactory: DriverFactoryByDataSource;
 
+  /**
+   * The external pre-aggregation driver, recorded when something resolves one.
+   * Tracked apart from `requestedDrivers` because its factory takes no data
+   * source and lives in `options`, which `QueryOrchestrator` reads directly — but
+   * released under the same rule: close what was built, never build to close.
+   */
+  private requestedExternalDriver: Promise<BaseDriver> | null = null;
+
+  /**
+   * The external factory with recording attached, or `undefined` when none is
+   * configured. It replaces the one in `options` before the orchestrator is
+   * constructed, so `QueryCache` and `PreAggregations` record through it too —
+   * wrapping only this class's own reads would leave the orchestrator's external
+   * driver unreleasable, which is the gap being closed, one layer down.
+   */
+  protected readonly externalDriverFactory?: DriverFactory;
+
+  /**
+   * A copy of the constructor's options, with the external driver factory swapped
+   * for the recording wrapper. Copied rather than mutated so the caller's object
+   * is left alone.
+   */
+  protected readonly options: OrchestratorApiOptions;
+
   public constructor(
     driverFactory: DriverFactoryByDataSource,
     protected readonly logger,
-    protected readonly options: OrchestratorApiOptions
+    options: OrchestratorApiOptions
   ) {
+    this.driverFactory = this.recordingDriverFactory(driverFactory);
+    this.externalDriverFactory = this.recordingExternalDriverFactory(options.externalDriverFactory);
+
+    // The orchestrator and everything under it read the external factory from
+    // `options`, so the recording wrapper has to be in there rather than only in
+    // this class's own field — otherwise the driver `QueryCache` resolves is not
+    // one `release()` can close.
+    this.options = { ...options, externalDriverFactory: this.externalDriverFactory };
+
     this.continueWaitTimeout = this.options.continueWaitTimeout || 10;
 
-    this.driverFactory = this.recordingDriverFactory(driverFactory);
-
     this.orchestrator = new QueryOrchestrator(
-      options.redisPrefix || 'STANDALONE',
+      this.options.redisPrefix || 'STANDALONE',
       this.driverFactory,
       logger,
-      options
+      this.options
     );
   }
 
@@ -80,11 +113,33 @@ export class OrchestratorApi {
       // One entry per distinct request, overwriting the previous promise for the
       // same one: a re-request returns the same connection, and the factory owns
       // its cache, so the latest promise is the one worth holding.
-      this.requestedDrivers.set(`${dataSource}${preAggregations ? '@pre_agg' : ''}`, {
+      //
+      // Keyed on the *request*, where the factory's own cache keys on the
+      // credentials it resolves to — so without a dedicated pre-aggregation
+      // connection this holds two entries for one driver. Harmless by design:
+      // identity dedup settles release, and the `tested` set settles the probe.
+      // Keying on the credentials instead would mean re-deriving the decision
+      // here, which is exactly the disagreement `driverCacheKey` exists to
+      // prevent.
+      this.requestedDrivers.set(driverCacheKey(dataSource, preAggregations), {
         dataSource,
         preAggregations,
         driver: Promise.resolve(driver),
       });
+
+      return driver;
+    };
+  }
+
+  private recordingExternalDriverFactory(driverFactory?: DriverFactory): DriverFactory | undefined {
+    if (!driverFactory) {
+      return undefined;
+    }
+
+    return () => {
+      const driver = driverFactory();
+
+      this.requestedExternalDriver = Promise.resolve(driver);
 
       return driver;
     };
@@ -231,7 +286,7 @@ export class OrchestratorApi {
    */
   public async testConnection() {
     if (this.options.rollupOnlyMode) {
-      return this.testDriverConnection(this.options.externalDriverFactory, DriverType.External);
+      return this.testDriverConnection(this.externalDriverFactory, DriverType.External);
     } else {
       // Requests that share a connection must not each cost a round-trip, and
       // only the resolved driver reveals which those are — the factory answers
@@ -248,7 +303,7 @@ export class OrchestratorApi {
             tested,
           ),
         ),
-        this.testDriverConnection(this.options.externalDriverFactory, DriverType.External),
+        this.testDriverConnection(this.externalDriverFactory, DriverType.External),
       ]);
     }
   }
@@ -345,11 +400,13 @@ export class OrchestratorApi {
 
   public async release() {
     const requested = [...this.requestedDrivers.values()];
+    const requestedExternal = this.requestedExternalDriver;
 
     // The api is spent once released, so stop tracking immediately; holding
     // closed drivers would keep their captured scope alive for as long as
     // anything references the api.
     this.requestedDrivers.clear();
+    this.requestedExternalDriver = null;
 
     // Each driver is released as soon as it resolves, so one whose connection
     // never settles cannot hold up the others, the external driver, or the
@@ -363,22 +420,14 @@ export class OrchestratorApi {
     const released = new Set<BaseDriver>();
 
     const results = await Promise.allSettled([
-      ...requested.map(async ({ driver }) => {
-        // A driver that never resolved was never built, so there is nothing to
-        // close and nothing leaked — whatever failed the resolution was already
-        // reported to whoever requested it.
-        const resolved = await driver.catch(() => null);
-
-        // A data source and its pre-aggregation request resolve to one driver
-        // unless a dedicated connection is configured; close it once.
-        if (!resolved || released.has(resolved)) {
-          return;
-        }
-        released.add(resolved);
-
-        await this.releaseDriverInstance(resolved);
-      }),
-      this.releaseDriver(this.options.externalDriverFactory),
+      ...requested.map(({ driver }) => this.releaseRequestedDriver(driver, released)),
+      // Same rule as the internal drivers, for the same reason: the external
+      // closure in `server.ts` nulls its cached promise on a failed resolution,
+      // so going back through the factory here would construct an external
+      // driver — and connection-test it — purely in order to close it. A
+      // deployment with an external store but no pre-aggregation traffic never
+      // built one, and now never builds one at shutdown either.
+      this.releaseRequestedDriver(requestedExternal, released),
       this.orchestrator.cleanup()
     ]);
 
@@ -401,11 +450,35 @@ export class OrchestratorApi {
     }
   }
 
+  /**
+   * @deprecated Resolves through the factory, which builds a driver whenever the
+   * cached one is gone — so it can open a connection in order to close it. Nothing
+   * in this class uses it any more; kept for out-of-tree subclasses.
+   */
   protected async releaseDriver(driverFn?: DriverFactoryByDataSource, dataSource: string = 'default') {
     if (driverFn) {
       const driver = await driverFn(dataSource);
       await this.releaseDriverInstance(driver);
     }
+  }
+
+  /**
+   * Closes a driver this api recorded, once. A promise that never resolved means
+   * the driver was never built, so there is nothing to close and nothing leaked —
+   * whatever failed the resolution was already reported to whoever requested it.
+   * The `released` set is what settles sharing: a data source and its
+   * pre-aggregation request resolve to one instance unless dedicated credentials
+   * are configured, and only the instance knows which case it is.
+   */
+  private async releaseRequestedDriver(driver: Promise<BaseDriver> | null, released: Set<BaseDriver>) {
+    const resolved = driver && await driver.catch(() => null);
+
+    if (!resolved || released.has(resolved)) {
+      return;
+    }
+    released.add(resolved);
+
+    await this.releaseDriverInstance(resolved);
   }
 
   private async releaseDriverInstance(driver: BaseDriver) {

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -36,8 +36,26 @@ export class OrchestratorStorage {
     return Promise.all([...this.storage.values()].map(api => api.testOrchestratorConnections()));
   }
 
+  /**
+   * Every api releases, then the map is cleared, and only then is a failure
+   * reported. An api is spent the moment `release()` is entered — it has stopped
+   * tracking its drivers and closed some of them — so a rejection must not leave
+   * it in the map: `get()` would hand a spent api back out, and a second
+   * `release()` on it is a no-op, so any pool that did survive becomes
+   * unreachable. `allSettled` for the same reason one level down: one pool
+   * refusing to close must not strand the other apis' teardown.
+   */
   public async releaseConnections() {
-    await Promise.all([...this.storage.values()].map(api => api.release()));
-    this.storage.clear();
+    try {
+      const results = await Promise.allSettled([...this.storage.values()].map(api => api.release()));
+
+      const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+      if (failure) {
+        throw failure.reason;
+      }
+    } finally {
+      this.storage.clear();
+    }
   }
 }

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -556,18 +556,27 @@ export class CubejsServerCore {
     return compilerApi;
   }
 
+  /**
+   * The rebuild runs even when releasing threw, then the failure is reported.
+   * `release()` is not atomic — it stops tracking and closes what it can before
+   * failing — so returning early would leave the dev server with the old
+   * orchestrators discarded and no refresh timer at all, which is worse than
+   * reloading over one pool that refused to close.
+   */
   public async resetInstanceState() {
-    await this.orchestratorStorage.releaseConnections();
+    try {
+      await this.orchestratorStorage.releaseConnections();
+    } finally {
+      this.orchestratorStorage.clear();
+      this.compilerCache.clear();
 
-    this.orchestratorStorage.clear();
-    this.compilerCache.clear();
+      this.reloadEnvVariables();
 
-    this.reloadEnvVariables();
+      this.repository = new FileRepository(this.options.schemaPath);
+      this.repositoryFactory = this.options.repositoryFactory || (() => this.repository);
 
-    this.repository = new FileRepository(this.options.schemaPath);
-    this.repositoryFactory = this.options.repositoryFactory || (() => this.repository);
-
-    this.startScheduledRefreshTimer();
+      this.startScheduledRefreshTimer();
+    }
   }
 
   public async getOrchestratorApi(context: RequestContext): Promise<OrchestratorApi> {
@@ -586,6 +595,15 @@ export class CubejsServerCore {
 
     let externalPreAggregationsDriverPromise: Promise<BaseDriver> | null = null;
 
+    /**
+     * `hasPreAggregationsEnvVars` allocates and scans all of `process.env`, and it
+     * now feeds the cache key, so it sits ahead of the cache-hit early return and
+     * would otherwise run on every query and every pre-aggregation check rather
+     * than once per data source. Safe to memoize for this orchestrator's lifetime:
+     * env vars only change under `reloadEnvVariables()`, which discards it.
+     */
+    const preAggregationsEnvVars: Record<string, boolean> = {};
+
     const contextToDbType: DbTypeInternalFn = this.contextToDbType.bind(this);
     const externalDbType = this.contextToExternalDbType(context);
 
@@ -602,7 +620,11 @@ export class CubejsServerCore {
        * Driver factory function `DriverFactoryByDataSource`.
        */
       async (dataSource = 'default', preAggregations = false) => {
-        const hasSeparatePreAggEnv = hasPreAggregationsEnvVars(dataSource);
+        if (!(dataSource in preAggregationsEnvVars)) {
+          preAggregationsEnvVars[dataSource] = hasPreAggregationsEnvVars(dataSource);
+        }
+
+        const hasSeparatePreAggEnv = preAggregationsEnvVars[dataSource];
         const usePreAgg = preAggregations && hasSeparatePreAggEnv && !this.optsHandler.isCustomDriverFactory();
 
         // Keyed on the credentials the driver is actually built with, not on the
@@ -897,17 +919,24 @@ export class CubejsServerCore {
     return this.orchestratorStorage.testConnections();
   }
 
+  /**
+   * The timers are cancelled even when releasing threw, then the failure is
+   * reported. A pool that refuses to close must not leave the process held open
+   * by a live interval — that turns a reported shutdown failure into a hang.
+   */
   public async releaseConnections() {
-    await this.orchestratorStorage.releaseConnections();
+    try {
+      await this.orchestratorStorage.releaseConnections();
+    } finally {
+      if (this.maxCompilerCacheKeep) {
+        clearInterval(this.maxCompilerCacheKeep);
+      }
 
-    if (this.maxCompilerCacheKeep) {
-      clearInterval(this.maxCompilerCacheKeep);
-    }
+      this.compilerCache.clear();
 
-    this.compilerCache.clear();
-
-    if (this.scheduledRefreshTimerInterval) {
-      await this.scheduledRefreshTimerInterval.cancel();
+      if (this.scheduledRefreshTimerInterval) {
+        await this.scheduledRefreshTimerInterval.cancel();
+      }
     }
   }
 

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -37,6 +37,7 @@ import { agentCollect } from './agentCollect';
 import { OrchestratorStorage } from './OrchestratorStorage';
 import { createLogger } from './logger';
 import { OptsHandler } from './OptsHandler';
+import { driverCacheKey } from './utils';
 import {
   driverDependencies,
   lookupDriverClass,
@@ -601,13 +602,19 @@ export class CubejsServerCore {
        * Driver factory function `DriverFactoryByDataSource`.
        */
       async (dataSource = 'default', preAggregations = false) => {
-        const factoryKey = preAggregations ? `${dataSource}@pre_agg` : dataSource;
+        const hasSeparatePreAggEnv = hasPreAggregationsEnvVars(dataSource);
+        const usePreAgg = preAggregations && hasSeparatePreAggEnv && !this.optsHandler.isCustomDriverFactory();
+
+        // Keyed on the credentials the driver is actually built with, not on the
+        // caller's `preAggregations` flag. Keying on the flag gave a request
+        // that resolves to the data source's own credentials a second cache
+        // entry — so a pre-aggregation build arriving before the first query
+        // made that query build a duplicate driver for one connection.
+        const factoryKey = driverCacheKey(dataSource, usePreAgg);
+
         if (driverPromise[factoryKey]) {
           return driverPromise[factoryKey];
         }
-
-        const hasSeparatePreAggEnv = hasPreAggregationsEnvVars(dataSource);
-        const usePreAgg = preAggregations && hasSeparatePreAggEnv && !this.optsHandler.isCustomDriverFactory();
 
         if (preAggregations && hasSeparatePreAggEnv && this.optsHandler.isCustomDriverFactory()) {
           this.logger('Pre-aggregation driver conflict', {
@@ -645,10 +652,6 @@ export class CubejsServerCore {
           } catch (e) {
             driverPromise[factoryKey] = null;
 
-            if (!preAggregations && !hasSeparatePreAggEnv) {
-              driverPromise[`${dataSource}@pre_agg`] = null;
-            }
-
             if (driver) {
               await driver.release();
             }
@@ -656,11 +659,6 @@ export class CubejsServerCore {
             throw e;
           }
         })();
-
-        // No separate pre-agg driver needed — share the same promise for both keys
-        if (!preAggregations && !hasSeparatePreAggEnv) {
-          driverPromise[`${dataSource}@pre_agg`] = driverPromise[factoryKey];
-        }
 
         return driverPromise[factoryKey];
       },

--- a/packages/cubejs-server-core/src/core/utils.ts
+++ b/packages/cubejs-server-core/src/core/utils.ts
@@ -1,14 +1,17 @@
 /**
- * The key a data source's driver is cached and tracked under.
+ * The key a data source's driver is filed under, given whether the request wants
+ * pre-aggregation credentials.
  *
- * A key of its own is earned only by a pre-aggregation request that resolves to
- * genuinely different credentials — `usePreAggregationCredentials`. Anything
- * else shares the data source's one driver, so it must share the one key:
- * caching a shared driver twice builds a second pool for the same connection,
- * and releasing it twice closes it twice.
- *
- * The caller supplies the predicate rather than this deriving it, so the key can
- * never disagree with the decision that actually picks the credentials.
+ * Both callers pass what *they* key on, and they key on different things. The
+ * factory cache passes `usePreAggregationCredentials` — the decision that picks
+ * the credentials — because a key of its own is earned only by a request that
+ * resolves to a genuinely different connection: caching a shared driver twice
+ * builds a second pool for it, and releasing it twice closes it twice. The
+ * factory's caller supplies that predicate rather than this deriving it, so the
+ * key can never disagree with which connection the driver was built for.
+ * `OrchestratorApi`'s tracking passes the raw request instead and may therefore
+ * hold two keys for one shared driver, which is harmless: it dedups on the
+ * resolved instance.
  */
 export function driverCacheKey(dataSource: string, usePreAggregationCredentials: boolean): string {
   return usePreAggregationCredentials ? `${dataSource}@pre_agg` : dataSource;

--- a/packages/cubejs-server-core/src/core/utils.ts
+++ b/packages/cubejs-server-core/src/core/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * The key a data source's driver is cached and tracked under.
+ *
+ * A key of its own is earned only by a pre-aggregation request that resolves to
+ * genuinely different credentials — `usePreAggregationCredentials`. Anything
+ * else shares the data source's one driver, so it must share the one key:
+ * caching a shared driver twice builds a second pool for the same connection,
+ * and releasing it twice closes it twice.
+ *
+ * The caller supplies the predicate rather than this deriving it, so the key can
+ * never disagree with the decision that actually picks the credentials.
+ */
+export function driverCacheKey(dataSource: string, usePreAggregationCredentials: boolean): string {
+  return usePreAggregationCredentials ? `${dataSource}@pre_agg` : dataSource;
+}

--- a/packages/cubejs-server-core/test/unit/driver-lifecycle.test.ts
+++ b/packages/cubejs-server-core/test/unit/driver-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { BaseDriver } from '@cubejs-backend/query-orchestrator';
+import * as sharedEnv from '@cubejs-backend/shared';
 
 import { CubejsServerCore } from '../../src/core/server';
 import { OrchestratorApi } from '../../src/core/OrchestratorApi';
@@ -263,6 +264,30 @@ describe('driver lifecycle', () => {
       expect(api.requestedDrivers.size).toEqual(1);
       expect(created).toHaveLength(1);
     });
+
+    // The pre-aggregation env-var check feeds the cache key, so it sits ahead of
+    // the cache-hit early return. It allocates and scans all of `process.env`,
+    // and the factory runs per query and per pre-aggregation check — so left
+    // unmemoized it moved from once per data source onto the hot path.
+    test('the pre-aggregation env-var scan runs once per data source', async () => {
+      const spy = jest.spyOn(sharedEnv, 'hasPreAggregationsEnvVars');
+
+      try {
+        const api = await getApi(createCore());
+
+        for (let i = 0; i < 10; i += 1) {
+          await api.driverFactory('default');
+          await api.driverFactory('default', true);
+          await api.driverFactory('analytics');
+        }
+
+        // Two data sources requested, so two scans — not one per request, which
+        // is 30 here.
+        expect(spy.mock.calls.map(([dataSource]) => dataSource).sort()).toEqual(['analytics', 'default']);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe('release does not build drivers', () => {
@@ -317,6 +342,152 @@ describe('driver lifecycle', () => {
       await expect(api.release()).rejects.toThrow('release failed');
 
       expect(created[1].released).toEqual(1);
+    });
+
+    // `release()` empties the record, which is what makes the api spent — and
+    // what the callers' `finally` blocks depend on: a spent api must not stay
+    // reachable, because a second `release()` on it closes nothing.
+    test('the record is emptied, so a second release is a no-op', async () => {
+      process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api);
+      expect(api.requestedDrivers.size).toEqual(2);
+
+      await api.release();
+
+      expect(api.requestedDrivers.size).toEqual(0);
+      expect(created.map(driver => driver.released)).toEqual([1, 1]);
+
+      await api.release();
+
+      expect(created.map(driver => driver.released)).toEqual([1, 1]);
+      expect(created).toHaveLength(2);
+    });
+
+    // The external driver used to be released through its factory — the pattern
+    // this fix removes for internal drivers. The external closure in `server.ts`
+    // caches its promise, so with no pre-aggregation traffic there is nothing
+    // cached and the factory would build an external driver, connection-test it,
+    // and immediately close it: a connection opened purely to be shut down.
+    test('an external driver that was never used is not constructed', async () => {
+      let externalBuilds = 0;
+
+      const api = new OrchestratorApi(
+        (async () => new TestDriver('internal')) as any,
+        noop,
+        <any>{
+          externalDriverFactory: async () => {
+            externalBuilds += 1;
+            return new TestDriver('external');
+          },
+          contextToDbType: async () => 'postgres',
+          contextToExternalDbType: () => 'cubestore',
+        },
+      );
+
+      await api.release();
+
+      expect(externalBuilds).toEqual(0);
+    });
+
+    test('an external driver that was used is released, exactly once', async () => {
+      const externalDriver = new TestDriver('external');
+      let externalBuilds = 0;
+
+      const api = new OrchestratorApi(
+        (async () => new TestDriver('internal')) as any,
+        noop,
+        <any>{
+          externalDriverFactory: async () => {
+            externalBuilds += 1;
+            return externalDriver;
+          },
+          contextToDbType: async () => 'postgres',
+          contextToExternalDbType: () => 'cubestore',
+        },
+      );
+
+      // What the readiness probe does: it legitimately resolves the external
+      // driver to test it, and that resolution is what makes it releasable.
+      await api.testConnection();
+      expect(externalBuilds).toEqual(1);
+
+      await api.release();
+
+      expect(externalDriver.released).toEqual(1);
+      // Released from the recorded instance, not by asking the factory again.
+      expect(externalBuilds).toEqual(1);
+    });
+  });
+
+  // `release()` can now realistically reject — before this fix it iterated
+  // `seenDataSources`, which only the readiness probe populates, so on an
+  // ordinary deployment it touched no internal driver and effectively could not
+  // fail. Every caller finishes its own teardown before reporting that failure:
+  // an api is spent the moment `release()` is entered, so leaving it reachable,
+  // or leaving a timer live, is worse than the failure itself.
+  describe('a failing release does not strand its callers', () => {
+    const failOnRelease = (api: any) => {
+      // eslint-disable-next-line no-param-reassign
+      api.release = async () => { throw new Error('release failed'); };
+    };
+
+    test('OrchestratorStorage empties itself, so a spent api is not handed back out', async () => {
+      const core = createCore();
+      const api = await getApi(core);
+      const storage = (core as any).orchestratorStorage;
+
+      failOnRelease(api);
+
+      await expect(storage.releaseConnections()).rejects.toThrow('release failed');
+
+      expect([...storage.storage.values()]).toHaveLength(0);
+    });
+
+    // `Promise.all` rejects on the first failure while the siblings are still
+    // releasing, so it returns — and the map is cleared — mid-teardown. The
+    // caller then believes teardown is over while a pool is still closing.
+    test('OrchestratorStorage waits for every api before reporting the failure', async () => {
+      const storage = (createCore() as any).orchestratorStorage;
+      let slowFinished = false;
+
+      storage.set('fast', <any>{ release: async () => { throw new Error('release failed'); } });
+      storage.set('slow', <any>{
+        release: async () => {
+          await new Promise(resolve => setTimeout(resolve, 50));
+          slowFinished = true;
+        },
+      });
+
+      await expect(storage.releaseConnections()).rejects.toThrow('release failed');
+
+      expect(slowFinished).toEqual(true);
+    });
+
+    test('releaseConnections still cancels the timers', async () => {
+      const core = createCore();
+      let cancelled = false;
+
+      failOnRelease(await getApi(core));
+      (core as any).scheduledRefreshTimerInterval = { cancel: async () => { cancelled = true; } };
+
+      await expect(core.releaseConnections()).rejects.toThrow('release failed');
+
+      expect(cancelled).toEqual(true);
+    });
+
+    test('resetInstanceState still rebuilds, so the dev server keeps a refresh timer', async () => {
+      const core = createCore();
+      let restarted = 0;
+
+      failOnRelease(await getApi(core));
+      (core as any).startScheduledRefreshTimer = () => { restarted += 1; };
+
+      await expect(core.resetInstanceState()).rejects.toThrow('release failed');
+
+      expect(restarted).toEqual(1);
     });
   });
 

--- a/packages/cubejs-server-core/test/unit/driver-lifecycle.test.ts
+++ b/packages/cubejs-server-core/test/unit/driver-lifecycle.test.ts
@@ -1,0 +1,342 @@
+import { BaseDriver } from '@cubejs-backend/query-orchestrator';
+
+import { CubejsServerCore } from '../../src/core/server';
+import { OrchestratorApi } from '../../src/core/OrchestratorApi';
+
+class CubejsServerCoreOpen extends CubejsServerCore {
+  public getOrchestratorApi = super.getOrchestratorApi;
+}
+
+class TestDriver extends BaseDriver {
+  public released = 0;
+
+  public tested = 0;
+
+  public constructor(public readonly name: string) {
+    super();
+  }
+
+  public async testConnection() {
+    this.tested += 1;
+  }
+
+  public async release() {
+    this.released += 1;
+  }
+
+  public async query(): Promise<any> {
+    return [];
+  }
+}
+
+const context = { requestId: 'test', authInfo: null, securityContext: null } as any;
+
+const noop = () => {
+  // noop
+};
+
+describe('driver lifecycle', () => {
+  let created: TestDriver[] = [];
+
+  beforeEach(() => {
+    created = [];
+    process.env.CUBEJS_DB_TYPE = 'postgres';
+  });
+
+  afterEach(() => {
+    delete process.env.CUBEJS_DB_TYPE;
+    delete process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST;
+    delete process.env.CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_HOST;
+  });
+
+  /**
+   * A core whose driver construction is stubbed, so every resolution yields a
+   * fresh identifiable driver without needing a database. Going through
+   * `resolveDriver` (rather than a `driverFactory` option) keeps the real
+   * pre-aggregation-credential code path in play — `isCustomDriverFactory()`
+   * would otherwise force `usePreAgg` off.
+   */
+  const createCore = () => {
+    const core = new CubejsServerCoreOpen(<any>{ apiSecret: 'secret', logger: noop });
+
+    (core as any).resolveDriver = async ({ dataSource }: any) => {
+      const driver = new TestDriver(dataSource);
+      created.push(driver);
+      return driver;
+    };
+
+    return core;
+  };
+
+  const getApi = async (core: CubejsServerCoreOpen): Promise<any> => core.getOrchestratorApi(context);
+
+  /** What the runtime does: the query path resolves one, pre-aggregations the other. */
+  const requestQueryAndPreAggDrivers = async (api: any, dataSource = 'default') => {
+    await api.driverFactory(dataSource);
+    await api.driverFactory(dataSource, true);
+  };
+
+  describe('with a dedicated pre-aggregation connection', () => {
+    beforeEach(() => {
+      process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+    });
+
+    // The pre-aggregation driver is cached under a key of its own, which the
+    // release path used to have no way of reaching.
+    test('releases the pre-aggregation driver, not only the query driver', async () => {
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api);
+
+      expect(created).toHaveLength(2);
+
+      await api.release();
+
+      expect(created.map(d => d.released)).toEqual([1, 1]);
+    });
+
+    test('connection-tests the pre-aggregation driver too', async () => {
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api);
+
+      created.forEach((driver) => { driver.tested = 0; });
+
+      await api.testConnection();
+
+      expect(created.map(d => d.tested)).toEqual([1, 1]);
+    });
+
+    test('releases a named data source pre-aggregation driver', async () => {
+      process.env.CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api, 'analytics');
+
+      expect(created).toHaveLength(2);
+
+      await api.release();
+
+      expect(created.map(d => d.released)).toEqual([1, 1]);
+    });
+  });
+
+  describe('without a dedicated pre-aggregation connection', () => {
+    // One connection serves both, so both requests must land on one driver —
+    // whichever arrives first. A refresh worker builds pre-aggregations before
+    // serving any query, which is the order that used to build two drivers.
+    test.each([
+      ['query first', [false, true]],
+      ['pre-aggregation first', [true, false]],
+    ])('builds a single driver (%s)', async (_name, order) => {
+      const api = await getApi(createCore());
+
+      for (const preAggregations of order) {
+        await api.driverFactory('default', preAggregations);
+      }
+
+      expect(created).toHaveLength(1);
+
+      await api.release();
+
+      expect(created[0].released).toEqual(1);
+    });
+
+    test('connection-tests the one driver that serves both', async () => {
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api);
+
+      created.forEach((driver) => { driver.tested = 0; });
+
+      await api.testConnection();
+
+      // One connection, so one round-trip — not one per request that shares it.
+      expect(created).toHaveLength(1);
+      expect(created[0].tested).toEqual(1);
+    });
+  });
+
+  // The standalone readiness probe announces a data source and then tests it,
+  // precisely so the first connection is opened and verified before traffic
+  // arrives. Testing only drivers that already exist would report healthy
+  // against an unreachable database.
+  // A custom `driverFactory` takes precedence over pre-aggregation env vars, so
+  // both requests resolve to the same credentials — and must therefore resolve
+  // to one driver. Keying the cache on the caller's flag instead of on the
+  // credentials actually used gave this configuration two identical pools.
+  describe('with a custom driverFactory overriding pre-aggregation env vars', () => {
+    test('builds and releases a single driver', async () => {
+      process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+
+      const core = new CubejsServerCoreOpen(<any>{
+        apiSecret: 'secret',
+        logger: noop,
+        driverFactory: () => {
+          const driver = new TestDriver(`custom#${created.length + 1}`);
+          created.push(driver);
+          return driver;
+        },
+      });
+
+      const api = await getApi(core);
+
+      await requestQueryAndPreAggDrivers(api);
+
+      expect(created).toHaveLength(1);
+
+      await api.release();
+
+      expect(created[0].released).toEqual(1);
+    });
+  });
+
+  describe('readiness probe on a fresh server', () => {
+    test('tests an announced data source that has not been queried yet', async () => {
+      const api = await getApi(createCore());
+
+      // Nothing has queried `analytics`; the probe announces it and expects the
+      // connection test to force and verify the connection.
+      api.addDataSeenSource('analytics');
+
+      await api.testConnection();
+
+      // Resolving it is what opens the connection, and the factory verifies it
+      // on construction — so a probe that never resolves it cannot report on it.
+      const analyticsDriver = created.find(driver => driver.name === 'analytics');
+
+      expect(analyticsDriver).toBeDefined();
+      expect(analyticsDriver!.tested).toBeGreaterThanOrEqual(1);
+    });
+
+    // A pre-aggregation build can be the first thing to touch a data source. On
+    // dedicated credentials that is a different database, so it is no evidence
+    // about the primary connection the probe was announced for.
+    test('still tests the primary connection when only the pre-aggregation one was built', async () => {
+      process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+
+      const api = await getApi(createCore());
+
+      await api.driverFactory('default', true);
+
+      expect(created).toHaveLength(1);
+
+      api.addDataSeenSource('default');
+
+      await api.testConnection();
+
+      // The query connection had to be built and tested to be reported on.
+      expect(created).toHaveLength(2);
+      expect(created[1].tested).toBeGreaterThanOrEqual(1);
+    });
+
+    test('reports the failure when that connection is unreachable', async () => {
+      const core = createCore();
+      (core as any).resolveDriver = async () => { throw new Error('connection refused'); };
+
+      const api = await getApi(core);
+
+      api.addDataSeenSource('default');
+
+      await expect(api.testConnection()).rejects.toThrow('connection refused');
+    });
+  });
+
+  // The record is keyed by what was asked for, which the schema bounds. Keying
+  // it by the promise handed back grows it once per call — an `async` factory
+  // returns a new promise even when it answers from its own cache — and every
+  // connection test then re-requests each entry, so it doubles per probe.
+  describe('tracking is bounded', () => {
+    test('repeated requests and probes do not accumulate entries', async () => {
+      const api = await getApi(createCore());
+
+      for (let i = 0; i < 5; i += 1) {
+        await api.driverFactory('default');
+      }
+
+      expect(api.requestedDrivers.size).toEqual(1);
+
+      await api.testConnection();
+      await api.testConnection();
+
+      expect(api.requestedDrivers.size).toEqual(1);
+      expect(created).toHaveLength(1);
+    });
+  });
+
+  describe('release does not build drivers', () => {
+    test('a data source that was never queried is not constructed', async () => {
+      const api = await getApi(createCore());
+
+      await api.release();
+
+      expect(created).toHaveLength(0);
+    });
+
+    // Releasing used to go back through the factory to obtain the driver it
+    // then closed. After a failed resolution the cache entry is empty, so that
+    // call would build a fresh driver — and open a connection — purely to
+    // close it.
+    test('a data source whose driver failed to resolve is not rebuilt', async () => {
+      const core = createCore();
+      let attempts = 0;
+
+      (core as any).resolveDriver = async () => {
+        attempts += 1;
+        throw new Error('connection refused');
+      };
+
+      const api = await getApi(core);
+
+      await expect(api.driverFactory('default')).rejects.toThrow('connection refused');
+      expect(attempts).toEqual(1);
+
+      // Announced as well, so the old release path — which went back through the
+      // factory for every seen data source — would resolve it a second time and
+      // build the driver it meant to close.
+      api.addDataSeenSource('default');
+
+      await api.release();
+
+      expect(attempts).toEqual(1);
+      expect(created).toHaveLength(0);
+    });
+
+    // Teardown runs to completion, then reports: shutdown exits non-zero on a
+    // failed release, and a reset must not reload over state it could not free.
+    test('one driver refusing to close does not strand the others', async () => {
+      process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'preagg-host';
+
+      const api = await getApi(createCore());
+
+      await requestQueryAndPreAggDrivers(api);
+
+      created[0].release = async () => { throw new Error('release failed'); };
+
+      await expect(api.release()).rejects.toThrow('release failed');
+
+      expect(created[1].released).toEqual(1);
+    });
+  });
+
+  describe('rollupOnlyMode', () => {
+    test('tests only the external driver', async () => {
+      const externalDriver = new TestDriver('external');
+      const api = new OrchestratorApi(
+        (async () => new TestDriver('internal')) as any,
+        noop,
+        <any>{
+          rollupOnlyMode: true,
+          externalDriverFactory: async () => externalDriver,
+          contextToDbType: async () => 'postgres',
+          contextToExternalDbType: () => 'cubestore',
+        },
+      );
+
+      await api.testConnection();
+
+      expect(externalDriver.tested).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A deployment with a dedicated pre-aggregation connection leaked that driver's connection pool on every orchestrator teardown, and never connection-tested it.

- **Root cause.** `OrchestratorApi.release()` and `testConnection()` iterated `seenDataSources`, which holds plain data source names. The driver factory caches a dedicated pre-aggregation driver separately, so that driver was unreachable from either path. `addDataSeenSource()` is also called from exactly one place — the standalone readiness probe, hardcoded to `default` — so on most deployments `release()` reached no internal driver at all.
- **The fix.** `OrchestratorApi` now wraps the driver factory it is constructed with and records every driver actually requested, then releases those instances. Because the wrapper is what it passes to `QueryOrchestrator`, the query path, the pre-aggregation subsystem and the data source probe all record through it — nothing has to guess which drivers exist.
- **Release no longer goes back through the factory.** It previously called the factory to obtain the driver it was about to close, which after a failed resolution built a fresh driver — opening a connection — purely to close it. It now releases already-resolved instances and skips what never resolved. Each driver is released as it resolves, so one whose initialization hangs cannot stall the others or the orchestrator's own cleanup.
- **Teardown completes, then reports.** One driver refusing to close no longer strands the rest or the caller's cache clear, but the failure still propagates — shutdown must exit non-zero on it, and a reset must not reload over state it could not free.
- **One key rule, one place.** `driverCacheKey()` decides when a pre-aggregation request earns its own connection, and it takes that decision as an argument rather than re-deriving it, so the cache key cannot disagree with the credentials actually used. That fixes a second, order-dependent duplicate: keying on the request flag alone meant a pre-aggregation build arriving before the first query cached separately, and the next query then built another driver for the same connection — which is exactly what a refresh worker does. It also covers the case where a custom `driverFactory` takes precedence over pre-aggregation env vars, where the two requests resolve to identical credentials and must therefore share one driver. The two compensating aliasing writes this replaces are deleted; the `@pre_agg` suffix now appears once in the tree instead of twice under two different rules.

### Behaviour change worth noting

`testConnection()` now covers dedicated pre-aggregation connections, so a broken one that was previously invisible to the readiness and liveness probes will now fail them. That is the point of the change, but it is the one way a deployment could newly report unhealthy.

The same change viewed from the load side: a probe now tests every *distinct connection* a driver has been built for, where before it tested only what `addDataSeenSource` had announced — in practice just `default`, and often nothing at all. Requests that share a connection resolve to one driver and are still tested once, so the fan-out is bounded by distinct connections rather than by requests; but on a tenant with many data sources a liveness probe every few seconds now issues N round-trips instead of one. That is the intended direction — a probe that tests one connection out of N is not much of a probe — and it is the reason the union with `seenDataSources` is kept narrow.

Not in scope: `OrchestratorStorage`'s LRU has no `dispose`, so an evicted orchestrator is still never released. Closing that would need to avoid dropping pools under queries still running on the evicted orchestrator, which deserves its own change — this one makes it easier, since `release()` can now neither construct a driver nor be stalled by one.

## Test plan

- [x] New `test/unit/driver-lifecycle.test.ts` (23 tests): both drivers released and tested with a dedicated pre-aggregation connection; named data sources; a single driver for both request orders without one, and for a custom `driverFactory` overriding the env vars; release never constructing a driver (never-queried, failed-to-resolve, and the external one); an external driver that *was* used released exactly once without re-entering its factory; a failing release reported without stranding the others, and each of the three callers still completing its own teardown; the record emptied so a second release is a no-op; the readiness probe still forcing the primary connection when only the pre-aggregation driver exists; tracking bounded across repeated requests and probes; the pre-aggregation env-var scan memoized per data source; `rollupOnlyMode` unchanged.
- [x] Every test red-checked against eight wrong implementations — release-by-`seenDataSources` (the original bug), no identity dedup, release re-resolving through the factory, dropping the readiness-probe union, a cache key omitting the credentials term, a no-op release, swallowed release errors, and unbounded per-call tracking. Each is caught by a distinct group.
- [x] `cubejs-server-core` unit suites green: `driver-lifecycle`, `index`, `OrchestratorApi`, `OptsHandler`, `CompilerApi` — 99 tests. `tsc` and `eslint` clean.
- [x] `RefreshScheduler.test.ts` fails on unmodified `master` in this package (order-dependent); verified by stashing, unrelated to this diff and unchanged by it.
- [ ] CI must pass

