### PR TITLE
docs(pre-aggregations): state that every rollup must declare its own joins' keys

### DIFF
--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -428,6 +428,23 @@ cube(`orders`, {
 
 </CodeGroup>
 
+<Warning>
+
+Every rollup listed in `rollups` must declare the dimensions that its own joins
+are on, **including keys that no query selects**. Above, `orders_rollup` includes
+`CUBE.user_id` for exactly this reason: it is the key the `orders` → `users` join
+uses, even though `orders_with_users_rollup` only exposes `users.name` and
+`orders.count`.
+
+A `rollup_join` is resolved one join at a time, and each one needs a rollup
+carrying that join's key on *each* side. So on a longer chain, a cube in the
+middle has to declare the keys of *both* joins it takes part in. A rollup missing
+one of them fails with an error starting `No rollups found that can be used for`.
+The error does not point at the key that is missing, so check each rollup in
+`rollups` against the joins on the path between the cubes being joined.
+
+</Warning>
+
 <Info>
 
 `rollup_join` is not required to join cubes from the same data source; instead,


### PR DESCRIPTION
## Summary

The `rollup_join` reference never stated that every rollup listed in `rollups` must declare the dimensions its own joins are on — including keys that no query selects. The page's own example includes `CUBE.user_id` in `orders_rollup` for exactly that reason, but never says why, so the requirement was only discoverable by hitting the error.

It matters most on a longer chain: a cube in the middle takes part in two joins and has to declare both keys, one of which belongs to the *upstream* hop and appears in no query. Missing it fails with `No rollups found that can be used for a rollup join`, which reads like a product limitation rather than a schema gap — that's how cube-js/cube#11362 came to be reported as a join-chain-depth limit.

Adds a `Warning` callout under `rollup_join` stating the rule and pointing at the existing example.

## Test plan

- [x] Wording verified against the error string **both** planners actually emit on master; the
  quoted substring is the part they share, so it matches whichever planner the reader is on.
- [x] Mintlify preview renders the callout.

