### PR TITLE
docs(dashboards): document connecting dashboard controls to a cross-view chart

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -108,7 +108,7 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] built on the control's own semantic view. Charts on other views are left alone, so a dashboard can mix scoped and unscoped charts by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
-Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it.
+Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it — when there's something it can connect. If none of the controls has a match on the new chart's view, no prompt appears — the chart's controls indicator is the only signal, and you map a control to it by hand.
 
 ### Incompatible controls
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -138,7 +138,7 @@ Four states show up in the mapping sidebar:
 |---|---|
 | **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
+| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. Names match ignoring case, and only when exactly one dimension matches — two that differ only in case are ambiguous, so neither is suggested. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |
 
 Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -108,7 +108,7 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] built on the control's own semantic view. Charts on other views are left alone, so a dashboard can mix scoped and unscoped charts by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
-Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it — when there's something it can connect. If none of the controls has a match on the new chart's view, no prompt appears — the chart's controls indicator is the only signal, and you map a control to it by hand.
+Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it. If none of the controls has a same-name, same-type match on the new chart's view, no prompt appears — the chart's controls indicator is the only signal, and you map a control to it by hand.
 
 ### Incompatible controls
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -108,6 +108,8 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
+Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it.
+
 ### Incompatible controls
 
 If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Controls of the other type still apply — for example, if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa.
@@ -130,17 +132,30 @@ Open **Controls mapping** from a chart's settings menu to inspect or override th
 - **Toggle the control on or off** for the chart, even when a mapping exists
 - **Pick a different dimension** from the chart's semantic view to remap the control to
 
-Three states show up in the mapping sidebar:
+Four states show up in the mapping sidebar:
 
 | Status | What it means |
 |---|---|
 | **Mapped automatically** | The control's dimension exists on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view. The chart is unaffected by the control until you map it manually. |
+| **Suggested match** | The chart's semantic view has a dimension with the same name and type as the control's. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
+| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name match was found. The chart is unaffected by the control until you map it manually. |
+
+A suggested match never applies on its own. Two semantic views can share a dimension name and mean different things by it, so a control reaches a chart on another view only once the mapping is saved.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 
 Mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire controls across charts that use different semantic views without you needing to revisit each chart manually.
+
+### Connecting controls to a new chart
+
+When you add a chart built on a semantic view that some of the dashboard's controls don't reach, a prompt appears naming the chart, its view, and how many controls can be connected to it. It appears whenever at least one control could be connected — including when other controls already apply to the new chart:
+
+- **Connect** maps every control that has a same-name, same-type dimension on the new chart's view, in one action. The confirmation offers **Undo**, which restores the previous mappings without touching anything else you've changed since.
+- **Review…** opens the chart's [Controls mapping](#controls-mapping) with the suggestions staged, so you can accept some and pick dimensions manually for the rest.
+- **Dismiss** leaves the chart unmapped. The chart's controls indicator still shows how many controls apply, so you can connect them later.
+
+Controls with no same-name match are left unmapped rather than guessed at, and a control you'd explicitly turned off for that chart stays off.
 
 [ref-time-grain]: #time-granularity-switcher
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -139,9 +139,9 @@ Four states show up in the mapping sidebar:
 | **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
 | **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
-| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no such match was found. The chart is unaffected by the control until you map it manually. |
+| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and nothing there could be suggested. The chart is unaffected by the control until you map it manually. |
 
-Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. Names match ignoring case, and only when exactly one dimension matches — two that differ only in case are ambiguous, so neither is suggested.
+Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. An exact name match wins; failing that, names are compared ignoring case, and only a single case-insensitive candidate is suggested — several are ambiguous, so none is.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -136,9 +136,9 @@ Four states show up in the mapping sidebar:
 
 | Status | What it means |
 |---|---|
-| **Mapped automatically** | The chart's query already uses the control's dimension, so it's wired up without configuration. |
+| **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Suggested match** | The chart's semantic view has a dimension with the same name and type as the control's. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
+| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |
 
 Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -138,7 +138,7 @@ Four states show up in the mapping sidebar:
 |---|---|
 | **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
+| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is pre-selected in the dimension picker, so saving maps the control; pick a different dimension, or clear it, to override. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and nothing there could be suggested. The chart is unaffected by the control until you map it manually. |
 
 Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. Among dimensions of the control's type, an exact name match wins; failing that, names are compared ignoring case, and only a single candidate is suggested — several are ambiguous, so none is.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -141,7 +141,7 @@ Four states show up in the mapping sidebar:
 | **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and nothing there could be suggested. The chart is unaffected by the control until you map it manually. |
 
-Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. An exact name match wins; failing that, names are compared ignoring case, and only a single case-insensitive candidate is suggested — several are ambiguous, so none is.
+Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. An exact name match wins; failing that, names are compared ignoring case among dimensions of the control's type, and only a single candidate is suggested — several are ambiguous, so none is.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -141,7 +141,7 @@ Four states show up in the mapping sidebar:
 | **Suggested match** | The chart's semantic view has a dimension with the same name and type as the control's. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |
 
-Two semantic views can share a dimension name and mean different things by it, so a control reaches a chart on another view only once the mapping is saved.
+Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -106,7 +106,7 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 ## Interaction with charts
 
-When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] built on the control's own semantic view. Charts on other views are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
+When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] built on the control's own semantic view. Charts on other views are left alone, so a dashboard can mix scoped and unscoped charts by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
 Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -138,7 +138,7 @@ Four states show up in the mapping sidebar:
 |---|---|
 | **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is pre-selected in the dimension picker, so saving maps the control; pick a different dimension, or clear it, to override. |
+| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is pre-selected in the dimension picker, so saving maps the control, along with any other pending suggestions; pick a different dimension, or clear it, to override. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and nothing there could be suggested. The chart is unaffected by the control until you map it manually. |
 
 Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. Among dimensions of the control's type, an exact name match wins; failing that, names are compared ignoring case, and only a single candidate is suggested — several are ambiguous, so none is.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -3,7 +3,7 @@ title: Controls
 description: Filter and time granularity switcher widgets that let dashboard viewers change what's shown on the dashboard.
 ---
 
-Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers two control types — both target a dimension from your semantic model and apply the selected value to every [chart][ref-charts] on the dashboard whose query references that dimension.
+Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers two control types — both target a dimension from your semantic model and apply the selected value to every [chart][ref-charts] on the dashboard built on that dimension's semantic view.
 
 - [Filter](#filter) — Narrow the data shown on the dashboard
 - [Time granularity switcher](#time-granularity-switcher) — Change the granularity of time-based dimensions
@@ -106,7 +106,7 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 ## Interaction with charts
 
-When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
+When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] built on the control's own semantic view. Charts on other views are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
 Adding a chart built on a different semantic view is the case where this needs attention, so the dashboard [prompts you to connect the controls](#connecting-controls-to-a-new-chart) as you add it.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -141,7 +141,7 @@ Four states show up in the mapping sidebar:
 | **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and nothing there could be suggested. The chart is unaffected by the control until you map it manually. |
 
-Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. An exact name match wins; failing that, names are compared ignoring case among dimensions of the control's type, and only a single candidate is suggested — several are ambiguous, so none is.
+Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. Among dimensions of the control's type, an exact name match wins; failing that, names are compared ignoring case, and only a single candidate is suggested — several are ambiguous, so none is.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -139,9 +139,9 @@ Four states show up in the mapping sidebar:
 | **Mapped automatically** | The control's dimension exists on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
 | **Suggested match** | The chart's semantic view has a dimension with the same name and type as the control's. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
-| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name match was found. The chart is unaffected by the control until you map it manually. |
+| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |
 
-A suggested match never applies on its own. Two semantic views can share a dimension name and mean different things by it, so a control reaches a chart on another view only once the mapping is saved.
+Two semantic views can share a dimension name and mean different things by it, so a control reaches a chart on another view only once the mapping is saved.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 
@@ -153,9 +153,9 @@ When you add a chart built on a semantic view that some of the dashboard's contr
 
 - **Connect** maps every control that has a same-name, same-type dimension on the new chart's view, in one action. The confirmation offers **Undo**, which restores the previous mappings without touching anything else you've changed since.
 - **Review…** opens the chart's [Controls mapping](#controls-mapping) with the suggestions staged, so you can accept some and pick dimensions manually for the rest.
-- **Dismiss** leaves the chart unmapped. The chart's controls indicator still shows how many controls apply, so you can connect them later.
+- **Dismiss** leaves the mappings as they are, so the connectable controls stay unmapped. The chart's controls indicator still shows how many controls apply, so you can connect them later.
 
-Controls with no same-name match are left unmapped rather than guessed at, and a control you'd explicitly turned off for that chart stays off.
+Controls with no same-name, same-type match are left unmapped rather than guessed at, and a control you'd explicitly turned off for that chart stays off.
 
 [ref-time-grain]: #time-granularity-switcher
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -3,7 +3,7 @@ title: Controls
 description: Filter and time granularity switcher widgets that let dashboard viewers change what's shown on the dashboard.
 ---
 
-Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers two control types — both target a dimension from your semantic model and apply the selected value to every [chart][ref-charts] on the dashboard built on that dimension's semantic view.
+Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers two control types — both target a dimension from your semantic model and, by default, apply the selected value to every [chart][ref-charts] on the dashboard built on that dimension's semantic view.
 
 - [Filter](#filter) — Narrow the data shown on the dashboard
 - [Time granularity switcher](#time-granularity-switcher) — Change the granularity of time-based dimensions

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -138,10 +138,10 @@ Four states show up in the mapping sidebar:
 |---|---|
 | **Mapped automatically** | The control's own dimension is on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. Names match ignoring case, and only when exactly one dimension matches — two that differ only in case are ambiguous, so neither is suggested. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
-| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |
+| **Suggested match** | The control's dimension isn't on the chart's semantic view, but a different dimension there has the same name and type. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
+| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no such match was found. The chart is unaffected by the control until you map it manually. |
 
-Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved.
+Two semantic views can share a dimension name and mean different things by it, so a suggested match reaches a chart only once the mapping is saved. Names match ignoring case, and only when exactly one dimension matches — two that differ only in case are ambiguous, so neither is suggested.
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -136,7 +136,7 @@ Four states show up in the mapping sidebar:
 
 | Status | What it means |
 |---|---|
-| **Mapped automatically** | The control's dimension exists on the chart's semantic view, so it's wired up without configuration. |
+| **Mapped automatically** | The chart's query already uses the control's dimension, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
 | **Suggested match** | The chart's semantic view has a dimension with the same name and type as the control's. The suggestion is offered, not applied — select it (or use **Accept all**) and save to map the control. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view, and no same-name, same-type match was found. The chart is unaffected by the control until you map it manually. |


### PR DESCRIPTION
## Summary

- Documents the prompt that offers to connect a dashboard's controls when a chart built on a different semantic view is added, and its actions.
- Adds the fourth mapping-sidebar state (**Suggested match**) alongside the existing three, and says explicitly that a suggested match is offered rather than applied — two views can share a dimension name and mean different things by it, so nothing reaches a chart until the mapping is saved.

## On hold: the prompt's Connect action

The implementation has merged, so the earlier "don't ship docs for a UI nobody can find" hold is spent. One hold remains.

This page is **not accurate against merged master**. The implementation dropped the prompt's
**Connect** action — `connectControlMappings` is defined once with no callers, and the prompt renders
**Review…** and **Dismiss** only — while the *Connecting controls to a new chart* section here
still leads with "**Connect** maps every control … The confirmation offers **Undo**".

Whether Connect is gone for good or comes back is a product call, and it decides how this section
gets rewritten — or whether it ships at all. Until that is settled, this PR is on hold. Every other
gate is clear: mergeable, CI green, docs-only.

## Test plan

- [x] Rendered locally with `mint dev` and checked the page, the new section, and the cross-reference anchor
- [x] CI green — 13 checks, 0 failures, 0 pending
