### PR TITLE
feat(schema-compiler): scaffolding emits drill_members so generated models can drill

### DIFF
--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
@@ -31,12 +31,6 @@ const DRILL_ATTRIBUTE_DICTIONARY = [
   'label',
 ];
 
-/**
- * Drill members are meant to identify one row, not to mirror the whole cube — a long
- * list makes the drill table unreadable and slow.
- */
-const MAX_DRILL_MEMBERS = 5;
-
 const JOIN_RELATIONSHIP_MAP = {
   hasOne: 'one_to_one',
   has_one: 'one_to_one',
@@ -152,8 +146,12 @@ export abstract class BaseSchemaFormatter {
 
   /**
    * Members that identify one source row, in the order a user reads them: the primary
-   * key, then a few describing attributes, then the main time dimension. Mirrors the
+   * key, then the describing attributes, then the main time dimension. Mirrors the
    * shape the AI model generator authors, so both generation paths drill alike.
+   *
+   * The list is not capped — no comparable generator caps one, and the attribute
+   * dictionary already bounds it to columns that describe the row. Truncating instead
+   * drops members the user would then have to add by hand.
    *
    * Derived from the dimensions actually being rendered rather than from the ones
    * ScaffoldingSchema computed: the cube-descriptor path lets the caller drop members,
@@ -162,7 +160,8 @@ export abstract class BaseSchemaFormatter {
   protected drillMembers(dimensions: Dimension[]): Dimension[] {
     const isTime = (d: Dimension) => (d.type ?? d.types?.[0]) === 'time';
 
-    // Deduped up front: a collision resolved after capping would waste the slot it took.
+    // Deduped because dimensions render into an object keyed by member name: two columns
+    // that collapse to one name must not repeat in the drill list.
     const candidates = this.dedupeByMemberName(dimensions);
 
     const primaryKeys = candidates.filter((d) => d.isPrimaryKey);
@@ -173,18 +172,7 @@ export abstract class BaseSchemaFormatter {
     // so the first one is the row's main timestamp.
     const mainTimeDimension = candidates.filter(isTime).slice(0, 1);
 
-    // The timestamp keeps its slot on a wide table — capping the attributes rather than
-    // the whole list is what stops "when" being crowded out by "what". A composite key
-    // can still fill the list on its own, so the total is capped too.
-    const cappedAttributes = attributes.slice(
-      0,
-      Math.max(0, MAX_DRILL_MEMBERS - primaryKeys.length - mainTimeDimension.length)
-    );
-
-    return [...primaryKeys, ...cappedAttributes, ...mainTimeDimension].slice(
-      0,
-      MAX_DRILL_MEMBERS
-    );
+    return [...primaryKeys, ...attributes, ...mainTimeDimension];
   }
 
   /**

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
@@ -9,8 +9,33 @@ import {
   TableName,
   TableSchema,
 } from '../ScaffoldingSchema';
+import { MemberReference } from '../descriptors/MemberReference';
 import { ValueWithComments } from '../descriptors/ValueWithComments';
 import { toSnakeCase } from '../utils';
+
+/**
+ * Dimension names that identify or describe a single source row well enough to be
+ * worth showing when drilling into a measure. Matched as a whole word against the
+ * member name, so `status` matches `order_status` but not `statusless`.
+ */
+const DRILL_ATTRIBUTE_DICTIONARY = [
+  'name',
+  'title',
+  'status',
+  'state',
+  'type',
+  'category',
+  'code',
+  'email',
+  'description',
+  'label',
+];
+
+/**
+ * Drill members are meant to identify one row, not to mirror the whole cube — a long
+ * list makes the drill table unreadable and slow.
+ */
+const MAX_DRILL_MEMBERS = 5;
 
 const JOIN_RELATIONSHIP_MAP = {
   hasOne: 'one_to_one',
@@ -125,6 +150,69 @@ export abstract class BaseSchemaFormatter {
     return !!name.match(/^[a-z0-9_]+$/);
   }
 
+  /**
+   * Members that identify one source row, in the order a user reads them: the primary
+   * key, then a few describing attributes, then the main time dimension. Mirrors the
+   * shape the AI model generator authors, so both generation paths drill alike.
+   *
+   * Derived from the dimensions actually being rendered rather than from the ones
+   * ScaffoldingSchema computed: the cube-descriptor path lets the caller drop members,
+   * and a drill member the cube doesn't define dead-ends at click time.
+   */
+  protected drillMembers(dimensions: Dimension[]): Dimension[] {
+    const isTime = (d: Dimension) => (d.type ?? d.types?.[0]) === 'time';
+
+    // Deduped up front: a collision resolved after capping would waste the slot it took.
+    const candidates = this.dedupeByMemberName(dimensions);
+
+    const primaryKeys = candidates.filter((d) => d.isPrimaryKey);
+    const attributes = candidates.filter(
+      (d) => !d.isPrimaryKey && !isTime(d) && this.isDrillAttribute(d)
+    );
+    // Already sorted by ScaffoldingSchema (created, then updated, then the rest),
+    // so the first one is the row's main timestamp.
+    const mainTimeDimension = candidates.filter(isTime).slice(0, 1);
+
+    // The timestamp keeps its slot on a wide table — capping the attributes rather than
+    // the whole list is what stops "when" being crowded out by "what". A composite key
+    // can still fill the list on its own, so the total is capped too.
+    const cappedAttributes = attributes.slice(
+      0,
+      Math.max(0, MAX_DRILL_MEMBERS - primaryKeys.length - mainTimeDimension.length)
+    );
+
+    return [...primaryKeys, ...cappedAttributes, ...mainTimeDimension].slice(
+      0,
+      MAX_DRILL_MEMBERS
+    );
+  }
+
+  /**
+   * Dimensions are rendered into an object keyed by member name, so columns that
+   * collapse to the same name yield one dimension — the drill list must collapse too,
+   * or the drill-down repeats a column.
+   */
+  private dedupeByMemberName(dimensions: Dimension[]): Dimension[] {
+    const seen = new Set<string>();
+
+    return dimensions.filter((d) => {
+      const name = this.memberName(d);
+      if (seen.has(name)) {
+        return false;
+      }
+      seen.add(name);
+      return true;
+    });
+  }
+
+  private isDrillAttribute(dimension: Dimension): boolean {
+    const name = toSnakeCase(this.memberName(dimension));
+
+    return DRILL_ATTRIBUTE_DICTIONARY.some(
+      (word) => name === word || name.startsWith(`${word}_`) || name.endsWith(`_${word}`)
+    );
+  }
+
   protected schemaDescriptorForTable(tableSchema: TableSchema, schemaContext: SchemaContext = {}) {
     let table = `${
       tableSchema.schema?.length ? `${this.escapeName(tableSchema.schema)}.` : ''
@@ -176,13 +264,24 @@ export abstract class BaseSchemaFormatter {
       })
       .reduce((a, b) => ({ ...a, ...b }), {});
 
+    const sortedDimensions = tableSchema.dimensions.sort((a) => (a.isPrimaryKey ? -1 : 0));
+
+    const drillMembers = this.drillMembers(sortedDimensions);
+    const drillMembersProp = drillMembers.length
+      ? {
+        [this.options.snakeCase ? 'drill_members' : 'drillMembers']: drillMembers.map(
+          (m) => new MemberReference(this.memberName(m))
+        ),
+      }
+      : {};
+
     return {
       cube: tableSchema.cube,
       ...sqlOption,
       ...dataSourceProp,
 
       joins,
-      dimensions: tableSchema.dimensions.sort((a) => (a.isPrimaryKey ? -1 : 0))
+      dimensions: sortedDimensions
         .map((m) => ({
           [this.memberName(m)]: {
             sql: this.sqlForMember(m),
@@ -200,11 +299,13 @@ export abstract class BaseSchemaFormatter {
             sql: this.sqlForMember(m),
             type: m.type ?? m.types[0],
             title: this.memberTitle(m),
+            ...drillMembersProp,
           },
         }))
         .reduce((a, b) => ({ ...a, ...b }), {
           count: {
             type: 'count',
+            ...drillMembersProp,
           },
         }),
 

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/BaseSchemaFormatter.ts
@@ -13,24 +13,6 @@ import { MemberReference } from '../descriptors/MemberReference';
 import { ValueWithComments } from '../descriptors/ValueWithComments';
 import { toSnakeCase } from '../utils';
 
-/**
- * Dimension names that identify or describe a single source row well enough to be
- * worth showing when drilling into a measure. Matched as a whole word against the
- * member name, so `status` matches `order_status` but not `statusless`.
- */
-const DRILL_ATTRIBUTE_DICTIONARY = [
-  'name',
-  'title',
-  'status',
-  'state',
-  'type',
-  'category',
-  'code',
-  'email',
-  'description',
-  'label',
-];
-
 const JOIN_RELATIONSHIP_MAP = {
   hasOne: 'one_to_one',
   has_one: 'one_to_one',
@@ -145,13 +127,17 @@ export abstract class BaseSchemaFormatter {
   }
 
   /**
-   * Members that identify one source row, in the order a user reads them: the primary
-   * key, then the describing attributes, then the main time dimension. Mirrors the
-   * shape the AI model generator authors, so both generation paths drill alike.
+   * The members that identify one source row: every dimension the cube defines, with the
+   * primary key first and the time dimensions last.
    *
-   * The list is not capped — no comparable generator caps one, and the attribute
-   * dictionary already bounds it to columns that describe the row. Truncating instead
-   * drops members the user would then have to add by hand.
+   * Every dimension, deliberately. Which columns are meaningful to drill into is not
+   * recoverable from a warehouse schema — the generator would have to guess from column
+   * names, and a name is not evidence of meaning. So the set isn't narrowed at all: a
+   * member the user doesn't want is one they delete from generated output they were
+   * going to review anyway, whereas one that was never emitted is one they must know to
+   * add. Ordering is the only editorial judgement here, and it costs nothing to be wrong
+   * about — key first because it identifies the row, time last because it reads as
+   * "when".
    *
    * Derived from the dimensions actually being rendered rather than from the ones
    * ScaffoldingSchema computed: the cube-descriptor path lets the caller drop members,
@@ -165,40 +151,32 @@ export abstract class BaseSchemaFormatter {
     const candidates = this.dedupeByMemberName(dimensions);
 
     const primaryKeys = candidates.filter((d) => d.isPrimaryKey);
-    const attributes = candidates.filter(
-      (d) => !d.isPrimaryKey && !isTime(d) && this.isDrillAttribute(d)
-    );
-    // Already sorted by ScaffoldingSchema (created, then updated, then the rest),
-    // so the first one is the row's main timestamp.
-    const mainTimeDimension = candidates.filter(isTime).slice(0, 1);
+    const attributes = candidates.filter((d) => !d.isPrimaryKey && !isTime(d));
+    // All of them, in the order they render. Picking one "main" timestamp would mean
+    // ranking `created_at` above `deleted_at` by what the names suggest.
+    const timeDimensions = candidates.filter((d) => !d.isPrimaryKey && isTime(d));
 
-    return [...primaryKeys, ...attributes, ...mainTimeDimension];
+    return [...primaryKeys, ...attributes, ...timeDimensions];
   }
 
   /**
    * Dimensions are rendered into an object keyed by member name, so columns that
    * collapse to the same name yield one dimension — the drill list must collapse too,
    * or the drill-down repeats a column.
+   *
+   * Last-wins, matching the spread-reduce that renders `dimensions`: on a collision the
+   * cube keeps the later definition, so classifying off the earlier one would read
+   * `isPrimaryKey` / `isTime` from a definition the cube discarded.
    */
   private dedupeByMemberName(dimensions: Dimension[]): Dimension[] {
-    const seen = new Set<string>();
-
-    return dimensions.filter((d) => {
-      const name = this.memberName(d);
-      if (seen.has(name)) {
-        return false;
-      }
-      seen.add(name);
-      return true;
-    });
-  }
-
-  private isDrillAttribute(dimension: Dimension): boolean {
-    const name = toSnakeCase(this.memberName(dimension));
-
-    return DRILL_ATTRIBUTE_DICTIONARY.some(
-      (word) => name === word || name.startsWith(`${word}_`) || name.endsWith(`_${word}`)
-    );
+    return [
+      ...dimensions
+        .reduce(
+          (memo, d) => memo.set(this.memberName(d), d),
+          new Map<string, Dimension>()
+        )
+        .values(),
+    ];
   }
 
   protected schemaDescriptorForTable(tableSchema: TableSchema, schemaContext: SchemaContext = {}) {

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -57,7 +57,11 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
         )
       ) {
         // The caller separates keys itself — a newline here doubles the blank line.
-        return ` [${value.map((v) => this.render(v)).join(', ')}]`;
+        // Pass the array as parent so scalar elements skip the leading-space branch
+        // that indents a value after its key.
+        return ` [${value
+          .map((v) => this.render(v, level + 1, value))
+          .join(', ')}]`;
       }
 
       return `\n${value

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -36,7 +36,8 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
   protected render(
     value: SchemaDescriptor,
     level = 0,
-    parent?: SchemaDescriptor
+    parent?: SchemaDescriptor,
+    flow = false
   ) {
     const indent = Array(level * 2)
       .fill(0)
@@ -58,9 +59,10 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       ) {
         // The caller separates keys itself — a newline here doubles the blank line.
         // Pass the array as parent so scalar elements skip the leading-space branch
-        // that indents a value after its key.
+        // that indents a value after its key, and `flow` so they quote on the
+        // characters that would otherwise end an item in a flow sequence.
         return ` [${value
-          .map((v) => this.render(v, level + 1, value))
+          .map((v) => this.render(v, level + 1, value, true))
           .join(', ')}]`;
       }
 
@@ -112,14 +114,24 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       return `\n${content}`;
     }
 
-    return `${Array.isArray(parent) ? '' : ' '}${this.escapedValue(value)}`;
+    return `${Array.isArray(parent) ? '' : ' '}${this.escapedValue(
+      value,
+      flow
+    )}`;
   }
 
-  private escapedValue(value: string | number | boolean): string | number | boolean {
+  private escapedValue(
+    value: string | number | boolean,
+    flow = false
+  ): string | number | boolean {
     if (typeof value !== 'string') {
       return value;
     }
 
-    return value.match(/[{}"]/) ? `"${value.replace(/"/g, '\\"')}"` : value;
+    // `,` and `]` end an item inside a flow sequence, so a value carrying either
+    // has to be quoted there even though it is harmless in a block scalar.
+    const needsQuotes = flow ? /[{}",[\]]/ : /[{}"]/;
+
+    return value.match(needsQuotes) ? `"${value.replace(/"/g, '\\"')}"` : value;
   }
 }

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -56,7 +56,8 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
           (v) => typeof v !== 'object' || v instanceof MemberReference
         )
       ) {
-        return ` [${value.map(this.render).join(', ')}]\n`;
+        // The caller separates keys itself — a newline here doubles the blank line.
+        return ` [${value.map((v) => this.render(v)).join(', ')}]`;
       }
 
       return `\n${value

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -86,8 +86,13 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
             )}${newLine}`;
           }
 
+          const entries = Object.entries(value[key] || {});
+
+          // An empty object renders inline as `[]`, which the array branch leaves
+          // unseparated; a non-empty one ends in its own newline. Keep both apart
+          // from the next key.
           return `${indent}${key}:${this.render(
-            Object.entries(value[key] || {}).map(([ok, ov]) => ({
+            entries.map(([ok, ov]) => ({
               name: ok,
               // @ts-ignore
               ...Object.entries(ov)
@@ -96,7 +101,7 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
             })),
             level + 1,
             value
-          )}`;
+          )}${entries.length ? '' : '\n'}`;
         })
         .join('\n');
 

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
@@ -24,7 +24,8 @@ exports[`ScaffoldingTemplate JavaScript formatter big query nested fields: order
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id]
     }
   },
   
@@ -59,12 +60,14 @@ exports[`ScaffoldingTemplate JavaScript formatter escaping back tick: some_order
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id]
     },
     
     amount: {
       sql: \`amount\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drill_members: [id]
     }
   },
   
@@ -102,7 +105,8 @@ exports[`ScaffoldingTemplate JavaScript formatter should add options if passed: 
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id]
     }
   },
   
@@ -142,12 +146,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template with snake case: acco
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id]
     },
     
     failure_count: {
       sql: \`failure_count\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drill_members: [id]
     }
   },
   
@@ -185,12 +191,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template with snake case: cust
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id, name]
     },
     
     visit_count: {
       sql: \`visit_count\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drill_members: [id, name]
     }
   },
   
@@ -223,12 +231,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template with snake case: orde
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id]
     },
     
     amount: {
       sql: \`amount\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drill_members: [id]
     }
   },
   
@@ -268,12 +278,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template: Accounts.js 1`] = `
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drillMembers: [id]
     },
     
     failureCount: {
       sql: \`failure_count\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drillMembers: [id]
     }
   },
   
@@ -311,12 +323,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template: Customers.js 1`] = `
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drillMembers: [id, name]
     },
     
     visitCount: {
       sql: \`visit_count\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drillMembers: [id, name]
     }
   },
   
@@ -349,12 +363,14 @@ exports[`ScaffoldingTemplate JavaScript formatter template: Orders.js 1`] = `
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drillMembers: [id]
     },
     
     amount: {
       sql: \`amount\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drillMembers: [id]
     }
   },
   
@@ -389,7 +405,8 @@ exports[`ScaffoldingTemplate JavaScript formatter uses dimension refs instead of
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id, name]
     }
   },
   
@@ -433,12 +450,14 @@ exports[`ScaffoldingTemplate JavaScript formatter uses dimension refs instead of
   
   measures: {
     count: {
-      type: \`count\`
+      type: \`count\`,
+      drill_members: [id, test]
     },
     
     amount: {
       sql: \`amount\`,
-      type: \`sum\`
+      type: \`sum\`,
+      drill_members: [id, test]
     }
   },
   
@@ -456,7 +475,6 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for MySQL driver: a
     sql_table: public.accounts
 
     joins: []
-
     dimensions:
       - name: id
         sql: id
@@ -474,10 +492,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for MySQL driver: a
     measures:
       - name: count
         type: count
+        drill_members: [id]
 
       - name: failure_count
         sql: failure_count
         type: sum
+        drill_members: [id]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -492,7 +512,6 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: ac
     sql_table: public.accounts
 
     joins: []
-
     dimensions:
       - name: id
         sql: id
@@ -510,10 +529,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: ac
     measures:
       - name: count
         type: count
+        drill_members: [id]
 
       - name: failure_count
         sql: failure_count
         type: sum
+        drill_members: [id]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -545,10 +566,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: cu
     measures:
       - name: count
         type: count
+        drill_members: [id, name]
 
       - name: visit_count
         sql: visit_count
         type: sum
+        drill_members: [id, name]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -576,10 +599,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: or
     measures:
       - name: count
         type: count
+        drill_members: [id]
 
       - name: amount
         sql: amount
         type: sum
+        drill_members: [id]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -594,7 +619,6 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema with a catalog: acc
     sql_table: hello_catalog.public.accounts
 
     joins: []
-
     dimensions:
       - name: id
         sql: id
@@ -612,10 +636,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema with a catalog: acc
     measures:
       - name: count
         type: count
+        drill_members: [id]
 
       - name: failure_count
         sql: failure_count
         type: sum
+        drill_members: [id]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -630,7 +656,6 @@ exports[`ScaffoldingTemplate Yaml formatter uses dimension refs instead of table
     sql_table: public.customers
 
     joins: []
-
     dimensions:
       - name: id
         sql: id
@@ -644,6 +669,7 @@ exports[`ScaffoldingTemplate Yaml formatter uses dimension refs instead of table
     measures:
       - name: count
         type: count
+        drill_members: [id, name]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -680,10 +706,12 @@ exports[`ScaffoldingTemplate Yaml formatter uses dimension refs instead of table
     measures:
       - name: count
         type: count
+        drill_members: [id, test]
 
       - name: amount
         sql: amount
         type: sum
+        drill_members: [id, test]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
@@ -25,7 +25,7 @@ exports[`ScaffoldingTemplate JavaScript formatter big query nested fields: order
   measures: {
     count: {
       type: \`count\`,
-      drill_members: [id]
+      drill_members: [id, some_dimension_inside]
     }
   },
   
@@ -61,13 +61,13 @@ exports[`ScaffoldingTemplate JavaScript formatter escaping back tick: some_order
   measures: {
     count: {
       type: \`count\`,
-      drill_members: [id]
+      drill_members: [id, somedimension]
     },
     
     amount: {
       sql: \`amount\`,
       type: \`sum\`,
-      drill_members: [id]
+      drill_members: [id, somedimension]
     }
   },
   
@@ -106,7 +106,7 @@ exports[`ScaffoldingTemplate JavaScript formatter should add options if passed: 
   measures: {
     count: {
       type: \`count\`,
-      drill_members: [id]
+      drill_members: [id, some_dimension_inside]
     }
   },
   
@@ -147,13 +147,13 @@ exports[`ScaffoldingTemplate JavaScript formatter template with snake case: acco
   measures: {
     count: {
       type: \`count\`,
-      drill_members: [id]
+      drill_members: [id, username, password]
     },
     
     failure_count: {
       sql: \`failure_count\`,
       type: \`sum\`,
-      drill_members: [id]
+      drill_members: [id, username, password]
     }
   },
   
@@ -279,13 +279,13 @@ exports[`ScaffoldingTemplate JavaScript formatter template: Accounts.js 1`] = `
   measures: {
     count: {
       type: \`count\`,
-      drillMembers: [id]
+      drillMembers: [id, username, password]
     },
     
     failureCount: {
       sql: \`failure_count\`,
       type: \`sum\`,
-      drillMembers: [id]
+      drillMembers: [id, username, password]
     }
   },
   
@@ -451,13 +451,13 @@ exports[`ScaffoldingTemplate JavaScript formatter uses dimension refs instead of
   measures: {
     count: {
       type: \`count\`,
-      drill_members: [id, test]
+      drill_members: [id, test, customerkey]
     },
     
     amount: {
       sql: \`amount\`,
       type: \`sum\`,
-      drill_members: [id, test]
+      drill_members: [id, test, customerkey]
     }
   },
   
@@ -492,12 +492,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for MySQL driver: a
     measures:
       - name: count
         type: count
-        drill_members: [id]
+        drill_members: [id, username, password]
 
       - name: failure_count
         sql: failure_count
         type: sum
-        drill_members: [id]
+        drill_members: [id, username, password]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -529,12 +529,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: ac
     measures:
       - name: count
         type: count
-        drill_members: [id]
+        drill_members: [id, username, password]
 
       - name: failure_count
         sql: failure_count
         type: sum
-        drill_members: [id]
+        drill_members: [id, username, password]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -636,12 +636,12 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema with a catalog: acc
     measures:
       - name: count
         type: count
-        drill_members: [id]
+        drill_members: [id, username, password]
 
       - name: failure_count
         sql: failure_count
         type: sum
-        drill_members: [id]
+        drill_members: [id, username, password]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.
@@ -706,12 +706,12 @@ exports[`ScaffoldingTemplate Yaml formatter uses dimension refs instead of table
     measures:
       - name: count
         type: count
-        drill_members: [id, test]
+        drill_members: [id, test, customerkey]
 
       - name: amount
         sql: amount
         type: sum
-        drill_members: [id, test]
+        drill_members: [id, test, customerkey]
 
     pre_aggregations:
       # Pre-aggregation definitions go here.

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/scaffolding-template.test.ts.snap
@@ -475,6 +475,7 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for MySQL driver: a
     sql_table: public.accounts
 
     joins: []
+
     dimensions:
       - name: id
         sql: id
@@ -512,6 +513,7 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema for base driver: ac
     sql_table: public.accounts
 
     joins: []
+
     dimensions:
       - name: id
         sql: id
@@ -619,6 +621,7 @@ exports[`ScaffoldingTemplate Yaml formatter generates schema with a catalog: acc
     sql_table: hello_catalog.public.accounts
 
     joins: []
+
     dimensions:
       - name: id
         sql: id
@@ -656,6 +659,7 @@ exports[`ScaffoldingTemplate Yaml formatter uses dimension refs instead of table
     sql_table: public.customers
 
     joins: []
+
     dimensions:
       - name: id
         sql: id

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-drill-members.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-drill-members.test.ts
@@ -1,0 +1,84 @@
+import { CubeToMetaTransformer } from '../../src/compiler/CubeToMetaTransformer';
+import {
+  ScaffoldingTemplate,
+  SchemaFormat,
+} from '../../src/scaffolding/ScaffoldingTemplate';
+import { prepareCompiler } from './PrepareCompiler';
+
+const driver = {
+  quoteIdentifier: (name) => `"${name}"`,
+};
+
+const dbSchema = {
+  public: {
+    orders: [
+      { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+      { name: 'order_status', type: 'character varying', attributes: [] },
+      { name: 'amount', type: 'integer', attributes: [] },
+      { name: 'created_at', type: 'timestamp', attributes: [] },
+    ],
+  },
+};
+
+/**
+ * Generated models are only useful if Cube can actually compile them and resolve the
+ * drill members — asserting the emitted text alone would pass on output the compiler
+ * rejects, so each format is compiled here and read back out of the meta.
+ */
+describe('Scaffolding drill members resolve after compilation', () => {
+  async function metaFor(format: SchemaFormat, snakeCase: boolean) {
+    const [file] = new ScaffoldingTemplate(dbSchema, driver, {
+      format,
+      snakeCase,
+    }).generateFilesByTableNames(['public.orders']);
+
+    const { compiler, metaTransformer } = prepareCompiler({
+      content: file.content,
+      fileName: file.fileName,
+    });
+
+    await compiler.compile();
+
+    return (metaTransformer as CubeToMetaTransformer).cubes[0];
+  }
+
+  it.each([
+    ['YAML', SchemaFormat.Yaml, true],
+    ['JavaScript, snake_case', SchemaFormat.JavaScript, true],
+    ['JavaScript, camelCase', SchemaFormat.JavaScript, false],
+  ] as const)('compiles the generated %s model with drill members', async (_label, format, snakeCase) => {
+    const cube = await metaFor(format, snakeCase);
+
+    const countMeasure = cube.config.measures.find(
+      (m) => m.name.endsWith('.count')
+    );
+
+    if (!countMeasure) {
+      throw new Error('The generated cube has no count measure');
+    }
+
+    // The names resolve to real members of the generated cube — an unresolvable
+    // reference is what makes a drill-down dead-end at click time.
+    const dimensionNames = cube.config.dimensions.map((d) => d.name);
+    const { drillMembers } = countMeasure;
+
+    expect(drillMembers.length).toBeGreaterThan(0);
+    drillMembers.forEach((member) => {
+      expect(dimensionNames).toContain(member);
+    });
+
+    // Primary key first, main time dimension last.
+    expect(drillMembers[0]).toMatch(/\.id$/);
+    expect(drillMembers[drillMembers.length - 1]).toMatch(/\.created_?[aA]t$/);
+  });
+
+  it('gives the aggregate measure the same drill members as count', async () => {
+    const cube = await metaFor(SchemaFormat.Yaml, true);
+
+    const count = cube.config.measures.find((m) => m.name.endsWith('.count'));
+    const amount = cube.config.measures.find((m) => m.name.endsWith('.amount'));
+
+    expect(amount?.drillMembers?.length).toBeGreaterThan(0);
+    expect(amount?.drillMembers).toEqual(count?.drillMembers);
+  });
+});

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -507,6 +507,30 @@ describe('ScaffoldingTemplate', () => {
       expect(content).toMatch(/\n\s+joins: \[\]\n\n\s+dimensions:/);
     });
 
+    it('renders an array-valued context prop without padding its elements', () => {
+      // `SchemaContext` only declares `dataSource`, so this shape can't arrive
+      // through the typed API today — the cast is the point. Drill members are all
+      // MemberReferences and return early; a plain scalar reaches the value branch,
+      // where a missing parent reads as "value after a key" and earns a leading
+      // space: `[ alpha,  beta]`. Pinned so widening the type can't reintroduce it.
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            orders: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'amount', type: 'integer', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.orders'], {
+        tags: ['alpha', 'beta'],
+      } as any)[0];
+
+      expect(content).toContain('tags: [alpha, beta]');
+    });
+
     it('uses the camelCase key and member names when snakeCase is off', () => {
       const { content } = new ScaffoldingTemplate(
         {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -499,6 +499,14 @@ describe('ScaffoldingTemplate', () => {
       expect(content).toMatch(/- name: count\n\s+type: count\n\s+drill_members:/);
     });
 
+    it('keeps a blank line after an empty joins block, like a non-empty one', () => {
+      // `drill_members` and an empty `joins` share the inline-array branch, so a
+      // separator added there for one silently doubles up for the other.
+      const content = generate(SchemaFormat.Yaml);
+
+      expect(content).toMatch(/\n\s+joins: \[\]\n\n\s+dimensions:/);
+    });
+
     it('uses the camelCase key and member names when snakeCase is off', () => {
       const { content } = new ScaffoldingTemplate(
         {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -401,19 +401,93 @@ describe('ScaffoldingTemplate', () => {
       }).generateFilesByTableNames(['public.orders'])[0].content;
     }
 
-    it('lists the primary key first, then attributes, then the main time dimension', () => {
-      // created_at, not updated_at: ScaffoldingSchema sorts time columns by timeColumnIndex.
+    it('lists the primary key first, then the rest, then the time dimensions', () => {
       expect(generate(SchemaFormat.Yaml)).toContain(
-        'drill_members: [id, order_status, created_at]'
+        'drill_members: [id, order_status, notes, created_at, updated_at]'
       );
     });
 
-    it('leaves out dimensions that do not identify a row', () => {
+    it('keeps every time dimension rather than ranking them by name', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            things: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'deleted_at', type: 'timestamp', attributes: [] },
+              { name: 'created_at', type: 'timestamp', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.things'])[0];
+
+      // Which timestamp is the row's "when" isn't derivable from its name, so none is
+      // dropped. (They render created-first because ScaffoldingSchema sorts time columns
+      // that way — an ordering detail, not a decision about which one matters.)
+      expect(content).toContain('drill_members: [id, created_at, deleted_at]');
+    });
+
+    it('does not repeat a primary key that is also a time column', () => {
+      // Only reachable via descriptors: ScaffoldingSchema never marks a time column as a
+      // primary key, but a caller can. Without the guard it would be listed twice — once
+      // as the key, once among the timestamps.
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            snapshots: [
+              { name: 'captured_at', type: 'timestamp', attributes: [] },
+              { name: 'label', type: 'character varying', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByCubeDescriptors([
+        {
+          cube: 'snapshots',
+          tableName: 'public.snapshots',
+          table: 'snapshots',
+          schema: 'public',
+          joins: [],
+          members: [
+            {
+              name: 'captured_at',
+              title: 'Captured At',
+              memberType: MemberType.Dimension,
+              types: ['time'],
+              isPrimaryKey: true,
+            },
+            {
+              name: 'label',
+              title: 'Label',
+              memberType: MemberType.Dimension,
+              types: ['string'],
+            },
+          ],
+        },
+      ])[0];
+
+      expect(content).toContain('drill_members: [captured_at, label]');
+    });
+
+    it('drills into every dimension the cube defines, and only those', () => {
       const content = generate(SchemaFormat.Yaml);
 
-      // `notes` is still a dimension — it just isn't worth drilling into.
-      expect(content).toContain('- name: notes');
-      expect(content).not.toMatch(/drill_members: \[[^\]]*notes/);
+      const dimensions = [
+        ...content
+          .split('dimensions:')[1]
+          .split('measures:')[0]
+          .matchAll(/- name: (\w+)/g),
+      ].map((m) => m[1]);
+      const drillMembers = content
+        .match(/drill_members: \[([^\]]+)\]/)?.[1]
+        .split(', ');
+
+      // Exactly the dimension set — `notes` included, though no dictionary would have
+      // called it meaningful. Ordering differs, so compare as sets.
+      expect(dimensions).toContain('notes');
+      expect([...(drillMembers ?? [])].sort()).toEqual([...dimensions].sort());
     });
 
     it('renders drill members on every measure, including the generated count', () => {
@@ -495,17 +569,66 @@ describe('ScaffoldingTemplate', () => {
       expect(content).not.toContain('order_status');
     });
 
-    it('keeps every describing attribute on a wide table', () => {
+    it('keeps the caller\'s members and order on the descriptor path', () => {
+      const template = new ScaffoldingTemplate(drillSchema, driver, {
+        format: SchemaFormat.Yaml,
+        snakeCase: true,
+      });
+
+      // ScaffoldingSchema's type filter and time-column sort don't reach this path — the
+      // descriptor's members are passed through as sent, numeric dimensions included.
+      // They're dimensions of the cube, so they drill.
+      const { content } = template.generateFilesByCubeDescriptors([
+        {
+          cube: 'orders',
+          tableName: 'public.orders',
+          table: 'orders',
+          schema: 'public',
+          joins: [],
+          members: [
+            {
+              name: 'id',
+              title: 'Id',
+              memberType: MemberType.Dimension,
+              types: ['number'],
+              isPrimaryKey: true,
+            },
+            {
+              name: 'lat',
+              title: 'Lat',
+              memberType: MemberType.Dimension,
+              types: ['number'],
+            },
+            {
+              name: 'deleted_at',
+              title: 'Deleted At',
+              memberType: MemberType.Dimension,
+              types: ['time'],
+            },
+            {
+              name: 'created_at',
+              title: 'Created At',
+              memberType: MemberType.Dimension,
+              types: ['time'],
+            },
+          ],
+        },
+      ])[0];
+
+      expect(content).toContain('drill_members: [id, lat, deleted_at, created_at]');
+    });
+
+    it('keeps every dimension on a wide table, whatever its columns are called', () => {
       const wide = {
         public: {
           things: [
             { name: 'id', type: 'integer', attributes: ['primaryKey'] },
             { name: 'name', type: 'character varying', attributes: [] },
-            { name: 'title', type: 'character varying', attributes: [] },
-            { name: 'status', type: 'character varying', attributes: [] },
-            { name: 'category', type: 'character varying', attributes: [] },
-            { name: 'type', type: 'character varying', attributes: [] },
-            { name: 'code', type: 'character varying', attributes: [] },
+            // Deliberately opaque names: selection must not depend on recognising them.
+            { name: 'zzz_top', type: 'character varying', attributes: [] },
+            { name: 'qux', type: 'character varying', attributes: [] },
+            { name: 'blorb', type: 'character varying', attributes: [] },
+            { name: 'is_active', type: 'boolean', attributes: [] },
             { name: 'created_at', type: 'timestamp', attributes: [] },
           ],
         },
@@ -516,9 +639,36 @@ describe('ScaffoldingTemplate', () => {
         snakeCase: true,
       }).generateFilesByTableNames(['public.things'])[0];
 
-      // Nothing is truncated: primary key, every dictionary attribute, then the timestamp.
+      // Nothing is truncated and nothing is judged by its name: primary key, every other
+      // dimension in rendered order, then the timestamp.
       expect(content).toContain(
-        'drill_members: [id, name, title, status, category, type, code, created_at]'
+        'drill_members: [id, name, zzz_top, qux, blorb, is_active, created_at]'
+      );
+    });
+
+    it('drills into non-scalar columns, which the type filter treats as strings', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            events: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'payload', type: 'jsonb', attributes: [] },
+              { name: 'blob_data', type: 'bytea', attributes: [] },
+              { name: 'tags', type: 'text[]', attributes: [] },
+              { name: 'created_at', type: 'timestamp', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.events'])[0];
+
+      // `columnType` recognises numbers, booleans and times and calls everything else a
+      // string, so JSON and binary columns are dimensions — and therefore drill members.
+      // Documented rather than special-cased: excluding them means deciding a JSON column
+      // can't be worth drilling into, which is the same guess as reading its name.
+      expect(content).toContain(
+        'drill_members: [id, payload, blob_data, tags, created_at]'
       );
     });
 
@@ -561,10 +711,39 @@ describe('ScaffoldingTemplate', () => {
       ).generateFilesByTableNames(['public.things'])[0];
 
       // `user name` and `user_name` render to one member, so it appears once — and
-      // collapsing it costs none of the attributes that follow.
+      // collapsing it costs none of the members that follow.
       expect(content).toContain(
         'drill_members: [id, user_name, title, status, category, created_at]'
       );
+    });
+
+    it('classifies a collapsed member off the definition the cube keeps', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            things: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'user_name', type: 'character varying', attributes: [] },
+              // Same member name, different type. The rendered `dimensions` object is a
+              // spread-reduce, so the cube defines `user_name` as the *later* one — time.
+              { name: 'USER NAME', type: 'timestamp', attributes: [] },
+              // A plain attribute after the collision, so the two dedupe strategies are
+              // told apart by where `user_name` lands relative to it.
+              { name: 'zebra', type: 'character varying', attributes: [] },
+              { name: 'created_at', type: 'timestamp', attributes: [] },
+              { name: 'amount', type: 'integer', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.things'])[0];
+
+      // The cube defines it as time, so the drill set must classify it as time too —
+      // grouped after `zebra` with the other timestamps. Reading the discarded varchar
+      // definition would file it as an attribute, putting it ahead of `zebra` instead.
+      expect(content).toMatch(/- name: user_name\n\s+sql: .*USER NAME.*\n\s+type: time/);
+      expect(content).toContain('drill_members: [id, zebra, user_name, created_at]');
     });
 
     it('keeps a composite primary key whole, with the timestamp after it', () => {
@@ -587,11 +766,15 @@ describe('ScaffoldingTemplate', () => {
       ).generateFilesByTableNames(['public.things'])[0];
 
       // A 6-column key no longer crowds out the attribute or the timestamp. The key
-      // columns follow the order `dimensions` renders them in, whatever that is — the
-      // point here is that all of them survive, plus what comes after.
-      expect(content).toContain(
-        'drill_members: [k6, k5, k4, k3, k2, k1, name, created_at]'
-      );
+      // columns' relative order isn't a contract — `dimensions.sort((a) => …)` ignores
+      // its second argument, so the permutation is implementation-defined — assert the
+      // set and what follows it, not the order within the key.
+      const drillMembers = content
+        .match(/drill_members: \[([^\]]+)\]/)?.[1]
+        .split(', ');
+
+      expect(drillMembers?.slice(0, 6).sort()).toEqual(['k1', 'k2', 'k3', 'k4', 'k5', 'k6']);
+      expect(drillMembers?.slice(6)).toEqual(['name', 'created_at']);
     });
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -531,6 +531,34 @@ describe('ScaffoldingTemplate', () => {
       expect(content).toContain('tags: [alpha, beta]');
     });
 
+    it('quotes flow-sequence elements that would otherwise end an item', () => {
+      // `escapedValue` quotes on `{}"`, which is enough for a block scalar. In a
+      // flow sequence `,` and `]` are structural, so an unquoted element carrying
+      // one silently splits the list or truncates it.
+      const render = (tags: string[]) => {
+        const template = new ScaffoldingTemplate(
+          {
+            public: {
+              orders: [
+                { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              ],
+            },
+          },
+          driver,
+          { format: SchemaFormat.Yaml, snakeCase: true }
+        );
+
+        return template.generateFilesByTableNames(['public.orders'], {
+          tags,
+        } as any)[0].content;
+      };
+
+      expect(render(['a, b', 'c'])).toContain('tags: ["a, b", c]');
+      expect(render(['a]'])).toContain('tags: ["a]"]');
+      // Nothing structural: still unquoted.
+      expect(render(['plain', 'ok'])).toContain('tags: [plain, ok]');
+    });
+
     it('uses the camelCase key and member names when snakeCase is off', () => {
       const { content } = new ScaffoldingTemplate(
         {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -495,7 +495,7 @@ describe('ScaffoldingTemplate', () => {
       expect(content).not.toContain('order_status');
     });
 
-    it('keeps the list short on a wide table', () => {
+    it('keeps every describing attribute on a wide table', () => {
       const wide = {
         public: {
           things: [
@@ -516,14 +516,10 @@ describe('ScaffoldingTemplate', () => {
         snakeCase: true,
       }).generateFilesByTableNames(['public.things'])[0];
 
-      const drillMembers = content
-        .match(/drill_members: \[([^\]]+)\]/)?.[1]
-        .split(', ');
-
-      expect(drillMembers).toHaveLength(5);
-      expect(drillMembers?.[0]).toBe('id');
-      // The timestamp keeps its slot — attributes are what get capped.
-      expect(drillMembers?.[drillMembers.length - 1]).toBe('created_at');
+      // Nothing is truncated: primary key, every dictionary attribute, then the timestamp.
+      expect(content).toContain(
+        'drill_members: [id, name, title, status, category, type, code, created_at]'
+      );
     });
 
     it('lists a member once when two columns render to the same name', () => {
@@ -545,7 +541,7 @@ describe('ScaffoldingTemplate', () => {
       expect(content).toContain('drill_members: [id, user_name]');
     });
 
-    it('does not waste a slot on a name collision', () => {
+    it('collapses a name collision without dropping later members', () => {
       const { content } = new ScaffoldingTemplate(
         {
           public: {
@@ -564,12 +560,14 @@ describe('ScaffoldingTemplate', () => {
         { format: SchemaFormat.Yaml, snakeCase: true }
       ).generateFilesByTableNames(['public.things'])[0];
 
+      // `user name` and `user_name` render to one member, so it appears once — and
+      // collapsing it costs none of the attributes that follow.
       expect(content).toContain(
-        'drill_members: [id, user_name, title, status, created_at]'
+        'drill_members: [id, user_name, title, status, category, created_at]'
       );
     });
 
-    it('caps the list even when the primary key is composite', () => {
+    it('keeps a composite primary key whole, with the timestamp after it', () => {
       const { content } = new ScaffoldingTemplate(
         {
           public: {
@@ -588,11 +586,12 @@ describe('ScaffoldingTemplate', () => {
         { format: SchemaFormat.Yaml, snakeCase: true }
       ).generateFilesByTableNames(['public.things'])[0];
 
-      const drillMembers = content
-        .match(/drill_members: \[([^\]]+)\]/)?.[1]
-        .split(', ');
-
-      expect(drillMembers).toHaveLength(5);
+      // A 6-column key no longer crowds out the attribute or the timestamp. The key
+      // columns follow the order `dimensions` renders them in, whatever that is — the
+      // point here is that all of them survive, plus what comes after.
+      expect(content).toContain(
+        'drill_members: [k6, k5, k4, k3, k2, k1, name, created_at]'
+      );
     });
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -2,6 +2,7 @@ import {
   ScaffoldingTemplate,
   SchemaFormat,
 } from '../../src/scaffolding/ScaffoldingTemplate';
+import { MemberType } from '../../src/scaffolding/ScaffoldingSchema';
 
 const driver = {
   quoteIdentifier: (name) => `"${name}"`,
@@ -375,6 +376,223 @@ describe('ScaffoldingTemplate', () => {
       template.generateFilesByTableNames(['public.orders', 'public.customers']).forEach((it) => {
         expect(it.content).toMatchSnapshot(it.fileName);
       });
+    });
+  });
+
+  describe('drill members', () => {
+    const drillSchema = {
+      public: {
+        orders: [
+          { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+          { name: 'order_status', type: 'character varying', attributes: [] },
+          { name: 'notes', type: 'character varying', attributes: [] },
+          { name: 'amount', type: 'integer', attributes: [] },
+          { name: 'updated_at', type: 'timestamp', attributes: [] },
+          { name: 'created_at', type: 'timestamp', attributes: [] },
+        ],
+      },
+    };
+
+    function generate(format: SchemaFormat, options = {}) {
+      return new ScaffoldingTemplate(drillSchema, driver, {
+        format,
+        snakeCase: true,
+        ...options,
+      }).generateFilesByTableNames(['public.orders'])[0].content;
+    }
+
+    it('lists the primary key first, then attributes, then the main time dimension', () => {
+      // created_at, not updated_at: ScaffoldingSchema sorts time columns by timeColumnIndex.
+      expect(generate(SchemaFormat.Yaml)).toContain(
+        'drill_members: [id, order_status, created_at]'
+      );
+    });
+
+    it('leaves out dimensions that do not identify a row', () => {
+      const content = generate(SchemaFormat.Yaml);
+
+      // `notes` is still a dimension — it just isn't worth drilling into.
+      expect(content).toContain('- name: notes');
+      expect(content).not.toMatch(/drill_members: \[[^\]]*notes/);
+    });
+
+    it('renders drill members on every measure, including the generated count', () => {
+      const content = generate(SchemaFormat.Yaml);
+      const drillMembers = content.match(/drill_members:/g);
+
+      // count + amount
+      expect(drillMembers).toHaveLength(2);
+      expect(content).toMatch(/- name: count\n\s+type: count\n\s+drill_members:/);
+    });
+
+    it('uses the camelCase key and member names when snakeCase is off', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            orders: [
+              { name: 'ID', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'ORDER_STATUS', type: 'character varying', attributes: [] },
+              { name: 'amount', type: 'integer', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.JavaScript, snakeCase: false }
+      ).generateFilesByTableNames(['public.orders'])[0];
+
+      // References the rendered member names, not the raw column names.
+      expect(content).toContain('drillMembers: [id, orderStatus]');
+    });
+
+    it('omits the key entirely when nothing identifies a row', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            events: [{ name: 'amount', type: 'integer', attributes: [] }],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.events'])[0];
+
+      expect(content).not.toContain('drill_members');
+    });
+
+    it('never references a dimension the caller deselected', () => {
+      const template = new ScaffoldingTemplate(drillSchema, driver, {
+        format: SchemaFormat.Yaml,
+        snakeCase: true,
+      });
+
+      // The onboarding flow hands back an edited member list; a drill member the cube
+      // no longer defines would dead-end at click time.
+      const { content } = template.generateFilesByCubeDescriptors([
+        {
+          cube: 'orders',
+          tableName: 'public.orders',
+          table: 'orders',
+          schema: 'public',
+          joins: [],
+          members: [
+            {
+              name: 'id',
+              title: 'Id',
+              memberType: MemberType.Dimension,
+              types: ['number'],
+              isPrimaryKey: true,
+            },
+            {
+              name: 'created_at',
+              title: 'Created At',
+              memberType: MemberType.Dimension,
+              types: ['time'],
+            },
+          ],
+        },
+      ])[0];
+
+      expect(content).toContain('drill_members: [id, created_at]');
+      expect(content).not.toContain('order_status');
+    });
+
+    it('keeps the list short on a wide table', () => {
+      const wide = {
+        public: {
+          things: [
+            { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+            { name: 'name', type: 'character varying', attributes: [] },
+            { name: 'title', type: 'character varying', attributes: [] },
+            { name: 'status', type: 'character varying', attributes: [] },
+            { name: 'category', type: 'character varying', attributes: [] },
+            { name: 'type', type: 'character varying', attributes: [] },
+            { name: 'code', type: 'character varying', attributes: [] },
+            { name: 'created_at', type: 'timestamp', attributes: [] },
+          ],
+        },
+      };
+
+      const { content } = new ScaffoldingTemplate(wide, driver, {
+        format: SchemaFormat.Yaml,
+        snakeCase: true,
+      }).generateFilesByTableNames(['public.things'])[0];
+
+      const drillMembers = content
+        .match(/drill_members: \[([^\]]+)\]/)?.[1]
+        .split(', ');
+
+      expect(drillMembers).toHaveLength(5);
+      expect(drillMembers?.[0]).toBe('id');
+      // The timestamp keeps its slot — attributes are what get capped.
+      expect(drillMembers?.[drillMembers.length - 1]).toBe('created_at');
+    });
+
+    it('lists a member once when two columns render to the same name', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            things: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'user_name', type: 'character varying', attributes: [] },
+              { name: 'user name', type: 'character varying', attributes: [] },
+              { name: 'amount', type: 'integer', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.things'])[0];
+
+      expect(content).toContain('drill_members: [id, user_name]');
+    });
+
+    it('does not waste a slot on a name collision', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            things: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: 'user_name', type: 'character varying', attributes: [] },
+              { name: 'user name', type: 'character varying', attributes: [] },
+              { name: 'title', type: 'character varying', attributes: [] },
+              { name: 'status', type: 'character varying', attributes: [] },
+              { name: 'category', type: 'character varying', attributes: [] },
+              { name: 'created_at', type: 'timestamp', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.things'])[0];
+
+      expect(content).toContain(
+        'drill_members: [id, user_name, title, status, created_at]'
+      );
+    });
+
+    it('caps the list even when the primary key is composite', () => {
+      const { content } = new ScaffoldingTemplate(
+        {
+          public: {
+            things: [
+              ...['k1', 'k2', 'k3', 'k4', 'k5', 'k6'].map((name) => ({
+                name,
+                type: 'character varying',
+                attributes: ['primaryKey'],
+              })),
+              { name: 'name', type: 'character varying', attributes: [] },
+              { name: 'created_at', type: 'timestamp', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.things'])[0];
+
+      const drillMembers = content
+        .match(/drill_members: \[([^\]]+)\]/)?.[1]
+        .split(', ');
+
+      expect(drillMembers).toHaveLength(5);
     });
   });
 });


### PR DESCRIPTION
## Summary

Scaffolding declared `drillMembers` on `TableSchema` and never assigned it — the only reference to that field in the whole package. So data models generated from a warehouse schema came out with no drill members, and every measure in them was a dead end: clicking a chart point or a table cell couldn't open the underlying rows.

This makes the scaffolding formatters emit `drill_members` on each measure, including the generated `count`.

```yaml
measures:
  - name: count
    type: count
    drill_members: [id, order_status, shipping_note, carrier_ref, is_expedited, created_at, shipped_at]
```

```javascript
measures: {
  count: {
    type: `count`,
    drillMembers: [id, orderStatus, shippingNote, carrierRef, isExpedited, createdAt, shippedAt]
  }
}
```

## The drill set is every dimension the cube defines

Ordered primary key first, then the rest, then the time dimensions. Nothing is filtered out and nothing is capped.

An earlier revision of this branch chose a few "describing" attributes by matching member names against a ten-word dictionary (`name`, `status`, `category`, …). That was rejected in review, and rightly: which columns are meaningful to drill into isn't recoverable from a warehouse schema, and a column name is not evidence of meaning. Once name-based inference is off the table, no signal remains that separates a describing column from any other — cardinality and nullability are the same guess wearing a structural costume, and neither is available at generation time without extra warehouse queries.

So the set isn't narrowed. The asymmetry settles it: a member you don't want is one you delete from generated output you were going to review anyway, whereas one that was never emitted is one you have to know to add.

**Ordering is the only editorial judgement left**, and a cheap one to get wrong — key first because it identifies the row, time last because it reads as "when".

**What bounds the list** is the type filter that already existed: `ScaffoldingSchema.dimensionColumns` routes numeric columns to measures, so they never reach the drill set. Worth being precise, though — `columnType()` is a fall-through that returns `string` for anything it doesn't recognise as numeric, boolean or time, so `jsonb`, `bytea`, `text[]` and geometry columns are dimensions and therefore drill members. There's a test pinning that rather than a special case excluding them; deciding a JSON column can't be worth drilling into is the same class of guess as reading its name.

**All time dimensions are kept.** Picking a single "main" timestamp would mean delegating the choice to `ScaffoldingSchema.timeColumnIndex`, which ranks time columns by whether their names contain `create` or `update` — reintroducing the rejected mechanism, and dropping every other timestamp on the strength of a two-word list. That sort still runs, so `created_at` renders before `deleted_at`, but it now affects display order only, never membership.

**The list is deduped by rendered member name, last-wins.** Dimensions render into an object built with a spread-reduce, so on a collision the cube keeps the *later* definition. Deduping first-wins would classify the drill member (`isPrimaryKey` / `isTime`) off the definition the cube discarded — a `user_name` varchar followed by a `USER NAME` timestamp would be filed as an attribute while the cube defines it as time.

## Why the formatter and not `ScaffoldingSchema`

The declared field is left unused and the set is derived where the model is rendered, for two reasons:

1. **The final member list isn't known until then.** `generateFilesByCubeDescriptors` spreads the caller's members over the generated descriptor, so the dimensions actually emitted can be a subset chosen elsewhere — the onboarding screen where members get deselected. A set computed upstream could name a dimension the cube no longer defines: the same click-time dead end, from the other direction.
2. **Drill members must name the rendered member, not the column.** `memberName()` derives the emitted name from the title and re-cases it, so `ORDER_STATUS` renders as `orderStatus` / `order_status`. Only the formatter knows that name.

Deriving there also gives the synthetic `count` its drill set — it exists only as the formatter's `reduce` seed and never appears in `tableSchema.measures`, yet it's the measure most likely to be drilled.

Note the descriptor path has no type filter at all, since `dimensionColumns` never runs on caller-supplied members: a numeric dimension the caller sends does become a drill member. Deliberate and tested — the caller called it a dimension.

## The emitted form is a bare list, not a function

Worth recording because the validator misleads: `CubeValidator.ts` has `drillMembers: Joi.func()`, which reads as though the generator should emit a function wrapper. It shouldn't — the authored form is a bare bracket list of identifiers in JS and a plain list in YAML, and `CubePropContextTranspiler` wraps it into the function the validator sees.

## Tests

Full `cubejs-schema-compiler` unit suite green: 697 tests, 110 snapshots, 36 suites. Lint clean.

The decisive test generates a model, **compiles it with the real compiler**, and asserts every drill member resolves to a dimension of the generated cube. Text assertions alone would happily pass on output that dead-ends at click time.

Every assertion was re-verified against deliberately wrong implementations: reinstating a lexical filter (13 tests red), first-wins dedupe (1), capping to one timestamp (5), time-before-attributes (9), and dropping the primary-key guard on the time filter (1).

The snapshot churn is itself the evidence for the change — fixtures that previously emitted `drill_members: [id]` now emit `[id, username, password]`, and `[id, test]` becomes `[id, test, customerkey]`. Those columns were always dimensions of the generated cube; the dictionary was silently dropping them.

## Backward compatibility

Additive to generated output only. Scaffolding runs at generation time, so nothing already in a user's repo changes — the new key appears in newly generated cube files, which is the point.

One incidental fix: `YamlSchemaFormatter`'s inline-array branch dropped its trailing newline, which had been doubling the blank line after any array-valued key. The same expression also passed array indices into `render` as its `level`/`parent` arguments; now bound properly.
