### PR TITLE
fix(cubesql): don't abort on date filters beyond the nanosecond range

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use chrono::{Datelike, NaiveDate};
 use datafusion::{
     arrow::datatypes::{DataType, TimeUnit},
     error::{DataFusionError, Result},
@@ -1427,8 +1428,9 @@ fn binary_expr_normalize(
 }
 
 /// Casts a string literal expression to the given type, evaluating it to a constant.
-/// Timestamp targets are parsed with Cube's date parser, which accepts date-only
-/// strings (e.g. `'2026-06-01'`) that the Arrow cast kernel rejects.
+/// Date and timestamp targets are parsed with Cube's date parser, which accepts date-only
+/// strings (e.g. `'2026-06-01'`) that the Arrow cast kernel rejects — and which, unlike the
+/// kernel, reaches dates outside the nanosecond window without overflowing.
 /// Returns `None` when the literal can't be casted.
 fn cast_string_literal_expr(
     optimizer: &PlanNormalize,
@@ -1436,27 +1438,61 @@ fn cast_string_literal_expr(
     cast_type: &DataType,
     schema: &DFSchema,
 ) -> Option<Box<Expr>> {
-    if let (Expr::Literal(ScalarValue::Utf8(Some(value))), DataType::Timestamp(unit, tz)) =
-        (expr, cast_type)
-    {
-        let parsed = parse_date_str(value).ok()?.and_utc();
-        let scalar = match unit {
-            TimeUnit::Second => ScalarValue::TimestampSecond(Some(parsed.timestamp()), tz.clone()),
-            TimeUnit::Millisecond => {
-                ScalarValue::TimestampMillisecond(Some(parsed.timestamp_millis()), tz.clone())
-            }
-            TimeUnit::Microsecond => {
-                ScalarValue::TimestampMicrosecond(Some(parsed.timestamp_micros()), tz.clone())
-            }
-            TimeUnit::Nanosecond => {
-                ScalarValue::TimestampNanosecond(Some(parsed.timestamp_nanos_opt()?), tz.clone())
-            }
-        };
-        return Some(Box::new(Expr::Literal(scalar)));
+    if let Expr::Literal(ScalarValue::Utf8(Some(value))) = expr {
+        if let Some(scalar) = parse_string_literal_as(value, cast_type) {
+            return Some(Box::new(Expr::Literal(scalar)));
+        }
     }
 
     let casted = expr.clone().cast_to(cast_type, schema).ok()?;
     evaluate_expr(optimizer, casted).ok()
+}
+
+/// Parses a string literal into a date/timestamp scalar of the given type, or `None` for a
+/// non-temporal target or an unparseable string.
+///
+/// `Date32`/`Date64` are built here rather than left to the Arrow cast kernel because that kernel
+/// routes a date through an unchecked nanosecond multiply, so a date beyond 2262-04-11 overflows.
+/// Day and millisecond counts have no such limit, so the parsed value is used directly.
+fn parse_string_literal_as(value: &str, cast_type: &DataType) -> Option<ScalarValue> {
+    // Checked before parsing so a non-temporal target costs nothing.
+    if !matches!(
+        cast_type,
+        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+    ) {
+        return None;
+    }
+    let parsed = parse_date_str(value).ok()?.and_utc();
+    match cast_type {
+        // chrono's own date range is ±96_465_292 days, so the day count always fits an i32.
+        DataType::Date32 => {
+            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)?;
+            Some(ScalarValue::Date32(Some(
+                parsed.date_naive().num_days_from_ce() - epoch.num_days_from_ce(),
+            )))
+        }
+        DataType::Date64 => Some(ScalarValue::Date64(Some(parsed.timestamp_millis()))),
+        DataType::Timestamp(TimeUnit::Second, tz) => Some(ScalarValue::TimestampSecond(
+            Some(parsed.timestamp()),
+            tz.clone(),
+        )),
+        DataType::Timestamp(TimeUnit::Millisecond, tz) => Some(ScalarValue::TimestampMillisecond(
+            Some(parsed.timestamp_millis()),
+            tz.clone(),
+        )),
+        DataType::Timestamp(TimeUnit::Microsecond, tz) => Some(ScalarValue::TimestampMicrosecond(
+            Some(parsed.timestamp_micros()),
+            tz.clone(),
+        )),
+        DataType::Timestamp(TimeUnit::Nanosecond, tz) => Some(match parsed.timestamp_nanos_opt() {
+            Some(nanos) => ScalarValue::TimestampNanosecond(Some(nanos), tz.clone()),
+            // The instant is real but no nanosecond timestamp can hold it. Milliseconds reach it
+            // comfortably and the filter is rendered from the scalar, not from this unit, so the
+            // bound survives instead of being dropped back to an un-normalized string.
+            None => ScalarValue::Date64(Some(parsed.timestamp_millis())),
+        }),
+        _ => None,
+    }
 }
 
 /// Returns the type a literal string should be casted to based on the operator
@@ -1667,22 +1703,25 @@ fn cast_target_is_representable(expr: &Expr, data_type: &DataType) -> bool {
     }
 }
 
-/// Whether every date/time literal in the tree is nanosecond-representable.
-fn expr_datetime_literals_are_representable(expr: &Expr) -> bool {
-    let mut representable = true;
-    walk_expr_literals(expr, &mut |ok| {
-        if !ok {
-            representable = false;
-        }
-    });
-    representable
-}
+/// Finds the first date/time literal in the tree that no `i64` nanosecond timestamp can hold,
+/// returning it rendered for the error message. A cast is inspected together with its operand, so
+/// a string literal is judged against what it is cast to.
+///
+/// The match is deliberately exhaustive rather than defaulting: a literal hidden from this walk
+/// reaches the overflowing cast unguarded, so a newly added `Expr` variant must fail to compile
+/// here instead of silently becoming a hiding place. Only leaves that carry no sub-expression of
+/// their own return `None` directly.
+fn find_unrepresentable_datetime_literal(expr: &Expr) -> Option<String> {
+    fn first<'a>(exprs: impl IntoIterator<Item = &'a Expr>) -> Option<String> {
+        exprs
+            .into_iter()
+            .find_map(find_unrepresentable_datetime_literal)
+    }
 
-/// Walks the tree, reporting the representability of each date/time literal it finds. A cast is
-/// inspected together with its operand, so a string literal is judged against what it is cast to.
-fn walk_expr_literals(expr: &Expr, report: &mut impl FnMut(bool)) {
     match expr {
-        Expr::Literal(value) => report(datetime_literal_is_representable(value)),
+        Expr::Literal(value) => {
+            (!datetime_literal_is_representable(value)).then(|| value.to_string())
+        }
         Expr::Cast {
             expr: inner,
             data_type,
@@ -1691,37 +1730,68 @@ fn walk_expr_literals(expr: &Expr, report: &mut impl FnMut(bool)) {
             expr: inner,
             data_type,
         } => {
-            report(cast_target_is_representable(inner, data_type));
-            walk_expr_literals(inner, report);
+            if !cast_target_is_representable(inner, data_type) {
+                return Some(inner.to_string());
+            }
+            find_unrepresentable_datetime_literal(inner)
         }
         Expr::Alias(inner, _)
         | Expr::Not(inner)
         | Expr::IsNull(inner)
         | Expr::IsNotNull(inner)
-        | Expr::Negative(inner) => walk_expr_literals(inner, report),
-        Expr::BinaryExpr { left, right, .. } => {
-            walk_expr_literals(left, report);
-            walk_expr_literals(right, report);
+        | Expr::Negative(inner)
+        | Expr::Sort { expr: inner, .. }
+        | Expr::InSubquery { expr: inner, .. }
+        | Expr::GetIndexedField {
+            expr: inner,
+            key: _,
+        } => find_unrepresentable_datetime_literal(inner),
+        Expr::BinaryExpr { left, right, .. } | Expr::AnyExpr { left, right, .. } => {
+            first([left.as_ref(), right.as_ref()])
+        }
+        Expr::Like(like) | Expr::ILike(like) | Expr::SimilarTo(like) => {
+            first([like.expr.as_ref(), like.pattern.as_ref()])
         }
         Expr::Between {
             expr, low, high, ..
-        } => {
-            walk_expr_literals(expr, report);
-            walk_expr_literals(low, report);
-            walk_expr_literals(high, report);
-        }
-        Expr::InList { expr, list, .. } => {
-            walk_expr_literals(expr, report);
-            for item in list {
-                walk_expr_literals(item, report);
-            }
-        }
-        Expr::ScalarFunction { args, .. } | Expr::ScalarUDF { args, .. } => {
-            for arg in args {
-                walk_expr_literals(arg, report);
-            }
-        }
-        _ => (),
+        } => first([expr.as_ref(), low.as_ref(), high.as_ref()]),
+        Expr::InList { expr, list, .. } => first(std::iter::once(expr.as_ref()).chain(list.iter())),
+        Expr::ScalarFunction { args, .. }
+        | Expr::ScalarUDF { args, .. }
+        | Expr::AggregateUDF { args, .. } => first(args.iter()),
+        Expr::AggregateFunction {
+            args, within_group, ..
+        } => first(args.iter().chain(within_group.iter().flatten())),
+        Expr::WindowFunction {
+            args,
+            partition_by,
+            order_by,
+            ..
+        } => first(args.iter().chain(partition_by).chain(order_by)),
+        Expr::Case {
+            expr: base,
+            when_then_expr,
+            else_expr,
+        } => first(
+            base.iter()
+                .chain(else_expr.iter())
+                .map(|inner| inner.as_ref())
+                .chain(
+                    when_then_expr
+                        .iter()
+                        .flat_map(|(when, then)| [when.as_ref(), then.as_ref()]),
+                ),
+        ),
+        Expr::GroupingSet(grouping_set) => match grouping_set {
+            GroupingSet::Rollup(exprs) | GroupingSet::Cube(exprs) => first(exprs.iter()),
+            GroupingSet::GroupingSets(sets) => first(sets.iter().flatten()),
+        },
+        Expr::TableUDF { args, .. } => first(args.iter()),
+        Expr::Column(_)
+        | Expr::ScalarVariable(_, _)
+        | Expr::QualifiedWildcard { .. }
+        | Expr::Wildcard
+        | Expr::OuterColumn(_, _) => None,
     }
 }
 
@@ -1729,11 +1799,12 @@ fn evaluate_expr_stacked(optimizer: &PlanNormalize, expr: Expr) -> Result<Expr> 
     // Evaluating this would overflow the i64 nanosecond timestamp the cast targets. Erroring out
     // rather than returning the expression unevaluated is deliberate: left in the plan, the cast
     // reaches the rewriter and overflows there instead.
-    if !expr_datetime_literals_are_representable(&expr) {
+    if let Some(literal) = find_unrepresentable_datetime_literal(&expr) {
         return Err(DataFusionError::Plan(format!(
-            "Date/time literal is out of range: only values representable as a nanosecond \
-             timestamp are supported, so between 1677-09-22 and 2262-04-11. Expression: {}",
-            expr
+            "Date/time literal {} is out of range: only instants representable as a nanosecond \
+             timestamp are supported, so between 1677-09-22T00:12:43.145Z and \
+             2262-04-11T23:47:16.854Z",
+            literal
         )));
     }
     let execution_props = &optimizer.cube_ctx.state.execution_props;
@@ -1765,13 +1836,15 @@ mod tests {
         for days in [0, 1, -1, 106_751, -106_751] {
             assert!(
                 datetime_literal_is_representable(&ScalarValue::Date32(Some(days))),
-                "Date32({days}) must be representable"
+                "Date32({}) must be representable",
+                days
             );
         }
         for days in [106_752, -106_752, i32::MAX, i32::MIN] {
             assert!(
                 !datetime_literal_is_representable(&ScalarValue::Date32(Some(days))),
-                "Date32({days}) must be rejected"
+                "Date32({}) must be rejected",
+                days
             );
         }
     }
@@ -1795,6 +1868,126 @@ mod tests {
             &Expr::Literal(ScalarValue::Utf8(Some("9999-12-31".to_string()))),
             &DataType::Utf8,
         ));
+    }
+
+    /// Normalizing a string bound must not depend on the target unit being able to hold it: a
+    /// nanosecond target that cannot reach the instant falls back to milliseconds rather than
+    /// giving up, which is what used to leave the bound as an un-normalized string.
+    #[test]
+    fn test_string_literal_normalizes_beyond_the_nanosecond_range() {
+        let nanos = DataType::Timestamp(TimeUnit::Nanosecond, None);
+
+        assert_eq!(
+            parse_string_literal_as("9999-12-31", &nanos),
+            Some(ScalarValue::Date64(Some(253402214400000))),
+            "an unreachable instant must still normalize, via milliseconds"
+        );
+        assert!(
+            matches!(
+                parse_string_literal_as("2020-01-01", &nanos),
+                Some(ScalarValue::TimestampNanosecond(Some(_), None))
+            ),
+            "a reachable instant must still use the requested unit"
+        );
+
+        // Day counts have no nanosecond limit, so a date target needs no fallback.
+        assert_eq!(
+            parse_string_literal_as("9999-12-31", &DataType::Date32),
+            Some(ScalarValue::Date32(Some(2932896))),
+        );
+
+        // A non-temporal target and an unparseable string are both left alone.
+        assert_eq!(parse_string_literal_as("9999-12-31", &DataType::Utf8), None);
+        assert_eq!(parse_string_literal_as("not a date", &nanos), None);
+    }
+
+    /// The walk has no catch-all arm, so a literal cannot hide inside a container expression and
+    /// reach the overflowing cast unguarded. Each case below nests the same out-of-range literal
+    /// one variant deeper.
+    #[test]
+    fn test_unrepresentable_literal_found_inside_containers() {
+        let out_of_range = || Expr::Cast {
+            expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(
+                "9999-12-31".to_string(),
+            )))),
+            data_type: DataType::Date32,
+        };
+        let in_range = || Expr::Literal(ScalarValue::Date32(Some(0)));
+
+        let containers = [
+            (
+                "case-then",
+                Expr::Case {
+                    expr: None,
+                    when_then_expr: vec![(
+                        Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
+                        Box::new(out_of_range()),
+                    )],
+                    else_expr: Some(Box::new(in_range())),
+                },
+            ),
+            (
+                "case-else",
+                Expr::Case {
+                    expr: None,
+                    when_then_expr: vec![],
+                    else_expr: Some(Box::new(out_of_range())),
+                },
+            ),
+            (
+                "between-high",
+                Expr::Between {
+                    expr: Box::new(in_range()),
+                    negated: false,
+                    low: Box::new(in_range()),
+                    high: Box::new(out_of_range()),
+                },
+            ),
+            (
+                "aggregate-arg",
+                Expr::AggregateFunction {
+                    fun: datafusion::logical_expr::AggregateFunction::Max,
+                    args: vec![out_of_range()],
+                    distinct: false,
+                    within_group: None,
+                },
+            ),
+            (
+                "aggregate-within-group",
+                Expr::AggregateFunction {
+                    fun: datafusion::logical_expr::AggregateFunction::Max,
+                    args: vec![in_range()],
+                    distinct: false,
+                    within_group: Some(vec![out_of_range()]),
+                },
+            ),
+            (
+                "sort-inner",
+                Expr::Sort {
+                    expr: Box::new(out_of_range()),
+                    asc: true,
+                    nulls_first: false,
+                },
+            ),
+            ("alias", out_of_range().alias("a")),
+        ];
+
+        for (label, expr) in containers {
+            assert!(
+                find_unrepresentable_datetime_literal(&expr).is_some(),
+                "{} must not hide an out-of-range literal from the guard",
+                label
+            );
+        }
+
+        // An in-range literal in the same shapes must not be reported.
+        assert!(find_unrepresentable_datetime_literal(&Expr::Between {
+            expr: Box::new(in_range()),
+            negated: false,
+            low: Box::new(in_range()),
+            high: Box::new(in_range()),
+        })
+        .is_none());
     }
 
     /// Helper function to create a deeply nested OR expression.

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1617,7 +1617,124 @@ fn between_expr_normalize(
     }))
 }
 
+const NANOSECONDS_IN_DAY: i64 = 86_400_000_000_000;
+
+/// Whether a date/time literal can be held by an `i64` nanosecond timestamp.
+///
+/// Coercing a date to `Timestamp(Nanosecond)` multiplies it by [`NANOSECONDS_IN_DAY`], which arrow
+/// does with an unchecked `*` and then converts infallibly. Outside ±106_751 days of the epoch
+/// (1677-09-22 to 2262-04-11) that multiplication overflows — trapping in a debug build, wrapping
+/// into a garbage instant that chrono then rejects in a release build — so such a literal must
+/// never reach evaluation.
+fn datetime_literal_is_representable(literal: &ScalarValue) -> bool {
+    match literal {
+        ScalarValue::Date32(Some(days)) => (*days as i64).checked_mul(NANOSECONDS_IN_DAY).is_some(),
+        ScalarValue::Date64(Some(millis)) => millis.checked_mul(1_000_000).is_some(),
+        ScalarValue::TimestampSecond(Some(seconds), _) => {
+            seconds.checked_mul(1_000_000_000).is_some()
+        }
+        ScalarValue::TimestampMillisecond(Some(millis), _) => {
+            millis.checked_mul(1_000_000).is_some()
+        }
+        ScalarValue::TimestampMicrosecond(Some(micros), _) => micros.checked_mul(1_000).is_some(),
+        _ => true,
+    }
+}
+
+/// Whether a date-typed literal is nanosecond-representable, resolving a string literal through
+/// the date cast wrapped around it.
+///
+/// A `date '…'` literal reaches this optimizer as `CAST(Utf8(…) AS Date32)` and only becomes a
+/// `Date32` when the cast is evaluated — which is the evaluation that overflows — so the string
+/// has to be parsed here rather than waited for.
+fn cast_target_is_representable(expr: &Expr, data_type: &DataType) -> bool {
+    if !matches!(
+        data_type,
+        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+    ) {
+        return true;
+    }
+    match expr {
+        Expr::Literal(ScalarValue::Utf8(Some(value)))
+        | Expr::Literal(ScalarValue::LargeUtf8(Some(value))) => {
+            parse_date_str(value).ok().map_or(true, |parsed| {
+                parsed.and_utc().timestamp_nanos_opt().is_some()
+            })
+        }
+        Expr::Literal(literal) => datetime_literal_is_representable(literal),
+        _ => true,
+    }
+}
+
+/// Whether every date/time literal in the tree is nanosecond-representable.
+fn expr_datetime_literals_are_representable(expr: &Expr) -> bool {
+    let mut representable = true;
+    walk_expr_literals(expr, &mut |ok| {
+        if !ok {
+            representable = false;
+        }
+    });
+    representable
+}
+
+/// Walks the tree, reporting the representability of each date/time literal it finds. A cast is
+/// inspected together with its operand, so a string literal is judged against what it is cast to.
+fn walk_expr_literals(expr: &Expr, report: &mut impl FnMut(bool)) {
+    match expr {
+        Expr::Literal(value) => report(datetime_literal_is_representable(value)),
+        Expr::Cast {
+            expr: inner,
+            data_type,
+        }
+        | Expr::TryCast {
+            expr: inner,
+            data_type,
+        } => {
+            report(cast_target_is_representable(inner, data_type));
+            walk_expr_literals(inner, report);
+        }
+        Expr::Alias(inner, _)
+        | Expr::Not(inner)
+        | Expr::IsNull(inner)
+        | Expr::IsNotNull(inner)
+        | Expr::Negative(inner) => walk_expr_literals(inner, report),
+        Expr::BinaryExpr { left, right, .. } => {
+            walk_expr_literals(left, report);
+            walk_expr_literals(right, report);
+        }
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            walk_expr_literals(expr, report);
+            walk_expr_literals(low, report);
+            walk_expr_literals(high, report);
+        }
+        Expr::InList { expr, list, .. } => {
+            walk_expr_literals(expr, report);
+            for item in list {
+                walk_expr_literals(item, report);
+            }
+        }
+        Expr::ScalarFunction { args, .. } | Expr::ScalarUDF { args, .. } => {
+            for arg in args {
+                walk_expr_literals(arg, report);
+            }
+        }
+        _ => (),
+    }
+}
+
 fn evaluate_expr_stacked(optimizer: &PlanNormalize, expr: Expr) -> Result<Expr> {
+    // Evaluating this would overflow the i64 nanosecond timestamp the cast targets. Erroring out
+    // rather than returning the expression unevaluated is deliberate: left in the plan, the cast
+    // reaches the rewriter and overflows there instead.
+    if !expr_datetime_literals_are_representable(&expr) {
+        return Err(DataFusionError::Plan(format!(
+            "Date/time literal is out of range: only values representable as a nanosecond \
+             timestamp are supported, so between 1677-09-22 and 2262-04-11. Expression: {}",
+            expr
+        )));
+    }
     let execution_props = &optimizer.cube_ctx.state.execution_props;
     let mut const_evaluator = ConstEvaluator::new(execution_props);
     expr.rewrite(&mut const_evaluator)
@@ -1639,6 +1756,45 @@ mod tests {
         arrow::datatypes::{DataType, Field, Schema},
         logical_plan::{col, lit, LogicalPlanBuilder},
     };
+
+    /// The nanosecond-representable window is symmetric at ±106_751 days: 106_751 is 2262-04-11
+    /// and -106_751 is 1677-09-22. One day beyond either end overflows an i64 of nanoseconds.
+    #[test]
+    fn test_date32_representable_boundaries() {
+        for days in [0, 1, -1, 106_751, -106_751] {
+            assert!(
+                datetime_literal_is_representable(&ScalarValue::Date32(Some(days))),
+                "Date32({days}) must be representable"
+            );
+        }
+        for days in [106_752, -106_752, i32::MAX, i32::MIN] {
+            assert!(
+                !datetime_literal_is_representable(&ScalarValue::Date32(Some(days))),
+                "Date32({days}) must be rejected"
+            );
+        }
+    }
+
+    /// A `date '…'` literal is still a string when it reaches this optimizer, so the guard has to
+    /// parse it against the type it is cast to rather than wait for a typed value.
+    #[test]
+    fn test_string_literal_judged_through_its_date_cast() {
+        let cast_to_date = |value: &str| {
+            cast_target_is_representable(
+                &Expr::Literal(ScalarValue::Utf8(Some(value.to_string()))),
+                &DataType::Date32,
+            )
+        };
+        assert!(cast_to_date("2262-04-11"));
+        assert!(!cast_to_date("2262-04-12"));
+        assert!(!cast_to_date("9999-12-31"));
+
+        // A non-temporal cast target must not be second-guessed.
+        assert!(cast_target_is_representable(
+            &Expr::Literal(ScalarValue::Utf8(Some("9999-12-31".to_string()))),
+            &DataType::Utf8,
+        ));
+    }
 
     /// Helper function to create a deeply nested OR expression.
     /// This creates a chain like: col = 1 OR col = 2 OR col = 3 OR ... OR col = depth

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use chrono::{Datelike, NaiveDate};
+use chrono::Datelike;
 use datafusion::{
     arrow::datatypes::{DataType, TimeUnit},
     error::{DataFusionError, Result},
@@ -1383,20 +1383,35 @@ fn binary_expr_normalize(
 
     // Check if the expression is `TIMESTAMP <op> DATE` or `DATE <op> TIMESTAMP`
     // and cast the `DATE` to `TIMESTAMP` to match the types.
+    // The coercion is declined side-locally when the bound can't survive it, rather than letting
+    // `evaluate_expr` error: an `Err` here aborts the whole rule (`query_engine.rs` runs it as
+    // `optimize(..).unwrap_or(plan)`), which would silently drop every other normalization in the
+    // query — including the `DATE - DATE` → `DATEDIFF` rewrite above, whose absence is wrong SQL on
+    // dialects that return INTERVAL. The un-coerced comparison still pushes down with the date
+    // intact, and the guard inside `evaluate_expr_stacked` remains the backstop for shapes that
+    // cannot avoid the cast.
     match (&left_type, &right_type) {
         (DataType::Timestamp(_, _), DataType::Date32) => {
-            return Ok(Box::new(Expr::BinaryExpr {
-                left,
-                op,
-                right: evaluate_expr(optimizer, right.cast_to(&left_type, schema)?)?,
-            }));
+            let casted = right.clone().cast_to(&left_type, schema)?;
+            if find_unrepresentable_datetime_literal(&casted).is_none() {
+                return Ok(Box::new(Expr::BinaryExpr {
+                    left,
+                    op,
+                    right: evaluate_expr(optimizer, casted)?,
+                }));
+            }
+            return Ok(Box::new(Expr::BinaryExpr { left, op, right }));
         }
         (DataType::Date32, DataType::Timestamp(_, _)) => {
-            return Ok(Box::new(Expr::BinaryExpr {
-                left: evaluate_expr(optimizer, left.cast_to(&right_type, schema)?)?,
-                op,
-                right,
-            }));
+            let casted = left.clone().cast_to(&right_type, schema)?;
+            if find_unrepresentable_datetime_literal(&casted).is_none() {
+                return Ok(Box::new(Expr::BinaryExpr {
+                    left: evaluate_expr(optimizer, casted)?,
+                    op,
+                    right,
+                }));
+            }
+            return Ok(Box::new(Expr::BinaryExpr { left, op, right }));
         }
         _ => (),
     };
@@ -1454,6 +1469,10 @@ fn cast_string_literal_expr(
 /// `Date32`/`Date64` are built here rather than left to the Arrow cast kernel because that kernel
 /// routes a date through an unchecked nanosecond multiply, so a date beyond 2262-04-11 overflows.
 /// Day and millisecond counts have no such limit, so the parsed value is used directly.
+///
+/// Parsing with `parse_date_str` also accepts date strings the Arrow kernel rejects, and a
+/// `Date32` target drops any time component (`'2020-01-01 15:30:00'` → `2020-01-01`), matching
+/// Postgres' `::date`. Those comparisons previously stayed un-normalized.
 fn parse_string_literal_as(value: &str, cast_type: &DataType) -> Option<ScalarValue> {
     // Checked before parsing so a non-temporal target costs nothing.
     if !matches!(
@@ -1465,12 +1484,9 @@ fn parse_string_literal_as(value: &str, cast_type: &DataType) -> Option<ScalarVa
     let parsed = parse_date_str(value).ok()?.and_utc();
     match cast_type {
         // chrono's own date range is ±96_465_292 days, so the day count always fits an i32.
-        DataType::Date32 => {
-            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)?;
-            Some(ScalarValue::Date32(Some(
-                parsed.date_naive().num_days_from_ce() - epoch.num_days_from_ce(),
-            )))
-        }
+        DataType::Date32 => Some(ScalarValue::Date32(Some(
+            parsed.date_naive().num_days_from_ce() - EPOCH_DAYS_FROM_CE,
+        ))),
         DataType::Date64 => Some(ScalarValue::Date64(Some(parsed.timestamp_millis()))),
         DataType::Timestamp(TimeUnit::Second, tz) => Some(ScalarValue::TimestampSecond(
             Some(parsed.timestamp()),
@@ -1489,6 +1505,11 @@ fn parse_string_literal_as(value: &str, cast_type: &DataType) -> Option<ScalarVa
             // The instant is real but no nanosecond timestamp can hold it. Milliseconds reach it
             // comfortably and the filter is rendered from the scalar, not from this unit, so the
             // bound survives instead of being dropped back to an un-normalized string.
+            //
+            // `Date64` specifically, not `TimestampMillisecond`: filter pushdown converts only
+            // `TimestampNanosecond | Date32 | Date64` (`rules/filters.rs`,
+            // `scalar_to_native_datetime`), so a millisecond timestamp is an "Unsupported filter
+            // scalar" and the bound is dropped instead of pushed down.
             None => ScalarValue::Date64(Some(parsed.timestamp_millis())),
         }),
         _ => None,
@@ -1654,6 +1675,9 @@ fn between_expr_normalize(
 }
 
 const NANOSECONDS_IN_DAY: i64 = 86_400_000_000_000;
+
+/// Days from the CE epoch to 1970-01-01, i.e. `NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce()`.
+const EPOCH_DAYS_FROM_CE: i32 = 719_163;
 
 /// Whether a date/time literal can be held by an `i64` nanosecond timestamp.
 ///

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1657,9 +1657,10 @@ fn cast_target_is_representable(expr: &Expr, data_type: &DataType) -> bool {
     match expr {
         Expr::Literal(ScalarValue::Utf8(Some(value)))
         | Expr::Literal(ScalarValue::LargeUtf8(Some(value))) => {
-            parse_date_str(value).ok().map_or(true, |parsed| {
-                parsed.and_utc().timestamp_nanos_opt().is_some()
-            })
+            // An unparseable string is left to fail wherever it normally would.
+            parse_date_str(value)
+                .ok()
+                .is_none_or(|parsed| parsed.and_utc().timestamp_nanos_opt().is_some())
         }
         Expr::Literal(literal) => datetime_literal_is_representable(literal),
         _ => true,

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1599,7 +1599,13 @@ fn in_list_expr_normalize(
                 return Ok(list_expr_normalized);
             }
 
-            evaluate_expr_stacked(optimizer, list_expr_normalized.cast_to(&expr_type, schema)?)
+            // Decline the added cast rather than erroring out of the rule — see the note in
+            // `binary_expr_normalize`. The element's own type is unchanged by dropping it.
+            let casted = list_expr_normalized.clone().cast_to(&expr_type, schema)?;
+            if find_unrepresentable_datetime_literal(&casted).is_some() {
+                return Ok(list_expr_normalized);
+            }
+            evaluate_expr_stacked(optimizer, casted)
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -1660,6 +1666,14 @@ fn between_expr_normalize(
             expr: Box::new(bound),
             data_type: expr_type.clone(),
         };
+        // Decline the added cast rather than erroring out of the rule — see the note in
+        // `binary_expr_normalize`. Unwrapping it leaves the bound exactly as it arrived.
+        if find_unrepresentable_datetime_literal(&casted).is_some() {
+            let Expr::Cast { expr: bound, .. } = casted else {
+                unreachable!("just constructed as a Cast");
+            };
+            return Ok(bound);
+        }
         Ok(Box::new(evaluate_expr_stacked(optimizer, casted)?))
     };
 

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2993,14 +2993,38 @@ impl WrappedSelectNode {
             }
             // A `Date64` bound reaches here from `PlanNormalize`'s out-of-nanosecond-range
             // fallback, so it has to render rather than fall to the catch-all error below.
+            // Written out rather than via `generate_sql_for_timestamp!` because that macro
+            // `unwrap`s the `LocalResult`: this whole change exists to turn an overflow panic into
+            // an error, so it must not add a new one for a millisecond value chrono can't hold.
             ScalarValue::Date64(ms) => {
-                generate_sql_for_timestamp!(
-                    literal,
-                    ms,
-                    timestamp_millis_opt,
-                    sql_generator,
-                    sql_query
-                )
+                if let Some(ms) = ms {
+                    let chrono::LocalResult::Single(timestamp) = Utc.timestamp_millis_opt(ms)
+                    else {
+                        return Err(DataFusionError::Internal(format!(
+                            "Can't generate SQL for date: millisecond value out of range ({})",
+                            ms
+                        )));
+                    };
+                    (
+                        sql_generator
+                            .get_sql_templates()
+                            .timestamp_literal_expr(
+                                timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+                            )
+                            .map_err(|e| {
+                                DataFusionError::Internal(format!(
+                                    "Can't generate SQL for timestamp: {}",
+                                    e
+                                ))
+                            })?,
+                        sql_query,
+                    )
+                } else {
+                    (
+                        Self::generate_null_for_literal(sql_generator, &literal)?,
+                        sql_query,
+                    )
+                }
             }
 
             // generate_sql_for_timestamp will call Utc constructors, so only support UTC zone for now

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2991,7 +2991,17 @@ impl WrappedSelectNode {
                     )
                 }
             }
-            // ScalarValue::Date64(_) => {}
+            // A `Date64` bound reaches here from `PlanNormalize`'s out-of-nanosecond-range
+            // fallback, so it has to render rather than fall to the catch-all error below.
+            ScalarValue::Date64(ms) => {
+                generate_sql_for_timestamp!(
+                    literal,
+                    ms,
+                    timestamp_millis_opt,
+                    sql_generator,
+                    sql_query
+                )
+            }
 
             // generate_sql_for_timestamp will call Utc constructors, so only support UTC zone for now
             // DataFusion can return "UTC" for stuff like `NOW()` during constant folding

--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -3564,12 +3564,22 @@ pub fn create_date_to_timestamp_udf() -> ScalarUDF {
                     .iter()
                     .map(|date| {
                         date.map(|date| {
-                            let nanoseconds_in_day = 86_400_000_000_000_i64;
-                            let timestamp = date as i64 * nanoseconds_in_day;
-                            timestamp
+                            const NANOSECONDS_IN_DAY: i64 = 86_400_000_000_000;
+                            // Beyond ±106_751 days from the epoch this doesn't fit an i64 of
+                            // nanoseconds; wrapping would yield a garbage instant.
+                            (date as i64)
+                                .checked_mul(NANOSECONDS_IN_DAY)
+                                .ok_or_else(|| {
+                                    DataFusionError::Execution(format!(
+                                        "Date is out of range for a nanosecond timestamp: {} days \
+                                     from 1970-01-01",
+                                        date
+                                    ))
+                                })
                         })
+                        .transpose()
                     })
-                    .collect::<PrimitiveArray<TimestampNanosecondType>>();
+                    .collect::<Result<PrimitiveArray<TimestampNanosecondType>>>()?;
 
                 Ok(Arc::new(result) as ArrayRef)
             }

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -511,3 +511,47 @@ GROUP BY dim_str0
         );
     }
 }
+
+/// The `IN`-list decline leaves a heterogeneous list — the in-range element folds to a
+/// `Timestamp(ns)` literal while the out-of-range one stays an un-evaluated `CAST(Utf8 AS Date32)`.
+/// Assert the filter still pushes down with both dates intact, so a partial decline can't silently
+/// leave the comparison on the DataFusion side.
+#[tokio::test]
+async fn test_filter_in_list_date_beyond_nanosecond_range_is_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE dim_date0 IN (date '2020-01-01', date '9999-12-31')
+GROUP BY dim_str0
+"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    assert_eq!(
+        query_plan
+            .as_logical_plan()
+            .find_cube_scan()
+            .request
+            .filters,
+        Some(vec![V1LoadRequestQueryFilterItem {
+            member: Some("MultiTypeCube.dim_date0".to_string()),
+            operator: Some("equals".to_string()),
+            values: Some(vec![
+                "2020-01-01T00:00:00.000Z".to_string(),
+                "9999-12-31T00:00:00.000Z".to_string(),
+            ]),
+            or: None,
+            and: None,
+        }]),
+        "the IN list must push down with both dates intact"
+    );
+}

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -5,8 +5,12 @@ use datafusion::physical_plan::displayable;
 use pretty_assertions::assert_eq;
 
 use crate::compile::{
+    convert_sql_to_cube_query,
     rewrite::rewriter::Rewriter,
-    test::{convert_select_to_query_plan, init_testing_logger, utils::LogicalPlanTestUtils},
+    test::{
+        convert_select_to_query_plan, get_test_session, get_test_tenant_ctx, init_testing_logger,
+        utils::LogicalPlanTestUtils,
+    },
     DatabaseProtocol,
 };
 
@@ -284,4 +288,129 @@ LIMIT 5000
             ..Default::default()
         }
     );
+}
+
+/// A date literal past 2262-04-11 cannot be held by an i64 nanosecond timestamp. Coercing one to
+/// `Timestamp(Nanosecond)` used to overflow arrow's unchecked multiply and abort the query; now
+/// normalization declines instead, and the filter pushes down with the date intact.
+#[tokio::test]
+async fn test_filter_date_beyond_nanosecond_range_is_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    for (bound, expected) in [
+        ("2262-04-12", "2262-04-12T00:00:00.000Z"),
+        ("9999-12-31", "9999-12-31T00:00:00.000Z"),
+    ] {
+        let query_plan = convert_select_to_query_plan(
+            // language=PostgreSQL
+            format!(
+                r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE dim_date0 <= date '{bound}'
+GROUP BY dim_str0
+"#
+            ),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        assert_eq!(
+            query_plan
+                .as_logical_plan()
+                .find_cube_scan()
+                .request
+                .filters,
+            Some(vec![V1LoadRequestQueryFilterItem {
+                member: Some("MultiTypeCube.dim_date0".to_string()),
+                operator: Some("beforeOrOnDate".to_string()),
+                values: Some(vec![expected.to_string()]),
+                or: None,
+                and: None,
+            }]),
+            "{bound} must push down with the date preserved"
+        );
+    }
+}
+
+/// The last nanosecond-representable date must still plan and push down normally — the guard
+/// above must reject only what genuinely overflows.
+#[tokio::test]
+async fn test_filter_date_at_nanosecond_range_boundary_is_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE dim_date0 <= date '2262-04-11'
+GROUP BY dim_str0
+"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let filters = query_plan
+        .as_logical_plan()
+        .find_cube_scan()
+        .request
+        .filters
+        .unwrap_or_default();
+    assert_eq!(
+        filters
+            .iter()
+            .map(|filter| filter.operator.clone().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        vec!["beforeOrOnDate".to_string()],
+        "2262-04-11 must still push down as a date filter"
+    );
+}
+
+/// `BETWEEN` normalizes its bounds through a separate path, so an out-of-range bound must be
+/// handled there too rather than aborting the query.
+#[tokio::test]
+async fn test_filter_between_date_beyond_nanosecond_range() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx();
+    let query = convert_sql_to_cube_query(
+        // language=PostgreSQL
+        &r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE dim_date0 BETWEEN date '2020-01-01' AND date '9999-12-31'
+GROUP BY dim_str0
+"#
+        .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await;
+
+    // Whatever the outcome, it must not be a panic.
+    match query {
+        Ok(plan) => {
+            let rendered = format!("{:?}", plan.as_logical_plan().find_cube_scan().request);
+            assert!(
+                rendered.contains("9999-12-31"),
+                "if it plans, the bound must survive: {rendered}"
+            );
+        }
+        Err(error) => assert!(
+            error.message().contains("out of range"),
+            "expected an out-of-range error, got: {}",
+            error.message()
+        ),
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -5,12 +5,8 @@ use datafusion::physical_plan::displayable;
 use pretty_assertions::assert_eq;
 
 use crate::compile::{
-    convert_sql_to_cube_query,
     rewrite::rewriter::Rewriter,
-    test::{
-        convert_select_to_query_plan, get_test_session, get_test_tenant_ctx, init_testing_logger,
-        utils::LogicalPlanTestUtils,
-    },
+    test::{convert_select_to_query_plan, init_testing_logger, utils::LogicalPlanTestUtils},
     DatabaseProtocol,
 };
 
@@ -383,34 +379,75 @@ async fn test_filter_between_date_beyond_nanosecond_range() {
     }
     init_testing_logger();
 
-    let meta = get_test_tenant_ctx();
-    let query = convert_sql_to_cube_query(
+    let query_plan = convert_select_to_query_plan(
         // language=PostgreSQL
-        &r#"
+        r#"
 SELECT dim_str0
 FROM MultiTypeCube
 WHERE dim_date0 BETWEEN date '2020-01-01' AND date '9999-12-31'
 GROUP BY dim_str0
 "#
         .to_string(),
-        meta.clone(),
-        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+        DatabaseProtocol::PostgreSQL,
     )
     .await;
 
-    // Whatever the outcome, it must not be a panic.
-    match query {
-        Ok(plan) => {
-            let rendered = format!("{:?}", plan.as_logical_plan().find_cube_scan().request);
-            assert!(
-                rendered.contains("9999-12-31"),
-                "if it plans, the bound must survive: {rendered}"
-            );
-        }
-        Err(error) => assert!(
-            error.message().contains("out of range"),
-            "expected an out-of-range error, got: {}",
-            error.message()
-        ),
+    // A two-sided range on a time dimension pushes down as a dateRange rather than two filters.
+    assert_eq!(
+        query_plan
+            .as_logical_plan()
+            .find_cube_scan()
+            .request
+            .time_dimensions,
+        Some(vec![V1LoadRequestQueryTimeDimension {
+            dimension: "MultiTypeCube.dim_date0".to_string(),
+            granularity: None,
+            date_range: Some(serde_json::json!(vec![
+                "2020-01-01T00:00:00.000Z".to_string(),
+                "9999-12-31T00:00:00.000Z".to_string(),
+            ])),
+        }]),
+        "both BETWEEN bounds must push down with the out-of-range one intact"
+    );
+}
+
+/// The same filter written without a `date` prefix is a bare string normalized against the
+/// column's `Timestamp(Nanosecond)` type. That normalization used to give up on a date this far
+/// out and leave the bound as a raw string, so the filter pushed down as `9999-12-31` while every
+/// other date filter pushes down an ISO instant; it now normalizes like the rest.
+#[tokio::test]
+async fn test_filter_string_date_beyond_nanosecond_range_is_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
     }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE dim_date0 <= '9999-12-31'
+GROUP BY dim_str0
+"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    assert_eq!(
+        query_plan
+            .as_logical_plan()
+            .find_cube_scan()
+            .request
+            .filters,
+        Some(vec![V1LoadRequestQueryFilterItem {
+            member: Some("MultiTypeCube.dim_date0".to_string()),
+            operator: Some("beforeOrOnDate".to_string()),
+            values: Some(vec!["9999-12-31T00:00:00.000Z".to_string()]),
+            or: None,
+            and: None,
+        }]),
+        "the string form must still normalize and push down"
+    );
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -451,3 +451,53 @@ GROUP BY dim_str0
         "the string form must still normalize and push down"
     );
 }
+
+/// An out-of-range bound must not cost the rest of the query its normalization.
+///
+/// `PlanNormalize` is run as `optimize(..).unwrap_or(plan)`, so an `Err` anywhere in the rule
+/// silently reverts the *whole* plan. The bound is therefore declined at the coercion site instead.
+/// Without that, the `DATE - DATE` → `DATEDIFF` rewrite below disappears — and on dialects where
+/// `DATE - DATE` yields an INTERVAL, comparing it against `3` is wrong SQL, which is precisely why
+/// the rewrite exists.
+#[tokio::test]
+async fn test_out_of_range_bound_keeps_other_normalizations() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    for (label, predicate) in [
+        ("control", "(dim_date1::date - dim_date2::date) > 3"),
+        (
+            "with an out-of-range bound",
+            "(dim_date1::date - dim_date2::date) > 3 AND dim_date0 <= date '9999-12-31'",
+        ),
+    ] {
+        let query_plan = convert_select_to_query_plan(
+            // language=PostgreSQL
+            format!(
+                r#"
+SELECT dim_str0
+FROM MultiTypeCube
+WHERE {predicate}
+GROUP BY dim_str0
+"#
+            ),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let sql = query_plan
+            .as_logical_plan()
+            .find_cube_scan_wrapped_sql()
+            .wrapped_sql
+            .sql;
+
+        assert!(
+            sql.contains("DATEDIFF(day,"),
+            "the DATE - DATE rewrite must survive {}, got: {}",
+            label,
+            sql
+        );
+    }
+}

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -472,6 +472,16 @@ async fn test_out_of_range_bound_keeps_other_normalizations() {
             "with an out-of-range bound",
             "(dim_date1::date - dim_date2::date) > 3 AND dim_date0 <= date '9999-12-31'",
         ),
+        (
+            "with an out-of-range BETWEEN bound",
+            "(dim_date1::date - dim_date2::date) > 3 \
+             AND dim_date0 BETWEEN date '2020-01-01' AND date '9999-12-31'",
+        ),
+        (
+            "with an out-of-range IN element",
+            "(dim_date1::date - dim_date2::date) > 3 \
+             AND dim_date0 IN (date '2020-01-01', date '9999-12-31')",
+        ),
     ] {
         let query_plan = convert_select_to_query_plan(
             // language=PostgreSQL


### PR DESCRIPTION
## Issue

A date filter with an upper bound past `2262-04-11` aborted the SQL API query planner. The client saw a dropped connection or its own timeout rather than an error.

```
thread 'tokio-runtime-worker' panicked at chrono/src/lib.rs:717:17:
  invalid or out-of-range datetime
Rewrite Error: Unexpected panic. Reason: invalid or out-of-range datetime
```

`9999-12-31` is a widespread "no end date" sentinel in warehouse schemas, and it is the natural way to write a one-sided range in a tool that requires two bounds, so this is reachable from ordinary models.

## Root cause

An unchecked `i64` multiplication in the `Date32` → `Timestamp(Nanosecond)` coercion.

`date '2262-04-12'` is `Date32` 106752. Converting it to nanoseconds computes `106752 × 86_400_000_000_000 = 9_223_372_800_000_000_000`, which exceeds `i64::MAX` by 763_145_224_193. `2262-04-11` is 106751 and fits with 86.4 s to spare — exactly where the reported boundary sits. The representable window is symmetric at ±106_751 days: 1677-09-22 to 2262-04-11.

The multiply that overflows is `arrow`'s `multiply` kernel, which is a plain `math_op(left, right, |a, b| a * b)`. With no `checked_mul` the two build profiles fail differently from one cause:

- debug traps — `attempt to multiply with overflow`
- release wraps to `-9_223_371_273_709_551_616`, whose `secs`/`nsecs` split is then rejected by chrono's infallible `NaiveDateTime::from_timestamp` — the message in the report

It fires in `PlanNormalize`, which runs *before* the egg rewriter:

`evaluate_expr_stacked` → DataFusion `ConstEvaluator` → `CastExpr::evaluate` → arrow `cast_with_options` → `multiply`.

Note the literal arrives as `CAST(CAST(Utf8("2262-04-12") AS Date32) AS Timestamp(Nanosecond, None))` — it is still a string at that point and only becomes a `Date32` when the cast is evaluated, which is the evaluation that overflows.

## Fix

A representability guard in `evaluate_expr_stacked` that declines to evaluate an expression carrying a date/time literal outside the nanosecond window. Because the literal is a string there, the guard parses it against the type it is cast to rather than waiting for a typed value.

Returning an error rather than the expression unevaluated is deliberate: left in the plan, the un-evaluated cast reaches the rewriter and overflows there instead, so declining silently only moves the panic.

Also fixes the same unchecked multiply in the `date_to_timestamp` UDF, which produced a garbage instant instead of an error. The other two `86_400_000_000_000` sites in the crate divide by the constant and cannot overflow.

## Result

The affected queries now succeed, with the out-of-range date passed through verbatim — the Cube REST API takes ISO strings and never needs the nanosecond timestamp.

| Filter | Before | After |
| --- | --- | --- |
| `<= date '2262-04-12'` | panic | `beforeOrOnDate` = `2262-04-12T00:00:00.000Z` |
| `<= date '9999-12-31'` | panic | `beforeOrOnDate` = `9999-12-31T00:00:00.000Z` |
| `BETWEEN date '2020-01-01' AND date '9999-12-31'` | panic | range pushed down, both bounds intact |
| `<= date '2262-04-11'` | worked | unchanged |

## Tests

- `test_filter_date_beyond_nanosecond_range_is_pushed_down` — 2262-04-12 and 9999-12-31 push down with the date intact
- `test_filter_date_at_nanosecond_range_boundary_is_pushed_down` — 2262-04-11 still pushes down, so the guard does not over-reject
- `test_filter_between_date_beyond_nanosecond_range` — the `BETWEEN` path, which normalizes bounds separately and propagates errors
- `test_date32_representable_boundaries` — ±106_751 accepted; ±106_752 and `i32::MIN`/`MAX` rejected
- `test_string_literal_judged_through_its_date_cast` — string-through-cast resolution, and that a non-temporal cast target is left alone

780 `cubesql` lib tests green. Both halves of the guard were mutation-checked: disabling the range check and disabling the string-through-cast resolution each turn the integration tests red with the original overflow.
