### PR TITLE
fix(query-orchestrator): enforce rollup-only mode on the streaming query path

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
@@ -184,6 +184,22 @@ export class QueryOrchestrator {
   }
 
   /**
+   * In rollup only mode a query that matched no pre-aggregation must fail rather
+   * than fall through to the source database, so that losing acceleration is
+   * loud instead of silently expensive. Both query entry points enforce it.
+   *
+   * @throw Error
+   */
+  private checkRollupOnlyMode(preAggregationsTablesToTempTables: PreAggTableToTempTable[]): void {
+    if (this.rollupOnlyMode && preAggregationsTablesToTempTables.length === 0) {
+      throw new Error(
+        'No pre-aggregation table has been built for this query yet. ' +
+        'Please check your refresh worker configuration if it persists.'
+      );
+    }
+  }
+
+  /**
    * Returns stream object which will be used to stream results from
    * the data source if applicable. Throw otherwise.
    *
@@ -194,6 +210,10 @@ export class QueryOrchestrator {
       preAggregationsTablesToTempTables,
       values,
     } = await this.preAggregations.loadAllPreAggregationsIfNeeded(query);
+
+    // Before the stream is created, so a miss can still be returned as an error.
+    this.checkRollupOnlyMode(preAggregationsTablesToTempTables);
+
     query.values = values || query.values;
     const _stream = await this.queryCache.cachedQueryResult(
       query,
@@ -215,6 +235,8 @@ export class QueryOrchestrator {
       values,
     } = await this.preAggregations.loadAllPreAggregationsIfNeeded(queryBody);
 
+    this.checkRollupOnlyMode(preAggregationsTablesToTempTables);
+
     if (values) {
       queryBody = {
         ...queryBody,
@@ -234,13 +256,6 @@ export class QueryOrchestrator {
         lastUpdatedAt: pa.lastUpdatedAt,
       })),
     )(preAggregationsTablesToTempTables);
-
-    if (this.rollupOnlyMode && Object.keys(usedPreAggregations).length === 0) {
-      throw new Error(
-        'No pre-aggregation table has been built for this query yet. ' +
-        'Please check your refresh worker configuration if it persists.'
-      );
-    }
 
     let lastRefreshTimestamp = getLastUpdatedAtTimestamp(
       preAggregationsTablesToTempTables.map(pa => pa[1].lastUpdatedAt)

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestratorRollupOnly.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestratorRollupOnly.test.ts
@@ -172,8 +172,11 @@ describe('QueryOrchestrator rollup only mode', () => {
     ).rejects.toThrow(rollupOnlyError);
   });
 
-  // The SQL API's native transport retries any error whose message contains
-  // "continue wait", so a miss worded that way would spin instead of failing.
+  // The SQL API's native transport retries an error whose message IS
+  // "continue wait" (`scan.rs` compares the whole string, case-insensitively),
+  // so a miss worded that way would spin instead of failing. The assertion
+  // below is deliberately stricter than that equality: a message merely
+  // mentioning a continue wait would be misleading even where it can't retry.
   test('the miss error is not mistaken for a continue wait', async () => {
     await expect(
       rollupOnlyOrchestrator.streamQuery(missQuery('rollup only wording'))

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestratorRollupOnly.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestratorRollupOnly.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { QueryOrchestrator } from '../../src/orchestrator/QueryOrchestrator';
+
+/**
+ * Rollup only mode must fail a pre-aggregation miss on BOTH query entry points.
+ * `streamQuery` (the SQL API transport) used to skip the check and fall through
+ * to the source database, so losing acceleration was silent.
+ */
+
+class MockDriver {
+  public tables: string[] = [];
+
+  public executedQueries: string[] = [];
+
+  public now: number = Date.now();
+
+  public schema: string | null = null;
+
+  public query(query: string): Promise<string[]> & { cancel?: () => Promise<void> } {
+    this.executedQueries.push(query);
+    const promise: Promise<string[]> & { cancel?: () => Promise<void> } = Promise.resolve([query]);
+    promise.cancel = async () => undefined;
+    return promise;
+  }
+
+  public async getTablesQuery(schema: string) {
+    return this.tables.map(t => ({ table_name: t.replace(`${schema}.`, '') }));
+  }
+
+  public async createSchemaIfNotExists(schema: string) {
+    this.schema = schema;
+    return null;
+  }
+
+  public loadPreAggregationIntoTable(preAggregationTableName: string, loadSql: string) {
+    this.tables.push(preAggregationTableName.substring(0, 100));
+    return this.query(loadSql);
+  }
+
+  public async dropTable(tableName: string) {
+    this.tables = this.tables.filter(t => t !== tableName);
+    return this.query(`DROP TABLE ${tableName}`);
+  }
+
+  public async downloadTable(table: string) {
+    return { rows: await this.query(`SELECT * FROM ${table}`) };
+  }
+
+  public async tableColumnTypes(_table: string) {
+    return [];
+  }
+
+  public async uploadTable(table: string, columns: any, _tableData: any) {
+    await this.createTable(table, columns);
+  }
+
+  public createTable(quotedTableName: string, _columns: any) {
+    this.tables.push(quotedTableName);
+  }
+
+  public readOnly() {
+    return false;
+  }
+
+  public nowTimestamp() {
+    return this.now;
+  }
+
+  public async release() {
+    return undefined;
+  }
+}
+
+const currentHourQuery = [
+  'SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour',
+  [],
+];
+
+// Partial query bodies: these fixtures carry only the fields the orchestrator reads
+// on the way to the rollup-only guard, so they're cast rather than fully populated.
+// No `preAggregations`, so nothing is loaded and the query hits the source database.
+const missQuery = (requestId: string): any => ({
+  query: 'SELECT "orders__status" "orders__status", count("orders".id) "orders__count" FROM public.orders AS "orders" GROUP BY 1 ORDER BY 1 ASC LIMIT 10000',
+  values: [],
+  cacheKeyQueries: {
+    renewalThreshold: 21600,
+    queries: [currentHourQuery],
+  },
+  preAggregations: [],
+  cacheMode: 'must-revalidate' as const,
+  requestId,
+});
+
+const hitQuery = (requestId: string): any => ({
+  query: 'SELECT "orders__status" "orders__status", sum("orders__count") "orders__count" FROM (SELECT * FROM stb_pre_aggregations.orders_status_and_count) as partition_union GROUP BY 1 ORDER BY 1 ASC LIMIT 10000',
+  values: [],
+  cacheKeyQueries: {
+    renewalThreshold: 21600,
+    queries: [currentHourQuery],
+  },
+  preAggregations: [{
+    preAggregationsSchema: 'stb_pre_aggregations',
+    tableName: 'stb_pre_aggregations.orders_status_and_count',
+    loadSql: ['CREATE TABLE stb_pre_aggregations.orders_status_and_count AS SELECT\n      "orders".status "orders__status", count("orders".id) "orders__count"\n    FROM\n      public.orders AS "orders" GROUP BY 1', []],
+    invalidateKeyQueries: [currentHourQuery],
+  }],
+  cacheMode: 'must-revalidate' as const,
+  requestId,
+});
+
+const rollupOnlyError = /No pre-aggregation table has been built for this query yet/;
+
+describe('QueryOrchestrator rollup only mode', () => {
+  jest.setTimeout(15000);
+
+  let mockDriver: MockDriver;
+  let externalMockDriver: MockDriver;
+  let rollupOnlyOrchestrator: QueryOrchestrator;
+  let orchestrator: QueryOrchestrator;
+  let testCount = 1;
+
+  beforeEach(() => {
+    mockDriver = new MockDriver();
+    externalMockDriver = new MockDriver();
+
+    const redisPrefix = `ROLLUP_ONLY_TEST_${testCount++}`;
+    const driverFactory = (() => mockDriver) as any;
+    const logger = (msg: string, params: any) => console.log(new Date().toJSON(), msg, params);
+    const options = {
+      externalDriverFactory: (() => externalMockDriver) as any,
+      queryCacheOptions: {
+        queueOptions: () => ({ concurrency: 2 }),
+      },
+      preAggregationsOptions: {
+        maxPartitions: 100,
+        queueOptions: () => ({ executionTimeout: 2, concurrency: 2 }),
+        usedTablePersistTime: 1,
+      },
+    };
+
+    rollupOnlyOrchestrator = new QueryOrchestrator(
+      redisPrefix,
+      driverFactory,
+      logger,
+      { ...options, rollupOnlyMode: true },
+    );
+    orchestrator = new QueryOrchestrator(
+      `${redisPrefix}_OFF`,
+      driverFactory,
+      logger,
+      options,
+    );
+  });
+
+  afterEach(async () => {
+    await rollupOnlyOrchestrator.cleanup();
+    await orchestrator.cleanup();
+  });
+
+  test('rejects a pre-aggregation miss on streamQuery', async () => {
+    await expect(
+      rollupOnlyOrchestrator.streamQuery(missQuery('rollup only stream miss'))
+    ).rejects.toThrow(rollupOnlyError);
+
+    // The guard runs before the stream exists, so the source database is never queried.
+    expect(mockDriver.executedQueries.join('\n')).not.toMatch(/FROM public\.orders AS "orders" GROUP BY 1/);
+  });
+
+  test('rejects a pre-aggregation miss on fetchQuery', async () => {
+    await expect(
+      rollupOnlyOrchestrator.fetchQuery(missQuery('rollup only fetch miss'))
+    ).rejects.toThrow(rollupOnlyError);
+  });
+
+  // The SQL API's native transport retries any error whose message contains
+  // "continue wait", so a miss worded that way would spin instead of failing.
+  test('the miss error is not mistaken for a continue wait', async () => {
+    await expect(
+      rollupOnlyOrchestrator.streamQuery(missQuery('rollup only wording'))
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringMatching(/continue wait/i),
+      })
+    );
+  });
+
+  test('serves streamQuery when a pre-aggregation matched', async () => {
+    const result = await rollupOnlyOrchestrator.streamQuery(hitQuery('rollup only stream hit'));
+
+    expect(result).toBeDefined();
+    expect(
+      mockDriver.tables.concat(externalMockDriver.tables).join('\n')
+    ).toMatch(/orders_status_and_count/);
+  });
+
+  test('lets a pre-aggregation miss fall through when rollup only mode is off', async () => {
+    const result = await orchestrator.fetchQuery(missQuery('rollup only disabled'));
+
+    expect(result.data[0]).toMatch(/FROM public\.orders AS "orders"/);
+  });
+});

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -62,7 +62,20 @@ export class OrchestratorApi {
    */
   public async streamQuery(query: QueryBody): Promise<stream.Writable> {
     // TODO merge with fetchQuery
-    return this.orchestrator.streamQuery(query);
+    try {
+      return await this.orchestrator.streamQuery(query);
+    } catch (err) {
+      this.logger('Error querying db', {
+        query: query.query?.replace(/\s+/g, ' '),
+        params: query.values,
+        error: ((err as Error).stack || err),
+        requestId: query.requestId,
+      });
+
+      // Shaped like executeQuery's rejection so the gateway reports a query
+      // error rather than falling through to its Internal Server Error branch.
+      throw { error: (err as Error).toString() };
+    }
   }
 
   /**

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -66,9 +66,13 @@ export class OrchestratorApi {
       return await this.orchestrator.streamQuery(query);
     } catch (err) {
       // A pre-aggregation still building is not a query error. `executeQuery`
-      // logs it as 'Continue wait' rather than a failure, and the gateway keys
-      // its retryable 200 off `err.message === 'Continue wait'` — which only
-      // survives if the error reaches it unwrapped.
+      // logs it as 'Continue wait' rather than a failure, and `ApiGateway.stream`
+      // keys its retryable 200 off `err.message === 'Continue wait'` — which
+      // only survives if the error reaches it unwrapped.
+      //
+      // `ApiGateway.load`, the other caller, does not normalize it and reports
+      // a building pre-aggregation as a 500. That is pre-existing and not this
+      // guard's to fix; rethrowing is simply never worse than wrapping.
       if (err instanceof ContinueWaitError) {
         this.logger('Continue wait', {
           query: query.query?.replace(/\s+/g, ' '),

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -65,6 +65,20 @@ export class OrchestratorApi {
     try {
       return await this.orchestrator.streamQuery(query);
     } catch (err) {
+      // A pre-aggregation still building is not a query error. `executeQuery`
+      // logs it as 'Continue wait' rather than a failure, and the gateway keys
+      // its retryable 200 off `err.message === 'Continue wait'` — which only
+      // survives if the error reaches it unwrapped.
+      if (err instanceof ContinueWaitError) {
+        this.logger('Continue wait', {
+          query: query.query?.replace(/\s+/g, ' '),
+          params: query.values,
+          requestId: query.requestId,
+        });
+
+        throw err;
+      }
+
       this.logger('Error querying db', {
         query: query.query?.replace(/\s+/g, ' '),
         params: query.values,

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -1,3 +1,5 @@
+import { ContinueWaitError } from '@cubejs-backend/query-orchestrator';
+
 import { OrchestratorApi } from '../../src/core/OrchestratorApi';
 
 describe('OrchestratorApi', () => {
@@ -14,5 +16,52 @@ describe('OrchestratorApi', () => {
     // dataSource to 'default', so calls without one keep working.
     await api.getPreAggregationQueueStates();
     expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith(undefined);
+  });
+
+  describe('streamQuery', () => {
+    const buildApi = (streamQuery: jest.Mock) => {
+      const api = Object.create(OrchestratorApi.prototype);
+      api.orchestrator = { streamQuery };
+      api.logger = jest.fn();
+      return api;
+    };
+
+    // A pre-aggregation still building reaches `streamQuery` as a
+    // `ContinueWaitError`. The gateway turns it into a retryable 200 by testing
+    // `err.message === 'Continue wait'` (gateway.ts), and cubesql retries only
+    // on that exact string (scan.rs `eq_ignore_ascii_case("continue wait")`).
+    // Wrapping it into `{ error: ... }` would drop `message`, so the query
+    // would fail with a 400 instead of waiting for the build.
+    test('lets a ContinueWaitError through unwrapped, so the SQL API still retries', async () => {
+      const api = buildApi(jest.fn().mockRejectedValue(new ContinueWaitError()));
+
+      await expect(api.streamQuery({ query: 'SELECT 1' })).rejects.toThrow(ContinueWaitError);
+
+      const err = await api.streamQuery({ query: 'SELECT 1' }).catch((e: any) => e);
+      expect(err.message).toBe('Continue wait');
+
+      // Logged as a wait, not as a failure — matching what `executeQuery` does
+      // for the same condition.
+      expect(api.logger).toHaveBeenCalledWith('Continue wait', expect.anything());
+      expect(api.logger).not.toHaveBeenCalledWith('Error querying db', expect.anything());
+    });
+
+    // Every other failure keeps the shape `executeQuery` rejects with, so the
+    // gateway reports a query error rather than an Internal Server Error.
+    test('wraps any other error the way executeQuery does', async () => {
+      const api = buildApi(jest.fn().mockRejectedValue(new Error('Boom')));
+
+      const err = await api.streamQuery({ query: 'SELECT 1' }).catch((e: any) => e);
+      expect(err).toEqual({ error: 'Error: Boom' });
+      expect(api.logger).toHaveBeenCalledWith('Error querying db', expect.anything());
+    });
+
+    test('returns the stream untouched when nothing throws', async () => {
+      const _stream = { pipe: jest.fn() };
+      const api = buildApi(jest.fn().mockResolvedValue(_stream));
+
+      await expect(api.streamQuery({ query: 'SELECT 1' })).resolves.toBe(_stream);
+      expect(api.logger).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
`CUBEJS_ROLLUP_ONLY=true` is meant to make a pre-aggregation miss **fail** instead of falling through to the source database. On the streaming path it did nothing: the query ran against the warehouse and returned correct rows, so an operator got no signal that acceleration had been lost.

`QueryOrchestrator` has two entry points that both load pre-aggregations, but only one applied the guard. `fetchQuery` checked `rollupOnlyMode` after deriving `usedPreAggregations`; `streamQuery` called the identical `loadAllPreAggregationsIfNeeded` and then went straight to `cachedQueryResult`, never checking. That check was the only enforcement site in the codebase, so anything reaching the orchestrator through `streamQuery` bypassed rollup-only completely — and `streamQuery` is the streaming / SQL API path, reached from the two `persistent: true` call sites in `ApiGateway`.

The bypass is the transport, not the planner. Multi-stage matching already fails closed — Tesseract's all-or-nothing rollback returns empty usages, which `fetchQuery` rejects — so this affected any query over the streaming path, multi-stage or not.

This matters beyond a missed optimisation: rollup-only is a cost-control and SLA guarantee, and it also disables source-database connection testing. A deployment could therefore be configured as if the warehouse were unreachable while still querying it on every SQL API request.

## What changed

The miss check is extracted into one `checkRollupOnlyMode` method and called from **both** entry points. In `streamQuery` it runs after pre-aggregations are loaded but before the stream is created, which is where an error can still be returned to the caller rather than surfacing mid-flight; the error message is unchanged, so a miss now looks the same whichever transport was used.

The guard tests `preAggregationsTablesToTempTables.length` rather than re-deriving `usedPreAggregations`. That derivation feeds two response shapes that only `fetchQuery` needs, and the emptiness condition is equivalent — `R.fromPairs` can collapse duplicate keys but never turns a non-empty array into zero keys — so the cheaper test is the same boolean, not an approximation of it.

`OrchestratorApi.streamQuery` now normalises a thrown error the way `executeQuery` already does. Without it, this failure reached `ApiGateway.handleError` as a bare `Error` and was reported as a 500 "Internal Server Error" with a stack, while the identical miss on `/v1/load` is a query error. The message the SQL client receives was already correct; the server-side log was not.

## Behaviour change

**A rollup-only deployment whose SQL API queries were silently missing pre-aggregations will now see those queries fail.** That is the point of the setting, and it is the same error `/v1/load` has always raised, so nothing new needs handling on the client. The fix reveals a pre-existing miss rather than creating one — but it is worth calling out for anyone who had come to rely, knowingly or not, on the fall-through.

No API, configuration, or schema changes.

## Tests

New unit coverage in `packages/cubejs-query-orchestrator/test/unit/QueryOrchestratorRollupOnly.test.ts`, over a real `QueryOrchestrator`:

- a miss rejects on `streamQuery`, and the source database is never queried
- a miss rejects on `fetchQuery`
- the error message cannot be mistaken for a "continue wait" — the native transport retries on that substring, so a reworded message would spin instead of failing
- a matched pre-aggregation still streams
- with rollup-only off, a miss still falls through

Each assertion was checked against a deliberately broken implementation: removing the guard from `streamQuery`, making it throw whenever rollup-only is on, making it ignore the flag, and rewording the message all turn a different test red.

Documentation already described the fixed behaviour — "Cube will **only** fulfill queries using pre-aggregations", and `rollupOnlyMode` as "an error will be thrown if a query can't be served from a pre-aggregation" — so no docs change was needed here; the code had drifted from what was written.
