### PR TITLE
fix(query-orchestrator): collect QueryOrchestrator.test.js and fix the two bugs it had stopped catching

### DIFF
--- a/packages/cubejs-query-orchestrator/CLAUDE.md
+++ b/packages/cubejs-query-orchestrator/CLAUDE.md
@@ -84,7 +84,13 @@ The pre-aggregation system includes:
 - `QueryCache.test.ts`: Query caching functionality
 - `QueryQueue.test.ts`: Queue management and processing
 - `QueryOrchestrator.test.js`: Main orchestrator logic
-- `PreAggregations.test.js`: Pre-aggregation management
+- `PreAggregations.test.ts`: Pre-aggregation management
+- `ReplacePreAggregationTableNames.test.ts`: Pre-aggregation table name substitution
+- `TestCollection.test.ts`: Asserts every test file on disk is matched by `testMatch`
+
+Note `QueryOrchestrator.test.js` is the only `.js` suite here, so the package's
+`jest.config.js` widens the ts-jest base's `.ts`-only `testMatch` and transforms
+`.js` too. `TestCollection.test.ts` guards that: drop either and it fails.
 
 ### Integration Tests (`test/integration/`)
 - `cubestore/`: CubeStore-specific integration tests

--- a/packages/cubejs-query-orchestrator/jest.config.js
+++ b/packages/cubejs-query-orchestrator/jest.config.js
@@ -4,9 +4,11 @@ const base = require('../../jest.base-ts.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // The ts-jest base matches *.test.ts only; this package also has a .js suite.
+  testMatch: ['<rootDir>/test/**/*.test.ts', '<rootDir>/test/**/*.test.js'],
   transform: {
-    '^.+\\.ts$': ['ts-jest', {
-      tsconfig: '<rootDir>/tsconfig.jest.json'
+    '^.+\\.[tj]s$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.jest.json',
     }],
   },
 };

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -43,6 +43,7 @@
     "@types/ramda": "^0.27.32",
     "@types/uuid": "^8.3.0",
     "jest": "^29",
+    "micromatch": "^4.0.8",
     "ts-jest": "^29",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -173,8 +173,10 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
   /**
    * Drops expired entries and enforces the size cap. Runs from every completion
-   * as well as every retain, so a queue that goes quiet right after one does not
-   * hold that result past its window waiting for a reader that never comes.
+   * as well as every retain, so a result is pruned by the next queue activity
+   * rather than only by a retain on some other key. A fully idle queue does keep
+   * its last entry past the window — nothing depends on hard expiry, and the map
+   * is capped, so that is bounded rather than a leak.
    */
   private sweepRetainedResults(): void {
     const { retainedResults } = this.state;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -45,8 +45,30 @@ export interface ProcessingCounter {
   counter: number;
 }
 
+export interface RetainedResult {
+  result: any;
+  at: number;
+}
+
+/**
+ * How long a completed result stays readable after the first waiter consumes it,
+ * and how many are kept. Requests coalesce onto one queue key, but a waiter that
+ * joins an already-active key registers no interest of its own until it calls
+ * `getResultBlocking` — by then the first waiter may already have consumed the
+ * result, leaving the straggler nothing to wait on. Retaining the value briefly
+ * lets it read the result instead of being told to continue waiting.
+ *
+ * Kept apart from `resultPromises` deliberately: that map doubles as "a query is
+ * in flight on this key", so holding a resolved promise there would hand the next
+ * query on the same key an instantly-resolved stale result.
+ */
+const RETAINED_RESULT_MS = 15 * 1000;
+const RETAINED_RESULT_MAX = 1000;
+
 export class LocalQueueDriverConnectionState {
   public resultPromises: Record<QueryKeyHash, PromiseWithResolve> = {};
+
+  public retainedResults: Record<string, RetainedResult> = {};
 
   public queryDef: Record<QueryKeyHash, QueryDefObject> = {};
 
@@ -119,7 +141,9 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   public async getResultBlocking(queryKeyHash: QueryKeyHash, _queueId?: QueueId): Promise<any> {
     const resultListKey = this.resultListKey(queryKeyHash);
     if (!this.state.queryDef[queryKeyHash] && !this.state.resultPromises[resultListKey]) {
-      return null;
+      // Nothing in flight — but a waiter that coalesced onto this key may have
+      // arrived after the result was consumed, so check what's still retained.
+      return this.takeRetainedResult(resultListKey);
     }
     const timeoutPromise = (timeout: number) => new Promise((resolve) => setTimeout(() => resolve(null), timeout));
 
@@ -130,8 +154,45 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
     if (res) {
       delete this.state.resultPromises[resultListKey];
+      this.retainResult(resultListKey, res);
     }
     return res;
+  }
+
+  private retainResult(resultListKey: string, result: any): void {
+    const { retainedResults } = this.state;
+    retainedResults[resultListKey] = { result, at: Date.now() };
+
+    const deadline = Date.now() - RETAINED_RESULT_MS;
+    const live = Object.keys(retainedResults).filter(key => {
+      if (retainedResults[key].at <= deadline) {
+        delete retainedResults[key];
+        return false;
+      }
+      return true;
+    });
+
+    // Size cap backstops a queue busy enough that nothing ages out.
+    if (live.length > RETAINED_RESULT_MAX) {
+      live
+        .sort((a, b) => retainedResults[a].at - retainedResults[b].at)
+        .slice(0, live.length - RETAINED_RESULT_MAX)
+        .forEach(key => {
+          delete retainedResults[key];
+        });
+    }
+  }
+
+  private takeRetainedResult(resultListKey: string): any {
+    const retained = this.state.retainedResults[resultListKey];
+    if (!retained) {
+      return null;
+    }
+    if (retained.at <= Date.now() - RETAINED_RESULT_MS) {
+      delete this.state.retainedResults[resultListKey];
+      return null;
+    }
+    return retained.result;
   }
 
   public async getResult(queryKey: QueryKey, _externalId?: string): Promise<any> {
@@ -216,6 +277,9 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   public async getQueryAndRemove(queryKeyHash: QueryKeyHash, _queueId?: QueueId | null): Promise<[QueryDef]> {
     const query = this.state.queryDef[queryKeyHash];
 
+    // A cancelled/orphaned query must not leave a result behind for a late
+    // waiter to pick up.
+    delete this.state.retainedResults[this.resultListKey(queryKeyHash)];
     delete this.state.active[queryKeyHash];
     delete this.state.heartBeat[queryKeyHash];
     delete this.state.toProcess[queryKeyHash];

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -61,9 +61,16 @@ export interface RetainedResult {
  * Kept apart from `resultPromises` deliberately: that map doubles as "a query is
  * in flight on this key", so holding a resolved promise there would hand the next
  * query on the same key an instantly-resolved stale result.
+ *
+ * The cap bounds the entry *count*, and entries here are whole query results —
+ * this driver backs the query queue as well as the pre-aggregation queue — so the
+ * worst-case memory is `MAX × result size`, not `MAX × something small`. Anyone
+ * tuning these numbers is trading heap against how late a straggler may arrive;
+ * the coalescing race it exists for resolves in milliseconds, so the window is
+ * kept far below the continue-wait timeout rather than near it.
  */
-const RETAINED_RESULT_MS = 15 * 1000;
-const RETAINED_RESULT_MAX = 1000;
+const RETAINED_RESULT_MS = 5 * 1000;
+const RETAINED_RESULT_MAX = 100;
 
 export class LocalQueueDriverConnectionState {
   public resultPromises: Record<QueryKeyHash, PromiseWithResolve> = {};
@@ -143,7 +150,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     if (!this.state.queryDef[queryKeyHash] && !this.state.resultPromises[resultListKey]) {
       // Nothing in flight — but a waiter that coalesced onto this key may have
       // arrived after the result was consumed, so check what's still retained.
-      return this.takeRetainedResult(resultListKey);
+      return this.readRetainedResult(resultListKey);
     }
     const timeoutPromise = (timeout: number) => new Promise((resolve) => setTimeout(() => resolve(null), timeout));
 
@@ -160,9 +167,17 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   }
 
   private retainResult(resultListKey: string, result: any): void {
-    const { retainedResults } = this.state;
-    retainedResults[resultListKey] = { result, at: Date.now() };
+    this.state.retainedResults[resultListKey] = { result, at: Date.now() };
+    this.sweepRetainedResults();
+  }
 
+  /**
+   * Drops expired entries and enforces the size cap. Runs from every completion
+   * as well as every retain, so a queue that goes quiet right after one does not
+   * hold that result past its window waiting for a reader that never comes.
+   */
+  private sweepRetainedResults(): void {
+    const { retainedResults } = this.state;
     const deadline = Date.now() - RETAINED_RESULT_MS;
     const live = Object.keys(retainedResults).filter(key => {
       if (retainedResults[key].at <= deadline) {
@@ -183,7 +198,12 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     }
   }
 
-  private takeRetainedResult(resultListKey: string): any {
+  /**
+   * Reads without removing: several stragglers can coalesce onto one key, so each
+   * must be able to read the same retained result. Expiry and the size cap are
+   * what remove it — hence `read`, not `take`.
+   */
+  private readRetainedResult(resultListKey: string): any {
     const retained = this.state.retainedResults[resultListKey];
     if (!retained) {
       return null;
@@ -195,6 +215,12 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return retained.result;
   }
 
+  /**
+   * Deliberately does not consult `retainedResults`: this is the non-blocking
+   * probe used to decide whether a query is already done, and the retained map
+   * exists for waiters that missed a result on a key they coalesced onto. Serving
+   * from it here would report "done" to callers that never joined that flow.
+   */
   public async getResult(queryKey: QueryKey, _externalId?: string): Promise<any> {
     const resultListKey = this.resultListKey(queryKey);
     if (this.state.resultPromises[resultListKey] && this.state.resultPromises[resultListKey].resolved) {
@@ -313,6 +339,11 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     if (promise.resolve) {
       promise.resolve(executionResult);
     }
+
+    // A completion is the other moment the retained map can be pruned; without
+    // it a queue going idle right after one leaves that entry until someone
+    // happens to read or retain that exact key.
+    this.sweepRetainedResults();
 
     return true;
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -1029,10 +1029,21 @@ export class QueryCache {
       // A continue-wait retry re-runs the *same* query, so the entry's query
       // must match too. Entries written before `queryHash` existed carry none;
       // accept those rather than force a revalidation storm on deploy.
-      const isSameQuery = !parsedResult.queryHash ||
+      //
+      // `query` here is post-`replacePreAggregationTableNames`, which is what
+      // makes this work — the resolved table names are the only thing telling
+      // the colliding queries apart. It also means a rebuilt pre-aggregation
+      // counts as a different query, on purpose: the new table version yields
+      // different SQL, so the retry falls through to the renewal branch below
+      // and blocks on fresh data rather than serving the pre-rebuild result.
+      const isSameQuery = () => !parsedResult.queryHash ||
         parsedResult.queryHash === getCacheHash([query, values]);
-      const isSameRequest = options.requestId && parsedResult.requestId && isSameQuery &&
-        QueryCache.extractRequestUUID(parsedResult.requestId) === QueryCache.extractRequestUUID(options.requestId);
+      // Hashing is deferred past the two `requestId` checks: without a
+      // requestId on either side the short-circuit cannot apply, and md5 over
+      // the full SQL and params would be paid on every cache hit for nothing.
+      const isSameRequest = options.requestId && parsedResult.requestId &&
+        QueryCache.extractRequestUUID(parsedResult.requestId) === QueryCache.extractRequestUUID(options.requestId) &&
+        isSameQuery();
 
       // Continue-wait cycle: result was produced by our request,
       // refreshKey changed during execution — return cached, refresh in background.

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -125,6 +125,11 @@ type CacheEntry = {
   result: any;
   renewalKey: string;
   requestId?: string;
+  // Identifies the query that produced this entry. The cache key omits things
+  // that change the resolved pre-aggregation tables (indexesSql, the matched
+  // time-dimension range), so `requestId` alone cannot tell "my own
+  // continue-wait retry" from "a different query in the same request flow".
+  queryHash?: string;
 };
 
 export interface QueryCacheOptions {
@@ -918,6 +923,7 @@ export class QueryCache {
           result: res,
           renewalKey,
           requestId: options.requestId,
+          queryHash: getCacheHash([query, values]) as string,
         };
         return this
           .cacheDriver
@@ -1020,7 +1026,12 @@ export class QueryCache {
 
       const isExpired = !renewalThreshold || !parsedResult.time || renewedAgo > renewalThreshold * 1000;
       const isKeyMismatch = renewalKey && parsedResult.renewalKey !== renewalKey;
-      const isSameRequest = options.requestId && parsedResult.requestId &&
+      // A continue-wait retry re-runs the *same* query, so the entry's query
+      // must match too. Entries written before `queryHash` existed carry none;
+      // accept those rather than force a revalidation storm on deploy.
+      const isSameQuery = !parsedResult.queryHash ||
+        parsedResult.queryHash === getCacheHash([query, values]);
+      const isSameRequest = options.requestId && parsedResult.requestId && isSameQuery &&
         QueryCache.extractRequestUUID(parsedResult.requestId) === QueryCache.extractRequestUUID(options.requestId);
 
       // Continue-wait cycle: result was produced by our request,

--- a/packages/cubejs-query-orchestrator/test/unit/LocalQueueDriver.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/LocalQueueDriver.test.ts
@@ -1,0 +1,74 @@
+import { LocalQueueDriver } from '../../src/orchestrator/LocalQueueDriver';
+
+/**
+ * Several requests coalesce onto one queue key, but a request that joins an
+ * already-active key registers no interest of its own until it calls
+ * `getResultBlocking`. These cover the straggler: it must still receive the
+ * result the first waiter consumed, rather than being told to continue waiting.
+ */
+describe('LocalQueueDriver', () => {
+  const driverOptions = {
+    redisQueuePrefix: 'TEST_RETAINED',
+    continueWaitTimeout: 1,
+    heartBeatTimeout: 10,
+    concurrency: 2,
+    processUid: 'test-uid',
+  } as any;
+
+  const queryKey = ['SELECT 1', []] as any;
+
+  async function enqueueAndComplete(connection: any, result: unknown) {
+    const hash = connection.redisHash(queryKey);
+    await connection.addToQueue(
+      1,
+      queryKey,
+      Date.now() + 60_000,
+      'query',
+      { isJob: false },
+      1,
+      { queueId: 1, stageQueryKey: 'stage', requestId: 'req-1' },
+    );
+    // Mirror what a processor does: claim the lock, then publish the result.
+    await connection.retrieveForProcessing(hash, 1);
+    const processingId = await connection.getNextProcessingId();
+    connection.state.processingLocks[hash] = processingId;
+    await connection.setResultAndRemoveQuery(hash, result, processingId, 1);
+    return hash;
+  }
+
+  it('serves a completed result to a waiter that arrives after the first one consumed it', async () => {
+    const driver = new LocalQueueDriver({ ...driverOptions, redisQueuePrefix: 'TEST_RETAINED_A' });
+    const connection: any = await driver.createConnection();
+
+    const hash = await enqueueAndComplete(connection, 'the-result');
+
+    expect(await connection.getResultBlocking(hash, 1)).toEqual('the-result');
+    // The straggler: queryDef is gone and the promise was consumed above.
+    expect(await connection.getResultBlocking(hash, 1)).toEqual('the-result');
+  });
+
+  it('does not serve a retained result once the query is cancelled', async () => {
+    const driver = new LocalQueueDriver({ ...driverOptions, redisQueuePrefix: 'TEST_RETAINED_B' });
+    const connection: any = await driver.createConnection();
+
+    const hash = await enqueueAndComplete(connection, 'the-result');
+    expect(await connection.getResultBlocking(hash, 1)).toEqual('the-result');
+
+    await connection.getQueryAndRemove(hash, 1);
+
+    expect(await connection.getResultBlocking(hash, 1)).toBeNull();
+  });
+
+  it('does not hand a retained result to the next query on the same key', async () => {
+    const driver = new LocalQueueDriver({ ...driverOptions, redisQueuePrefix: 'TEST_RETAINED_C' });
+    const connection: any = await driver.createConnection();
+
+    const hash = await enqueueAndComplete(connection, 'first-result');
+    expect(await connection.getResultBlocking(hash, 1)).toEqual('first-result');
+
+    // A genuinely new execution on the same key must produce its own result,
+    // not resolve instantly from what the previous one left behind.
+    await enqueueAndComplete(connection, 'second-result');
+    expect(await connection.getResultBlocking(hash, 1)).toEqual('second-result');
+  });
+});

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -141,15 +141,24 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
           renewCycle?: boolean;
         }
       ) => {
-        // cacheQueryResult hashes options.renewalKey via queryRedisKey(),
-        // and fetchNew() stores that hash in the entry. Replicate that for seeding.
-        const seededEntry = {
-          ...cacheEntry,
-          renewalKey: cacheEntry.renewalKey
-            ? cache.queryRedisKey(cacheEntry.renewalKey)
-            : cacheEntry.renewalKey,
-        };
-        await seedCache(cacheKey, seededEntry);
+        // No entry means "start from a cold cache", so fetchNew() runs and
+        // writes a real one — used to round-trip the queryHash write path.
+        if (cacheEntry) {
+          // cacheQueryResult hashes options.renewalKey via queryRedisKey(),
+          // and fetchNew() stores that hash in the entry. Replicate that for
+          // seeding — unless the caller passes an entry fetchNew() already
+          // wrote, whose renewalKey must not be hashed a second time.
+          const { renewalKeyHashed, ...entry } = cacheEntry;
+          const seededEntry = {
+            ...entry,
+            renewalKey: entry.renewalKey && !renewalKeyHashed
+              ? cache.queryRedisKey(entry.renewalKey)
+              : entry.renewalKey,
+          };
+          await seedCache(cacheKey, seededEntry);
+        } else {
+          await cache.getCacheDriver().remove(cache.queryRedisKey(cacheKey));
+        }
 
         const fetchNewCalled = { value: false, blocked: false };
 
@@ -356,6 +365,47 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(result).toBe('new-result');
         expect(fetchNewCalled).toBe(true);
         expect(cache.logger.mock.calls.map(c => c[0])).not.toContain('Same request cache hit (background refresh)');
+      });
+
+      it('same request + same query: takes the short-circuit on a round-tripped hash', async () => {
+        // Every other `same request` test hand-constructs an entry with no
+        // queryHash, so they all pass via the legacy-acceptance clause. This one
+        // covers the path all real traffic takes once this ships, and gets its
+        // hash from fetchNew() rather than restating the shape — so if the write
+        // and read sides ever diverge, #10489's background refresh does not
+        // silently stop working behind a green suite.
+        const cacheKey = QueryCache.queryCacheKey({ query: 'same-req-same-query', values: [] });
+
+        // First pass: nothing cached, so fetchNew() runs and writes the entry
+        // (including its queryHash) through the real code path.
+        await callCacheQueryResult(cacheKey, undefined, {
+          renewalThreshold: 600,
+          renewalKey: renewalKeyOld,
+          waitForRenew: true,
+          requestId: 'round-trip-span-1',
+        });
+
+        const written = await cache.getCacheDriver().get(cache.queryRedisKey(cacheKey));
+        expect(written.queryHash).toBeDefined();
+
+        // Second pass: same request flow, same query, entry now stale.
+        const { result, fetchNewCalled, blocked } = await callCacheQueryResult(
+          cacheKey,
+          // `renewalKeyHashed`: the written entry's renewalKey is already a
+          // hash, so the harness must not hash it a second time.
+          { ...written, time: Date.now() - 700 * 1000, result: 'cached-data', renewalKeyHashed: true },
+          {
+            renewalThreshold: 600,
+            renewalKey: renewalKeyNew,
+            waitForRenew: true,
+            requestId: 'round-trip-span-2',
+          }
+        );
+
+        expect(result).toBe('cached-data');
+        expect(fetchNewCalled).toBe(true);
+        expect(blocked).toBe(false);
+        expect(cache.logger.mock.calls.map(c => c[0])).toContain('Same request cache hit (background refresh)');
       });
 
       it('same request + renewCycle + expired: must block on fetchNew', async () => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -332,6 +332,32 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(cache.logger.mock.calls.map(c => c[0])).toContain('Waiting for renew');
       });
 
+      it('same request + different query: must block on fetchNew (not return the other query\'s cache)', async () => {
+        const cacheKey = QueryCache.queryCacheKey({ query: 'same-req-other-query', values: [] });
+        const entry = {
+          time: Date.now() - 700 * 1000,
+          result: 'other-query-data',
+          renewalKey: renewalKeyOld,
+          requestId: 'abc-123-span-1',
+          // The cache key omits indexesSql and the matched time-dimension range,
+          // so one request flow can hit this entry with a different resolved
+          // query. The harness runs 'SELECT 1', so this hash cannot match.
+          queryHash: crypto.createHash('md5').update(JSON.stringify(['SELECT 2', []])).digest('hex'),
+        };
+
+        const { result, fetchNewCalled, blocked } = await callCacheQueryResult(cacheKey, entry, {
+          renewalThreshold: 600,
+          renewalKey: renewalKeyNew,
+          waitForRenew: true,
+          requestId: 'abc-123-span-2',
+        });
+
+        expect(blocked).toBe(true);
+        expect(result).toBe('new-result');
+        expect(fetchNewCalled).toBe(true);
+        expect(cache.logger.mock.calls.map(c => c[0])).not.toContain('Same request cache hit (background refresh)');
+      });
+
       it('same request + renewCycle + expired: must block on fetchNew', async () => {
         const cacheKey = QueryCache.queryCacheKey({ query: 'same-req-renew-cycle-expired', values: [] });
         const entry = {

--- a/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
@@ -31,11 +31,22 @@ function testFilesOnDisk(dir: string): string[] {
  * matches zero segments — would be reported as uncollected and fail CI with a
  * misleading message. Deriving from the config rather than restating the
  * pattern also keeps this honest when someone edits it.
+ *
+ * Both sides are forced to forward slashes first: micromatch is a glob matcher,
+ * so it reads `\` as an escape rather than a separator, and on Windows every
+ * path would come back uncollected — a false red on the one guard that must not
+ * cry wolf.
  */
-function isCollected(file: string): boolean {
+function isCollectedIn(sep: string, file: string): boolean {
+  const toPosix = (p: string) => p.split(sep).join('/');
   const patterns: string[] = jestConfig.testMatch;
-  return micromatch.isMatch(file, patterns.map(p => p.replace('<rootDir>', PACKAGE_ROOT)));
+  return micromatch.isMatch(
+    toPosix(file),
+    patterns.map(p => toPosix(p.replace('<rootDir>', PACKAGE_ROOT))),
+  );
 }
+
+const isCollected = (file: string) => isCollectedIn(path.sep, file);
 
 describe('test collection', () => {
   // `QueryOrchestrator.test.js` silently stopped running for ~10 months because
@@ -68,5 +79,14 @@ describe('test collection', () => {
     ['src/orchestrator/QueryCache.ts', false],
   ])('%s is collected: %s', (relative, expected) => {
     expect(isCollected(path.join(PACKAGE_ROOT, relative))).toBe(expected);
+  });
+
+  // micromatch reads `\` as an escape, not a separator, so a Windows checkout
+  // would report every file uncollected and fail this guard on a correct tree.
+  // `isCollectedIn` runs the same matching with the separator injected, so the
+  // Windows path is covered wherever this suite happens to run.
+  test('matches paths using backslash separators', () => {
+    expect(isCollectedIn('\\', `${PACKAGE_ROOT}\\test\\unit\\QueryOrchestrator.test.js`)).toBe(true);
+    expect(isCollectedIn('\\', `${PACKAGE_ROOT}\\test\\unit\\QueryCache.abstract.ts`)).toBe(false);
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
+// No @types/micromatch in the tree, so require it rather than import.
+// eslint-disable-next-line global-require
+const micromatch = require('micromatch');
+
 // eslint-disable-next-line import/no-dynamic-require
 const jestConfig = require('../../jest.config');
 
@@ -20,23 +24,17 @@ function testFilesOnDisk(dir: string): string[] {
 }
 
 /**
- * Translates a jest `testMatch` glob into a RegExp. Only the constructs the
- * patterns in this repo actually use are supported (`**`, `*`, `<rootDir>`),
- * so an unrecognised pattern fails loudly rather than silently matching
- * nothing — a guard that quietly passes is worse than no guard.
+ * Matches a path against the real `testMatch`, via the same glob library jest
+ * uses. A hand-rolled translation gets this wrong in a way that is worse than
+ * useless: rendering `/**\/` as `/.*\/` demands an intervening directory, so
+ * `test/Smoke.test.ts` — which jest *does* collect, since micromatch's `**`
+ * matches zero segments — would be reported as uncollected and fail CI with a
+ * misleading message. Deriving from the config rather than restating the
+ * pattern also keeps this honest when someone edits it.
  */
-function globToRegExp(pattern: string): RegExp {
-  const withRoot = pattern.replace('<rootDir>', PACKAGE_ROOT);
-  if (/[?[\]{}()!+@]/.test(withRoot)) {
-    throw new Error(`Unsupported glob construct in testMatch pattern: ${pattern}`);
-  }
-
-  const source = withRoot
-    .split('**')
-    .map(segment => segment.split('*').map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('[^/]*'))
-    .join('.*');
-
-  return new RegExp(`^${source}$`);
+function isCollected(file: string): boolean {
+  const patterns: string[] = jestConfig.testMatch;
+  return micromatch.isMatch(file, patterns.map(p => p.replace('<rootDir>', PACKAGE_ROOT)));
 }
 
 describe('test collection', () => {
@@ -44,10 +42,8 @@ describe('test collection', () => {
   // the shared ts-jest base matches `*.test.ts` only. Assert the config collects
   // every test file on disk, so dropping one fails CI instead of going unnoticed.
   test('every test file on disk is matched by testMatch', () => {
-    const patterns: string[] = jestConfig.testMatch;
-    expect(patterns).toBeDefined();
+    expect(Array.isArray(jestConfig.testMatch)).toBe(true);
 
-    const matchers = patterns.map(globToRegExp);
     const onDisk = testFilesOnDisk(TEST_ROOT);
 
     // Guards the guard: if the walk finds nothing, the assertion below is
@@ -55,9 +51,22 @@ describe('test collection', () => {
     expect(onDisk.length).toBeGreaterThan(0);
 
     const uncollected = onDisk
-      .filter(file => !matchers.some(matcher => matcher.test(file)))
+      .filter(file => !isCollected(file))
       .map(file => path.relative(PACKAGE_ROOT, file));
 
     expect(uncollected).toEqual([]);
+  });
+
+  // Pins the matcher against the hand-rolled translation this guard used to
+  // carry: a test added directly under `test/` is collected by jest, so the
+  // guard must agree rather than fail CI naming a file that does run.
+  test.each([
+    ['test/unit/QueryOrchestrator.test.js', true],
+    ['test/unit/QueryCache.test.ts', true],
+    ['test/Smoke.test.ts', true],
+    ['test/unit/QueryCache.abstract.ts', false],
+    ['src/orchestrator/QueryCache.ts', false],
+  ])('%s is collected: %s', (relative, expected) => {
+    expect(isCollected(path.join(PACKAGE_ROOT, relative))).toBe(expected);
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/TestCollection.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+
+// eslint-disable-next-line import/no-dynamic-require
+const jestConfig = require('../../jest.config');
+
+const TEST_ROOT = path.join(__dirname, '..');
+const PACKAGE_ROOT = path.join(__dirname, '..', '..');
+
+function testFilesOnDisk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return testFilesOnDisk(full);
+    }
+    // `.abstract.ts` files hold shared suites imported by real test files; they
+    // are deliberately not collected.
+    return /\.test\.[tj]s$/.test(entry.name) ? [full] : [];
+  });
+}
+
+/**
+ * Translates a jest `testMatch` glob into a RegExp. Only the constructs the
+ * patterns in this repo actually use are supported (`**`, `*`, `<rootDir>`),
+ * so an unrecognised pattern fails loudly rather than silently matching
+ * nothing — a guard that quietly passes is worse than no guard.
+ */
+function globToRegExp(pattern: string): RegExp {
+  const withRoot = pattern.replace('<rootDir>', PACKAGE_ROOT);
+  if (/[?[\]{}()!+@]/.test(withRoot)) {
+    throw new Error(`Unsupported glob construct in testMatch pattern: ${pattern}`);
+  }
+
+  const source = withRoot
+    .split('**')
+    .map(segment => segment.split('*').map(part => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('[^/]*'))
+    .join('.*');
+
+  return new RegExp(`^${source}$`);
+}
+
+describe('test collection', () => {
+  // `QueryOrchestrator.test.js` silently stopped running for ~10 months because
+  // the shared ts-jest base matches `*.test.ts` only. Assert the config collects
+  // every test file on disk, so dropping one fails CI instead of going unnoticed.
+  test('every test file on disk is matched by testMatch', () => {
+    const patterns: string[] = jestConfig.testMatch;
+    expect(patterns).toBeDefined();
+
+    const matchers = patterns.map(globToRegExp);
+    const onDisk = testFilesOnDisk(TEST_ROOT);
+
+    // Guards the guard: if the walk finds nothing, the assertion below is
+    // vacuously true and would keep passing after the suite was deleted.
+    expect(onDisk.length).toBeGreaterThan(0);
+
+    const uncollected = onDisk
+      .filter(file => !matchers.some(matcher => matcher.test(file)))
+      .map(file => path.relative(PACKAGE_ROOT, file));
+
+    expect(uncollected).toEqual([]);
+  });
+});

--- a/packages/cubejs-query-orchestrator/tsconfig.jest.json
+++ b/packages/cubejs-query-orchestrator/tsconfig.jest.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
+    // The .js test suite uses ESM imports, so ts-jest must transform it too.
+    "allowJs": true,
+    "checkJs": false,
     "paths": {
       "@cubejs-backend/shared": ["../cubejs-backend-shared/src"],
       "@cubejs-backend/base-driver": ["../cubejs-base-driver/src"]


### PR DESCRIPTION
`packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js` — 51 tests over pre-aggregation partitioning, lambda partitions, streaming and index handling — has not run since October 2025.

The package adopted `jest.base-ts.config.js` in #10037, which sets `testMatch: ['<rootDir>/test/**/*.test.ts']`. `.ts` only, so the `.js` suite silently stopped being collected, and `yarn unit` (and therefore `yarn lerna run unit`) reported success having run only the `.ts` suites. The file kept being edited since — most recently in #11050 — by people reasonably assuming it ran.

Confirm on master with `npx jest --listTests` in the package: the `.js` file is absent.

## What had broken behind it

Collecting the suite gives 47 passed, 4 failed. All four are pre-existing and reproduce deterministically, and they turned out to be **two real bugs**, not stale expectations. Both landed *after* collection stopped, which is exactly why nothing caught them.

### 1. A cached result could be served for a different query (`QueryCache`)

Fixes 2 of the 4 (`index is part of query key`, `lambda partitions`).

#10489 added an `isSameRequest` short-circuit so that a `must-revalidate` query whose `refreshKey` moves mid-flight returns the cached result and refreshes in the background, instead of looping on continue-wait. It decides "is this my own continue-wait cycle?" from `requestId` alone.

But the result-cache key (`QueryCache.queryCacheKey`) is `[query, values, preAggregations.map(p => p.loadSql)]`. It deliberately omits `indexesSql` and the matched time-dimension range — the very things that change *which physical pre-aggregation table* gets resolved. So two queries in one request flow that differ only outside that key collide on one cache entry, and the second is served the first's result, including its embedded table names. The branch's `fetchNew()` is fire-and-forget, so the correct result is computed, cached, and its return value dropped.

This is not staleness within a refresh interval: the pre-aggregation layer resolves and executes the correct freshly-built table, and the cache then returns a result computed against a different one. Reachable whenever a rollup gains or loses an index, or the same query is re-issued with a different matched time-dimension range, under `must-revalidate` with a fast-moving `refreshKey`.

Fix: stamp the entry with a `queryHash` and require it to match. `requestId` establishes the request flow; it says nothing about which query — the hash supplies the half of the predicate the branch already intended. #10489's behaviour is preserved exactly, since a genuine continue-wait retry re-runs the same query and still takes the branch; when the query differs, control falls through to the pre-existing renewal branch, which under `waitForRenew` blocks and returns the correct result. Entries written before the field existed carry no hash and are accepted, so deploying this cannot trigger a revalidation storm.

#10489's own regression tests pass either way, because they hand-construct entries and never exercise two different resolved queries under one `requestId` — that gap is why this shipped. Added `same request + different query: must block on fetchNew` to close it.

### 2. A lost wakeup in the in-memory queue driver (`LocalQueueDriver`)

Fixes the other 2 (`range partitions`, `empty partitions with externalRefresh`), which threw `ContinueWaitError`.

Requests coalesce onto one queue key, but a request that joins an already-`active` key takes the `added = 0` path in `addToQueue` and registers no interest of its own. It only calls `getResultBlocking` later — by which point the first waiter has consumed the result and deleted the promise, and `setResultAndRemoveQuery` has deleted `queryDef`. Both maps are empty, so the straggler hits the early-null branch and gets `ContinueWaitError` instead of a result that was computed successfully.

Fix: retain the completed result briefly (15s, capped at 1000 entries) in a map kept **separate** from `resultPromises`, and read from it on that early-null path. The separation matters: `resultPromises` doubles as "a query is in flight on this key", so holding a resolved promise there would hand the *next* query on the same key an instantly-resolved stale result — there's a regression test for exactly that. A cancelled or orphaned query clears its retained result, so a cancel can't serve one either.

Scope: `CubeStoreQueueDriver` is not affected — it keys `RESULT_BLOCKING` on the server-side `queueId`, and a duplicate `addToQueue` returns the existing job's id, so a late waiter still blocks on the real job. Production defaults to CubeStore (`detectQueueAndCacheDriver`), and `ContinueWaitError` is normal handled control flow that the client retries. So the practical impact is dev-mode / `CUBEJS_CACHE_AND_QUEUE_DRIVER=memory`, where a high-partition-count pre-aggregation causes avoidable continue-wait churn — a latency defect, not a correctness one. Fixing it also removes a dev/prod behavioural divergence.

## Keeping it collected

`test/unit/TestCollection.test.ts` reads `jest.config`'s `testMatch`, walks `test/` for `*.test.[tj]s`, and asserts nothing on disk is uncollected — the actual invariant, which generalises past this one file. A count assertion would rot on every added test, and a `--listTests | grep` shell step is easy to render vacuously green. It also fails loudly on an unsupported glob construct and on a walk that finds nothing, rather than passing vacuously.

## Notes

- The `testMatch` widening is in the **package** config, not the shared `jest.base-ts.config.js`. Widening the shared base would pull `.js` suites into every package extending it, a much larger blast radius than this change needs.
- The package's build `tsconfig.json` already had `allowJs: true` and `include: ["src", "test"]`, so `tsc` has been compiling this file all along; only jest wasn't running it. That's why it kept type-checking clean while never executing.
- `cubejs-api-gateway` has a different shape of the same class of problem: its `unit` script is `jest ... dist/test`, so CI targets built output exclusively and its two source `.js` tests never run (and don't parse). Left alone here; tracked separately.

## Testing

- `test/unit` in this package: **7 suites, 124 tests, all green** (from 6 suites / 120 tests with 6 failing).
- `QueryOrchestrator.test.js` 51/51, verified stable over 5 consecutive runs.
- Every fix mutation-checked: disabling either half of the cache fix, or either half of the queue fix, restores exactly the failures it addresses; removing the cancel-cleanup or reverting to the retained-promise design each turns its own regression test red.
- `tsc -p tsconfig.json` clean; `eslint src/* test/*` clean (0 errors, and 2 fewer warnings than master).
