### PR TITLE
fix(tesseract): keep the query row set when a multi-stage filter directive drops a filter

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-grain.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-grain.test.ts
@@ -133,6 +133,22 @@ cubes:
             - orders.status
           include:
             - orders.id
+
+      # ── grain.exclude + filter.exclude on the same dim ────────────
+      # "Share of the whole universe" denominator: the value ignores both
+      # the query filter on status and the status partition. The result row
+      # set must stay the query's — dropping the filter may not resurrect
+      # rows the query filtered out.
+      - name: amount_grain_and_filter_exclude_status
+        sql: "{CUBE.total_amount}"
+        type: sum
+        multi_stage: true
+        grain:
+          exclude:
+            - orders.status
+        filter:
+          exclude:
+            - orders.status
     `);
 
   if (getEnv('nativeSqlPlanner')) {
@@ -257,6 +273,23 @@ cubes:
       { orders__status: 'pending', orders__category: 'books', orders__total_amount: '50', orders__amount_grain_keep_status_include_id: '125' },
       { orders__status: 'pending', orders__category: 'electronics', orders__total_amount: '75', orders__amount_grain_keep_status_include_id: '125' },
     ], { joinGraph, cubeEvaluator, compiler }));
+
+    // ── grain.exclude + filter.exclude on the same dim ────────────
+    it('grain.exclude + filter.exclude: keeps the query row set', async () => dbRunner.runQueryTest({
+      measures: ['orders.total_amount', 'orders.amount_grain_and_filter_exclude_status'],
+      dimensions: ['orders.status', 'orders.category'],
+      filters: [
+        { member: 'orders.status', operator: 'equals', values: ['completed'] },
+      ],
+      order: [{ id: 'orders.status' }, { id: 'orders.category' }],
+      timezone: 'UTC',
+    }, [
+      // The denominator is the per-category total over every status (books=250,
+      // electronics=275), while the rows stay the filtered ones — no pending or
+      // cancelled row may come back through the join.
+      { orders__status: 'completed', orders__category: 'books', orders__total_amount: '170', orders__amount_grain_and_filter_exclude_status: '250' },
+      { orders__status: 'completed', orders__category: 'electronics', orders__total_amount: '200', orders__amount_grain_and_filter_exclude_status: '275' },
+    ], { joinGraph, cubeEvaluator, compiler }));
   } else {
     // These tests rely on Tesseract; v1 planner does not implement the directive.
     test.skip('exclude: drops a dim from the partition', () => { expect(1).toBe(1); });
@@ -267,5 +300,6 @@ cubes:
     test.skip('keep_only: two-element array narrows to the (status, category) cell', () => { expect(1).toBe(1); });
     test.skip('include: two-element array extends the leaf grain', () => { expect(1).toBe(1); });
     test.skip('keep_only + include: keep narrows, include extends', () => { expect(1).toBe(1); });
+    test.skip('grain.exclude + filter.exclude: keeps the query row set', () => { expect(1).toBe(1); });
   }
 });

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/keys_aggregate_strategy.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/keys_aggregate_strategy.rs
@@ -175,14 +175,17 @@ impl FullKeyAggregateStrategy for KeysFullKeyAggregateStrategy<'_> {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            // Null-safe dimension join when keys are derived from the
-            // measure refs (FULL JOIN-equivalent shape). For the JOIN-model
-            // path (explicit keys) it's a one-to-one match — null-safety is
-            // unnecessary but stays correct.
+            // Dimension values include NULL, and a plain `=` never matches
+            // NULL to NULL — the key row would keep its place in the grid but
+            // lose the measure. Both shapes need the null-safe comparison; it
+            // costs the planner's ability to hash- or merge-join these keys on
+            // engines that treat the null-safe operator as unhashable, which is
+            // the same cost the keys-derived-from-measure-refs shape has always
+            // paid.
             join_builder.left_join_subselect(
                 query,
                 query_alias,
-                JoinCondition::new_dimension_join(conditions, !has_explicit_keys),
+                JoinCondition::new_dimension_join(conditions, true),
             );
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/keys_aggregate_strategy.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/keys_aggregate_strategy.rs
@@ -175,13 +175,22 @@ impl FullKeyAggregateStrategy for KeysFullKeyAggregateStrategy<'_> {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            // Dimension values include NULL, and a plain `=` never matches
-            // NULL to NULL — the key row would keep its place in the grid but
-            // lose the measure. Both shapes need the null-safe comparison; it
-            // costs the planner's ability to hash- or merge-join these keys on
-            // engines that treat the null-safe operator as unhashable, which is
-            // the same cost the keys-derived-from-measure-refs shape has always
-            // paid.
+            // Both shapes join on the null-safe comparison, unconditionally.
+            // A plain `=` never matches NULL to NULL, so a key row whose
+            // dimension is NULL would keep its place in the grid and lose the
+            // measure.
+            //
+            // It has to be unconditional because nothing here can rule NULL
+            // out. The data model carries no nullability information, and even
+            // a column declared NOT NULL reaches this join as NULL once the
+            // dimension is read through an outer join in the cube's join
+            // graph — so the grid can hold a NULL key whatever the source
+            // table says.
+            //
+            // The cost is the planner's ability to hash- or merge-join these
+            // keys on engines that treat the null-safe operator as unhashable.
+            // Correctness is not tradeable against it: the alternative drops a
+            // measure value silently, on a row that is still returned.
             join_builder.left_join_subselect(
                 query,
                 query_alias,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree_ops.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree_ops.rs
@@ -102,3 +102,30 @@ pub fn has_filter_for_member(member_name: &String, filters: &[FilterItem]) -> bo
     }
     false
 }
+
+/// Structural equality that also compares the member each leaf filter targets.
+/// `FilterItem`'s own `PartialEq` compares a filter's type, operator and values
+/// but not its member, so two filters differing only in the dimension they
+/// restrict count as equal there. Groups are compared element-wise in order.
+/// Segments carry their member in `full_name` and compare as-is.
+pub fn eq_with_member(a: &FilterItem, b: &FilterItem) -> bool {
+    match (a, b) {
+        (FilterItem::Item(a), FilterItem::Item(b)) => a.member_name() == b.member_name() && a == b,
+        (FilterItem::Group(a), FilterItem::Group(b)) => {
+            a.operator == b.operator
+                && a.items.len() == b.items.len()
+                && a.items
+                    .iter()
+                    .zip(b.items.iter())
+                    .all(|(a, b)| eq_with_member(a, b))
+        }
+        _ => a == b,
+    }
+}
+
+/// True when `items` holds a filter equal to `item` under [`eq_with_member`].
+pub fn contains_with_member(items: &[FilterItem], item: &FilterItem) -> bool {
+    items
+        .iter()
+        .any(|candidate| eq_with_member(item, candidate))
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -10,6 +10,7 @@ use crate::planner::apply_static_filter_to_symbol;
 use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::collectors::member_childs;
 use crate::planner::filter::base_filter::FilterType;
+use crate::planner::filter::tree_ops;
 use crate::planner::filter::BaseFilter;
 use crate::planner::filter::FilterItem;
 use crate::planner::filter::FilterOperator;
@@ -641,12 +642,26 @@ impl MultiStageQueryPlanner {
                 // enumerates the query's rows — except here the grid keeps
                 // every dimension and only the row count within it grows.
                 //
-                // A parent state with no dimensions is exempt: its grid is a
-                // single row that no filter change can widen, and a keys side
-                // with no key dimensions is not a shape the assembly renders.
+                // Three shapes are exempt. A parent state with no dimensions is
+                // a single-row grid that no filter change can widen, and an
+                // empty key-dimension list degenerates into a cross join rather
+                // than being rejected. A Dimension inode never reads
+                // `keys_input`, so building one leaves unreferenced CTEs
+                // behind. And a Rank inode ranks within whatever its source
+                // carries: handing it the keys side would shrink the ranked
+                // population to the grid and collapse the ranks, trading a
+                // widened row set for wrong values. Rank needs the rows
+                // restricted *after* the window, which this assembly cannot
+                // express.
                 let grid_has_dimensions =
                     !state.dimensions().is_empty() || !state.time_dimensions().is_empty();
-                if any_missing || (query_filter_dropped && grid_has_dimensions) {
+                let inode_can_hold_grid = !matches!(
+                    multi_stage_member.inode_type(),
+                    MultiStageInodeMemberType::Dimension | MultiStageInodeMemberType::Rank
+                );
+                if any_missing
+                    || (query_filter_dropped && grid_has_dimensions && inode_can_hold_grid)
+                {
                     self.make_childs(
                         member.clone(),
                         state.clone(),
@@ -1137,35 +1152,11 @@ fn query_filters_dropped(
     base: &QueryProperties,
     narrowed: &QueryProperties,
 ) -> bool {
-    // `FilterItem`'s own equality compares a filter's type, operator and
-    // values but not the member it targets, so two filters differing only in
-    // their member count as equal. Left alone, a dropped filter would be
-    // cancelled out by an unrelated look-alike that survived, hiding the
-    // widening. Segments carry their member in `full_name` and compare as-is.
-    fn same_filter(a: &FilterItem, b: &FilterItem) -> bool {
-        match (a, b) {
-            (FilterItem::Item(a), FilterItem::Item(b)) => {
-                a.member_name() == b.member_name() && a == b
-            }
-            (FilterItem::Group(a), FilterItem::Group(b)) => {
-                a.operator == b.operator
-                    && a.items.len() == b.items.len()
-                    && a.items
-                        .iter()
-                        .zip(b.items.iter())
-                        .all(|(a, b)| same_filter(a, b))
-            }
-            _ => a == b,
-        }
-    }
-
-    fn has(items: &[FilterItem], item: &FilterItem) -> bool {
-        items.iter().any(|candidate| same_filter(item, candidate))
-    }
-
     fn any_dropped(root: &[FilterItem], base: &[FilterItem], narrowed: &[FilterItem]) -> bool {
-        base.iter()
-            .any(|item| has(root, item) && !has(narrowed, item))
+        base.iter().any(|item| {
+            tree_ops::contains_with_member(root, item)
+                && !tree_ops::contains_with_member(narrowed, item)
+        })
     }
 
     any_dropped(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -575,6 +575,26 @@ impl MultiStageQueryPlanner {
                 multi_stage_member = multi_stage_member.with_use_window_path(false);
             }
 
+            // Whether this inode can actually act on that, decided here so both
+            // halves of the decision stay together — the keys side that carries
+            // the query's rows is requested further down.
+            //
+            // A parent state with no dimensions is a single-row grid that no
+            // filter change can widen, and an empty key-dimension list
+            // degenerates into a cross join rather than being rejected. A
+            // Dimension inode never reads `keys_input`, so building one leaves
+            // unreferenced CTEs behind. And a Rank inode ranks within whatever
+            // its source carries: handing it the keys side would shrink the
+            // ranked population to the grid and collapse the ranks, trading a
+            // widened row set for wrong values. Rank needs its rows restricted
+            // *after* the window, which this assembly cannot express.
+            let needs_query_grid = query_filter_dropped
+                && (!state.dimensions().is_empty() || !state.time_dimensions().is_empty())
+                && !matches!(
+                    multi_stage_member.inode_type(),
+                    MultiStageInodeMemberType::Dimension | MultiStageInodeMemberType::Rank
+                );
+
             let use_window_path = multi_stage_member.use_window_path();
             let new_state = {
                 let mut new_state = filtered_state;
@@ -641,27 +661,7 @@ impl MultiStageQueryPlanner {
                 // reason a shrunk grain does — the measure side no longer
                 // enumerates the query's rows — except here the grid keeps
                 // every dimension and only the row count within it grows.
-                //
-                // Three shapes are exempt. A parent state with no dimensions is
-                // a single-row grid that no filter change can widen, and an
-                // empty key-dimension list degenerates into a cross join rather
-                // than being rejected. A Dimension inode never reads
-                // `keys_input`, so building one leaves unreferenced CTEs
-                // behind. And a Rank inode ranks within whatever its source
-                // carries: handing it the keys side would shrink the ranked
-                // population to the grid and collapse the ranks, trading a
-                // widened row set for wrong values. Rank needs the rows
-                // restricted *after* the window, which this assembly cannot
-                // express.
-                let grid_has_dimensions =
-                    !state.dimensions().is_empty() || !state.time_dimensions().is_empty();
-                let inode_can_hold_grid = !matches!(
-                    multi_stage_member.inode_type(),
-                    MultiStageInodeMemberType::Dimension | MultiStageInodeMemberType::Rank
-                );
-                if any_missing
-                    || (query_filter_dropped && grid_has_dimensions && inode_can_hold_grid)
-                {
+                if any_missing || needs_query_grid {
                     self.make_childs(
                         member.clone(),
                         state.clone(),
@@ -1147,6 +1147,15 @@ fn filter_directive_match_names(symbol: &Rc<MemberSymbol>) -> Vec<String> {
 // CTE state to begin with — `build_root_state` drops them — so there is no
 // query-level measure filter for a directive to lose. Filters added on top of
 // `base` don't count either: they shrink the grid, which is safe.
+//
+// The query-membership check compares whole filters, so a filter whose values
+// were rewritten between the root state and `base` reads as one the query never
+// asked for, and the drop goes undetected. That is deliberately out of scope: a
+// path that rewrites filter values on the way down has to bound the row set by
+// other means. The rolling-window date-range rewrite is the one such path, and
+// it does — its rows come from the time series and its values through the frame
+// condition, both built from the query's own range. A new rewriting path has to
+// establish the same, or anchor this check on the member instead of the value.
 fn query_filters_dropped(
     root: &QueryProperties,
     base: &QueryProperties,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -174,12 +174,16 @@ impl MultiStageQueryPlanner {
                 .multi_stage()
                 .map(|ms| ms.grain.clone())
                 .unwrap_or_default();
-            // Window-path eligibility intentionally checks only `include`:
-            // `exclude` and `keep_only` are realised through the window's
-            // PARTITION BY at render time, so they don't disqualify the
-            // path. `include` extends the leaf grain, which the JOIN-model
-            // is required for. Revisit if window-path expands to cases
-            // where exclude/keep_only affect render correctness.
+            // Of the `grain` lists only `include` disqualifies the window path
+            // here: `exclude` and `keep_only` are realised through the window's
+            // PARTITION BY at render time, while `include` extends the leaf
+            // grain, which the JOIN-model is required for.
+            //
+            // Grain is not the only disqualifier. A `filter` directive that
+            // drops a filter the query restricts the grid by also rules the
+            // window path out. Detecting that needs the inherited state, which
+            // only exists further down in `make_queries_descriptions` — the
+            // flag is revoked there.
             let has_include = grain.include.as_ref().is_some_and(|v| !v.is_empty());
             let use_window_path = matches!(member_type, MultiStageInodeMemberType::Aggregate)
                 && !has_include
@@ -512,7 +516,7 @@ impl MultiStageQueryPlanner {
                 alias.clone(),
             )
         } else {
-            let (multi_stage_member, is_ungrupped) = self
+            let (mut multi_stage_member, is_ungrupped) = self
                 .create_multi_stage_inode_member(member.clone(), resolved_multi_stage_dimensions)?;
 
             let mut dimensions_to_add = multi_stage_member
@@ -544,16 +548,39 @@ impl MultiStageQueryPlanner {
             // The window-path Aggregate inode skips step 2: the leaf stays
             // at the parent state plus any `include` extension, and the
             // window function does the `exclude` collapse at outer level.
-            let use_window_path = multi_stage_member.use_window_path();
-            let new_state = {
-                let mut new_state = match directive_filter.as_ref().map(|f| &f.mode) {
+            let filtered_state = {
+                let mut filtered_state = match directive_filter.as_ref().map(|f| &f.mode) {
                     Some(MultiStageFilterMode::Fixed) => self.root_state().as_ref().clone(),
                     Some(MultiStageFilterMode::Relative) | None => state.as_ref().clone(),
                 };
 
                 if let Some(filter) = &directive_filter {
-                    apply_filter_directive_to_state(filter, &mut new_state);
+                    apply_filter_directive_to_state(filter, &mut filtered_state);
                 }
+                filtered_state
+            };
+
+            // Step 1 can drop a filter the query restricts the grid by, and the
+            // window path cannot honour that. A window has a single row set
+            // serving both roles: the rows it reports and the rows it
+            // aggregates over. Dropping the filter widens the aggregation
+            // input, which is the point of the directive — but on the window
+            // path it widens the reported rows with it, so values the query
+            // filtered out come back as result rows. The JOIN-model can hold
+            // the two apart, so hand the inode to it.
+            //
+            // Handing it over restores the row set only for inodes that also
+            // reshape the grain: the keys side below is gated on the grain
+            // losing a dimension, and it is the keys side that carries the
+            // query's rows. An inode that drops a filter while keeping the
+            // parent grain gets no keys side and still reports the wider set.
+            if query_filters_dropped(self.root_state(), &state, &filtered_state) {
+                multi_stage_member = multi_stage_member.with_use_window_path(false);
+            }
+
+            let use_window_path = multi_stage_member.use_window_path();
+            let new_state = {
+                let mut new_state = filtered_state;
 
                 if !use_window_path
                     && matches!(
@@ -1082,6 +1109,67 @@ fn filter_directive_match_names(symbol: &Rc<MemberSymbol>) -> Vec<String> {
     } else {
         vec![full]
     }
+}
+
+// True when `narrowed` lost a *query-level* filter that `base` restricts the
+// grid by. Three conditions per filter: `base` has it, the query asked for it,
+// and `narrowed` doesn't have it.
+//
+// The query membership check is what keeps the notion anchored to the result
+// grid. A filter a parent multi-stage member introduced through its own
+// `filter: include` narrows that parent's view, not the grid the query asked
+// for; a child dropping it (`mode: fixed`) therefore cannot widen the grid
+// past the query, and needs no keys side.
+//
+// Measure filters are absent from the comparison because they never reach a
+// CTE state to begin with — `build_root_state` drops them — so there is no
+// query-level measure filter for a directive to lose. Filters added on top of
+// `base` don't count either: they shrink the grid, which is safe.
+fn query_filters_dropped(
+    root: &QueryProperties,
+    base: &QueryProperties,
+    narrowed: &QueryProperties,
+) -> bool {
+    // `FilterItem`'s own equality compares a filter's type, operator and
+    // values but not the member it targets, so two filters differing only in
+    // their member count as equal. Left alone, a dropped filter would be
+    // cancelled out by an unrelated look-alike that survived, hiding the
+    // widening. Segments carry their member in `full_name` and compare as-is.
+    fn same_filter(a: &FilterItem, b: &FilterItem) -> bool {
+        match (a, b) {
+            (FilterItem::Item(a), FilterItem::Item(b)) => {
+                a.member_name() == b.member_name() && a == b
+            }
+            (FilterItem::Group(a), FilterItem::Group(b)) => {
+                a.operator == b.operator
+                    && a.items.len() == b.items.len()
+                    && a.items
+                        .iter()
+                        .zip(b.items.iter())
+                        .all(|(a, b)| same_filter(a, b))
+            }
+            _ => a == b,
+        }
+    }
+
+    fn has(items: &[FilterItem], item: &FilterItem) -> bool {
+        items.iter().any(|candidate| same_filter(item, candidate))
+    }
+
+    fn any_dropped(root: &[FilterItem], base: &[FilterItem], narrowed: &[FilterItem]) -> bool {
+        base.iter()
+            .any(|item| has(root, item) && !has(narrowed, item))
+    }
+
+    any_dropped(
+        root.dimensions_filters(),
+        base.dimensions_filters(),
+        narrowed.dimensions_filters(),
+    ) || any_dropped(
+        root.time_dimensions_filters(),
+        base.time_dimensions_filters(),
+        narrowed.time_dimensions_filters(),
+    ) || any_dropped(root.segments(), base.segments(), narrowed.segments())
 }
 
 fn apply_filter_directive_to_state(filter: &MultiStageFilter, state: &mut QueryProperties) {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -560,21 +560,17 @@ impl MultiStageQueryPlanner {
                 filtered_state
             };
 
-            // Step 1 can drop a filter the query restricts the grid by, and the
-            // window path cannot honour that. A window has a single row set
-            // serving both roles: the rows it reports and the rows it
-            // aggregates over. Dropping the filter widens the aggregation
-            // input, which is the point of the directive — but on the window
-            // path it widens the reported rows with it, so values the query
-            // filtered out come back as result rows. The JOIN-model can hold
-            // the two apart, so hand the inode to it.
-            //
-            // Handing it over restores the row set only for inodes that also
-            // reshape the grain: the keys side below is gated on the grain
-            // losing a dimension, and it is the keys side that carries the
-            // query's rows. An inode that drops a filter while keeping the
-            // parent grain gets no keys side and still reports the wider set.
-            if query_filters_dropped(self.root_state(), &state, &filtered_state) {
+            // Step 1 can drop a filter the query restricts the grid by. That is
+            // the point of the directive — the aggregation input widens — but
+            // the rows the inode *reports* must stay the query's, and only the
+            // JOIN-model can hold the two apart: its keys side enumerates the
+            // grid while its measure side spans the widened set. A window
+            // expression has one row set serving both roles, so it reports the
+            // widened rows too and values the query filtered out come back as
+            // result rows. Hand such an inode to the JOIN-model.
+            let query_filter_dropped =
+                query_filters_dropped(self.root_state(), &state, &filtered_state);
+            if query_filter_dropped {
                 multi_stage_member = multi_stage_member.with_use_window_path(false);
             }
 
@@ -616,14 +612,15 @@ impl MultiStageQueryPlanner {
                 scope,
             )?;
 
-            // JOIN-model: when new_state misses any dim that was on the
-            // parent's `state`, this inode shrinks the parent grain. We
-            // build keys-side descriptions per child on the parent state
-            // so the FullKeyAggregate can broadcast measure values back
-            // to the full query grain. Window-path Aggregate inodes
-            // (sum-of-sum / sum-of-count with no leaf-extending `include`)
-            // handle broadcast via the window expression instead and don't
-            // need keys_input.
+            // JOIN-model: when the measure side no longer enumerates the rows
+            // this inode has to report — because new_state misses a dim that
+            // was on the parent's `state`, or because a dropped query filter
+            // widened it — we build keys-side descriptions per child on the
+            // parent state, so the FullKeyAggregate broadcasts measure values
+            // onto the query grain and only onto it. Window-path Aggregate
+            // inodes (sum-of-sum / sum-of-count with no leaf-extending
+            // `include`) handle broadcast via the window expression instead and
+            // don't need keys_input.
             let mut keys_input: Vec<Rc<MultiStageQueryDescription>> = vec![];
             if !use_window_path {
                 let new_state_has = |sym: &Rc<MemberSymbol>| {
@@ -639,7 +636,17 @@ impl MultiStageQueryPlanner {
                     .iter()
                     .chain(state.time_dimensions().iter())
                     .any(|d| !new_state_has(d));
-                if any_missing {
+                // A dropped query filter needs the keys side for the same
+                // reason a shrunk grain does — the measure side no longer
+                // enumerates the query's rows — except here the grid keeps
+                // every dimension and only the row count within it grows.
+                //
+                // A parent state with no dimensions is exempt: its grid is a
+                // single row that no filter change can widen, and a keys side
+                // with no key dimensions is not a shape the assembly renders.
+                let grid_has_dimensions =
+                    !state.dimensions().is_empty() || !state.time_dimensions().is_empty();
+                if any_missing || (query_filter_dropped && grid_has_dimensions) {
                     self.make_childs(
                         member.clone(),
                         state.clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -1093,14 +1093,30 @@ impl QueryProperties {
     /// Equality over members (chain-resolved), the three filter slots,
     /// segments and time-shifts. Excludes ordering, limits, planner flags
     /// and join hints; for those fields use the full [`PartialEq`].
+    ///
+    /// Filters are compared with [`tree_ops::eq_with_member`] rather than with
+    /// `FilterItem`'s own equality, which looks at a filter's operator and
+    /// values but not at the member it restricts. Two states filtering
+    /// different dimensions to the same value are different states, and
+    /// conflating them makes a CTE serve a filter it was never built for.
     pub fn eq_as_state(&self, other: &Self) -> bool {
         Self::members_equivalent(&self.dimensions, &other.dimensions)
+            && Self::filters_equivalent(&self.dimensions_filters, &other.dimensions_filters)
             && Self::members_equivalent(&self.time_dimensions, &other.time_dimensions)
-            && self.dimensions_filters == other.dimensions_filters
-            && self.time_dimensions_filters == other.time_dimensions_filters
-            && self.measures_filters == other.measures_filters
-            && self.segments == other.segments
+            && Self::filters_equivalent(
+                &self.time_dimensions_filters,
+                &other.time_dimensions_filters,
+            )
+            && Self::filters_equivalent(&self.measures_filters, &other.measures_filters)
+            && Self::filters_equivalent(&self.segments, &other.segments)
             && self.time_shifts == other.time_shifts
+    }
+
+    fn filters_equivalent(a: &[FilterItem], b: &[FilterItem]) -> bool {
+        a.len() == b.len()
+            && a.iter()
+                .zip(b.iter())
+                .all(|(a, b)| tree_ops::eq_with_member(a, b))
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -677,6 +677,25 @@ cubes:
             multi_stage: true
             sql: "coalesce(100 * {CUBE.total_amount} / nullif({CUBE.amount_grand_total_unfiltered}, 0), 0)"
 
+          # A rolling window rewrites the query date range for its base state
+          # (extending it backwards by the trailing interval). The inner measure
+          # below drops that date filter, so detecting the drop must not depend
+          # on the filter still carrying the query's own bounds.
+          - name: amount_no_date_bound
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            filter:
+                exclude:
+                    - orders.created_at
+
+          - name: rolling_amount_no_date_bound
+            type: sum
+            sql: "{CUBE.amount_no_date_bound}"
+            multi_stage: true
+            rolling_window:
+                trailing: 3 month
+
           - name: amount_only_completed
             type: sum
             sql: "{CUBE.total_amount}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -696,6 +696,37 @@ cubes:
             rolling_window:
                 trailing: 3 month
 
+          # The `include` predicate matches the dropped query filter on
+          # operator and values while naming a different member, so the CTE
+          # dedup key has to compare members to keep the two states apart.
+          - name: amount_exclude_status_include_lookalike
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            filter:
+                exclude:
+                    - orders.status
+                include:
+                    - member: orders.category
+                      operator: notEquals
+                      values: [pending]
+
+          # A rank whose ordering ignores the query filter on `status` and whose
+          # partition drops it. Rank is deliberately left out of the keys side,
+          # so the ranks span the whole universe and the rows do too.
+          - name: category_rank_all_statuses
+            type: rank
+            multi_stage: true
+            grain:
+                exclude:
+                    - orders.status
+            filter:
+                exclude:
+                    - orders.status
+            order_by:
+                - sql: "{CUBE.total_amount}"
+                  dir: desc
+
           - name: amount_only_completed
             type: sum
             sql: "{CUBE.total_amount}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -125,6 +125,12 @@ cubes:
                 else:
                     sql: "{CUBE.status}"
 
+          # Every books row is NULL here, so a query grouping by it carries a
+          # NULL dimension key through the multi-stage assembly.
+          - name: category_nullable
+            type: string
+            sql: "NULLIF(category, 'books')"
+
           - name: customer_name
             type: string
             sql: "{customers.name}"
@@ -635,6 +641,41 @@ cubes:
             filter:
                 keep_only:
                     - orders.status
+
+          # Both directives name `status`: the value ignores the query filter
+          # on it (`filter`) and collapses its partition (`grain`). The result
+          # row set must still be the query's.
+          - name: amount_grain_and_filter_exclude_status
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            grain:
+                exclude:
+                    - orders.status
+            filter:
+                exclude:
+                    - orders.status
+
+          # Share-of-total shape: a grand-total denominator (grain drops every
+          # dimension) that also ignores the query filter on `status`, consumed
+          # by a ratio that coalesces a missing denominator to 0 — so a widened
+          # row set surfaces as extra rows reading 0 rather than NULL.
+          - name: amount_grand_total_unfiltered
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            grain:
+                exclude:
+                    - orders.status
+                    - orders.category
+            filter:
+                exclude:
+                    - orders.status
+
+          - name: amount_share_percent
+            type: number
+            multi_stage: true
+            sql: "coalesce(100 * {CUBE.total_amount} / nullif({CUBE.amount_grand_total_unfiltered}, 0), 0)"
 
           - name: amount_only_completed
             type: sum

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -346,3 +346,34 @@ async fn test_grain_exclude_keeps_null_dimension_key() {
         insta::assert_snapshot!(result);
     }
 }
+
+// The dropped filter's dimension is not one the query groups by, so the grain
+// reshape has nothing to remove and the measure side keeps the full grid — yet
+// the rows within that grid still widen. Grouping by the primary key makes it
+// visible: only the six completed orders may appear.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_filter_exclude_keeps_row_set_when_member_not_grouped() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_exclude_status
+          - orders.amount_grain_and_filter_exclude_status
+        dimensions:
+          - orders.id
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.id
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -472,3 +472,67 @@ async fn test_rolling_window_over_dropped_date_filter_by_dimension() {
         insta::assert_snapshot!(result);
     }
 }
+
+// The directive's `include` predicate shares operator and values with the query
+// filter it drops but names a different member. The keys side is planned on the
+// inherited state, so a member-blind CTE dedup key would hand back the widened
+// measure CTE and leave the row set widened.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_filter_exclude_with_lookalike_include_keeps_query_row_set() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_exclude_status_include_lookalike
+        dimensions:
+          - orders.status
+          - orders.category
+        filters:
+          - dimension: orders.status
+            operator: notEquals
+            values:
+              - pending
+        order:
+          - id: orders.status
+          - id: orders.category
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// Rank is out of the keys side on purpose: ranking within the query grid would
+// leave one row per partition and collapse every rank to 1. The cost is that the
+// statuses the query filtered out stay in the result, carrying a NULL for every
+// measure that does honour the filter. Pins that trade rather than endorsing it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rank_with_filter_exclude_ranks_over_whole_universe() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.category_rank_all_statuses
+        dimensions:
+          - orders.status
+          - orders.category
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.status
+          - id: orders.category
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -303,8 +303,9 @@ async fn test_share_of_grand_total_keeps_query_row_set() {
     "#};
 
     let sql = ctx.build_sql(query).unwrap();
-    // Whitespace-stripped so the check survives a dialect rendering `OVER(`
-    // or breaking the window expression across lines.
+    // The window text comes from a `format!` in the physical plan, not from a
+    // dialect template, so `OVER (` is stable; whitespace is stripped only so
+    // the check does not depend on how the expression is laid out.
     let dense: String = sql.chars().filter(|c| !c.is_whitespace()).collect();
     assert!(
         !dense.contains("OVER("),
@@ -338,6 +339,7 @@ async fn test_grain_exclude_keeps_null_dimension_key() {
               - completed
         order:
           - id: orders.status
+          - id: orders.category_nullable
     "#};
 
     ctx.build_sql(query).unwrap();
@@ -369,6 +371,38 @@ async fn test_filter_exclude_keeps_row_set_when_member_not_grouped() {
               - completed
         order:
           - id: orders.id
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// `keep_only` on a segment, with the dropped filter's dimension outside the
+// query grid so the value differs from the plain measure: the segment still
+// restricts to completed orders while the category filter is gone, so the
+// measure spans every category and the plain measure only books.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_keep_only_segment_value_ignores_dropped_filter() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_keep_only_segment
+        dimensions:
+          - orders.status
+        segments:
+          - orders.completed_orders
+        filters:
+          - dimension: orders.category
+            operator: equals
+            values:
+              - books
+        order:
+          - id: orders.status
     "#};
 
     ctx.build_sql(query).unwrap();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -245,3 +245,104 @@ async fn test_mode_fixed_in_chain_diverges_from_relative() {
         insta::assert_snapshot!(result);
     }
 }
+
+// `grain.exclude` and `filter.exclude` naming the same dimension, which the
+// query both groups by and filters on. The value ignores the filter and the
+// partition; the row set stays the query's — the statuses the query filtered
+// out may not reappear.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_grain_and_filter_exclude_keeps_query_row_set() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_grain_and_filter_exclude_status
+        dimensions:
+          - orders.status
+          - orders.category
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.status
+          - id: orders.category
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// Share-of-total over a grand-total denominator that ignores the query filter.
+// The denominator's own aggregation must span every status while the ratio is
+// reported only for the rows the query asked for; a widened row set would show
+// up as extra rows whose share coalesces to 0.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_share_of_grand_total_keeps_query_row_set() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_share_percent
+        dimensions:
+          - orders.status
+          - orders.category
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.status
+          - id: orders.category
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    // Whitespace-stripped so the check survives a dialect rendering `OVER(`
+    // or breaking the window expression across lines.
+    let dense: String = sql.chars().filter(|c| !c.is_whitespace()).collect();
+    assert!(
+        !dense.contains("OVER("),
+        "the denominator has to hold the query's rows through a keys side, \
+         which a window expression cannot do:\n{}",
+        sql
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// A NULL dimension value is a grid key like any other: the keys side and the
+// measure side must still meet on it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_grain_exclude_keeps_null_dimension_key() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_grain_and_filter_exclude_status
+        dimensions:
+          - orders.status
+          - orders.category_nullable
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.status
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -411,3 +411,64 @@ async fn test_keep_only_segment_value_ignores_dropped_filter() {
         insta::assert_snapshot!(result);
     }
 }
+
+// A rolling window rewrites the date range it hands to its base state, so the
+// filter the inner measure drops no longer carries the query's own bounds. The
+// row set survives that regardless: a rolling window takes its rows from the
+// time series built out of the query's `dateRange`, and its values through the
+// frame condition derived from the same range — neither depends on the leaf
+// keeping its date filter.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_window_over_dropped_date_filter() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.rolling_amount_no_date_bound
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-03-01"
+              - "2024-03-31"
+        order:
+          - id: orders.created_at
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// The same shape with a dimension and a range narrow enough that the trailing
+// window reaches months the leaf can see but the query did not ask for.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_window_over_dropped_date_filter_by_dimension() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.rolling_amount_no_date_bound
+        dimensions:
+          - orders.category
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
+        order:
+          - id: orders.created_at
+          - id: orders.category
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_keeps_row_set_when_member_not_grouped.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_keeps_row_set_when_member_not_grouped.snap
@@ -1,0 +1,13 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 377
+expression: result
+---
+orders__id | orders__total_amount | orders__amount_exclude_status | orders__amount_grain_and_filter_exclude_status
+-----------+----------------------+-------------------------------+-----------------------------------------------
+1          | 100.00               | 100.00                        | 100.00                                        
+2          | 200.00               | 200.00                        | 200.00                                        
+6          | 300.00               | 300.00                        | 300.00                                        
+7          | 200.00               | 200.00                        | 200.00                                        
+11         | 400.00               | 400.00                        | 400.00                                        
+12         | 200.00               | 200.00                        | 200.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_keeps_row_set_when_member_not_grouped.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_keeps_row_set_when_member_not_grouped.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 377
 expression: result
 ---
 orders__id | orders__total_amount | orders__amount_exclude_status | orders__amount_grain_and_filter_exclude_status

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_with_lookalike_include_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__filter_exclude_with_lookalike_include_keeps_query_row_set.snap
@@ -1,0 +1,12 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+expression: result
+---
+orders__status | orders__category | orders__total_amount | orders__amount_exclude_status_include_lookalike
+---------------+------------------+----------------------+------------------------------------------------
+cancelled      | books            | 100.00               | 100.00                                         
+cancelled      | clothing         | 50.00                | 50.00                                          
+cancelled      | electronics      | 50.00                | 50.00                                          
+completed      | books            | 600.00               | 600.00                                         
+completed      | clothing         | 300.00               | 300.00                                         
+completed      | electronics      | 500.00               | 500.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_and_filter_exclude_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_and_filter_exclude_keeps_query_row_set.snap
@@ -1,0 +1,10 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 277
+expression: result
+---
+orders__status | orders__category | orders__total_amount | orders__amount_grain_and_filter_exclude_status
+---------------+------------------+----------------------+-----------------------------------------------
+completed      | books            | 600.00               | 880.00                                        
+completed      | clothing         | 300.00               | 720.00                                        
+completed      | electronics      | 500.00               | 650.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_and_filter_exclude_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_and_filter_exclude_keeps_query_row_set.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 277
 expression: result
 ---
 orders__status | orders__category | orders__total_amount | orders__amount_grain_and_filter_exclude_status

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_exclude_keeps_null_dimension_key.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_exclude_keeps_null_dimension_key.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 343
 expression: result
 ---
 orders__status | orders__category_nullable | orders__total_amount | orders__amount_grain_and_filter_exclude_status

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_exclude_keeps_null_dimension_key.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__grain_exclude_keeps_null_dimension_key.snap
@@ -1,0 +1,10 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 343
+expression: result
+---
+orders__status | orders__category_nullable | orders__total_amount | orders__amount_grain_and_filter_exclude_status
+---------------+---------------------------+----------------------+-----------------------------------------------
+completed      | clothing                  | 300.00               | 720.00                                        
+completed      | electronics               | 500.00               | 650.00                                        
+completed      | NULL                      | 600.00               | 880.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_drops_other_filters.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_drops_other_filters.snap
@@ -5,6 +5,4 @@ expression: result
 ---
 orders__category | orders__total_amount | orders__amount_keep_only_segment
 -----------------+----------------------+---------------------------------
-books            | 600.00               | 600.00                          
-clothing         | NULL                 | 300.00                          
-electronics      | NULL                 | 500.00
+books            | 600.00               | 600.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_value_ignores_dropped_filter.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_value_ignores_dropped_filter.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 411
 expression: result
 ---
 orders__status | orders__total_amount | orders__amount_keep_only_segment

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_value_ignores_dropped_filter.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__keep_only_segment_value_ignores_dropped_filter.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 411
+expression: result
+---
+orders__status | orders__total_amount | orders__amount_keep_only_segment
+---------------+----------------------+---------------------------------
+completed      | 600.00               | 1400.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rank_with_filter_exclude_ranks_over_whole_universe.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rank_with_filter_exclude_ranks_over_whole_universe.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+expression: result
+---
+orders__status | orders__category | orders__total_amount | orders__category_rank_all_statuses
+---------------+------------------+----------------------+-----------------------------------
+cancelled      | books            | NULL                 | 3                                 
+cancelled      | clothing         | NULL                 | 3                                 
+cancelled      | electronics      | NULL                 | 3                                 
+completed      | books            | 600.00               | 1                                 
+completed      | clothing         | 300.00               | 2                                 
+completed      | electronics      | 500.00               | 1                                 
+pending        | books            | NULL                 | 2                                 
+pending        | clothing         | NULL                 | 1                                 
+pending        | electronics      | NULL                 | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 442
+expression: result
+---
+orders__created_at_month | orders__total_amount | orders__rolling_amount_no_date_bound
+-------------------------+----------------------+-------------------------------------
+2024-03-01 00:00:00      | 1000.00              | 2250.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 442
 expression: result
 ---
 orders__created_at_month | orders__total_amount | orders__rolling_amount_no_date_bound

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter_by_dimension.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter_by_dimension.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 472
 expression: result
 ---
 orders__category | orders__created_at_month | orders__total_amount | orders__rolling_amount_no_date_bound

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter_by_dimension.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__rolling_window_over_dropped_date_filter_by_dimension.snap
@@ -1,0 +1,10 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 472
+expression: result
+---
+orders__category | orders__created_at_month | orders__total_amount | orders__rolling_amount_no_date_bound
+-----------------+--------------------------+----------------------+-------------------------------------
+books            | 2024-01-01 00:00:00      | 230.00               | 230.00                              
+clothing         | 2024-01-01 00:00:00      | 120.00               | 120.00                              
+electronics      | 2024-01-01 00:00:00      | 150.00               | 150.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__share_of_grand_total_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__share_of_grand_total_keeps_query_row_set.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
-assertion_line: 314
 expression: result
 ---
 orders__status | orders__category | orders__amount_share_percent

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__share_of_grand_total_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__share_of_grand_total_keeps_query_row_set.snap
@@ -1,0 +1,10 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+assertion_line: 314
+expression: result
+---
+orders__status | orders__category | orders__amount_share_percent
+---------------+------------------+-----------------------------
+completed      | books            | 26.6666666666666667         
+completed      | clothing         | 13.3333333333333333         
+completed      | electronics      | 22.2222222222222222

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
@@ -1,9 +1,8 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+assertion_line: 317
 expression: result
 ---
 orders_ms_view__category | orders_ms_view__total_amount | orders_ms_view__amount_keep_only_segment
 -------------------------+------------------------------+-----------------------------------------
-books                    | 600.00                       | 600.00                                  
-clothing                 | NULL                         | 300.00                                  
-electronics              | NULL                         | 500.00
+books                    | 600.00                       | 600.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
-assertion_line: 317
 expression: result
 ---
 orders_ms_view__category | orders_ms_view__total_amount | orders_ms_view__amount_keep_only_segment


### PR DESCRIPTION
## Summary

A multi-stage measure whose `filter:` directive drops a query filter reported dimension values the query had filtered out. Those values are the keys the `FullKeyAggregate` joins on, so they came back as result rows carrying NULL for every other measure — the reported symptom being a share-of-total denominator returning the whole universe with a share of 0.

The directive is meant to free the *inner aggregation stage* from a filter, which is what makes a "share of total ignoring this filter" denominator possible. It must not free the rows the measure *reports*. Only the JOIN-model assembly can hold those two apart — its keys side enumerates the query grid while its measure side spans the widened set — so a member that drops a query filter is now handed to it.

## Changes

- `query_filters_dropped` detects a directive dropping a filter the query itself restricts the grid by. Membership is checked against the root query state, so a filter an upstream member introduced through its own `filter: include` does not count — that narrows the upstream member's view, not the result grid. The comparison is member-aware, since `FilterItem` equality compares a filter's operator and values but not the member it targets, and a dropped filter would otherwise be cancelled out by an unrelated look-alike that survived.
- When it fires, `use_window_path` is revoked (a window expression has one row set serving both the rows it reports and the rows it aggregates over) and the keys side is built, alongside the pre-existing grain-shrink trigger.
- Three shapes are exempt: a dimensionless parent grid is a single row no filter change can widen; a `Dimension` inode never reads `keys_input`; and a `Rank` inode ranks within whatever its source carries, so a keys side would shrink the ranked population and collapse the ranks — trading a widened row set for wrong values.
- `QueryProperties::eq_as_state`, the multi-stage CTE dedup key, is member-aware too. It compared filter vectors with the same member-blind equality, which let the keys side dedup onto the very CTE it exists to bound: a directive combining `exclude` with an `include` whose operator and values coincide on another member plans the widened measure child first, and the keys child then matched it and came back as the same CTE.
- The explicit-keys join is now null-safe, consistent with the full-join and inner-join strategies which already were. A plain `=` never matches NULL to NULL, so a key row whose dimension was NULL kept its place in the grid and lost the measure. It cannot be narrowed to the dimensions that need it: the data model carries no nullability information, and a dimension read through an outer join in the join graph arrives as NULL even from a column declared NOT NULL.
- Member-aware filter-tree equality lives in `planner/filter/tree_ops`, beside the other tree walkers, and is used by both call sites.

## Testing

Reproduced against the shape from the customer model — a grand-total denominator whose `grain.exclude` and `filter.exclude` both name a dimension the query groups by and filters on, consumed by a ratio with `coalesce`. The generated SQL matched the reported production plan: 9 rows with 6 extra reading 0, now 3 rows with correct shares.

Nine new Rust integration tests, all value-based:

- the share-of-grand-total shape, plus an assertion that no window expression is emitted
- `grain.exclude` + `filter.exclude` on a grouped and filtered dimension
- a dropped filter whose dimension the query does *not* group by, grouped by the primary key so the widening is visible: 15 rows before, 6 after
- a directive whose `include` predicate matches the dropped filter on operator and values while naming another member — the dedup shape above: 9 rows before, 6 after
- a NULL dimension key keeping its measure
- the value side of a `keep_only` segment drop, at a grain where the dropped filter changes the number (600 against 1400)
- a rolling window over a dropped date filter, at two grains. A rolling window rewrites the date range it hands to its base state, so the dropped filter is not detected there; these pin that the row set stays bounded anyway, because the window takes its rows from the time series and its values through the frame condition
- a rank measure with a filter directive, pinning the row set `Rank` keeps reporting and failing loudly if `Rank` were dropped from the exemption

Two pre-existing snapshots changed: both filtered `category = books` yet returned `clothing` and `electronics` rows with a NULL measure.

One JS Postgres integration test covers the same combination end-to-end through the schema compiler.

`cargo test --features integration-postgres -p cubesqlplanner`: 1124 passed. 16 JS Postgres suites green, including `sql-generation` (134), `pre-aggregations` (47) and `calc-groups` (24) — the dedup-key change touches every multi-stage plan, so the pre-aggregation and sql-generation suites are the relevant ones.

### Known limitations

- A rollup that does not store the dropped filter's dimension can no longer serve such a query. Before, the filter was absent from the plan entirely, so the rollup answered a query the user had not made; a rollup that does carry the dimension still matches.
- `Rank` measures keep reporting the wider row set, for the reason above. Pinned by a test rather than left implicit.
- The null-safe keys join costs hash- and merge-joinability on engines that treat the operator as unhashable (PostgreSQL; Redshift has no such operator and falls back to an equally unhashable OR-form). Behaviour on Snowflake was not measured.
- Detection compares whole filters, so a path that rewrites filter values between the root state and a CTE state reads as one the query never asked for. The rolling-window date-range rewrite is the one such path today and bounds its rows by other means; the constraint is recorded at the predicate.
