### PR TITLE
fix(tesseract): don't serve ungrouped queries from collapsing rollups

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -98,10 +98,19 @@ granularity (e.g., `day` or `month`).
 There are extra considerations that apply to matching [ungrouped
 queries][ref-ungrouped-queries]:
 
-- The pre-aggregation should include [primary keys][ref-primary-key] of all
-cubes involved in the query.
-- If multiple cubes are referenced in the query, the pre-aggregation should
-include only members of these cubes.
+An ungrouped query returns raw rows, so a pre-aggregation can only serve one if
+each of its rows is one row of that query's join:
+
+- The pre-aggregation should include the [primary key][ref-primary-key] of the
+first cube in the query's join, and of every cube joined to it through a
+`one_to_many` relationship. Cubes joined through `many_to_one` or `one_to_one`
+cannot multiply rows, so their primary keys are not required.
+- The pre-aggregation should not group by a member of a cube that the query does
+not join. Its `segments` count here as well, since they group its rows just like
+its `dimensions` do.
+- Measures stored in a mergeable form rather than as a final value, such as
+[`count_distinct_approx`][ref-count-distinct-approx], cannot be read row by row,
+so a pre-aggregation containing one is not used.
 
 ## Matching multi-fact and multi-stage queries
 
@@ -155,6 +164,7 @@ configuration option.
 [ref-conf-scheduled-refresh-time-zones]: /reference/configuration/config#scheduled_refresh_time_zones
 [ref-ungrouped-queries]: /reference/core-data-apis/queries#ungrouped-query
 [ref-primary-key]: /reference/data-modeling/dimensions#primary_key
+[ref-count-distinct-approx]: /reference/data-modeling/measures#type
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-views]: /docs/data-modeling/views
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -95,14 +95,13 @@ granularity (e.g., `day` or `month`).
 
 ### Matching ungrouped queries
 
-There are extra considerations that apply to matching [ungrouped
-queries][ref-ungrouped-queries]:
-
-An ungrouped query returns raw rows, so a pre-aggregation can only serve one if
-each of its rows is one row of that query's join:
+An [ungrouped query][ref-ungrouped-queries] returns raw rows, so a
+pre-aggregation can only serve one if each of its rows is one row of that query's
+join:
 
 - The pre-aggregation should include the [primary key][ref-primary-key] of the
-first cube in the query's join, and of every cube joined to it through a
+cube the join starts from — the cube whose members the query requests, or the
+cube a queried view joins from — and of every cube joined to it through a
 `one_to_many` relationship. Cubes joined through `many_to_one` or `one_to_one`
 cannot multiply rows, so their primary keys are not required.
 - The pre-aggregation should not group by a member of a cube that the query does
@@ -111,6 +110,15 @@ its `dimensions` do.
 - Measures stored in a mergeable form rather than as a final value, such as
 [`count_distinct_approx`][ref-count-distinct-approx], cannot be read row by row,
 so a pre-aggregation containing one is not used.
+
+<Warning>
+
+These criteria are applied by Tesseract, the [next-generation data modeling
+engine][link-tesseract]. A deployment that opts out of it with
+[`CUBEJS_TESSERACT_SQL_PLANNER`][ref-env-tesseract]`=false` matches ungrouped
+queries by different criteria.
+
+</Warning>
 
 ## Matching multi-fact and multi-stage queries
 
@@ -165,6 +173,7 @@ configuration option.
 [ref-ungrouped-queries]: /reference/core-data-apis/queries#ungrouped-query
 [ref-primary-key]: /reference/data-modeling/dimensions#primary_key
 [ref-count-distinct-approx]: /reference/data-modeling/measures#type
+[ref-env-tesseract]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-views]: /docs/data-modeling/views
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -95,30 +95,13 @@ granularity (e.g., `day` or `month`).
 
 ### Matching ungrouped queries
 
-An [ungrouped query][ref-ungrouped-queries] returns raw rows, so a
-pre-aggregation can only serve one if each of its rows is one row of that query's
-join:
+There are extra considerations that apply to matching [ungrouped
+queries][ref-ungrouped-queries]:
 
-- The pre-aggregation should include the [primary key][ref-primary-key] of the
-cube the join starts from — the cube whose members the query requests, or the
-cube a queried view joins from — and of every cube joined to it through a
-`one_to_many` relationship. Cubes joined through `many_to_one` or `one_to_one`
-cannot multiply rows, so their primary keys are not required.
-- The pre-aggregation should not group by a member of a cube that the query does
-not join. Its `segments` count here as well, since they group its rows just like
-its `dimensions` do.
-- Measures stored in a mergeable form rather than as a final value, such as
-[`count_distinct_approx`][ref-count-distinct-approx], cannot be read row by row,
-so a pre-aggregation containing one is not used.
-
-<Warning>
-
-These criteria are applied by Tesseract, the [next-generation data modeling
-engine][link-tesseract]. A deployment that opts out of it with
-[`CUBEJS_TESSERACT_SQL_PLANNER`][ref-env-tesseract]`=false` matches ungrouped
-queries by different criteria.
-
-</Warning>
+- The pre-aggregation should include [primary keys][ref-primary-key] of all
+cubes involved in the query.
+- If multiple cubes are referenced in the query, the pre-aggregation should
+include only members of these cubes.
 
 ## Matching multi-fact and multi-stage queries
 
@@ -172,8 +155,6 @@ configuration option.
 [ref-conf-scheduled-refresh-time-zones]: /reference/configuration/config#scheduled_refresh_time_zones
 [ref-ungrouped-queries]: /reference/core-data-apis/queries#ungrouped-query
 [ref-primary-key]: /reference/data-modeling/dimensions#primary_key
-[ref-count-distinct-approx]: /reference/data-modeling/measures#type
-[ref-env-tesseract]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-views]: /docs/data-modeling/views
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-ungrouped-cross-cube.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-ungrouped-cross-cube.test.ts
@@ -1,0 +1,233 @@
+import { PostgresQuery } from '../../../src/adapter/PostgresQuery';
+import { prepareYamlCompiler } from '../../unit/PrepareCompiler';
+
+const CUBES = `
+cubes:
+  - name: visitors
+    sql: "SELECT * FROM visitors"
+    joins:
+      - name: visitor_checkins
+        relationship: one_to_many
+        sql: "{CUBE.id} = {visitor_checkins.visitor_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: source
+        type: string
+        sql: source
+
+  - name: visitor_checkins
+    sql: "SELECT * FROM visitor_checkins"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+      - name: created_at
+        type: time
+        sql: created_at
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+`;
+
+// Renames every member, so the query spells members no pre-aggregation mentions.
+const VIEW = `
+views:
+  - name: visitors_view
+    cubes:
+      - join_path: visitors
+        includes:
+          - id
+          - source
+        prefix: true
+      - join_path: visitors.visitor_checkins
+        includes:
+          - visitor_id
+          - count
+        prefix: true
+`;
+
+// Grouped by a non-key dimension plus a cross-cube one, so its rows are already
+// collapsed and reading them flat would drop the join.
+const COLLAPSED_ROLLUP = `
+      - name: joined_rollup
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - visitor_id
+          - visitors.source
+        time_dimension: created_at
+        granularity: day
+`;
+
+// The same collapsed rollup without a time dimension, so the query's member set
+// matches it exactly. Nothing but the primary-key rule stands between this query
+// and a join-less read of collapsed rows.
+const COLLAPSED_ROLLUP_NO_TIME_DIMENSION = `
+      - name: no_keys_rollup
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - visitor_id
+          - visitors.source
+`;
+
+// Same cross-cube shape, but grouped by the primary keys of both cubes, so each
+// stored row is one raw joined row.
+const KEYED_ROLLUP = `
+      - name: joined_keys_rollup
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - id
+          - visitor_id
+          - visitors.id
+          - visitors.source
+`;
+
+const BASE_QUERY = {
+  ungrouped: true,
+  // Without this a joined ungrouped query is rejected by `initUngrouped` unless
+  // it selects the primary keys of every joined cube. It is a server-level
+  // option (`CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY`) that inherits
+  // `CUBESQL_SQL_PUSH_DOWN`'s default, so it is normally on.
+  allowUngroupedWithoutPrimaryKey: true,
+  timezone: 'America/Los_Angeles',
+  preAggregationsSchema: '',
+};
+
+const PLANNERS: [string, boolean][] = [
+  ['legacy planner', false],
+  ['native planner', true],
+];
+
+describe('PreAggregations ungrouped cross-cube query', () => {
+  jest.setTimeout(200000);
+
+  describe('rollup whose grouping collapses raw rows', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(
+      CUBES + COLLAPSED_ROLLUP + VIEW
+    );
+
+    it.each(PLANNERS)('is not matched, keeping the join (%s)', async (_label, useNativeSqlPlanner) => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...BASE_QUERY,
+        dimensions: ['visitor_checkins.visitor_id', 'visitors.source'],
+        filters: [{ member: 'visitors.source', operator: 'equals', values: ['google'] }],
+        useNativeSqlPlanner,
+      } as any);
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const [sql] = query.buildSqlAndParams();
+
+      expect(preAggregationsDescription).toEqual([]);
+      expect(sql).not.toContain('joined_rollup');
+      expect(sql.toLowerCase()).toContain('join');
+    });
+
+    it.each(PLANNERS)('is not matched through a view either (%s)', async (_label, useNativeSqlPlanner) => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...BASE_QUERY,
+        dimensions: ['visitors_view.visitor_checkins_visitor_id', 'visitors_view.visitors_source'],
+        filters: [{ member: 'visitors_view.visitors_source', operator: 'equals', values: ['google'] }],
+        useNativeSqlPlanner,
+      } as any);
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const [sql] = query.buildSqlAndParams();
+
+      expect(preAggregationsDescription).toEqual([]);
+      expect(sql).not.toContain('joined_rollup');
+      expect(sql.toLowerCase()).toContain('join');
+    });
+  });
+
+  // Native planner only: legacy matches this rollup and reads it without the
+  // join, so asserting legacy here would pin that bug.
+  describe('collapsed rollup whose member set matches the query exactly', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(
+      CUBES + COLLAPSED_ROLLUP_NO_TIME_DIMENSION + VIEW
+    );
+
+    it('is not matched, keeping the join (native planner)', async () => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...BASE_QUERY,
+        dimensions: ['visitor_checkins.visitor_id', 'visitors.source'],
+        useNativeSqlPlanner: true,
+      } as any);
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const [sql] = query.buildSqlAndParams();
+
+      expect(preAggregationsDescription).toEqual([]);
+      expect(sql).not.toContain('no_keys_rollup');
+      expect(sql.toLowerCase()).toContain('join');
+    });
+  });
+
+  describe('rollup grouped by the primary keys of both cubes', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(
+      CUBES + KEYED_ROLLUP + VIEW
+    );
+
+    it.each(PLANNERS)('is matched when the query carries the primary keys (%s)', async (_label, useNativeSqlPlanner) => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...BASE_QUERY,
+        dimensions: [
+          'visitors.id',
+          'visitor_checkins.id',
+          'visitors.source',
+          'visitor_checkins.visitor_id',
+        ],
+        useNativeSqlPlanner,
+      } as any);
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const [sql] = query.buildSqlAndParams();
+
+      expect(preAggregationsDescription.map((d: any) => d.tableName)).toEqual([
+        'visitor_checkins_joined_keys_rollup',
+      ]);
+      expect(sql).toContain('visitor_checkins_joined_keys_rollup');
+    });
+
+    // Native planner only: legacy rejects this rollup even though one stored row
+    // is one raw joined row. Going through the view also pins that the view is
+    // not mistaken for a third cube.
+    it('is matched through a view (native planner)', async () => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        ...BASE_QUERY,
+        dimensions: ['visitors_view.visitors_source', 'visitors_view.visitor_checkins_visitor_id'],
+        useNativeSqlPlanner: true,
+      } as any);
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const [sql] = query.buildSqlAndParams();
+
+      expect(preAggregationsDescription.map((d: any) => d.tableName)).toEqual([
+        'visitor_checkins_joined_keys_rollup',
+      ]);
+      expect(sql).toContain('visitor_checkins_joined_keys_rollup');
+    });
+  });
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/join.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/join.rs
@@ -11,7 +11,9 @@ use typed_builder::TypedBuilder;
 pub struct LogicalJoinItem {
     cube: Rc<Cube>,
     on_sql: Rc<SqlCall>,
-    #[builder(default)]
+    /// Required, with no default: `false` is the answer that lets a rollup
+    /// collapsing this edge's rows serve a raw-row query, so a construction site
+    /// must not be able to omit it.
     splits_rows: bool,
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/join.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/join.rs
@@ -11,6 +11,8 @@ use typed_builder::TypedBuilder;
 pub struct LogicalJoinItem {
     cube: Rc<Cube>,
     on_sql: Rc<SqlCall>,
+    #[builder(default)]
+    splits_rows: bool,
 }
 
 impl LogicalJoinItem {
@@ -20,6 +22,12 @@ impl LogicalJoinItem {
 
     pub fn on_sql(&self) -> &Rc<SqlCall> {
         &self.on_sql
+    }
+
+    /// Whether joining this cube in splits a row of its parent into
+    /// several, i.e. it sits on the `one_to_many` side of its edge.
+    pub fn splits_rows(&self) -> bool {
+        self.splits_rows
     }
 }
 
@@ -129,6 +137,7 @@ impl LogicalNode for LogicalJoin {
                 Ok(LogicalJoinItem::builder()
                     .cube(item.clone().into_logical_node()?)
                     .on_sql(self_item.on_sql().clone())
+                    .splits_rows(self_item.splits_rows())
                     .build())
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -37,6 +37,16 @@ impl PreAggregationUsage {
     }
 }
 
+/// What a query does with the rows underneath it, which decides whether a
+/// pre-aggregation's grain has to match those rows one for one.
+enum RowGrain {
+    /// The query aggregates, so a coarser stored grain is still usable.
+    Aggregated,
+    /// The query returns raw rows over the given join. `None` when the node is
+    /// not a plain cube join, leaving nothing to establish row identity against.
+    RawRows(Option<Rc<LogicalJoin>>),
+}
+
 pub struct PreAggregationOptimizer {
     query_tools: Rc<State>,
     allow_multi_stage: bool,
@@ -150,19 +160,19 @@ impl PreAggregationOptimizer {
         // Row identity for an ungrouped read is judged against the join this
         // very node will render, taken from the node itself rather than
         // re-resolved, so the two can never disagree.
-        let raw_rows_join = if is_user_query && query.modifers().ungrouped {
-            Some(match query.source() {
+        let row_grain = if is_user_query && query.modifers().ungrouped {
+            RowGrain::RawRows(match query.source() {
                 QuerySource::LogicalJoin(join) => Some(join.clone()),
                 _ => None,
             })
         } else {
-            None
+            RowGrain::Aggregated
         };
         if let Some(matched_measures) = self.is_schema_and_filters_match(
             &query.schema(),
             &query.filter(),
             pre_aggregation,
-            raw_rows_join,
+            row_grain,
         )? {
             let source =
                 self.make_pre_aggregation_source(pre_aggregation, &matched_measures, date_range)?;
@@ -195,9 +205,16 @@ impl PreAggregationOptimizer {
                 &TimeShiftState::default(),
                 external,
             );
-            if let Some(matched_measures) =
-                self.is_schema_and_filters_match(schema, filter, pre_aggregation, None)?
-            {
+            // This node holds no `Query` of its own, so its `ungrouped` flag is
+            // not reachable here and no join is available to judge row identity
+            // against. An ungrouped request routed through here can still be
+            // served by a pre-aggregation that collapses its rows.
+            if let Some(matched_measures) = self.is_schema_and_filters_match(
+                schema,
+                filter,
+                pre_aggregation,
+                RowGrain::Aggregated,
+            )? {
                 let source = self.make_pre_aggregation_source(
                     pre_aggregation,
                     &matched_measures,
@@ -508,10 +525,7 @@ impl PreAggregationOptimizer {
         schema: &Rc<LogicalSchema>,
         filters: &Rc<LogicalFilter>,
         pre_aggregation: &CompiledPreAggregation,
-        // `Some` when the query returns raw rows: the inner option carries the
-        // node's own join, or `None` when the node is not a plain cube join and
-        // its row grain cannot be established.
-        raw_rows_join: Option<Option<Rc<LogicalJoin>>>,
+        row_grain: RowGrain,
     ) -> Result<Option<HashSet<String>>, CubeError> {
         let helper = OptimizerHelper::new();
 
@@ -529,15 +543,15 @@ impl PreAggregationOptimizer {
             return Ok(None);
         }
 
-        // The query's join groups answer both the multiplicativity gate
-        // and the join-path comparison below, so build them once.
-        let query_groups = self.query_join_groups(schema, &all_measures)?;
-
-        if let Some(node_join) = &raw_rows_join {
+        if let RowGrain::RawRows(node_join) = &row_grain {
             if !self.is_raw_rows_match(node_join.as_ref(), pre_aggregation)? {
                 return Ok(None);
             }
         }
+
+        // The query's join groups answer both the multiplicativity gate
+        // and the join-path comparison below, so build them once.
+        let query_groups = self.query_join_groups(schema, &all_measures)?;
 
         // A measure sitting under a row-multiplying join can't be rolled
         // up from a partially matching pre-aggregation.
@@ -557,15 +571,13 @@ impl PreAggregationOptimizer {
         // An ungrouped read projects stored columns as they are, with no
         // aggregate around them, so a measure kept as a mergeable sketch would
         // reach the client as the sketch instead of a number.
-        if raw_rows_join.is_some() {
-            for measure in pre_aggregation.measures.iter() {
-                if !matched_measures.contains(&measure.full_name()) {
+        if matches!(row_grain, RowGrain::RawRows(_)) {
+            for symbol in pre_aggregation.measures.iter() {
+                if !matched_measures.contains(symbol.full_name().as_str()) {
                     continue;
                 }
-                if let Ok(measure) = measure.as_measure() {
-                    if measure.kind().is_stored_as_state() {
-                        return Ok(None);
-                    }
+                if symbol.as_measure()?.kind().is_stored_as_state() {
+                    return Ok(None);
                 }
             }
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -677,7 +677,7 @@ impl PreAggregationOptimizer {
         // The pre-aggregation must not be stored at a finer grain than the node
         // reads either: a cube it groups by but the node never joins splits its
         // rows further, so the same row would come back more than once.
-        for cube_name in Self::pre_aggregation_cubes(pre_aggregation)? {
+        for cube_name in Self::pre_aggregation_grain_cubes(pre_aggregation)? {
             if !joined_cubes.contains(&cube_name) {
                 return Ok(false);
             }
@@ -704,14 +704,18 @@ impl PreAggregationOptimizer {
         Ok(true)
     }
 
-    /// Cubes the pre-aggregation's own members span.
-    fn pre_aggregation_cubes(
+    /// Cubes that set the grain the pre-aggregation stores its rows at, which is
+    /// what it groups by: its dimensions and time dimensions, plus its segments,
+    /// which are appended to the dimension list when the table is materialized
+    /// and so group the stored rows too. Measures are excluded — a measure joins
+    /// whatever its own SQL references, but that join is aggregated away inside
+    /// the rollup and leaves its row count untouched.
+    fn pre_aggregation_grain_cubes(
         pre_aggregation: &CompiledPreAggregation,
     ) -> Result<Vec<String>, CubeError> {
         let members = pre_aggregation
-            .measures
+            .dimensions
             .iter()
-            .chain(pre_aggregation.dimensions.iter())
             .chain(pre_aggregation.time_dimensions.iter())
             .chain(pre_aggregation.segments.iter())
             .cloned()

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -2,17 +2,19 @@ use super::PreAggregationsCompiler;
 use super::*;
 use crate::logical_plan::visitor::{LogicalPlanRewriter, NodeRewriteResult};
 use crate::logical_plan::*;
-use crate::planner::collectors::has_multi_stage_members;
+use crate::planner::collectors::{collect_cube_names_from_symbols, has_multi_stage_members};
 use crate::planner::filter::FilterItem;
 use crate::planner::filter::FilterOp;
 use crate::planner::join_hints::JoinHints;
 use crate::planner::multi_fact_join_groups::{MeasuresJoinHints, MultiFactJoinGroups};
 use crate::planner::planners::multi_stage::TimeShiftState;
+use crate::planner::planners::CommonUtils;
 use crate::planner::state::State;
 use crate::planner::time_dimension::QueryDateTime;
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
-use std::collections::HashSet;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 pub struct PreAggregationUsage {
@@ -40,6 +42,9 @@ pub struct PreAggregationOptimizer {
     allow_multi_stage: bool,
     usages: Vec<PreAggregationUsage>,
     usage_counter: usize,
+    /// Resolved primary-key names per cube. Every candidate pre-aggregation asks
+    /// for the same cubes, and resolving them crosses the JS bridge.
+    primary_keys_cache: RefCell<HashMap<String, Vec<String>>>,
 }
 
 impl PreAggregationOptimizer {
@@ -49,6 +54,7 @@ impl PreAggregationOptimizer {
             allow_multi_stage,
             usages: Vec::new(),
             usage_counter: 0,
+            primary_keys_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -88,6 +94,7 @@ impl PreAggregationOptimizer {
             root.query(),
             compiled_pre_aggregations,
             &TimeShiftState::default(),
+            true,
         )? {
             return Ok(Some(Rc::new(
                 RootQuery::builder().ctes(vec![]).query(rewritten).build(),
@@ -109,18 +116,22 @@ impl PreAggregationOptimizer {
         std::mem::take(&mut self.usages)
     }
 
+    // `is_user_query` marks the query the user actually asked for, as opposed to
+    // an internal multi-stage leaf. Only the former's `ungrouped` flag means
+    // "return raw rows"; a leaf may carry it purely for how its stage renders.
     fn try_rewrite_query(
         &mut self,
         query: &Rc<Query>,
         compiled_pre_aggregations: &[Rc<CompiledPreAggregation>],
         time_shifts: &TimeShiftState,
+        is_user_query: bool,
     ) -> Result<Option<Rc<Query>>, CubeError> {
         for pre_aggregation in compiled_pre_aggregations.iter() {
             let external = pre_aggregation.external.unwrap_or(false);
             let date_range =
                 Self::extract_date_range(&query.filter(), &self.query_tools, time_shifts, external);
             if let Some(rewritten) =
-                self.try_rewrite_simple_query(query, pre_aggregation, date_range)?
+                self.try_rewrite_simple_query(query, pre_aggregation, date_range, is_user_query)?
             {
                 return Ok(Some(rewritten));
             }
@@ -134,10 +145,25 @@ impl PreAggregationOptimizer {
         query: &Rc<Query>,
         pre_aggregation: &Rc<CompiledPreAggregation>,
         date_range: Option<(String, String)>,
+        is_user_query: bool,
     ) -> Result<Option<Rc<Query>>, CubeError> {
-        if let Some(matched_measures) =
-            self.is_schema_and_filters_match(&query.schema(), &query.filter(), pre_aggregation)?
-        {
+        // Row identity for an ungrouped read is judged against the join this
+        // very node will render, taken from the node itself rather than
+        // re-resolved, so the two can never disagree.
+        let raw_rows_join = if is_user_query && query.modifers().ungrouped {
+            Some(match query.source() {
+                QuerySource::LogicalJoin(join) => Some(join.clone()),
+                _ => None,
+            })
+        } else {
+            None
+        };
+        if let Some(matched_measures) = self.is_schema_and_filters_match(
+            &query.schema(),
+            &query.filter(),
+            pre_aggregation,
+            raw_rows_join,
+        )? {
             let source =
                 self.make_pre_aggregation_source(pre_aggregation, &matched_measures, date_range)?;
             let new_query = Query::builder()
@@ -170,7 +196,7 @@ impl PreAggregationOptimizer {
                 external,
             );
             if let Some(matched_measures) =
-                self.is_schema_and_filters_match(schema, filter, pre_aggregation)?
+                self.is_schema_and_filters_match(schema, filter, pre_aggregation, None)?
             {
                 let source = self.make_pre_aggregation_source(
                     pre_aggregation,
@@ -238,6 +264,7 @@ impl PreAggregationOptimizer {
                             &multi_stage_leaf_measure.query,
                             compiled_pre_aggregations,
                             &multi_stage_leaf_measure.evaluation_context.time_shifts,
+                            false,
                         )? {
                             let new_leaf = Rc::new(MultiStageLeafMeasure {
                                 measures: multi_stage_leaf_measure.measures.clone(),
@@ -481,6 +508,10 @@ impl PreAggregationOptimizer {
         schema: &Rc<LogicalSchema>,
         filters: &Rc<LogicalFilter>,
         pre_aggregation: &CompiledPreAggregation,
+        // `Some` when the query returns raw rows: the inner option carries the
+        // node's own join, or `None` when the node is not a plain cube join and
+        // its row grain cannot be established.
+        raw_rows_join: Option<Option<Rc<LogicalJoin>>>,
     ) -> Result<Option<HashSet<String>>, CubeError> {
         let helper = OptimizerHelper::new();
 
@@ -502,6 +533,12 @@ impl PreAggregationOptimizer {
         // and the join-path comparison below, so build them once.
         let query_groups = self.query_join_groups(schema, &all_measures)?;
 
+        if let Some(node_join) = &raw_rows_join {
+            if !self.is_raw_rows_match(node_join.as_ref(), pre_aggregation)? {
+                return Ok(None);
+            }
+        }
+
         // A measure sitting under a row-multiplying join can't be rolled
         // up from a partially matching pre-aggregation.
         if match_state == MatchState::Partial && query_groups.has_multiplied_measures()? {
@@ -516,6 +553,22 @@ impl PreAggregationOptimizer {
         let Some(matched_measures) = matched else {
             return Ok(None);
         };
+
+        // An ungrouped read projects stored columns as they are, with no
+        // aggregate around them, so a measure kept as a mergeable sketch would
+        // reach the client as the sketch instead of a number.
+        if raw_rows_join.is_some() {
+            for measure in pre_aggregation.measures.iter() {
+                if !matched_measures.contains(&measure.full_name()) {
+                    continue;
+                }
+                if let Ok(measure) = measure.as_measure() {
+                    if measure.kind().is_stored_as_state() {
+                        return Ok(None);
+                    }
+                }
+            }
+        }
 
         // Even when the query itself has no multiplied measures, a measure that
         // is multiplied in the pre-aggregation (because the pre-agg groups by a
@@ -564,6 +617,121 @@ impl PreAggregationOptimizer {
         }
 
         Ok(Some(matched_measures))
+    }
+
+    // An ungrouped query returns raw rows, so a pre-aggregation may serve it
+    // only when each of its stored rows is exactly one row of the raw join.
+    //
+    // What identifies such a row is the key of the join root plus the key of
+    // every cube joined in on an edge that splits a row of its parent into
+    // several. A cube reached only over non-splitting edges cannot make the
+    // output finer, so its key is not needed, while a cube that merely transits
+    // the tree still splits rows and counts even when the query names no member
+    // of it. The root is always needed: it is what tells apart the rows an outer
+    // join leaves unmatched. A cube without a primary key has no row identity at
+    // all, so nothing can be read raw from it.
+    //
+    // The join comes from the node being rewritten, so it is by construction the
+    // one that node renders — filters, join hints and order-by members included.
+    fn is_raw_rows_match(
+        &self,
+        node_join: Option<&Rc<LogicalJoin>>,
+        pre_aggregation: &CompiledPreAggregation,
+    ) -> Result<bool, CubeError> {
+        // Only a plain rollup describes the grain its rows were stored at. A
+        // join or union source is described by declared members that need not
+        // reflect what the underlying rollups actually store, so its grain
+        // cannot be established here.
+        if !matches!(
+            pre_aggregation.source.as_ref(),
+            PreAggregationSource::Single(_)
+        ) {
+            return Ok(false);
+        }
+
+        // Anything but a plain cube join — a full-key aggregate, or a source
+        // already rewritten to a pre-aggregation — has no single join to judge
+        // row identity against.
+        let Some(node_join) = node_join else {
+            return Ok(false);
+        };
+        let Some(root) = node_join.root() else {
+            return Ok(false);
+        };
+
+        let stored_dimensions: HashSet<String> = pre_aggregation
+            .dimensions
+            .iter()
+            .map(|d| d.clone().resolve_reference_chain().full_name())
+            .collect();
+
+        let joined_cubes: HashSet<String> = std::iter::once(root.name().clone())
+            .chain(
+                node_join
+                    .joins()
+                    .iter()
+                    .map(|item| item.cube().name().clone()),
+            )
+            .collect();
+
+        // The pre-aggregation must not be stored at a finer grain than the node
+        // reads either: a cube it groups by but the node never joins splits its
+        // rows further, so the same row would come back more than once.
+        for cube_name in Self::pre_aggregation_cubes(pre_aggregation)? {
+            if !joined_cubes.contains(&cube_name) {
+                return Ok(false);
+            }
+        }
+
+        let identifying_cubes = std::iter::once(root.name().clone()).chain(
+            node_join
+                .joins()
+                .iter()
+                .filter(|item| item.splits_rows())
+                .map(|item| item.cube().name().clone()),
+        );
+
+        for cube_name in identifying_cubes {
+            let keys = self.resolved_primary_keys(&cube_name)?;
+            if keys.is_empty() {
+                return Ok(false);
+            }
+            if !keys.iter().all(|key| stored_dimensions.contains(key)) {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Cubes the pre-aggregation's own members span.
+    fn pre_aggregation_cubes(
+        pre_aggregation: &CompiledPreAggregation,
+    ) -> Result<Vec<String>, CubeError> {
+        let members = pre_aggregation
+            .measures
+            .iter()
+            .chain(pre_aggregation.dimensions.iter())
+            .chain(pre_aggregation.time_dimensions.iter())
+            .chain(pre_aggregation.segments.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        collect_cube_names_from_symbols(&members)
+    }
+
+    fn resolved_primary_keys(&self, cube_name: &String) -> Result<Vec<String>, CubeError> {
+        if let Some(cached) = self.primary_keys_cache.borrow().get(cube_name) {
+            return Ok(cached.clone());
+        }
+        let keys = CommonUtils::new(self.query_tools.clone())
+            .primary_keys_dimensions(cube_name)?
+            .into_iter()
+            .map(|key| key.resolve_reference_chain().full_name())
+            .collect::<Vec<_>>();
+        self.primary_keys_cache
+            .borrow_mut()
+            .insert(cube_name.clone(), keys.clone());
+        Ok(keys)
     }
 
     fn query_join_groups(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/join_tree.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/join_tree.rs
@@ -10,14 +10,21 @@ pub struct JoinTreeItem {
     cube: Rc<BaseCube>,
     original_from: String,
     on_sql: Rc<SqlCall>,
+    splits_rows: bool,
 }
 
 impl JoinTreeItem {
-    pub fn new(cube: Rc<BaseCube>, original_from: String, on_sql: Rc<SqlCall>) -> Self {
+    pub fn new(
+        cube: Rc<BaseCube>,
+        original_from: String,
+        on_sql: Rc<SqlCall>,
+        splits_rows: bool,
+    ) -> Self {
         Self {
             cube,
             original_from,
             on_sql,
+            splits_rows,
         }
     }
 
@@ -31,6 +38,16 @@ impl JoinTreeItem {
 
     pub fn on_sql(&self) -> &Rc<SqlCall> {
         &self.on_sql
+    }
+
+    /// Whether joining this cube in splits a row of its parent into
+    /// several — true exactly for the `one_to_many` side of an edge.
+    /// Unlike `JoinTree::is_multiplied`, which answers whether a cube's
+    /// own rows repeat and is only populated for the cubes the query
+    /// asked for, this is a property of the edge itself and so also
+    /// holds for cubes that merely transit the tree.
+    pub fn splits_rows(&self) -> bool {
+        self.splits_rows
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_planner.rs
@@ -87,6 +87,7 @@ impl JoinPlanner {
                 LogicalJoinItem::builder()
                     .cube(Cube::new(item.cube().clone()))
                     .on_sql(item.on_sql().clone())
+                    .splits_rows(item.splits_rows())
                     .build()
             })
             .collect();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_tree_builder.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_tree_builder.rs
@@ -31,10 +31,7 @@ impl JoinTreeBuilder {
                 cube,
                 static_data.original_from.clone(),
                 on_sql,
-                matches!(
-                    relationship.as_str(),
-                    "hasMany" | "one_to_many" | "belongsToMany" | "many_to_many"
-                ),
+                relationship_splits_rows(&relationship),
             ));
         }
         Ok(JoinTree::new(
@@ -42,5 +39,50 @@ impl JoinTreeBuilder {
             joins,
             join.static_data().multiplication_factor.clone(),
         ))
+    }
+}
+
+/// Whether joining the `to` side of an edge with this relationship splits one row
+/// of the `from` side into several. Only many-to-one and one-to-one keep the row
+/// count, and a relationship arrives either normalized or in one of its model
+/// spellings, so every spelling of those two is listed. Anything unrecognized
+/// counts as splitting: requiring a primary key that is not needed only refuses a
+/// usable pre-aggregation, while omitting a needed one serves collapsed rows.
+fn relationship_splits_rows(relationship: &str) -> bool {
+    !matches!(
+        relationship,
+        "belongsTo"
+            | "belongs_to"
+            | "many_to_one"
+            | "manyToOne"
+            | "hasOne"
+            | "has_one"
+            | "one_to_one"
+            | "oneToOne"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relationship_splits_rows;
+
+    #[test]
+    fn splits_rows_covers_every_relationship_spelling() {
+        for keeps_row_count in ["belongsTo", "many_to_one", "hasOne", "one_to_one"] {
+            assert!(
+                !relationship_splits_rows(keeps_row_count),
+                "`{keeps_row_count}` joins at most one row"
+            );
+        }
+        for splits in ["hasMany", "one_to_many"] {
+            assert!(
+                relationship_splits_rows(splits),
+                "`{splits}` joins many rows"
+            );
+        }
+        assert!(
+            relationship_splits_rows("something_else"),
+            "an unrecognized relationship has to be treated as splitting"
+        );
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_tree_builder.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/join_tree_builder.rs
@@ -26,10 +26,15 @@ impl JoinTreeBuilder {
             let static_data = join_definition.static_data();
             let cube = self.utils.cube_from_path(static_data.original_to.clone())?;
             let on_sql = self.utils.compile_join_condition(join_definition.clone())?;
+            let relationship = join_definition.join()?.static_data().relationship.clone();
             joins.push(JoinTreeItem::new(
                 cube,
                 static_data.original_from.clone(),
                 on_sql,
+                matches!(
+                    relationship.as_str(),
+                    "hasMany" | "one_to_many" | "belongsToMany" | "many_to_many"
+                ),
             ));
         }
         Ok(JoinTree::new(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -120,6 +120,14 @@ impl MeasureKind {
         }
     }
 
+    /// True if a rollup stores this kind as a mergeable sketch rather than the
+    /// final value — either it already is that state form, or it is the kind
+    /// that has one. Derived from [`Self::as_state`] so both answers cannot
+    /// drift apart.
+    pub fn is_stored_as_state(&self) -> bool {
+        matches!(self, Self::AggregatedState(_)) || self.as_state().is_some()
+    }
+
     pub fn measure_type_str(&self) -> &str {
         match self {
             Self::Count(_) | Self::MultipliedCount(_) => "count",

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_aggregation_matching_test.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_aggregation_matching_test.yaml
@@ -170,3 +170,14 @@ cubes:
           - high_priority
         time_dimension: created_at
         granularity: day
+
+      # Groups by the primary key, so every stored row is a single order —
+      # the only shape a rollup may serve an ungrouped query from.
+      - name: primary_key_rollup
+        type: rollup
+        measures:
+          - total_amount
+        dimensions:
+          - id
+          - status
+          - city

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_aggregations_test.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_aggregations_test.yaml
@@ -126,6 +126,18 @@ cubes:
           - visitor_checkins.for_lambda
           - visitor_checkins2.for_lambda
 
+      # Same cross-cube shape as joined_rollup, but grouped by the primary keys
+      # of both cubes, so each stored row is one raw joined row
+      - name: joined_keys_rollup
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - id
+          - visitor_id
+          - visitors.id
+          - visitors.source
+
   # Second cube for rollupLambda example
   - name: visitor_checkins2
     sql: "SELECT * FROM visitor_checkins"
@@ -154,3 +166,20 @@ cubes:
         time_dimension: created_at
         granularity: day
         partition_granularity: day
+
+views:
+  # Renames every member (prefix), so view members are references whose names
+  # differ from the cube members the pre-aggregations are declared over.
+  - name: visitors_view
+    cubes:
+      - join_path: visitors
+        includes:
+          - id
+          - source
+        prefix: true
+      - join_path: visitors.visitor_checkins
+        includes:
+          - id
+          - visitor_id
+          - count
+        prefix: true

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_multiplied_dup.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_multiplied_dup.yaml
@@ -17,9 +17,6 @@ cubes:
         type: string
         sql: name
     measures:
-      - name: ltv_sum
-        type: sum
-        sql: ltv
       # The aggregate lives inside the measure's own sql, so nothing may wrap it
       # and the select it lands in has to group.
       - name: ltv_agg_number

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_multiplied_dup.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_multiplied_dup.yaml
@@ -1,0 +1,41 @@
+# Two customers share the same name, each with one order of the same status, so
+# grouping by the requested dimensions would collapse two distinct primary keys
+# into one row.
+cubes:
+  - name: dup_customers
+    sql: "SELECT * FROM dup_customers"
+    joins:
+      - name: dup_orders
+        relationship: one_to_many
+        sql: "{CUBE.id} = {dup_orders.customer_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: name
+        type: string
+        sql: name
+    measures:
+      - name: ltv_sum
+        type: sum
+        sql: ltv
+      # The aggregate lives inside the measure's own sql, so nothing may wrap it
+      # and the select it lands in has to group.
+      - name: ltv_agg_number
+        type: number
+        sql: "sum(ltv)"
+
+  - name: dup_orders
+    sql: "SELECT * FROM dup_orders"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: customer_id
+        type: number
+        sql: customer_id
+      - name: status
+        type: string
+        sql: status

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
@@ -1,0 +1,461 @@
+# Models for the ungrouped pre-aggregation eligibility rule. Each cube group is
+# self-contained so a query only ever pulls in the cubes it names.
+cubes:
+  # No primary key at all. `collapsing` groups by non-key columns only.
+  - name: no_pk_orders
+    sql: "SELECT * FROM orders"
+    dimensions:
+      - name: status
+        type: string
+        sql: status
+      - name: city
+        type: string
+        sql: city
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: collapsing
+        type: rollup
+        measures:
+          - total
+        dimensions:
+          - status
+          - city
+
+  # Single cube that does declare a key, with a rollup that omits it.
+  - name: sc_orders
+    sql: "SELECT * FROM orders"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: status
+        type: string
+        sql: status
+      - name: city
+        type: string
+        sql: city
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: sc_coarse
+        type: rollup
+        measures:
+          - total
+        dimensions:
+          - status
+          - city
+
+  # visitors -> checkins -> cities. `checkins` fans out but is only a transit
+  # hop, so a query naming just visitors and cities members still multiplies.
+  - name: chain_visitors
+    sql: "SELECT * FROM visitors"
+    joins:
+      - name: chain_checkins
+        relationship: one_to_many
+        sql: "{CUBE.id} = {chain_checkins.visitor_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: source
+        type: string
+        sql: source
+    pre_aggregations:
+      - name: chain_rollup
+        type: rollup
+        dimensions:
+          - id
+          - source
+          - chain_cities.id
+          - chain_cities.name
+
+      # Keyed on the root only, with a segment reaching across the fan-out.
+      - name: root_key_seg_rollup
+        type: rollup
+        dimensions:
+          - id
+          - source
+        segments:
+          - chain_cities.named_x
+
+  - name: chain_checkins
+    sql: "SELECT * FROM visitor_checkins"
+    joins:
+      - name: chain_cities
+        relationship: many_to_one
+        sql: "{CUBE.city_id} = {chain_cities.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+      - name: city_id
+        type: number
+        sql: city_id
+
+  - name: chain_cities
+    sql: "SELECT * FROM cities"
+    segments:
+      - name: named_x
+        sql: "{CUBE}.name = 'X'"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: name
+        type: string
+        sql: name
+
+  # Canonical star: fact many_to_one dimension cube, so the join cannot
+  # multiply rows and the fact key alone identifies every stored row.
+  - name: star_checkins
+    sql: "SELECT * FROM visitor_checkins"
+    joins:
+      - name: star_visitors
+        relationship: many_to_one
+        sql: "{CUBE.visitor_id} = {star_visitors.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+      # Proxy for this cube's own primary key, which row identity does require.
+      - name: own_ref
+        type: number
+        sql: "{id}"
+    measures:
+      - name: cnt
+        type: count
+    pre_aggregations:
+      - name: star_rollup
+        type: rollup
+        measures:
+          - cnt
+        dimensions:
+          - id
+          - star_visitors.source
+
+      # Stores the fact key only through a proxy dimension.
+      - name: proxy_rollup
+        type: rollup
+        measures:
+          - cnt
+        dimensions:
+          - own_ref
+          - star_visitors.source
+
+      # 1:1 with raw rows; the cross-cube segment only filters.
+      - name: seg_rollup
+        type: rollup
+        measures:
+          - cnt
+        dimensions:
+          - id
+          - visitor_id
+        segments:
+          - star_visitors.source_google
+
+  - name: star_visitors
+    sql: "SELECT * FROM visitors"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: source
+        type: string
+        sql: source
+    segments:
+      - name: source_google
+        sql: "{CUBE}.source = 'google'"
+
+  # Pure many_to_one chain: the middle cube only bridges, so it cannot split a
+  # row and its key is not part of row identity.
+  - name: bridge_orders
+    sql: "SELECT * FROM orders"
+    joins:
+      - name: bridge_stores
+        relationship: many_to_one
+        sql: "{CUBE.store_id} = {bridge_stores.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: store_id
+        type: number
+        sql: store_id
+    measures:
+      - name: cnt
+        type: count
+    pre_aggregations:
+      - name: bridge_rollup
+        type: rollup
+        measures:
+          - cnt
+        dimensions:
+          - id
+          - bridge_regions.name
+
+  - name: bridge_stores
+    sql: "SELECT * FROM stores"
+    joins:
+      - name: bridge_regions
+        relationship: many_to_one
+        sql: "{CUBE.region_id} = {bridge_regions.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: region_id
+        type: number
+        sql: region_id
+
+  - name: bridge_regions
+    sql: "SELECT * FROM regions"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: name
+        type: string
+        sql: name
+
+  # Non-additive stored state: a rollup row holds an HLL sketch, not a number.
+  - name: hll_orders
+    sql: "SELECT * FROM orders"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: status
+        type: string
+        sql: status
+      - name: user_id
+        type: number
+        sql: user_id
+    measures:
+      - name: uniq
+        type: count_distinct_approx
+        sql: user_id
+    pre_aggregations:
+      - name: hll_pk_rollup
+        type: rollup
+        measures:
+          - uniq
+        dimensions:
+          - id
+          - status
+
+  # Fan-out measure: forces the multiplied-subquery planning path.
+  - name: mult_customers
+    sql: "SELECT * FROM customers"
+    joins:
+      - name: mult_orders
+        relationship: one_to_many
+        sql: "{CUBE.id} = {mult_orders.customer_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: name
+        type: string
+        sql: name
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: mult_collapsing
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - name
+          - mult_orders.status
+
+  - name: mult_orders
+    sql: "SELECT * FROM orders"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: customer_id
+        type: number
+        sql: customer_id
+      - name: status
+        type: string
+        sql: status
+
+  # Non-additive rolling measure: its leaf stage is planned ungrouped for
+  # rendering reasons even though the user query is grouped.
+  - name: roll_orders
+    sql: "SELECT * FROM orders"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: category
+        type: string
+        sql: category
+      - name: created_at
+        type: time
+        sql: created_at
+    measures:
+      - name: rolling_avg_7d
+        type: avg
+        sql: amount
+        rolling_window:
+          trailing: 7 day
+    pre_aggregations:
+      - name: rolling_avg_rollup
+        type: rollup
+        measures:
+          - rolling_avg_7d
+        dimensions:
+          - category
+        time_dimension: created_at
+        granularity: day
+
+  # rollupLambda union where the second branch groups by a non-unique column
+  # that merely shares the short name `id` with the first branch's key.
+  - name: lam_a
+    sql: "SELECT * FROM visitor_checkins"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+      - name: created_at
+        type: time
+        sql: created_at
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: lam_base
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - id
+          - visitor_id
+        time_dimension: created_at
+        granularity: day
+        partition_granularity: day
+
+      - name: lam_union
+        type: rollupLambda
+        rollups:
+          - lam_a.lam_base
+          - lam_b.lam_base
+
+  - name: lam_b
+    sql: "SELECT * FROM visitor_checkins"
+    dimensions:
+      - name: row_id
+        type: number
+        sql: row_id
+        primary_key: true
+      # Shares the short name with lam_a's key but is not unique.
+      - name: id
+        type: number
+        sql: visitor_id
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+      - name: created_at
+        type: time
+        sql: created_at
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: lam_base
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - id
+          - visitor_id
+        time_dimension: created_at
+        granularity: day
+        partition_granularity: day
+
+  # rollupJoin advertising a primary key that neither member rollup stores.
+  - name: rj_checkins
+    sql: "SELECT * FROM visitor_checkins"
+    joins:
+      - name: rj_visitors
+        relationship: many_to_one
+        sql: "{CUBE.visitor_id} = {rj_visitors.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: visitor_id
+        type: number
+        sql: visitor_id
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: rj_base
+        type: rollup
+        measures:
+          - count
+        dimensions:
+          - visitor_id
+
+      - name: rj_keys_join
+        type: rollupJoin
+        measures:
+          - count
+        dimensions:
+          - id
+          - visitor_id
+          - rj_visitors.id
+          - rj_visitors.source
+        rollups:
+          - rj_checkins.rj_base
+          - rj_visitors.rj_base
+
+  - name: rj_visitors
+    sql: "SELECT * FROM visitors"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: source
+        type: string
+        sql: source
+    pre_aggregations:
+      - name: rj_base
+        type: rollup
+        dimensions:
+          - id
+          - source

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
@@ -158,7 +158,8 @@ cubes:
           - own_ref
           - star_visitors.source
 
-      # 1:1 with raw rows; the cross-cube segment only filters.
+      # 1:1 with raw rows: the segment groups the stored rows, but it reaches
+      # star_visitors over a many_to_one edge that cannot split a fact row.
       - name: seg_rollup
         type: rollup
         measures:
@@ -282,7 +283,21 @@ cubes:
     measures:
       - name: count
         type: count
+      # Joins mult_orders inside its own sql; the rollup aggregates that away.
+      - name: orders_total
+        type: sum
+        sql: "{mult_orders.cnt}"
     pre_aggregations:
+      # Grouped by the primary key, and carrying a measure whose sql reaches
+      # another cube without that cube touching the stored grain.
+      - name: mult_keyed
+        type: rollup
+        measures:
+          - orders_total
+        dimensions:
+          - id
+          - name
+
       - name: mult_collapsing
         type: rollup
         measures:
@@ -304,6 +319,9 @@ cubes:
       - name: status
         type: string
         sql: status
+    measures:
+      - name: cnt
+        type: count
 
   # Non-additive rolling measure: its leaf stage is planned ungrouped for
   # rendering reasons even though the user query is grouped.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/ungrouped_pre_agg_gate.yaml
@@ -137,10 +137,24 @@ cubes:
       - name: own_ref
         type: number
         sql: "{id}"
+      - name: created_at
+        type: time
+        sql: created_at
     measures:
       - name: cnt
         type: count
     pre_aggregations:
+      # Keyed on the primary key, so 1:1 with raw rows, but it stores the time
+      # dimension truncated to the day.
+      - name: star_day_rollup
+        type: rollup
+        measures:
+          - cnt
+        dimensions:
+          - id
+        time_dimension: created_at
+        granularity: day
+
       - name: star_rollup
         type: rollup
         measures:

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/ungrouped_multiplied_dup_tables.sql
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/ungrouped_multiplied_dup_tables.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS dup_orders CASCADE;
+DROP TABLE IF EXISTS dup_customers CASCADE;
+
+CREATE TABLE dup_customers (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    ltv NUMERIC(10, 2) NOT NULL
+);
+
+-- Same name, different keys and different ltv.
+INSERT INTO dup_customers (id, name, ltv) VALUES
+    (1, 'dup', 100),
+    (2, 'dup', 50);
+
+CREATE TABLE dup_orders (
+    id INTEGER PRIMARY KEY,
+    customer_id INTEGER NOT NULL,
+    status TEXT NOT NULL
+);
+
+INSERT INTO dup_orders (id, customer_id, status) VALUES
+    (10, 1, 'new'),
+    (11, 2, 'new');

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/modifiers.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/modifiers.rs
@@ -279,3 +279,71 @@ async fn test_ungrouped_with_time_dimension() {
         insta::assert_snapshot!(result);
     }
 }
+
+const UNGROUPED_DUP_SEED: &str = "ungrouped_multiplied_dup_tables.sql";
+
+// A measure whose own sql already aggregates cannot be projected row-level: the
+// select it lands in must group, or the SQL is not valid at all. This holds for
+// an ungrouped request too, so the multiplied CTE keeps its GROUP BY here.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_multiplied_keeps_group_by_for_aggregate_sql_measure() {
+    let schema = MockSchema::from_yaml_file("common/ungrouped_multiplied_dup.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query = indoc! {"
+        measures:
+          - dup_customers.ltv_agg_number
+        dimensions:
+          - dup_customers.name
+          - dup_orders.status
+        ungrouped: true
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    let lower = sql.to_lowercase();
+
+    assert!(
+        lower.contains("select distinct"),
+        "expected the keys subquery of a multiplied measure, got:\n{sql}"
+    );
+    assert!(
+        lower.contains("group by"),
+        "a measure that aggregates in its own sql needs the enclosing select to \
+         group, got:\n{sql}"
+    );
+
+    // Executing is the real assertion: without the grouping the engine rejects
+    // the statement outright.
+    if let Some(result) = ctx.try_execute_pg(query, UNGROUPED_DUP_SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// A CTE hoisted out of a multi-stage leaf is consumed by the stage above it,
+// which re-aggregates its rows. It projects row-level values for that reason, so
+// it has to keep grouping to the leaf's own grain no matter what the request
+// asked for — an ungrouped request does not make this CTE a raw-row scan.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_request_keeps_group_by_in_hoisted_multi_stage_leaf() {
+    let schema =
+        MockSchema::from_yaml_file("common/integration_multi_stage_multiplied_pre_agg.yaml")
+            .only_pre_aggregations(&[]);
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query = indoc! {"
+        measures:
+          - customers.total_lifetime_value_prev_month_by_returns
+        time_dimensions:
+          - dimension: returns.created_at
+            granularity: month
+        ungrouped: true
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.to_lowercase().contains("group by"),
+        "the hoisted leaf feeds a stage that re-aggregates it, so it must stay \
+         grouped, got:\n{sql}"
+    );
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/modifiers.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/modifiers.rs
@@ -15,6 +15,39 @@ fn create_multi_fact_context() -> TestContext {
 const BASIC_SEED: &str = "integration_basic_tables.sql";
 const MULTI_FACT_SEED: &str = "integration_multi_fact_tables.sql";
 
+/// Body of the first `<name> AS ( ... )` block, in text order, whose text
+/// contains `marker`, so an assertion can be aimed at one CTE instead of the
+/// whole statement. `marker` must be lower-case.
+fn cte_body_containing(sql: &str, marker: &str) -> Option<String> {
+    let lower = sql.to_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(" as (") {
+        let open = from + rel + " as (".len() - 1;
+        let mut depth = 0;
+        let mut close = None;
+        for (offset, ch) in sql[open..].char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + offset + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close = close?;
+        let body = &sql[open..close];
+        if body.to_lowercase().contains(marker) {
+            return Some(body.to_string());
+        }
+        from = open + 1;
+    }
+    None
+}
+
 // 9.1: ORDER BY dimension ASC, measure DESC
 #[tokio::test(flavor = "multi_thread")]
 async fn test_order_by_dimension_and_measure() {
@@ -341,9 +374,14 @@ async fn test_ungrouped_request_keeps_group_by_in_hoisted_multi_stage_leaf() {
 
     let sql = ctx.build_sql(query).unwrap();
 
+    // The hoisted leaf is the CTE holding the multiplied-measure keys subquery.
+    let leaf = cte_body_containing(&sql, "as \"keys\"").unwrap_or_else(|| {
+        panic!("expected a hoisted keys subquery, got:\n{sql}");
+    });
+
     assert!(
-        sql.to_lowercase().contains("group by"),
+        leaf.to_lowercase().contains("group by"),
         "the hoisted leaf feeds a stage that re-aggregates it, so it must stay \
-         grouped, got:\n{sql}"
+         grouped, got:\n{leaf}"
     );
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
@@ -1,3 +1,4 @@
 mod multi_fact;
 mod multi_stage;
 mod sql_generation;
+mod ungrouped_gate;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_cross_cube_view_joined_keys_rollup_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_cross_cube_view_joined_keys_rollup_cubestore_result.snap
@@ -1,0 +1,19 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+expression: result
+---
+visitors_view__visitors_source | visitors_view__visitor_checkins_visitor_id
+-------------------------------+-------------------------------------------
+google                         | NULL                                      
+google                         | NULL                                      
+google                         | NULL                                      
+google                         | 1                                         
+google                         | 1                                         
+google                         | 1                                         
+google                         | 8                                         
+organic                        | NULL                                      
+organic                        | 6                                         
+twitter                        | 4                                         
+twitter                        | 4                                         
+twitter                        | 5                                         
+NULL                           | 7

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_pre_agg_measure_reads_rollup_column_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_pre_agg_measure_reads_rollup_column_cubestore_result.snap
@@ -2,12 +2,15 @@
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
 expression: result
 ---
-orders__status | orders__city | orders__total_amount
----------------+--------------+---------------------
-cancelled      | Chicago      | 25                  
-completed      | Boston       | 375                 
-completed      | Chicago      | 400                 
-completed      | New York     | 150                 
-pending        | Boston       | 150                 
-pending        | Chicago      | 175                 
-pending        | New York     | 260
+orders__id | orders__status | orders__city | orders__total_amount
+-----------+----------------+--------------+---------------------
+1          | completed      | New York     | 100                 
+2          | pending        | New York     | 200                 
+3          | completed      | New York     | 50                  
+4          | completed      | Boston       | 300                 
+5          | pending        | Boston       | 150                 
+6          | completed      | Boston       | 75                  
+7          | cancelled      | Chicago      | 25                  
+8          | completed      | Chicago      | 400                 
+9          | pending        | Chicago      | 175                 
+10         | pending        | New York     | 60

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_view_query_for_join_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_view_query_for_join_cubestore_result.snap
@@ -1,0 +1,16 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+expression: result
+---
+visitors_view__visitors_id | visitors_view__visitors_source
+---------------------------+-------------------------------
+1                          | google                        
+2                          | google                        
+3                          | google                        
+4                          | twitter                       
+5                          | twitter                       
+6                          | organic                       
+7                          | NULL                          
+8                          | google                        
+9                          | google                        
+10                         | organic

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -1438,25 +1438,25 @@ async fn test_order_by_only_measure_dropped_from_pre_agg() -> Result<(), CubeErr
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ungrouped_pre_agg_measure_reads_rollup_column() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
-        .only_pre_aggregations(&["main_rollup"]);
+        .only_pre_aggregations(&["primary_key_rollup"]);
     let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
           - orders.total_amount
         dimensions:
+          - orders.id
           - orders.status
           - orders.city
         ungrouped: true
         order:
-          - id: orders.status
-          - id: orders.city
+          - id: orders.id
     "};
 
     let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
-    assert_eq!(pre_aggrs[0].name(), "main_rollup");
+    assert_eq!(pre_aggrs[0].name(), "primary_key_rollup");
     assert!(
         sql.contains("\"orders__total_amount\" \"orders__total_amount\""),
         "ungrouped measure should project the rollup column, got:\n{sql}"
@@ -1516,6 +1516,178 @@ async fn test_rollup_lambda_cross_cube_union_aliases() -> Result<(), CubeError> 
         .await
     {
         insta::assert_snapshot!("rollup_lambda_cross_cube_union_cubestore_result", result);
+    }
+
+    Ok(())
+}
+
+// `joined_rollup` is a rollup on the fact cube `visitor_checkins` that includes
+// a cross-cube dimension from the many_to_one joined `visitors` cube, plus a
+// `time_dimension`. An ungrouped query with no measures and no time dimension
+// requests raw rows, so it may only use a pre-aggregation whose dimensions
+// cover the primary keys of every cube in the query. Here they don't, so
+// reading flat rollup columns would silently drop the join between the two
+// cubes: the query must fall back to base SQL.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_no_measures_cross_cube_query_should_not_match_rollup(
+) -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml")
+        .only_pre_aggregations(&["joined_rollup"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - visitor_checkins.visitor_id
+          - visitors.source
+        filters:
+          - dimension: visitors.source
+            operator: equals
+            values:
+              - google
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "expected no pre-aggregation, got `{}`. Generated SQL:\n{sql}",
+        pre_aggrs
+            .iter()
+            .map(|p| p.name().clone())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    assert!(
+        sql.to_lowercase().contains("join"),
+        "expected base SQL with a JOIN between visitor_checkins and visitors, got:\n{sql}"
+    );
+
+    Ok(())
+}
+
+// Same rejection as above, reached through a view. The view renames every
+// member, so the ungrouped gate must compare the cubes and primary keys the
+// view members resolve to rather than the names the query spells them with.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_cross_cube_view_query_should_not_match_rollup() -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml")
+        .only_pre_aggregations(&["joined_rollup"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - visitors_view.visitor_checkins_visitor_id
+          - visitors_view.visitors_source
+        filters:
+          - dimension: visitors_view.visitors_source
+            operator: equals
+            values:
+              - google
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "expected no pre-aggregation, got `{}`. Generated SQL:\n{sql}",
+        pre_aggrs
+            .iter()
+            .map(|p| p.name().clone())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    assert!(
+        sql.to_lowercase().contains("join"),
+        "expected base SQL with a JOIN between visitor_checkins and visitors, got:\n{sql}"
+    );
+
+    Ok(())
+}
+
+// The mirror case: `for_join` covers the primary key of the only cube the query
+// resolves to, so an ungrouped view query must still match it. Guards the gate
+// against reading the view itself as a separate cube, which would make the cube
+// sets differ and reject every ungrouped query issued through a view.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_view_query_matches_rollup_covering_primary_key() -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml")
+        .only_pre_aggregations(&["for_join"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - visitors_view.visitors_id
+          - visitors_view.visitors_source
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "expected `visitors.for_join` to be used, got SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "for_join");
+    assert_eq!(pre_aggrs[0].cube_name(), "visitors");
+
+    // The rows are the claim: one per raw visitor, not per (id, source) group.
+    if let Some(result) = ctx
+        .try_execute(query_yaml, "pre_aggregation_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!("ungrouped_view_query_for_join_cubestore_result", result);
+    }
+
+    Ok(())
+}
+
+// `joined_keys_rollup` has the same cross-cube shape as `joined_rollup` but is
+// grouped by the primary keys of both cubes, so it does hold one row per raw
+// joined row and an ungrouped view query spanning both cubes may use it. The
+// contrast with the rejected `joined_rollup` is what the gate is discriminating.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_cross_cube_view_query_matches_rollup_covering_both_primary_keys(
+) -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml")
+        .only_pre_aggregations(&["joined_keys_rollup"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - visitors_view.visitors_source
+          - visitors_view.visitor_checkins_visitor_id
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "expected `joined_keys_rollup` to be used, got SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "joined_keys_rollup");
+    // Tokenized so the check is immune to line breaks and to `join` appearing
+    // inside the rollup's own table name.
+    assert!(
+        !sql.to_lowercase().split_whitespace().any(|t| t == "join"),
+        "reading the rollup should not re-join the cubes, got:\n{sql}"
+    );
+
+    // The rows are the claim the gate rests on: one per raw joined row.
+    if let Some(result) = ctx
+        .try_execute(query_yaml, "pre_aggregation_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(
+            "ungrouped_cross_cube_view_joined_keys_rollup_cubestore_result",
+            result
+        );
     }
 
     Ok(())

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
@@ -515,3 +515,53 @@ async fn test_ungrouped_rejects_rollup_whose_unrequested_segment_splits_rows(
 
     Ok(())
 }
+
+// A rollup stores its time dimension truncated to `granularity`, so that column
+// must never reach a raw-row result. It cannot: a time dimension requested
+// without a granularity is a filter, not an output member, and one requested
+// with a granularity only matches a rollup storing that same granularity.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_never_reads_a_truncated_time_dimension() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["star_day_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - star_checkins.cnt
+        dimensions:
+          - star_checkins.id
+        time_dimensions:
+          - dimension: star_checkins.created_at
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "`star_day_rollup` is grouped by the primary key, so it holds one row per          checkin and may serve raw rows. Generated SQL:\n{sql}"
+    );
+    assert!(
+        !sql.contains("created_at"),
+        "the stored time dimension is truncated to the day, so no raw-row result          may read it. Generated SQL:\n{sql}"
+    );
+
+    // Asking for the raw value as a plain dimension finds no match at all: the
+    // rollup groups by `id` alone and stores no untruncated timestamp.
+    let raw_value_query = indoc! {"
+        dimensions:
+          - star_checkins.id
+          - star_checkins.created_at
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(raw_value_query)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "`{}` stores no untruncated timestamp. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
@@ -458,3 +458,60 @@ async fn test_ungrouped_accepts_rollup_across_a_many_to_one_bridge() -> Result<(
 
     Ok(())
 }
+
+// A measure joins whatever its own sql references, but the rollup aggregates
+// that join away, so the referenced cube is no part of the stored grain and must
+// not make the rollup ineligible.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_accepts_rollup_with_a_measure_reaching_another_cube(
+) -> Result<(), CubeError> {
+    let ctx = ctx_with(&["mult_keyed"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - mult_customers.id
+          - mult_customers.name
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "`mult_keyed` is grouped by the primary key, so it should be used. \
+         Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "mult_keyed");
+
+    Ok(())
+}
+
+// A rollup's segments are appended to its dimension list when the table is
+// materialized, so a segment groups the stored rows just like a dimension. One
+// reaching across a row-splitting join therefore stores a row per (entity,
+// segment value) even though the query never asks for the segment.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_whose_unrequested_segment_splits_rows(
+) -> Result<(), CubeError> {
+    let ctx = ctx_with(&["root_key_seg_rollup"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - chain_visitors.id
+          - chain_visitors.source
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "`{}` groups by a segment of `chain_cities`, reached over the fan-out to \
+         `chain_checkins`, so it holds more than one row per visitor. Generated \
+         SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/ungrouped_gate.rs
@@ -1,0 +1,460 @@
+//! Eligibility of pre-aggregations for ungrouped queries.
+//!
+//! An ungrouped query returns raw rows, so a pre-aggregation may serve it only
+//! when each stored row maps to exactly one row of the query result. These tests
+//! pin both directions of that rule: rollups whose grouping collapses rows must
+//! be refused, and rollups that are provably 1:1 with raw rows must be kept.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use cubenativeutils::CubeError;
+use indoc::indoc;
+
+fn ctx_with(pre_aggregations: &[&str]) -> Result<TestContext, CubeError> {
+    let schema = MockSchema::from_yaml_file("common/ungrouped_pre_agg_gate.yaml")
+        .only_pre_aggregations(pre_aggregations);
+    TestContext::new(schema)
+}
+
+fn used_names(pre_aggrs: &[crate::logical_plan::PreAggregationUsage]) -> String {
+    pre_aggrs
+        .iter()
+        .map(|p| p.name().clone())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// A cube may legally declare no primary key. Nothing then identifies a raw row,
+// so no rollup can be read as raw rows and the query must fall back to the
+// source table.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_when_cube_has_no_primary_key() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["collapsing"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - no_pk_orders.total
+        dimensions:
+          - no_pk_orders.status
+          - no_pk_orders.city
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "a cube without a primary key has no raw-row identity, so `{}` must not \
+         serve an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// `chain_checkins` is not named by the query, but it sits between the two cubes
+// that are, and its one_to_many edge multiplies rows. The rollup is grouped by
+// the visitor and city keys only, so it stores one row per (visitor, city) pair
+// while the raw join yields one row per checkin.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_missing_transit_cube_key() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["chain_rollup"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - chain_visitors.source
+          - chain_cities.name
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "the fan-out transit cube `chain_checkins` is unaccounted for, so `{}` \
+         must not serve an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// A many_to_one join cannot multiply rows, so the fact primary key alone
+// identifies every stored row and the dimension cube's key is not needed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_accepts_star_rollup_without_dimension_cube_key() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["star_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - star_checkins.cnt
+        dimensions:
+          - star_checkins.id
+          - star_visitors.source
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "the fact key identifies each row across a many_to_one join, so \
+         `star_rollup` should be used. Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "star_rollup");
+
+    Ok(())
+}
+
+// `own_ref` is a proxy for the fact cube's own primary key, which row identity
+// does require, so the key is stored even though it is spelled under another
+// name and only a resolved comparison can see it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_accepts_rollup_storing_primary_key_by_reference() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["proxy_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - star_checkins.cnt
+        dimensions:
+          - star_checkins.own_ref
+          - star_visitors.source
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "`own_ref` resolves to `star_checkins.id`, so `proxy_rollup` does store \
+         the identifying key and should be used. Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "proxy_rollup");
+
+    Ok(())
+}
+
+// A cross-cube segment only filters rows; it neither adds columns nor changes
+// the stored grain, so the segment's cube must not be required to contribute a
+// primary key.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_accepts_rollup_whose_extra_cube_comes_from_a_segment(
+) -> Result<(), CubeError> {
+    let ctx = ctx_with(&["seg_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - star_checkins.cnt
+        dimensions:
+          - star_checkins.id
+          - star_checkins.visitor_id
+        segments:
+          - star_visitors.source_google
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "a segment only filters, so `seg_rollup` stays 1:1 with raw rows and \
+         should be used. Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "seg_rollup");
+
+    Ok(())
+}
+
+// The rollup is 1:1 with raw rows, but `uniq` is stored as an HLL sketch that
+// only means anything after a merge. An ungrouped read projects the column
+// as-is, so it would hand the client a binary sketch instead of a count.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_storing_non_additive_state() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["hll_pk_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - hll_orders.uniq
+        dimensions:
+          - hll_orders.id
+          - hll_orders.status
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "an ungrouped read cannot finalize the stored HLL state, so `{}` must \
+         not serve this query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// A fan-out measure under `ungrouped` is rendered inline rather than through a
+// multiplied subquery, so this stays a simple query. The rollup groups by
+// non-key columns and must be refused.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_collapsing_rollup_with_fan_out_measure() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["mult_collapsing"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - mult_customers.count
+        dimensions:
+          - mult_customers.name
+          - mult_orders.status
+        ungrouped: true
+        cubestoreSupportMultistage: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "`{}` groups by non-key columns, so it must not serve an ungrouped \
+         query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// A non-additive rolling measure makes the planner render its leaf stage
+// ungrouped, but the user query is grouped and asks for aggregates, so the
+// raw-row rule must not be applied to that leaf.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_grouped_non_additive_rolling_query_still_uses_rollup() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["rolling_avg_rollup"])?;
+
+    let query_yaml = indoc! {r#"
+        measures:
+          - roll_orders.rolling_avg_7d
+        dimensions:
+          - roll_orders.category
+        time_dimensions:
+          - dimension: roll_orders.created_at
+            granularity: day
+            dateRange:
+              - "2024-01-10"
+              - "2024-01-25"
+        cubestoreSupportMultistage: true
+    "#};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "the user query is grouped, so the internal ungrouped leaf must not cost \
+         it `rolling_avg_rollup`. Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "rolling_avg_rollup");
+
+    Ok(())
+}
+
+// `lam_union` exposes only its first member rollup's symbols. The second branch
+// groups by a non-unique column that merely shares the short name `id`, so the
+// union as a whole is not 1:1 with raw rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_lambda_whose_other_branch_collapses() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["lam_base", "lam_union"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - lam_a.count
+        dimensions:
+          - lam_a.id
+          - lam_a.visitor_id
+        time_dimensions:
+          - dimension: lam_a.created_at
+            granularity: day
+        ungrouped: true
+        pre_aggregation_id: lam_a.lam_union
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "the union's second branch is grouped on a non-key column, so `{}` must \
+         not serve an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// `rj_keys_join` declares both primary keys, but the rollups it actually reads
+// store neither `rj_checkins.id` nor a per-checkin grain, so its rows are one
+// per visitor.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_join_advertising_unstored_keys() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["rj_base", "rj_keys_join"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - rj_checkins.count
+        dimensions:
+          - rj_checkins.visitor_id
+          - rj_visitors.source
+        ungrouped: true
+        pre_aggregation_id: rj_checkins.rj_keys_join
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "the member rollups do not store `rj_checkins.id`, so `{}` must not serve \
+         an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// The single-cube shape: the cube has a key, the rollup omits it, so its rows
+// are collapsed and an ungrouped query must read the source table instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_single_cube_rejects_rollup_missing_primary_key() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["sc_coarse"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - sc_orders.total
+        dimensions:
+          - sc_orders.status
+          - sc_orders.city
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "`{}` groups by non-key columns, so it must not serve an ungrouped \
+         single-cube query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// A filter is enough to pull a fan-out cube into the join even though the query
+// selects none of its members, so row identity has to account for it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_when_a_filter_widens_the_join() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["chain_rollup"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - chain_visitors.id
+          - chain_visitors.source
+        filters:
+          - dimension: chain_cities.name
+            operator: equals
+            values:
+              - X
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "the filter joins in the fan-out cube `chain_checkins`, so `{}` must not \
+         serve an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// The mirror direction of the rule: the rollup is grouped across a fan-out cube
+// the query never joins, so it holds more rows than the query asks for and would
+// return each visitor once per city.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_stored_at_a_finer_grain() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["chain_rollup"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - chain_visitors.id
+          - chain_visitors.source
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "`{}` is stored per (visitor, city) while the query reads one row per \
+         visitor, so it must not serve it. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// A segment only filters, but reaching it joins in the fan-out cube, so a rollup
+// keyed on the root alone no longer holds one row per output row.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_rejects_rollup_whose_segment_crosses_a_fan_out() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["root_key_seg_rollup"])?;
+
+    let query_yaml = indoc! {"
+        dimensions:
+          - chain_visitors.id
+          - chain_visitors.source
+        segments:
+          - chain_cities.named_x
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "the segment joins in the fan-out cube `chain_checkins`, so `{}` must not \
+         serve an ungrouped query. Generated SQL:\n{sql}",
+        used_names(&pre_aggrs)
+    );
+
+    Ok(())
+}
+
+// `bridge_stores` only bridges two many_to_one edges, so it cannot split a row
+// and its key is no part of row identity — the fact key alone identifies the
+// output row even though the bridge sits in the middle of the join.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_accepts_rollup_across_a_many_to_one_bridge() -> Result<(), CubeError> {
+    let ctx = ctx_with(&["bridge_rollup"])?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - bridge_orders.cnt
+        dimensions:
+          - bridge_orders.id
+          - bridge_regions.name
+        ungrouped: true
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "a many_to_one bridge cannot split a row, so `bridge_rollup` should be \
+         used. Generated SQL:\n{sql}"
+    );
+    assert_eq!(pre_aggrs[0].name(), "bridge_rollup");
+
+    Ok(())
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__modifiers__ungrouped_multiplied_keeps_group_by_for_aggregate_sql_measure.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__modifiers__ungrouped_multiplied_keeps_group_by_for_aggregate_sql_measure.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/modifiers.rs
+expression: result
+---
+dup_customers__name | dup_orders__status | dup_customers__ltv_agg_number
+--------------------+--------------------+------------------------------
+dup                 | new                | 150.00


### PR DESCRIPTION
## Summary

Fixes #11383. Under Tesseract, an `ungrouped: true` query with no measures matched a rollup grouped on non-key columns, read its columns flat, and silently dropped the JOIN between cubes — returning pre-summed groups where the user asked for raw rows. Pre-aggregation matching never consulted `query.modifers().ungrouped`, and with zero measures `try_match_measures` trivially succeeds whatever the dimension `MatchState` is. The rule is documented under "Matching ungrouped queries" but was never implemented in this planner.

An ungrouped query returns raw rows, so a rollup may serve one only when each stored row is one row of the query's join. That needs the primary key of the join root plus the key of every joined cube whose edge multiplies rows, read from the node's own `LogicalJoin` rather than re-derived from hints.

## Changes

- **New raw-rows gate** in `pre_aggregation/optimizer.rs`, threaded through `is_schema_and_filters_match` as `raw_rows_join`. Requires the root's primary key plus the key of every row-splitting joined cube, compares both sides through `resolve_reference_chain` so a key stored via a proxy dimension counts, refuses a cube with no primary key, refuses non-`Single` sources, and refuses a measure stored as a mergeable sketch (new `MeasureKind::is_stored_as_state`).
- **Per-edge row splitting** carried through the plan: new `splits_rows` on `JoinTreeItem` and `LogicalJoinItem`, derived from the join relationship. `is_multiplied` could not be used — it is undefined for transit cubes. Fixes a pre-existing bug where `LogicalJoin::with_inputs` dropped a join item's flags.
- **Grain is the rollup's `GROUP BY`**: dimensions, time dimensions and segments. Measures are excluded — a measure joins whatever its own sql references, but that join is aggregated away inside the rollup. Segments are included because `CubeEvaluator` appends them to the dimension list when the table is materialized.
- **Docs**: `matching-pre-aggregations.mdx` asked for the keys of every queried cube, which is stricter than what a raw-row result needs; it now describes the implemented rule plus the two conditions that were undocumented.

## Testing

- 18 Rust integration tests in `pre_aggregations/ungrouped_gate.rs` over a purpose-built model: accepted shapes (key-grain rollup, key via proxy reference, star `many_to_one`, `many_to_one` bridge, rollup with a measure reaching another cube) and refused ones (fan-out without the splitting cube's key, transit cube key missing, no primary key, mergeable sketch, `rollupJoin` advertising unstored keys, lambda branch that collapses, segment splitting rows whether or not the query asks for it, filter widening the join). Every refusal test was red before the gate.
- Cross-planner JS integration tests in `pre-aggregations-ungrouped-cross-cube.test.ts` (8 cases) running the same query under both planners against Postgres.
- Row-grain execution snapshots: the pre-existing `test_ungrouped_pre_agg_measure_reads_rollup_column` recorded 7 pre-summed groups as the answer to an ungrouped query — the same bug class without a dropped join — and now returns 10 raw per-order rows.
- Full suite green on both backends: `cargo test --features integration-postgres --lib` and `--features integration-cubestore --lib`, 1154 passed / 0 failed. `cargo fmt --check` clean.

Known gaps left to follow-up tickets, each with a reproduction: the gate is not wired into the multi-stage leaf or multiplied-CTE rewrite paths, so those two shapes can still be served collapsed; a stored `count`/`count_distinct` read raw returns 0 where the base query returns NULL; `subquery_joins` are ignored; and all `rollupLambda`/`rollupJoin` sources are refused rather than checked.
