### PR TITLE
fix(core): declare the dist-only test target in six remaining jest configs

### DIFF
--- a/packages/cubejs-backend-maven/jest.config.js
+++ b/packages/cubejs-backend-maven/jest.config.js
@@ -4,4 +4,9 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
 };

--- a/packages/cubejs-bigquery-driver/jest.config.js
+++ b/packages/cubejs-bigquery-driver/jest.config.js
@@ -4,4 +4,9 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
 };

--- a/packages/cubejs-databricks-jdbc-driver/jest.config.js
+++ b/packages/cubejs-databricks-jdbc-driver/jest.config.js
@@ -4,4 +4,9 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
 };

--- a/packages/cubejs-druid-driver/jest.config.js
+++ b/packages/cubejs-druid-driver/jest.config.js
@@ -4,6 +4,11 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
   transformIgnorePatterns: [
     'node_modules/(?!axios)/'
   ],

--- a/packages/cubejs-duckdb-driver/jest.config.js
+++ b/packages/cubejs-duckdb-driver/jest.config.js
@@ -4,4 +4,9 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
 };

--- a/packages/cubejs-mysql-driver/jest.config.js
+++ b/packages/cubejs-mysql-driver/jest.config.js
@@ -4,4 +4,9 @@ const base = require('../../jest.base.config');
 module.exports = {
   ...base,
   rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
 };


### PR DESCRIPTION
## Summary

- `jest.base.config.js` declares no `preset` and no `transform`, so the TypeScript under a package's `test/` cannot execute — those packages are meant to run their suites from compiled output in `dist/test/`. Six packages extended it without declaring a `testMatch`, so jest's **default** pattern collected the compiled output *and* the untransformable sources, and a bare `jest` in the package directory died with `SyntaxError: Cannot use import statement outside a module`. The path argument in each package's npm script (`jest --verbose dist/test`, `jest dist/test/*.js`, …) was the only thing keeping the suites runnable.
- Each of the six now declares the dist-pointing `testMatch`, following the same shape and comment already used by the packages fixed earlier in this sweep: `cubejs-bigquery-driver`, `cubejs-druid-driver`, `cubejs-duckdb-driver`, `cubejs-mysql-driver`, `cubejs-databricks-jdbc-driver`, `cubejs-backend-maven`.
- The pattern is **not** hoisted into `jest.base.config.js`, deliberately: several packages keep integration suites next to their unit ones and split the two with the path argument in their scripts, so a hoisted pattern would enroll suites needing live warehouse credentials in packages that pass no such argument.

Config-only; no source or test files change.

## Why this is behaviour-preserving

Every existing script already passes a `dist/test` path argument, so its selection is unchanged. The only invocation whose behaviour changes is a bare `jest` typed by hand in a package directory — which fails today and works after.

Nothing in CI invokes these six packages' own test scripts: the per-package suites run through `yarn lerna run … unit`, and none of the six declares a script named `unit` (four have only `integration:*`; the others are `unit-tests` and `unit:disabled-for-ci`). The driver matrix exercises `testing-drivers`, not these scripts.

## Test plan

- [x] `jest --listTests` diffed per (package, script) pair, before vs. after: **8 lines removed, 0 added** — the removals are exactly the untransformable `test/*.ts` entries that a bare `jest` used to collect in each of the six.
- [x] The "existing scripts" half of that output is **byte-identical** on both sides (same md5), covering all 8 jest-invoking scripts across the six packages.
- [x] Before/after on a bare `jest` in `cubejs-druid-driver`: `2 failed, 2 skipped, 2 of 4 total` (`SyntaxError: Cannot use import statement outside a module`, `Missing semicolon`) → `2 skipped, 0 of 2 total`, no failures.
- [x] `cubejs-druid-driver`'s in-process unit suite (`dist/test/druid-query.test.js`) runs green through the new config: 2 passed.
- [x] Each of the six configs loads under Node and yields a well-formed `testMatch`; `eslint` clean.
- [x] Checked that the glob loses nothing: `MySqlDriverPool.disabled.ts` and `mysql.db.runner.ts` don't match `*.{test,spec}.*` but were never collected before either (the first is dormant, the second a helper imported by the suite). `.d.ts` and `.js.map` files can't match the pattern. No package among the six has subdirectories under `dist/test`, and none sets `roots`, `testRegex`, or `testPathIgnorePatterns` that would interact with the added key.
- [ ] CI must pass

Two of the six suites can't execute on a dev machine for reasons predating this change: `cubejs-databricks-jdbc-driver` needs the optional `java` native module, and `cubejs-backend-maven`'s suite downloads a Maven distribution from a URL that now 404s (hence its script name, `unit:disabled-for-ci`). Both fail identically with and without this change.
