### PR TITLE
feat(schema-compiler): compute a default measure drill-member set behind an env flag

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -45,6 +45,40 @@ any other value (including unset) is treated as on.
 | ---------------- | ----------------------- | ----------------------- |
 | `true`, `false`  | `true`                   | `true`                   |
 
+## `CUBEJS_AUTO_DRILL_MEMBERS`
+
+If `true`, measures that declare no [`drill_members`][ref-drill-members] get a
+default set computed when the data model is compiled: the cube's own dimensions,
+primary key first, capped by
+[`CUBEJS_AUTO_DRILL_MEMBERS_LIMIT`](#cubejs_auto_drill_members_limit). Without
+this, a measure with no `drill_members` offers no [drill down][ref-drilldowns]
+at all.
+
+A measure that declares `drill_members` is never touched — including
+`drill_members: []`, which is how you suppress the default for one measure.
+Non-public dimensions are excluded, except the primary key; sub-query dimensions
+are excluded too, since each one costs a join per drill.
+
+For a view, the default names the view's own members, so a drill from a view
+measure resolves rather than dead-ending. A view has no primary key of its own,
+so there the set is simply the dimensions the view includes, in the order it
+includes them.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
+## `CUBEJS_AUTO_DRILL_MEMBERS_LIMIT`
+
+The most drill members
+[`CUBEJS_AUTO_DRILL_MEMBERS`](#cubejs_auto_drill_members) will add to a measure.
+Has no effect unless that variable is enabled. `0` disables the default set
+entirely.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A number        | `10`                   | `10`                  |
+
 ## `CUBEJS_AWS_KEY`
 
 The AWS Access Key ID to use for database connections.
@@ -2247,6 +2281,8 @@ The port for a Cube deployment to listen to API connections on.
 [link-tesseract]: https://cube.dev/blog/introducing-next-generation-data-modeling-engine
 [ref-multi-stage-calculations]: /docs/data-modeling/measures#multi-stage-measures
 [ref-folders]: /reference/data-modeling/view#folders
+[ref-drill-members]: /reference/data-modeling/measures#drill_members
+[ref-drilldowns]: /recipes/core-data-api/drilldowns
 [ref-dataviz-tools]: /admin/connect-to-data/visualization-tools
 [ref-context-to-app-id]: /reference/configuration/config#context_to_app_id
 [ref-environments]: /admin/deployment/environments

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -45,6 +45,40 @@ any other value (including unset) is treated as on.
 | ---------------- | ----------------------- | ----------------------- |
 | `true`, `false`  | `true`                   | `true`                   |
 
+## `CUBEJS_AUTO_DRILL_MEMBERS`
+
+If `true`, measures that declare no [`drill_members`][ref-drill-members] get a
+default set computed when the data model is compiled: the cube's own dimensions,
+primary key first, capped by
+[`CUBEJS_AUTO_DRILL_MEMBERS_LIMIT`](#cubejs_auto_drill_members_limit). Without
+this, a measure with no `drill_members` offers no [drill down][ref-drilldowns]
+at all.
+
+A measure that declares `drill_members` is never touched — including
+`drill_members: []`, which is how you suppress the default for one measure.
+Non-public dimensions are excluded, except the primary key; sub-query dimensions
+are excluded too, since each one costs a join per drill.
+
+For a view, the default names the view's own members, so a drill from a view
+measure resolves rather than dead-ending. A view has no primary key of its own,
+so there the set is simply the dimensions the view includes, in the order it
+includes them.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
+## `CUBEJS_AUTO_DRILL_MEMBERS_LIMIT`
+
+The most drill members
+[`CUBEJS_AUTO_DRILL_MEMBERS`](#cubejs_auto_drill_members) will add to a measure.
+Has no effect unless that variable is enabled. `0` disables the default set
+entirely.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A number        | `10`                   | `10`                  |
+
 ## `CUBEJS_AWS_KEY`
 
 The AWS Access Key ID to use for database connections.
@@ -2211,6 +2245,8 @@ The port for a Cube deployment to listen to API connections on.
 [link-tesseract]: https://cube.dev/blog/introducing-next-generation-data-modeling-engine
 [ref-multi-stage-calculations]: /docs/data-modeling/measures#multi-stage-measures
 [ref-folders]: /reference/data-modeling/view#folders
+[ref-drill-members]: /reference/data-modeling/measures#drill_members
+[ref-drilldowns]: /recipes/core-data-api/drilldowns
 [ref-dataviz-tools]: /admin/connect-to-data/visualization-tools
 [ref-context-to-app-id]: /reference/configuration/config#context_to_app_id
 [ref-environments]: /admin/deployment/environments

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -31,20 +31,6 @@ different for multitenant setups.
 | --------------- | ---------------------- | --------------------- |
 | A valid string  | `cubejs`               | `cubejs`              |
 
-## `CUBEJS_AUTO_RUN_MODE`
-
-The deployment-wide default for whether [Explore](/docs/explore-analyze/explore)
-and [Workbooks](/docs/explore-analyze/workbooks/querying-data) tabs run their
-query automatically as it's built, or wait for an explicit **Run query**. Set
-via the **Auto-run** switch in [Model Configuration](/docs/data-modeling/configuration#auto-run).
-A view's `meta.auto_run` setting and a user's per-tab toggle both take
-precedence over this default. Only the literal string `false` turns it off —
-any other value (including unset) is treated as on.
-
-| Possible Values | Default in Development | Default in Production |
-| ---------------- | ----------------------- | ----------------------- |
-| `true`, `false`  | `true`                   | `true`                   |
-
 ## `CUBEJS_AUTO_DRILL_MEMBERS`
 
 If `true`, measures that declare no [`drill_members`][ref-drill-members] get a
@@ -73,11 +59,26 @@ includes them.
 The most drill members
 [`CUBEJS_AUTO_DRILL_MEMBERS`](#cubejs_auto_drill_members) will add to a measure.
 Has no effect unless that variable is enabled. `0` disables the default set
-entirely.
+entirely. With `CUBEJS_AUTO_DRILL_MEMBERS` enabled, a value that isn't a number
+fails data model compilation.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
 | A number        | `10`                   | `10`                  |
+
+## `CUBEJS_AUTO_RUN_MODE`
+
+The deployment-wide default for whether [Explore](/docs/explore-analyze/explore)
+and [Workbooks](/docs/explore-analyze/workbooks/querying-data) tabs run their
+query automatically as it's built, or wait for an explicit **Run query**. Set
+via the **Auto-run** switch in [Model Configuration](/docs/data-modeling/configuration#auto-run).
+A view's `meta.auto_run` setting and a user's per-tab toggle both take
+precedence over this default. Only the literal string `false` turns it off —
+any other value (including unset) is treated as on.
+
+| Possible Values | Default in Development | Default in Production |
+| ---------------- | ----------------------- | ----------------------- |
+| `true`, `false`  | `true`                   | `true`                   |
 
 ## `CUBEJS_AWS_KEY`
 

--- a/docs-mintlify/reference/data-modeling/measures.mdx
+++ b/docs-mintlify/reference/data-modeling/measures.mdx
@@ -1489,6 +1489,16 @@ cube(`orders`, {
 
 </CodeGroup>
 
+<Info>
+
+A measure with no `drill_members` offers no drill down at all. Set
+[`CUBEJS_AUTO_DRILL_MEMBERS`][ref-auto-drill-members] to give such measures a
+default set — the cube's own dimensions, primary key first. Measures that
+declare `drill_members` keep exactly what they declare, and `drill_members: []`
+suppresses the default for a single measure.
+
+</Info>
+
 
 [ref-ai-context]: /docs/data-modeling/ai-context
 [ref-ref-cubes]: /reference/data-modeling/cube
@@ -1510,3 +1520,4 @@ cube(`orders`, {
 [link-iso-4217]: https://en.wikipedia.org/wiki/ISO_4217
 [ref-calculated-measures]: /docs/data-modeling/measures#calculated-measures
 [ref-schema-ref-preaggs-rollup]: /reference/data-modeling/pre-aggregations#rollup
+[ref-auto-drill-members]: /reference/configuration/environment-variables#cubejs_auto_drill_members

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -338,6 +338,14 @@ const variables: Record<string, (...args: any) => any> = {
   nestedFoldersDelimiter: () => get('CUBEJS_NESTED_FOLDERS_DELIMITER')
     .default('')
     .asString(),
+  // Measures that declare no drill members get a default set computed at
+  // compilation time. Declared drill members always take precedence.
+  autoDrillMembers: () => get('CUBEJS_AUTO_DRILL_MEMBERS')
+    .default('false')
+    .asBoolStrict(),
+  autoDrillMembersLimit: () => get('CUBEJS_AUTO_DRILL_MEMBERS_LIMIT')
+    .default('10')
+    .asInt(),
   defaultTimezone: () => get('CUBEJS_DEFAULT_TIMEZONE')
     .default('UTC')
     .asString(),

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -351,6 +351,14 @@ const variables: Record<string, (...args: any) => any> = {
   nestedFoldersDelimiter: () => get('CUBEJS_NESTED_FOLDERS_DELIMITER')
     .default('')
     .asString(),
+  // Measures that declare no drill members get a default set computed at
+  // compilation time. Declared drill members always take precedence.
+  autoDrillMembers: () => get('CUBEJS_AUTO_DRILL_MEMBERS')
+    .default('false')
+    .asBoolStrict(),
+  autoDrillMembersLimit: () => get('CUBEJS_AUTO_DRILL_MEMBERS_LIMIT')
+    .default('10')
+    .asInt(),
   defaultTimezone: () => {
     const value = (get('CUBEJS_DEFAULT_TIMEZONE').asString() || '').trim() || 'UTC';
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -79,6 +79,7 @@ export type DimensionDefinition = {
   type: string;
   sql(): string;
   primaryKey?: true;
+  subQuery?: boolean;
   ownedByCube: boolean;
   fieldType?: string;
   multiStage?: boolean;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -61,6 +61,7 @@ export interface ExtendedCubeSymbolDefinition extends CubeSymbolDefinition {
     params?: Array<{ key: string; value: (...args: any[]) => string }>;
   }>;
   synthetic?: boolean;
+  subQuery?: boolean;
 }
 
 interface ExtendedCubeDefinition extends CubeDefinitionExtended {
@@ -236,6 +237,8 @@ export class CubeToMetaTransformer implements CompilerInterface {
     const flatFolderSeparator = getEnv('nestedFoldersDelimiter');
     const flatFolders: FlatFolder[] = [];
 
+    const autoDrillMembers = this.defaultDrillMembers(cubeName, extendedCube);
+
     const processFolder = (folder: Folder, path: string[] = [], mergedMembers: string[] = []): NestedFolder => {
       const flatMembers: string[] = [];
       // After evaluation in CubeEvaluator, folder.includes contains resolved FolderMember items
@@ -290,7 +293,7 @@ export class CubeToMetaTransformer implements CompilerInterface {
           const metricDef = nameToMetric[1] as ExtendedCubeSymbolDefinition;
           const measureVisibility = isCubeVisible ? this.isVisible(metricDef, true) : false;
           return {
-            ...this.measureConfig(cubeName, cubeTitle, nameToMetric),
+            ...this.measureConfig(cubeName, cubeTitle, nameToMetric, autoDrillMembers),
             isVisible: measureVisibility,
             public: measureVisibility,
           };
@@ -419,7 +422,78 @@ export class CubeToMetaTransformer implements CompilerInterface {
     return dimensionType === 'switch' ? 'string' : dimensionType;
   }
 
-  private measureConfig(cubeName: string, cubeTitle: string, nameToMetric: [string, any]): Omit<MeasureConfig, 'isVisible' | 'public'> {
+  /**
+   * A view's included members don't carry `subQuery`, so a dimension reached
+   * through a view is resolved back to its source definition to classify it.
+   */
+  private isSubQuery(extendedDimDef: ExtendedCubeSymbolDefinition): boolean {
+    if (extendedDimDef.subQuery) {
+      return true;
+    }
+
+    if (!extendedDimDef.aliasMember) {
+      return false;
+    }
+
+    try {
+      return !!this.cubeEvaluator.dimensionByPath(extendedDimDef.aliasMember)?.subQuery;
+    } catch (e) {
+      // An alias that no longer resolves is not this method's problem to report.
+      return false;
+    }
+  }
+
+  /**
+   * Drill members for measures that declare none: the cube's own dimensions,
+   * primary key first, capped.
+   *
+   * The primary key is included whatever its visibility — it is hidden by
+   * default, yet it is the member that identifies a row, and hand-written
+   * `drillMembers` name it routinely. Visibility governs the member picker,
+   * not what a drill query may reference. Everything else must be public.
+   *
+   * Views have no primary key (it is not propagated onto included members) and
+   * their dimensions span every source cube, so there the set is simply the
+   * view's own dimensions in include order.
+   */
+  private defaultDrillMembers(cubeName: string, extendedCube: ExtendedCubeDefinition): string[] {
+    // The flag is checked before the limit is parsed: a malformed limit must not
+    // fail compilation for deployments that never enabled the feature.
+    if (!getEnv('autoDrillMembers')) {
+      return [];
+    }
+
+    const limit = getEnv('autoDrillMembersLimit');
+    if (limit <= 0) {
+      return [];
+    }
+
+    const primaryKeys: string[] = [];
+    const rest: string[] = [];
+
+    for (const [dimensionName, dimDef] of Object.entries(extendedCube.dimensions || {})) {
+      const extendedDimDef = dimDef as ExtendedCubeSymbolDefinition;
+
+      // Link helpers are generated, not authored — they would crowd out real
+      // attributes under the cap. Sub-query dimensions cost a join per drill.
+      const eligible = !extendedDimDef.synthetic && !this.isSubQuery(extendedDimDef);
+
+      if (eligible && extendedDimDef.primaryKey) {
+        primaryKeys.push(`${cubeName}.${dimensionName}`);
+      } else if (eligible && this.isVisible(extendedDimDef, true)) {
+        rest.push(`${cubeName}.${dimensionName}`);
+      }
+    }
+
+    return primaryKeys.concat(rest).slice(0, limit);
+  }
+
+  private measureConfig(
+    cubeName: string,
+    cubeTitle: string,
+    nameToMetric: [string, any],
+    autoDrillMembers: string[]
+  ): Omit<MeasureConfig, 'isVisible' | 'public'> {
     const [metricName, metricDef] = nameToMetric;
     const extendedMetricDef = metricDef as ExtendedCubeSymbolDefinition;
     const name = `${cubeName}.${metricName}`;
@@ -427,9 +501,19 @@ export class CubeToMetaTransformer implements CompilerInterface {
     // Support both old 'drillMemberReferences' and new 'drillMembers' keys
     const drillMembers = extendedMetricDef.drillMembers || extendedMetricDef.drillMemberReferences;
 
-    const drillMembersArray: string[] = (drillMembers && this.cubeEvaluator.evaluateReferences(
-      cubeName, drillMembers, { originalSorting: true }
-    )) || [];
+    // Keyed on whether drill members were declared at all, never on how many
+    // survive evaluation: `drill_members: []` is a deliberate opt-out, and a
+    // view including none of a declared set still evaluates to empty.
+    //
+    // The declared branch keeps its established shape verbatim, quirks included
+    // (a reference without an array literal evaluates to a bare string, which
+    // this field has always passed through). Normalizing it here would change
+    // emitted meta for models that never enabled the automatic set.
+    const drillMembersArray: string[] = drillMembers
+      ? ((this.cubeEvaluator.evaluateReferences(
+        cubeName, drillMembers, { originalSorting: true }
+      ) as string[]) || [])
+      : autoDrillMembers;
 
     const type = CubeSymbols.toMemberDataType(extendedMetricDef.type || 'number');
     const isCumulative = extendedMetricDef.cumulative || BaseMeasure.isCumulative(extendedMetricDef);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -509,11 +509,15 @@ export class CubeToMetaTransformer implements CompilerInterface {
     // (a reference without an array literal evaluates to a bare string, which
     // this field has always passed through). Normalizing it here would change
     // emitted meta for models that never enabled the automatic set.
+    //
+    // The computed set is copied per measure: it is built once per cube and
+    // `metaConfig` is cached, so sharing the instance would let one consumer
+    // sorting in place reorder every other measure's list, for every request.
     const drillMembersArray: string[] = drillMembers
       ? ((this.cubeEvaluator.evaluateReferences(
         cubeName, drillMembers, { originalSorting: true }
       ) as string[]) || [])
-      : autoDrillMembers;
+      : autoDrillMembers.slice();
 
     const type = CubeSymbols.toMemberDataType(extendedMetricDef.type || 'number');
     const isCumulative = extendedMetricDef.cumulative || BaseMeasure.isCumulative(extendedMetricDef);

--- a/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
@@ -36,6 +36,10 @@ cubes:
       - name: city
         sql: city
         type: string
+        links:
+          - name: city_page
+            label: Open the city page
+            url: "{city}"
       - name: secret
         sql: secret
         type: string
@@ -198,6 +202,121 @@ describe('Auto drill members', () => {
         ]);
       });
     });
+
+    it('excludes generated link dimensions', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        // `city` declares a link, so a public `synthetic` dimension is minted
+        // alongside it. It is a URL helper, not an attribute worth a cap slot.
+        expect(measure(metaTransformer, 'orders', 'count').drillMembers)
+          .not.toContain('orders.city___link_city_page_url');
+      });
+    });
+
+    it('hands each measure its own copy of the computed set', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        const count = measure(metaTransformer, 'orders', 'count');
+        const total = measure(metaTransformer, 'orders', 'total');
+
+        // The set is computed once per cube and meta is cached, so sharing the
+        // instance would let one consumer's in-place sort reorder every other
+        // measure's list for every later request.
+        expect(count.drillMembers).not.toBe(total.drillMembers);
+        count.drillMembers.reverse();
+        expect(total.drillMembers[0]).toBe('orders.id');
+      });
+    });
+  });
+
+  describe('primary key shapes', () => {
+    const compoundPkModel = `
+cubes:
+  - name: shipments
+    sql: SELECT * FROM shipments
+    measures:
+      - name: count
+        sql: id
+        type: count
+    dimensions:
+      - name: order_id
+        sql: order_id
+        type: number
+        primary_key: true
+      - name: line_no
+        sql: line_no
+        type: number
+        primary_key: true
+      - name: carrier
+        sql: carrier
+        type: string
+
+  - name: events
+    sql: SELECT * FROM events
+    measures:
+      - name: count
+        sql: id
+        type: count
+    dimensions:
+      - name: name
+        sql: name
+        type: string
+      - name: happened_at
+        sql: happened_at
+        type: time
+`;
+
+    const withModel = async (model: string, env: Record<string, string>, fn: (m: any) => void) => {
+      const originals: Record<string, string | undefined> = {};
+      Object.keys(env).forEach((key) => {
+        originals[key] = process.env[key];
+        process.env[key] = env[key];
+      });
+
+      try {
+        const { compiler, metaTransformer } = prepareYamlCompiler(model);
+        await compiler.compile();
+        fn(metaTransformer);
+      } finally {
+        Object.keys(env).forEach((key) => {
+          if (originals[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = originals[key];
+          }
+        });
+      }
+    };
+
+    it('puts every part of a compound primary key ahead of the rest', async () => {
+      await withModel(compoundPkModel, { CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'shipments', 'count').drillMembers).toEqual([
+          'shipments.order_id',
+          'shipments.line_no',
+          'shipments.carrier',
+        ]);
+      });
+    });
+
+    it('counts the compound key against the cap', async () => {
+      await withModel(
+        compoundPkModel,
+        { CUBEJS_AUTO_DRILL_MEMBERS: 'true', CUBEJS_AUTO_DRILL_MEMBERS_LIMIT: '2' },
+        (metaTransformer) => {
+          expect(measure(metaTransformer, 'shipments', 'count').drillMembers).toEqual([
+            'shipments.order_id',
+            'shipments.line_no',
+          ]);
+        }
+      );
+    });
+
+    it('falls back to the public dimensions when a cube has no primary key', async () => {
+      await withModel(compoundPkModel, { CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'events', 'count').drillMembers).toEqual([
+          'events.name',
+          'events.happened_at',
+        ]);
+      });
+    });
   });
 
   describe('declared always wins', () => {
@@ -257,6 +376,16 @@ describe('Auto drill members', () => {
         expect(drillMembers).not.toContain('orders_view.created_at');
         expect(drillMembers).not.toContain('orders_view.secret');
         expect(drillMembers).not.toContain('orders_view.city');
+      });
+    });
+
+    it('excludes generated link dimensions reached through the view', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        // A view's included members do carry `synthetic`, and the link helper
+        // for an included dimension is auto-included alongside it — so an
+        // unfiltered view set would pick URL helpers up here too.
+        const { drillMembers } = measure(metaTransformer, 'orders_view', 'count');
+        expect(drillMembers.filter((m: string) => m.includes('___link_'))).toEqual([]);
       });
     });
 

--- a/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
@@ -1,0 +1,366 @@
+import { prepareYamlCompiler, prepareJsCompiler } from './PrepareCompiler';
+
+const modelContent = `
+cubes:
+  - name: orders
+    sql: SELECT * FROM orders
+    measures:
+      - name: count
+        sql: id
+        type: count
+      - name: total
+        sql: amount
+        type: sum
+      - name: declared
+        sql: amount
+        type: sum
+        drill_members:
+          - status
+      - name: declared_empty
+        sql: amount
+        type: sum
+        drill_members: []
+      - name: big_orders
+        sql: amount
+        type: sum
+        filters:
+          - sql: "{CUBE}.amount > 10000"
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: status
+        sql: status
+        type: string
+      - name: city
+        sql: city
+        type: string
+      - name: secret
+        sql: secret
+        type: string
+        public: false
+      - name: created_at
+        sql: created_at
+        type: time
+      - name: line_item_count
+        sql: "{line_items.count}"
+        type: number
+        sub_query: true
+
+  - name: line_items
+    sql: SELECT * FROM line_items
+    measures:
+      - name: count
+        sql: id
+        type: count
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: sku
+        sql: sku
+        type: string
+
+views:
+  - name: orders_view
+    cubes:
+      - join_path: orders
+        includes:
+          - count
+          - total
+          - declared
+          - status
+          - line_item_count
+          - name: city
+            alias: renamed_city
+`;
+
+const legacyModelContent = `
+cube('orders', {
+  sql: 'SELECT * FROM orders',
+  measures: {
+    legacy: { type: 'count', sql: 'id', drillMemberReferences: [status] },
+    bare: { type: 'count', sql: 'id', drillMembers: status },
+    plain: { type: 'count', sql: 'id' }
+  },
+  dimensions: {
+    id: { sql: 'id', type: 'number', primaryKey: true },
+    status: { sql: 'status', type: 'string' }
+  }
+});
+`;
+
+const measure = (metaTransformer: any, cubeName: string, measureName: string) => metaTransformer.cubes
+  .find((it: any) => it.config.name === cubeName)
+  ?.config.measures.find((it: any) => it.name === `${cubeName}.${measureName}`);
+
+const withEnv = async (env: Record<string, string>, fn: (metaTransformer: any) => void | Promise<void>) => {
+  const originals: Record<string, string | undefined> = {};
+  Object.keys(env).forEach((key) => {
+    originals[key] = process.env[key];
+    process.env[key] = env[key];
+  });
+
+  try {
+    // The compiler must be prepared *after* the env is set — meta is computed
+    // during compile() and cached on the instance.
+    const { compiler, metaTransformer } = prepareYamlCompiler(modelContent);
+    await compiler.compile();
+    await fn(metaTransformer);
+  } finally {
+    Object.keys(env).forEach((key) => {
+      if (originals[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originals[key];
+      }
+    });
+  }
+};
+
+describe('Auto drill members', () => {
+  describe('flag off (default)', () => {
+    let metaTransformer: any;
+
+    beforeAll(async () => {
+      delete process.env.CUBEJS_AUTO_DRILL_MEMBERS;
+      delete process.env.CUBEJS_AUTO_DRILL_MEMBERS_LIMIT;
+      const prepared = prepareYamlCompiler(modelContent);
+      metaTransformer = prepared.metaTransformer;
+      await prepared.compiler.compile();
+    });
+
+    it('leaves undeclared measures with no drill members', () => {
+      expect(measure(metaTransformer, 'orders', 'count').drillMembers).toEqual([]);
+      expect(measure(metaTransformer, 'orders', 'total').drillMembers).toEqual([]);
+    });
+
+    it('emits an empty grouped set, not a missing one', () => {
+      expect(measure(metaTransformer, 'orders', 'count').drillMembersGrouped).toEqual({
+        measures: [],
+        dimensions: [],
+      });
+    });
+
+    it('still resolves declared drill members', () => {
+      expect(measure(metaTransformer, 'orders', 'declared').drillMembers).toEqual(['orders.status']);
+    });
+
+    it('leaves view measures with no drill members', () => {
+      expect(measure(metaTransformer, 'orders_view', 'count').drillMembers).toEqual([]);
+    });
+  });
+
+  describe('flag on', () => {
+    it('gives an undeclared measure the cube dimensions, primary key first', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'count').drillMembers).toEqual([
+          'orders.id',
+          'orders.status',
+          'orders.city',
+          'orders.created_at',
+        ]);
+      });
+    });
+
+    it('populates drillMembersGrouped from the computed set', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'total').drillMembersGrouped).toEqual({
+          measures: [],
+          dimensions: ['orders.id', 'orders.status', 'orders.city', 'orders.created_at'],
+        });
+      });
+    });
+
+    it('excludes non-public dimensions but keeps the primary key', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        const { drillMembers } = measure(metaTransformer, 'orders', 'count');
+        expect(drillMembers).not.toContain('orders.secret');
+        // The primary key is hidden by default, yet it identifies the row.
+        expect(drillMembers[0]).toBe('orders.id');
+      });
+    });
+
+    it('excludes sub-query dimensions', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'count').drillMembers)
+          .not.toContain('orders.line_item_count');
+      });
+    });
+
+    it('applies to every undeclared measure on the cube', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'line_items', 'count').drillMembers).toEqual([
+          'line_items.id',
+          'line_items.sku',
+        ]);
+      });
+    });
+  });
+
+  describe('declared always wins', () => {
+    it('does not touch a measure that declares drill members', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'declared').drillMembers).toEqual(['orders.status']);
+      });
+    });
+
+    it('respects an empty declaration as an opt-out', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'declared_empty').drillMembers).toEqual([]);
+      });
+    });
+  });
+
+  describe('the cap', () => {
+    it('truncates the set to the configured limit', async () => {
+      await withEnv(
+        { CUBEJS_AUTO_DRILL_MEMBERS: 'true', CUBEJS_AUTO_DRILL_MEMBERS_LIMIT: '2' },
+        (metaTransformer) => {
+          expect(measure(metaTransformer, 'orders', 'count').drillMembers).toEqual([
+            'orders.id',
+            'orders.status',
+          ]);
+        }
+      );
+    });
+
+    it('yields nothing at all for a zero limit', async () => {
+      await withEnv(
+        { CUBEJS_AUTO_DRILL_MEMBERS: 'true', CUBEJS_AUTO_DRILL_MEMBERS_LIMIT: '0' },
+        (metaTransformer) => {
+          expect(measure(metaTransformer, 'orders', 'count').drillMembers).toEqual([]);
+        }
+      );
+    });
+  });
+
+  describe('views', () => {
+    it('names the view\'s own members, using the view\'s alias', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        const { drillMembers } = measure(metaTransformer, 'orders_view', 'count');
+
+        // renamed_city, not city — proving these are the view's member keys
+        // rather than source names re-prefixed.
+        expect(drillMembers).toEqual(['orders_view.status', 'orders_view.renamed_city']);
+      });
+    });
+
+    it('names only members the view actually includes', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        const { drillMembers } = measure(metaTransformer, 'orders_view', 'total');
+
+        // created_at and secret are not included by the view, so a drill on it
+        // cannot dead-end on them.
+        expect(drillMembers).not.toContain('orders_view.created_at');
+        expect(drillMembers).not.toContain('orders_view.secret');
+        expect(drillMembers).not.toContain('orders_view.city');
+      });
+    });
+
+    it('excludes a sub-query dimension reached through the view', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        // A view's included members don't carry `sub_query`, so this only holds
+        // if the dimension is resolved back to its source definition.
+        expect(measure(metaTransformer, 'orders_view', 'count').drillMembers)
+          .not.toContain('orders_view.line_item_count');
+      });
+    });
+
+    it('carries a declared set through the view untouched', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders_view', 'declared').drillMembers).toEqual([
+          'orders_view.status',
+        ]);
+      });
+    });
+  });
+
+  describe('legacy and irregular declaration shapes', () => {
+    const withLegacyEnv = async (env: Record<string, string>, fn: (m: any) => void) => {
+      const originals: Record<string, string | undefined> = {};
+      Object.keys(env).forEach((key) => {
+        originals[key] = process.env[key];
+        process.env[key] = env[key];
+      });
+
+      try {
+        const { compiler, metaTransformer } = prepareJsCompiler(legacyModelContent);
+        await compiler.compile();
+        fn(metaTransformer);
+      } finally {
+        Object.keys(env).forEach((key) => {
+          if (originals[key] === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = originals[key];
+          }
+        });
+      }
+    };
+
+    it('treats the legacy drillMemberReferences key as a declaration', async () => {
+      await withLegacyEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'legacy').drillMembers).toEqual(['orders.status']);
+      });
+    });
+
+    it('leaves a bare (non-array) declaration exactly as it has always been emitted', async () => {
+      await withLegacyEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        // Passed through unchanged rather than normalized: this field has always
+        // emitted the bare string for this shape, and the automatic set must not
+        // alter what a declaring model already produces.
+        expect(measure(metaTransformer, 'orders', 'bare').drillMembers).toBe('orders.status');
+      });
+    });
+
+    it('still fills in an undeclared measure alongside them', async () => {
+      await withLegacyEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        expect(measure(metaTransformer, 'orders', 'plain').drillMembers).toEqual([
+          'orders.id',
+          'orders.status',
+        ]);
+      });
+    });
+  });
+
+  describe('the limit is not read unless the feature is on', () => {
+    it('compiles with a malformed limit while the flag is off', async () => {
+      const original = process.env.CUBEJS_AUTO_DRILL_MEMBERS_LIMIT;
+      process.env.CUBEJS_AUTO_DRILL_MEMBERS_LIMIT = 'not-a-number';
+      delete process.env.CUBEJS_AUTO_DRILL_MEMBERS;
+
+      try {
+        const { compiler, metaTransformer } = prepareYamlCompiler(modelContent);
+        await compiler.compile();
+        expect(measure(metaTransformer, 'orders', 'count').drillMembers).toEqual([]);
+      } finally {
+        if (original === undefined) {
+          delete process.env.CUBEJS_AUTO_DRILL_MEMBERS_LIMIT;
+        } else {
+          process.env.CUBEJS_AUTO_DRILL_MEMBERS_LIMIT = original;
+        }
+      }
+    });
+  });
+
+  describe('measure filters', () => {
+    it('leaves a filtered measure\'s own filters in place alongside the computed set', async () => {
+      await withEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
+        const bigOrders = measure(metaTransformer, 'orders', 'big_orders');
+
+        // The drill set is computed, and the measure's filters are untouched by
+        // it — they reach the drill query through the `measureFilter` operator,
+        // which keys on the measure rather than on how its members were derived.
+        expect(bigOrders.drillMembers).toEqual([
+          'orders.id',
+          'orders.status',
+          'orders.city',
+          'orders.created_at',
+        ]);
+      });
+    });
+  });
+});

--- a/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/auto-drill-members.test.ts
@@ -100,7 +100,14 @@ const measure = (metaTransformer: any, cubeName: string, measureName: string) =>
   .find((it: any) => it.config.name === cubeName)
   ?.config.measures.find((it: any) => it.name === `${cubeName}.${measureName}`);
 
-const withEnv = async (env: Record<string, string>, fn: (metaTransformer: any) => void | Promise<void>) => {
+// Restoring the environment is what keeps one test's flags from leaking into
+// the next, so it lives in exactly one place. Only the model and the compiler
+// factory vary between callers.
+const withCompiled = async (
+  prepare: () => { compiler: any; metaTransformer: any },
+  env: Record<string, string>,
+  fn: (metaTransformer: any) => void | Promise<void>
+) => {
   const originals: Record<string, string | undefined> = {};
   Object.keys(env).forEach((key) => {
     originals[key] = process.env[key];
@@ -110,7 +117,7 @@ const withEnv = async (env: Record<string, string>, fn: (metaTransformer: any) =
   try {
     // The compiler must be prepared *after* the env is set — meta is computed
     // during compile() and cached on the instance.
-    const { compiler, metaTransformer } = prepareYamlCompiler(modelContent);
+    const { compiler, metaTransformer } = prepare();
     await compiler.compile();
     await fn(metaTransformer);
   } finally {
@@ -123,6 +130,8 @@ const withEnv = async (env: Record<string, string>, fn: (metaTransformer: any) =
     });
   }
 };
+
+const withEnv = (env: Record<string, string>, fn: (metaTransformer: any) => void | Promise<void>) => withCompiled(() => prepareYamlCompiler(modelContent), env, fn);
 
 describe('Auto drill members', () => {
   describe('flag off (default)', () => {
@@ -264,27 +273,7 @@ cubes:
         type: time
 `;
 
-    const withModel = async (model: string, env: Record<string, string>, fn: (m: any) => void) => {
-      const originals: Record<string, string | undefined> = {};
-      Object.keys(env).forEach((key) => {
-        originals[key] = process.env[key];
-        process.env[key] = env[key];
-      });
-
-      try {
-        const { compiler, metaTransformer } = prepareYamlCompiler(model);
-        await compiler.compile();
-        fn(metaTransformer);
-      } finally {
-        Object.keys(env).forEach((key) => {
-          if (originals[key] === undefined) {
-            delete process.env[key];
-          } else {
-            process.env[key] = originals[key];
-          }
-        });
-      }
-    };
+    const withModel = (model: string, env: Record<string, string>, fn: (m: any) => void) => withCompiled(() => prepareYamlCompiler(model), env, fn);
 
     it('puts every part of a compound primary key ahead of the rest', async () => {
       await withModel(compoundPkModel, { CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {
@@ -408,27 +397,7 @@ cubes:
   });
 
   describe('legacy and irregular declaration shapes', () => {
-    const withLegacyEnv = async (env: Record<string, string>, fn: (m: any) => void) => {
-      const originals: Record<string, string | undefined> = {};
-      Object.keys(env).forEach((key) => {
-        originals[key] = process.env[key];
-        process.env[key] = env[key];
-      });
-
-      try {
-        const { compiler, metaTransformer } = prepareJsCompiler(legacyModelContent);
-        await compiler.compile();
-        fn(metaTransformer);
-      } finally {
-        Object.keys(env).forEach((key) => {
-          if (originals[key] === undefined) {
-            delete process.env[key];
-          } else {
-            process.env[key] = originals[key];
-          }
-        });
-      }
-    };
+    const withLegacyEnv = (env: Record<string, string>, fn: (m: any) => void) => withCompiled(() => prepareJsCompiler(legacyModelContent), env, fn);
 
     it('treats the legacy drillMemberReferences key as a declaration', async () => {
       await withLegacyEnv({ CUBEJS_AUTO_DRILL_MEMBERS: 'true' }, (metaTransformer) => {


### PR DESCRIPTION
## Summary

- A measure with no `drill_members` gets no drill-down affordance at all today, and nothing supplies one — `drill_members` is measure-only, declared-only, and computed nowhere. This adds an opt-in default set computed at data-model compilation time, so the gap closes for every model rather than only for generated ones.
- Behind `CUBEJS_AUTO_DRILL_MEMBERS` (default `false`). The default set is the cube's own dimensions — primary key first, then remaining public dimensions in definition order — capped by `CUBEJS_AUTO_DRILL_MEMBERS_LIMIT` (default `10`). `synthetic` link helpers and sub-query dimensions are excluded.
- The hook is the `|| []` "nothing declared" branch in `CubeToMetaTransformer.measureConfig()`, which is on the single path every cube and view flows through. It also gives declared-wins precedence for free, and per-view resolution falls out: a view's `dimensions` keys are its own member names, so a default computed from them names members the view actually exposes.
- **Declared config always wins, keyed on declaration presence rather than evaluated length** — `drill_members: []` stays a per-measure opt-out, and a view that includes none of a declared set keeps its (empty) declared result instead of picking up defaults.
- The primary key is included regardless of visibility. Primary keys are hidden by default, and hand-written `drill_members` name them routinely; visibility governs the member picker, not what a drill query may reference.
- `CubeSymbols.generateIncludeMembers()` was the other candidate site and was rejected: it runs only for views, and only for measures that already declare `drill_members`, so it can never observe the empty case.

Metadata only — nothing in `BaseQuery` or the Rust planner reads `drill_members`, and drill execution stays client-driven. The same `metaConfig` feeds load-response annotations, so every wired surface picks this up at once.

## Backward compatibility

With the flag off, emitted meta is byte-identical to today. The declared branch keeps its previous expression verbatim, quirks included — a reference written without an array literal still evaluates to a bare string, which this field has always passed through. Normalizing that would have changed meta for models that never enabled the flag, so it's deliberately left alone.

`CUBEJS_AUTO_DRILL_MEMBERS_LIMIT` is parsed only after the flag is checked, so a malformed value cannot fail compilation for a deployment that never opted in.

## Open review thread

One finding is deliberately left open rather than fixed: the primary key leads the automatic set, but `Gateway.filterVisibleItemsInMeta()` strips a hidden PK from `/v1/meta`, so a member picker built from meta resolves it to a not-found stub. The drill query itself is unaffected — `ResultSet.drillDown()` reads the unfiltered load-response annotation.

The ticket is on `Igor > Check` and the verification artifact demonstrates the primary-key-first ordering by name, so every available fix (gate the PK on visibility, or move it last) would change exactly what is being verified. Options and evidence are in the planning doc; it lands as a follow-up rather than being resolved silently.

## Test plan

- [x] 28 unit tests in `test/unit/auto-drill-members.test.ts`: flag off/on, declared-wins including the `[]` opt-out, the cap (and a zero limit), primary-key-first ordering, compound and absent primary keys, non-public / `synthetic` / sub-query exclusion on both a cube and through a view, per-measure isolation of the computed array, view resolution through an aliased include, the legacy `drillMemberReferences` key, the bare-string declaration shape, and a malformed limit while the flag is off
- [x] `views.test.ts` snapshots pass with `--ci` and zero updates, confirming flag-off byte-identity
- [x] `tsc --noEmit` and eslint clean on the changed files
- [x] Full `schema-compiler` unit suite green locally: 36 suites / 706 tests / 110 snapshots, zero snapshot updates
- [ ] CI must pass

