### PR TITLE
fix(core): declare the dist-only test target in five package.json-configured packages

### DIFF
--- a/packages/cubejs-firebolt-driver/jest.config.js
+++ b/packages/cubejs-firebolt-driver/jest.config.js
@@ -1,0 +1,16 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
+  // test-env.js maps DRIVERS_TESTS_FIREBOLT_* onto the CUBEJS_DB_* names the
+  // driver reads, so it must survive alongside the base setup file. It stays a
+  // source path: tsc has no allowJs, so it is never emitted into dist/.
+  setupFiles: [...base.setupFiles, '<rootDir>/test/test-env.js'],
+};

--- a/packages/cubejs-firebolt-driver/package.json
+++ b/packages/cubejs-firebolt-driver/package.json
@@ -42,12 +42,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "jest": {
-    "testEnvironment": "node",
-    "setupFiles": [
-      "./test/test-env.js"
-    ]
-  },
   "eslintConfig": {
     "extends": "../cubejs-linter"
   }

--- a/packages/cubejs-materialize-driver/jest.config.js
+++ b/packages/cubejs-materialize-driver/jest.config.js
@@ -1,0 +1,12 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
+};

--- a/packages/cubejs-materialize-driver/package.json
+++ b/packages/cubejs-materialize-driver/package.json
@@ -41,9 +41,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "eslintConfig": {
     "extends": "../cubejs-linter"
   }

--- a/packages/cubejs-mongobi-driver/jest.config.js
+++ b/packages/cubejs-mongobi-driver/jest.config.js
@@ -1,0 +1,12 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
+};

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -42,9 +42,6 @@
     "testcontainers": "^10.28.0",
     "typescript": "~5.2.2"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "eslintConfig": {
     "extends": "../cubejs-linter"
   }

--- a/packages/cubejs-postgres-driver/jest.config.js
+++ b/packages/cubejs-postgres-driver/jest.config.js
@@ -1,0 +1,12 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
+};

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -44,9 +44,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "eslintConfig": {
     "extends": "../cubejs-linter"
   }

--- a/packages/cubejs-questdb-driver/jest.config.js
+++ b/packages/cubejs-questdb-driver/jest.config.js
@@ -1,0 +1,12 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+  // Suites run from the compiled output — the sources under test/ have no
+  // transform and cannot execute.
+  testMatch: [
+    '<rootDir>/dist/test/**/*.{test,spec}.{ts,js}'
+  ],
+};

--- a/packages/cubejs-questdb-driver/package.json
+++ b/packages/cubejs-questdb-driver/package.json
@@ -45,9 +45,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "jest": {
-    "testEnvironment": "node"
-  },
   "eslintConfig": {
     "extends": "../cubejs-linter"
   }


### PR DESCRIPTION
## Summary

- Five driver packages expressed their jest config as an inline `jest` key in `package.json` rather than a `jest.config.js`, so the dist-only convention never reached them: each has TypeScript test sources, no transform that can compile them, and nothing confining collection to `dist/`. A bare `jest` collected the sources and failed to parse them — the `dist/test` path argument in each package's script was the only thing keeping the suite runnable.
- Each one now extends `jest.base.config.js` and declares a dist-pointing `testMatch`, matching the convention the other packages in this class already follow. The inline `testEnvironment: 'node'` is dropped because the base config already sets it.
- `cubejs-firebolt-driver` is the one non-mechanical case: its inline key also carried `setupFiles: ['./test/test-env.js']`, and the base config declares its own `setupFiles`, so the new config unions the two rather than letting the spread drop it. That file maps the `DRIVERS_TESTS_FIREBOLT_*` env vars onto the `CUBEJS_DB_*` names the driver reads, and it stays a source path — `tsc` has no `allowJs`, so it is never emitted into `dist/`.

Three of these five (`postgres`, `mongobi`, `firebolt`) are exercised by the `integration` matrix, which runs `lerna run integration:<db>`. Since jest intersects a script's path argument with `testMatch`, the risk here is a config narrower than the path argument silently *shrinking* what CI runs, so that is what the test plan proves rather than assumes.

## Test plan

- [x] `jest --listTests` captured before vs after for every jest-invoking script in all five packages: **byte-identical** on both sides (md5-matched per package) — no existing script collects fewer suites than it did before.
- [x] Bare `jest` in each package: **9 untransformable `test/*.ts` entries no longer collected, 0 compiled suites lost.**
- [x] Red-checked the defect: with the change backed out, `jest` in `cubejs-postgres-driver` fails `test/type-parsers.test.ts` with `SyntaxError: Cannot use import statement outside a module`; with it, only `dist/test/type-parsers.test.js` is collected and passes (3 tests).
- [x] `cubejs-firebolt-driver`'s resolved `setupFiles` asserted to contain both the base setup file and `test/test-env.js`, and a suite run through the new config to confirm both resolve at run time (3 passed).
- [x] All five configs load under Node with a well-formed `testMatch`; `eslint` clean.
- [ ] CI must pass.
