### PR TITLE
fix(cubestore-driver): don't fail queries on `write EPIPE`, report over-limit messages readably

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1018,13 +1018,20 @@ A cache entry at or above `CUBESTORE_CACHE_MAX_ENTRY_SIZE` is rejected explicitl
 with `Unable to SET cache with '<key>' key, exceeds maximum allowed size for
 payload: <size>, max allowed: <limit>`.
 
-<Warning>
+A message above the *transport* limit is answered with an error naming the
+size and the limit, and the connection stays up for the other queries
+multiplexed over it:
 
-**Known limitation.** A message above the *transport* limit is not answered
-with an error. The deployment then reports `ConnectionError: CubeStore connection error:
-write EPIPE`.
+```
+Request of 70000000 bytes exceeds the maximum message size of 67108864 bytes.
+Reduce the size of the query, e.g. by sending fewer or smaller inline tables,
+or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
+```
 
-</Warning>
+A result too large for Cube's own limit is reported the same way, as
+`Cube Store response size exceeds the maximum message size of 100 MB`. That
+limit is [`CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE`](/reference/configuration/environment-variables#cubejs_cubestore_max_message_size),
+which is independent of the Cube Store side and defaults to 100 MB.
 
 If a query hits this limit, reduce the size of its result set — add filters
 or a lower `limit`, drop dimensions, or split it into several queries.

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1028,6 +1028,10 @@ Reduce the size of the query, e.g. by sending fewer or smaller inline tables,
 or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
 ```
 
+That holds up to twice the configured limit. A message beyond it is refused
+before it can be attributed to a query, so the connection is closed instead
+and the other queries multiplexed over it are re-sent on a new one.
+
 A result too large for Cube's own limit is reported the same way, as
 `Cube Store response size exceeds the maximum message size of 100 MB`. That
 limit is [`CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE`](/reference/configuration/environment-variables#cubejs_cubestore_max_message_size),

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1028,9 +1028,11 @@ Reduce the size of the query, e.g. by sending fewer or smaller inline tables,
 or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
 ```
 
-That holds up to twice the configured limit. A message beyond it is refused
-before it can be attributed to a query, so the connection is closed instead
-and the other queries multiplexed over it are re-sent on a new one.
+That holds up to twice whichever of the two transport limits above is lower.
+A message beyond it is refused before it can be attributed to a query, so the
+connection is closed instead and the other queries multiplexed over it are
+re-sent on a new one. The close names the limit that refused it, so it says
+which of the two to raise.
 
 A result too large for Cube's own limit is reported the same way, as
 `Cube Store response size exceeds the maximum message size of 100 MB`. That

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -184,6 +184,20 @@ The port of the Cube Store deployment.
 | ------------------- | ---------------------- | --------------------- |
 | A valid port number | `3030`                 | `3030`                |
 
+## `CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE`
+
+The maximum size of a single message Cube will send to or accept from Cube
+Store. A result above this size is reported as `Cube Store response size
+exceeds the maximum message size`; see
+[message size limits](/docs/pre-aggregations/cube-store-architecture#message-size-limits).
+This is Cube's own limit and is independent of
+[`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE`](#cubestore_transport_max_message_size),
+which Cube Store applies to what it receives.
+
+| Possible Values      | Default in Development | Default in Production |
+| -------------------- | ---------------------- | --------------------- |
+| A size in bytes      | `104857600` (100 MB)   | `104857600` (100 MB)  |
+
 ## `CUBEJS_QUEUE_FAST_TRACK`
 
 <Warning>
@@ -2149,7 +2163,7 @@ If `true`, then sends telemetry to Cube.
 ## `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE`
 
 The maximum size of a single message on the WebSocket connection between Cube
-and Cube Store. Messages above this size close the connection; see
+and Cube Store. Messages above this size are answered with an error; see
 [message size limits](/docs/pre-aggregations/cube-store-architecture#message-size-limits).
 
 | Possible Values | Default in Development | Default in Production |

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1903,9 +1903,13 @@ const variables: Record<string, (...args: any) => any> = {
     .asInt(),
   /**
    * Maximum size in bytes of a single message exchanged with Cube Store, both
-   * of a query sent to it and of a response received from it. Its Cube Store
-   * side counterpart, which limits what Cube Store accepts, is
-   * CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
+   * of a query sent to it and of a response received from it.
+   *
+   * It is the only limit that applies to responses, since Cube Store doesn't
+   * cap what it sends. For queries it is independent of, and by default looser
+   * than, CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE (64 MB), which is what Cube
+   * Store itself accepts: a query over that but under this one is refused by
+   * Cube Store rather than by this limit.
    */
   cubeStoreMaxMessageSize: () => get('CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE')
     .default(String(100 * 1024 * 1024))

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1879,9 +1879,13 @@ const variables: Record<string, (...args: any) => any> = {
     .asInt(),
   /**
    * Maximum size in bytes of a single message exchanged with Cube Store, both
-   * of a query sent to it and of a response received from it. Its Cube Store
-   * side counterpart, which limits what Cube Store accepts, is
-   * CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
+   * of a query sent to it and of a response received from it.
+   *
+   * It is the only limit that applies to responses, since Cube Store doesn't
+   * cap what it sends. For queries it is independent of, and by default looser
+   * than, CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE (64 MB), which is what Cube
+   * Store itself accepts: a query over that but under this one is refused by
+   * Cube Store rather than by this limit.
    */
   cubeStoreMaxMessageSize: () => get('CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE')
     .default(String(100 * 1024 * 1024))

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1877,6 +1877,15 @@ const variables: Record<string, (...args: any) => any> = {
   cubeStoreNoHeartBeatTimeout: () => get('CUBEJS_CUBESTORE_NO_HEART_BEAT_TIMEOUT')
     .default('30')
     .asInt(),
+  /**
+   * Maximum size in bytes of a single message exchanged with Cube Store, both
+   * of a query sent to it and of a response received from it. Its Cube Store
+   * side counterpart, which limits what Cube Store accepts, is
+   * CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
+   */
+  cubeStoreMaxMessageSize: () => get('CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE')
+    .default(String(100 * 1024 * 1024))
+    .asIntPositive(),
   cubeStoreRollingWindowJoin: () => get('CUBEJS_CUBESTORE_ROLLING_WINDOW_JOIN')
     .default('true')
     .asBoolStrict(),

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1901,6 +1901,15 @@ const variables: Record<string, (...args: any) => any> = {
   cubeStoreNoHeartBeatTimeout: () => get('CUBEJS_CUBESTORE_NO_HEART_BEAT_TIMEOUT')
     .default('30')
     .asInt(),
+  /**
+   * Maximum size in bytes of a single message exchanged with Cube Store, both
+   * of a query sent to it and of a response received from it. Its Cube Store
+   * side counterpart, which limits what Cube Store accepts, is
+   * CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
+   */
+  cubeStoreMaxMessageSize: () => get('CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE')
+    .default(String(100 * 1024 * 1024))
+    .asIntPositive(),
   cubeStoreRollingWindowJoin: () => get('CUBEJS_CUBESTORE_ROLLING_WINDOW_JOIN')
     .default('true')
     .asBoolStrict(),

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -22,8 +22,9 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint src/*.ts",
-    "lint:fix": "eslint --fix src/*.ts"
+    "lint": "eslint src/*.ts test/*.ts",
+    "lint:fix": "eslint --fix src/*.ts test/*.ts",
+    "unit": "jest --coverage"
   },
   "dependencies": {
     "@cubejs-backend/base-driver": "1.7.27",

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -22,8 +22,9 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint src/*.ts",
-    "lint:fix": "eslint --fix src/*.ts"
+    "lint": "eslint src/*.ts test/*.ts",
+    "lint:fix": "eslint --fix src/*.ts test/*.ts",
+    "unit": "jest --coverage"
   },
   "dependencies": {
     "@cubejs-backend/base-driver": "1.7.16",

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { InlineTable } from '@cubejs-backend/base-driver';
 import { getEnv, getProcessUid } from '@cubejs-backend/shared';
 import { parseCubestoreResultMessage } from '@cubejs-backend/native';
-import { ConnectionError, QueryError } from './errors';
+import { ConnectionError, MessageTooLargeError, QueryError } from './errors';
 import {
   BinaryValue,
   BoolValue,
@@ -21,6 +21,18 @@ import {
   QueryResultFormat,
   StringValue,
 } from '../codegen';
+
+// The WebSocket close code for a message that is too big to be processed: `ws`
+// closes with it when an incoming message is over `maxPayload`, and a peer that
+// refuses a message of ours is expected to close with it as well.
+const MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
+
+// The `ws` error code for an incoming message bigger than `maxPayload`.
+const MAX_PAYLOAD_EXCEEDED_CODE = 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH';
+
+function formatSize(bytes: number): string {
+  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+}
 
 interface SentMessage {
   resolve: (value: any) => void;
@@ -47,6 +59,9 @@ interface CubeStoreWebSocket extends WebSocket {
   // Set as soon as the 'close' handler has scheduled a re-send of the messages
   // that are still in flight on this socket.
   resendScheduled: boolean;
+  // A failure that killed this socket and that re-sending can't fix, so pending
+  // messages are rejected with it instead of being retried.
+  fatalError: Error | null;
 }
 
 export class WebSocketConnection {
@@ -55,6 +70,8 @@ export class WebSocketConnection {
   protected readonly maxConnectRetries: number;
 
   protected readonly noHeartBeatTimeout: number;
+
+  protected readonly maxMessageSize: number;
 
   protected currentConnectionTry: number;
 
@@ -71,6 +88,7 @@ export class WebSocketConnection {
     this.messageCounter = 1;
     this.maxConnectRetries = getEnv('cubeStoreMaxConnectRetries');
     this.noHeartBeatTimeout = getEnv('cubeStoreNoHeartBeatTimeout');
+    this.maxMessageSize = getEnv('cubeStoreMaxMessageSize');
     this.currentConnectionTry = 0;
     this.connectionId = uuidv4();
   }
@@ -80,7 +98,7 @@ export class WebSocketConnection {
       const headers: Record<string, string> = {};
       headers['x-process-id'] = getProcessUid();
 
-      const webSocket = new WebSocket(this.url, { headers }) as CubeStoreWebSocket;
+      const webSocket = new WebSocket(this.url, { headers, maxPayload: this.maxMessageSize }) as CubeStoreWebSocket;
       webSocket.on('upgrade', (response: any) => {
         this.cubeStoreVersion = response.headers['x-cubestore-version'] || null;
       });
@@ -119,6 +137,28 @@ export class WebSocketConnection {
         });
         webSocket.on('open', () => resolve(webSocket));
         webSocket.on('error', (err) => {
+          if ((err as any).code === MAX_PAYLOAD_EXCEEDED_CODE) {
+            // Cube Store answered with a message bigger than this connection
+            // accepts, and `ws` is tearing the connection down. Neither
+            // reconnecting nor retrying the query helps: the response would be
+            // just as big. Pending messages are rejected by the 'close' handler.
+            webSocket.fatalError = new MessageTooLargeError(
+              `Cube Store response size exceeds the maximum message size of ${formatSize(this.maxMessageSize)}. ` +
+              'Reduce the amount of data the query returns, e.g. by adding filters or a limit, ' +
+              'or raise CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE.',
+              err
+            );
+
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            // No-op if the connection was already established.
+            reject(webSocket.fatalError);
+
+            return;
+          }
+
           this.currentConnectionTry += 1;
 
           if (this.currentConnectionTry < this.maxConnectRetries) {
@@ -142,10 +182,32 @@ export class WebSocketConnection {
           }
           webSocket.lastHeartBeat = new Date();
         });
-        webSocket.on('close', () => {
+        webSocket.on('close', (code: number) => {
           clearInterval(pingInterval);
 
           if (Object.keys(webSocket.sentMessages).length) {
+            const fatalError = webSocket.fatalError || (
+              // Cube Store refused a message that didn't fit into its limits.
+              code === MESSAGE_TOO_BIG_CLOSE_CODE ? new MessageTooLargeError(
+                'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
+                'Reduce the size of the query and of the inline tables it sends, or raise ' +
+                'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+              ) : null
+            );
+
+            if (fatalError) {
+              // eslint-disable-next-line no-restricted-syntax
+              for (const key of Object.keys(webSocket.sentMessages)) {
+                webSocket.sentMessages[key].reject(fatalError);
+              }
+
+              if (webSocket === this.webSocket) {
+                this.webSocket = null;
+              }
+
+              return;
+            }
+
             webSocket.resendScheduled = true;
 
             setTimeout(async () => {
@@ -205,6 +267,7 @@ export class WebSocketConnection {
 
       webSocket.sentMessages = {};
       webSocket.resendScheduled = false;
+      webSocket.fatalError = null;
       this.webSocket = webSocket;
     }
 
@@ -252,6 +315,17 @@ export class WebSocketConnection {
   }
 
   private async sendMessage(messageId: number, buffer: Uint8Array): Promise<any> {
+    if (buffer.length > this.maxMessageSize) {
+      // Cube Store would close the connection on such a message, which shows up
+      // as an unrelated `write EPIPE`, so report it before sending anything.
+      throw new MessageTooLargeError(
+        `Cube Store request size of ${formatSize(buffer.length)} exceeds the maximum message size of ` +
+        `${formatSize(this.maxMessageSize)}. Reduce the size of the query and of the inline tables it sends, ` +
+        'or raise CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE together with CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE ' +
+        'on the Cube Store side.'
+      );
+    }
+
     const socket = await this.initWebSocket();
     return new Promise((resolve, reject) => {
       socket.sentMessages[messageId] = {

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -207,11 +207,12 @@ export class WebSocketConnection {
             // -- so every message in flight gets one more round, which answers
             // the innocent ones and usually leaves the offender alone to be
             // named next time. That includes a message that was alone in
-            // flight: the close can just as well be an ordinary disconnect,
-            // and re-sending is what recovers it. Whatever is still in flight
-            // after that round is failed regardless: an offender whose
-            // response keeps arriving before the other answers would otherwise
-            // be re-sent forever.
+            // flight: `fatalError` says an oversized frame was seen on this
+            // socket, not which query produced it, and it can be the response
+            // to a query rejected on an earlier round that was still on the
+            // wire. Whatever is still in flight after its round is failed
+            // regardless: an offender whose response keeps arriving before the
+            // other answers would otherwise be re-sent forever.
             if (fatalError) {
               // eslint-disable-next-line no-restricted-syntax
               for (const key of pending) {

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -193,16 +193,25 @@ export class WebSocketConnection {
           const pending = Object.keys(webSocket.sentMessages);
 
           if (pending.length) {
-            // Cube Store names the size and the limit in the close reason. A
-            // peer that closes with 1009 and no reason -- an intermediary, or
-            // an older Cube Store -- leaves only the generic wording.
-            const closeReason = reason?.length ? `${reason}. ` : '';
+            // Cube Store names the size and the limit that refused it here,
+            // which is strictly better than the generic wording, so it
+            // replaces it rather than being appended to it. Peer-supplied
+            // text lands in an error a user reads, so control characters are
+            // folded out and the trailing full stop is normalised rather than
+            // assumed absent. A peer that closes with 1009 and no reason --
+            // an intermediary, or an older Cube Store -- keeps the generic
+            // wording, which is the only reason it still exists.
+            const closeReason = reason?.length
+              // eslint-disable-next-line no-control-regex
+              ? `${reason}`.replace(/[\u0000-\u001F\u007F]+/g, ' ').replace(/\s*\.?\s*$/, '')
+              : '';
             const fatalError = webSocket.fatalError || (
               // Cube Store refused a message that didn't fit into its limits.
               code === MESSAGE_TOO_BIG_CLOSE_CODE ? new MessageTooLargeError(
-                `Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ${closeReason}`
+                `Cube Store closed the connection: ${closeReason || 'message size exceeds the maximum message size Cube Store accepts'}. `
                 + 'Reduce the size of the query and of the inline tables it sends, or raise '
-                + 'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+                + 'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE or CUBESTORE_TRANSPORT_MAX_FRAME_SIZE '
+                + 'on the Cube Store side.'
               ) : null
             );
 

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -243,6 +243,13 @@ export class WebSocketConnection {
             setTimeout(async () => {
               try {
                 const nextWebSocket = await this.openSocket();
+                const resent: [string, SentMessage][] = [];
+
+                // Register the whole batch before writing any of it. Writing
+                // yields, and a socket that closes mid-batch must find every
+                // message of it in `sentMessages`: the ones not registered yet
+                // would end up on a socket whose 'close' has already been
+                // handled, with nobody left to write or to re-send them.
                 // eslint-disable-next-line no-restricted-syntax
                 for (const key of Object.keys(webSocket.sentMessages)) {
                   const sentMessage = webSocket.sentMessages[key];
@@ -254,6 +261,15 @@ export class WebSocketConnection {
                   } else {
                     sentMessage.resendCount += 1;
                     nextWebSocket.sentMessages[key] = sentMessage;
+                    resent.push([key, sentMessage]);
+                  }
+                }
+
+                // eslint-disable-next-line no-restricted-syntax
+                for (const [key, sentMessage] of resent) {
+                  // Skip what was answered, or failed, while the batch was
+                  // being written.
+                  if (nextWebSocket.sentMessages[key] === sentMessage) {
                     await nextWebSocket.sendAsync(sentMessage.buffer, Number(key));
                   }
                 }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -187,18 +187,22 @@ export class WebSocketConnection {
           }
           webSocket.lastHeartBeat = new Date();
         });
-        webSocket.on('close', (code: number) => {
+        webSocket.on('close', (code: number, reason: Buffer) => {
           clearInterval(pingInterval);
 
           const pending = Object.keys(webSocket.sentMessages);
 
           if (pending.length) {
+            // Cube Store names the size and the limit in the close reason. A
+            // peer that closes with 1009 and no reason -- an intermediary, or
+            // an older Cube Store -- leaves only the generic wording.
+            const closeReason = reason?.length ? `${reason}. ` : '';
             const fatalError = webSocket.fatalError || (
               // Cube Store refused a message that didn't fit into its limits.
               code === MESSAGE_TOO_BIG_CLOSE_CODE ? new MessageTooLargeError(
-                'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
-                'Reduce the size of the query and of the inline tables it sends, or raise ' +
-                'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+                `Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ${closeReason}`
+                + 'Reduce the size of the query and of the inline tables it sends, or raise '
+                + 'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
               ) : null
             );
 

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -229,6 +229,16 @@ export class WebSocketConnection {
 
                 return;
               }
+            } else {
+              // Only consecutive unattributable failures count towards giving
+              // up on a message: a query that outlived an ordinary disconnect
+              // gets its extra round back, so a later, unrelated oversized
+              // response can't fail it on the spot. The loop the counter
+              // bounds is fatal every round, so nothing resets there.
+              // eslint-disable-next-line no-restricted-syntax
+              for (const key of pending) {
+                webSocket.sentMessages[key].fatalRounds = 0;
+              }
             }
 
             setTimeout(async () => {
@@ -332,7 +342,9 @@ export class WebSocketConnection {
         // 'close' already fired for this socket, so no re-send is going to pick
         // this message up and nothing would ever settle it. That handler also
         // dropped `this.webSocket`, so trying again establishes a fresh
-        // connection rather than failing a query that was never written.
+        // connection rather than failing a query that was never written. The
+        // `messageId` is deliberately kept, like a re-send: Cube Store
+        // de-duplicates on `(connection_id, message_id)`.
         delete socket.sentMessages[messageId];
         this.sendMessage(messageId, buffer).then(resolve, reject);
       }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -46,6 +46,9 @@ interface SentMessage {
   resolve: (value: any) => void;
   reject: (reason?: any) => void;
   buffer: Uint8Array;
+  // How many connections died under this message from a failure that can't be
+  // attributed to a single message. Used to give it exactly one more round.
+  fatalRounds: number;
 }
 
 export type QueryParameter = null | boolean | number | string | Buffer;
@@ -201,26 +204,50 @@ export class WebSocketConnection {
 
             // The connection multiplexes messages and an oversized one can't be
             // attributed -- `ws` drops the frame before its message id is read
-            // -- so only a message that was alone in flight can be failed with
-            // it. Anything else is re-sent as usual: answering the innocent
-            // messages leaves the offender alone, and the next round names it.
-            if (fatalError && pending.length === 1) {
-              webSocket.sentMessages[pending[0]].reject(fatalError);
-              delete webSocket.sentMessages[pending[0]];
+            // -- so a message that was alone in flight is the one at fault.
+            // Anything else gets one more round, which answers the innocent
+            // messages and usually leaves the offender alone to be named next
+            // time. Whatever is still in flight after that round is failed
+            // regardless: an offender whose response keeps arriving before the
+            // other answers would otherwise be re-sent forever.
+            if (fatalError) {
+              // eslint-disable-next-line no-restricted-syntax
+              for (const key of pending) {
+                const sentMessage = webSocket.sentMessages[key];
+                sentMessage.fatalRounds += 1;
 
-              if (webSocket === this.webSocket) {
-                this.webSocket = null;
+                if (pending.length === 1 || sentMessage.fatalRounds > 1) {
+                  delete webSocket.sentMessages[key];
+                  sentMessage.reject(fatalError);
+                }
               }
 
-              return;
+              if (!Object.keys(webSocket.sentMessages).length) {
+                if (webSocket === this.webSocket) {
+                  this.webSocket = null;
+                }
+
+                return;
+              }
             }
 
             setTimeout(async () => {
               try {
                 const nextWebSocket = await this.initWebSocket();
+                const resent = Object.keys(webSocket.sentMessages);
+
+                // Register the whole batch before writing any of it. Writing
+                // yields, and a socket that closes in between must find every
+                // message of the batch: the ones not registered yet would end
+                // up on a socket whose 'close' has already been handled, with
+                // nobody left to write or to re-send them.
                 // eslint-disable-next-line no-restricted-syntax
-                for (const key of Object.keys(webSocket.sentMessages)) {
+                for (const key of resent) {
                   nextWebSocket.sentMessages[key] = webSocket.sentMessages[key];
+                }
+
+                // eslint-disable-next-line no-restricted-syntax
+                for (const key of resent) {
                   await nextWebSocket.sendAsync(webSocket.sentMessages[key].buffer);
                 }
               } catch (e) {
@@ -290,7 +317,7 @@ export class WebSocketConnection {
 
     const socket = await this.initWebSocket();
     return new Promise((resolve, reject) => {
-      socket.sentMessages[messageId] = { resolve, reject, buffer };
+      socket.sentMessages[messageId] = { resolve, reject, buffer, fatalRounds: 0 };
 
       // If socket is closing this message should be resent
       if (socket.readyState === WebSocket.OPEN) {
@@ -303,9 +330,11 @@ export class WebSocketConnection {
         });
       } else if (socket.readyState === WebSocket.CLOSED) {
         // 'close' already fired for this socket, so no re-send is going to pick
-        // this message up and nothing would ever settle it.
+        // this message up and nothing would ever settle it. That handler also
+        // dropped `this.webSocket`, so trying again establishes a fresh
+        // connection rather than failing a query that was never written.
         delete socket.sentMessages[messageId];
-        reject(new ConnectionError('CubeStore connection is closed'));
+        this.sendMessage(messageId, buffer).then(resolve, reject);
       }
     });
   }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -26,6 +26,9 @@ interface SentMessage {
   resolve: (value: any) => void;
   reject: (reason?: any) => void;
   buffer: Uint8Array;
+  // How many times this message was re-sent over a freshly established
+  // connection. Used to give up instead of retrying forever.
+  resendCount: number;
 }
 
 export type QueryParameter = null | boolean | number | string | Buffer;
@@ -40,7 +43,10 @@ interface CubeStoreWebSocket extends WebSocket {
   readyPromise: Promise<CubeStoreWebSocket>;
   lastHeartBeat: Date;
   sentMessages: Record<number, SentMessage>;
-  sendAsync: (message: Uint8Array) => Promise<void>;
+  sendAsync: (message: Uint8Array, messageId?: number) => Promise<void>;
+  // Set as soon as the 'close' handler has scheduled a re-send of the messages
+  // that are still in flight on this socket.
+  resendScheduled: boolean;
 }
 
 export class WebSocketConnection {
@@ -91,20 +97,25 @@ export class WebSocketConnection {
           }
         }, 5000);
 
-        webSocket.sendAsync = async (message: Uint8Array) => new Promise<void>((resolveSend, rejectSend) => {
+        webSocket.sendAsync = async (message: Uint8Array, messageId?: number) => new Promise<void>((resolveSend) => {
           // If socket is closing this message should be resent
-          if (webSocket.readyState === WebSocket.OPEN) {
-            webSocket.send(message, (err) => {
-              if (err) {
-                rejectSend(new ConnectionError(
-                  `CubeStore connection error: ${err.message}`,
-                  err
-                ));
-              } else {
-                resolveSend();
-              }
-            });
+          if (webSocket.readyState !== WebSocket.OPEN) {
+            resolveSend();
+            return;
           }
+
+          webSocket.send(message, (err) => {
+            if (err) {
+              // The write failed (EPIPE/ECONNRESET when Cube Store dropped the
+              // connection). The message stays registered in `sentMessages`, so
+              // it's re-sent once this socket is closed and a new one is
+              // established -- failing it here would surface a spurious
+              // `write EPIPE` to the user for a perfectly retryable query.
+              this.handleSendError(webSocket, err, messageId);
+            }
+
+            resolveSend();
+          });
         });
         webSocket.on('open', () => resolve(webSocket));
         webSocket.on('error', (err) => {
@@ -135,13 +146,24 @@ export class WebSocketConnection {
           clearInterval(pingInterval);
 
           if (Object.keys(webSocket.sentMessages).length) {
+            webSocket.resendScheduled = true;
+
             setTimeout(async () => {
               try {
                 const nextWebSocket = await this.initWebSocket();
                 // eslint-disable-next-line no-restricted-syntax
                 for (const key of Object.keys(webSocket.sentMessages)) {
-                  nextWebSocket.sentMessages[key] = webSocket.sentMessages[key];
-                  await nextWebSocket.sendAsync(webSocket.sentMessages[key].buffer);
+                  const sentMessage = webSocket.sentMessages[key];
+
+                  if (sentMessage.resendCount >= this.maxConnectRetries) {
+                    sentMessage.reject(new ConnectionError(
+                      `CubeStore connection lost: message wasn't delivered after ${sentMessage.resendCount} retries`
+                    ));
+                  } else {
+                    sentMessage.resendCount += 1;
+                    nextWebSocket.sentMessages[key] = sentMessage;
+                    await nextWebSocket.sendAsync(sentMessage.buffer, Number(key));
+                  }
                 }
               } catch (e) {
                 // eslint-disable-next-line no-restricted-syntax
@@ -182,6 +204,7 @@ export class WebSocketConnection {
       });
 
       webSocket.sentMessages = {};
+      webSocket.resendScheduled = false;
       this.webSocket = webSocket;
     }
 
@@ -192,26 +215,60 @@ export class WebSocketConnection {
     return 1000 * (this.currentConnectionTry + 1);
   }
 
+  /**
+   * Handles a failed write to an already established socket, e.g. `write EPIPE`
+   * when Cube Store closed the connection between the `readyState` check and the
+   * actual write to the underlying TCP socket.
+   *
+   * Such a message is not lost: it stays registered in `sentMessages` and is
+   * re-sent by the 'close' handler over a freshly established connection, so it
+   * must not be rejected here. The socket is terminated to make sure that
+   * 'close' (and with it the re-send) really happens.
+   */
+  private handleSendError(webSocket: CubeStoreWebSocket, err: Error, messageId?: number) {
+    if (webSocket.readyState !== WebSocket.CLOSED) {
+      if (webSocket.readyState === WebSocket.OPEN) {
+        // The socket is broken, but `ws` doesn't know it yet. Terminating it
+        // emits 'close', which re-sends everything still pending on it.
+        webSocket.terminate();
+      }
+
+      // 'close' is still to come and will re-send pending messages.
+      return;
+    }
+
+    // The socket is already closed and the re-send loop is not going to pick
+    // this message up, so there's nothing left to wait for.
+    if (!webSocket.resendScheduled && messageId !== undefined) {
+      const sentMessage = webSocket.sentMessages[messageId];
+      if (sentMessage) {
+        delete webSocket.sentMessages[messageId];
+        sentMessage.reject(new ConnectionError(
+          `CubeStore connection error: ${err.message}`,
+          err
+        ));
+      }
+    }
+  }
+
   private async sendMessage(messageId: number, buffer: Uint8Array): Promise<any> {
     const socket = await this.initWebSocket();
     return new Promise((resolve, reject) => {
-      if (socket.readyState === WebSocket.OPEN) {
-        socket.send(buffer, (err) => {
-          if (err) {
-            delete socket.sentMessages[messageId];
-            reject(new ConnectionError(
-              `CubeStore connection error: ${err.message}`,
-              err
-            ));
-          }
-        });
-      }
-
       socket.sentMessages[messageId] = {
         resolve,
         reject,
-        buffer
+        buffer,
+        resendCount: 0,
       };
+
+      // If socket is closing this message should be resent
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(buffer, (err) => {
+          if (err) {
+            this.handleSendError(socket, err, messageId);
+          }
+        });
+      }
     });
   }
 

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -31,7 +31,15 @@ const MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
 const MAX_PAYLOAD_EXCEEDED_CODE = 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH';
 
 function formatSize(bytes: number): string {
-  return `${Math.round((bytes / (1024 * 1024)) * 10) / 10} MB`;
+  const units: [number, string][] = [[1024 * 1024, 'MB'], [1024, 'KB']];
+
+  for (const [unit, name] of units) {
+    if (bytes >= unit) {
+      return `${Math.round((bytes / unit) * 10) / 10} ${name}`;
+    }
+  }
+
+  return `${bytes} bytes`;
 }
 
 interface SentMessage {
@@ -41,6 +49,9 @@ interface SentMessage {
   // How many times this message was re-sent over a freshly established
   // connection. Used to give up instead of retrying forever.
   resendCount: number;
+  // How many times this message was in flight when the connection died from a
+  // failure that can't be attributed to a single message.
+  fatalRounds: number;
 }
 
 export type QueryParameter = null | boolean | number | string | Buffer;
@@ -196,23 +207,42 @@ export class WebSocketConnection {
             );
 
             if (fatalError) {
+              // The connection multiplexes messages, and an oversized one can't
+              // be attributed: `ws` drops the frame before its message id is
+              // read. A message that was alone in flight is certainly the one at
+              // fault. Otherwise every message gets one more round, which
+              // answers the innocent ones and usually leaves the offender alone
+              // on the connection, where the next round does attribute it. What
+              // is still in flight after that round is failed regardless, so an
+              // offender that keeps killing the connection before the others are
+              // answered can't turn into a re-send loop.
+              const pending = Object.keys(webSocket.sentMessages);
+
               // eslint-disable-next-line no-restricted-syntax
-              for (const key of Object.keys(webSocket.sentMessages)) {
-                webSocket.sentMessages[key].reject(fatalError);
+              for (const key of pending) {
+                const sentMessage = webSocket.sentMessages[key];
+                sentMessage.fatalRounds += 1;
+
+                if (pending.length === 1 || sentMessage.fatalRounds > 1) {
+                  delete webSocket.sentMessages[key];
+                  sentMessage.reject(fatalError);
+                }
               }
 
-              if (webSocket === this.webSocket) {
-                this.webSocket = null;
-              }
+              if (!Object.keys(webSocket.sentMessages).length) {
+                if (webSocket === this.webSocket) {
+                  this.webSocket = null;
+                }
 
-              return;
+                return;
+              }
             }
 
             webSocket.resendScheduled = true;
 
             setTimeout(async () => {
               try {
-                const nextWebSocket = await this.initWebSocket();
+                const nextWebSocket = await this.openSocket();
                 // eslint-disable-next-line no-restricted-syntax
                 for (const key of Object.keys(webSocket.sentMessages)) {
                   const sentMessage = webSocket.sentMessages[key];
@@ -279,6 +309,28 @@ export class WebSocketConnection {
   }
 
   /**
+   * Returns a socket that can still carry a message.
+   *
+   * `initWebSocket()` resolves as soon as a socket is open, but that socket may
+   * have been closed again by then. Registering a message on a closed socket
+   * would strand it: nothing writes it, and the re-send loop of that socket has
+   * already taken its snapshot, so the message would never settle.
+   */
+  private async openSocket(): Promise<CubeStoreWebSocket> {
+    // A closed socket is dropped from `this.webSocket` by its 'close' handler,
+    // so the next attempt establishes a new one.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const socket = await this.initWebSocket();
+
+      if (socket.readyState !== WebSocket.CLOSED) {
+        return socket;
+      }
+    }
+
+    throw new ConnectionError('CubeStore connection is closed');
+  }
+
+  /**
    * Handles a failed write to an already established socket, e.g. `write EPIPE`
    * when Cube Store closed the connection between the `readyState` check and the
    * actual write to the underlying TCP socket.
@@ -318,6 +370,9 @@ export class WebSocketConnection {
     if (buffer.length > this.maxMessageSize) {
       // Cube Store would close the connection on such a message, which shows up
       // as an unrelated `write EPIPE`, so report it before sending anything.
+      // This only catches what is over our own limit: Cube Store applies its
+      // own, by default stricter, CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE, and a
+      // message it refuses is reported once it closes the connection.
       throw new MessageTooLargeError(
         `Cube Store request size of ${formatSize(buffer.length)} exceeds the maximum message size of ` +
         `${formatSize(this.maxMessageSize)}. Reduce the size of the query and of the inline tables it sends, ` +
@@ -326,13 +381,14 @@ export class WebSocketConnection {
       );
     }
 
-    const socket = await this.initWebSocket();
+    const socket = await this.openSocket();
     return new Promise((resolve, reject) => {
       socket.sentMessages[messageId] = {
         resolve,
         reject,
         buffer,
         resendCount: 0,
+        fatalRounds: 0,
       };
 
       // If socket is closing this message should be resent

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -204,19 +204,21 @@ export class WebSocketConnection {
 
             // The connection multiplexes messages and an oversized one can't be
             // attributed -- `ws` drops the frame before its message id is read
-            // -- so a message that was alone in flight is the one at fault.
-            // Anything else gets one more round, which answers the innocent
-            // messages and usually leaves the offender alone to be named next
-            // time. Whatever is still in flight after that round is failed
-            // regardless: an offender whose response keeps arriving before the
-            // other answers would otherwise be re-sent forever.
+            // -- so every message in flight gets one more round, which answers
+            // the innocent ones and usually leaves the offender alone to be
+            // named next time. That includes a message that was alone in
+            // flight: the close can just as well be an ordinary disconnect,
+            // and re-sending is what recovers it. Whatever is still in flight
+            // after that round is failed regardless: an offender whose
+            // response keeps arriving before the other answers would otherwise
+            // be re-sent forever.
             if (fatalError) {
               // eslint-disable-next-line no-restricted-syntax
               for (const key of pending) {
                 const sentMessage = webSocket.sentMessages[key];
                 sentMessage.fatalRounds += 1;
 
-                if (pending.length === 1 || sentMessage.fatalRounds > 1) {
+                if (sentMessage.fatalRounds > 1) {
                   delete webSocket.sentMessages[key];
                   sentMessage.reject(fatalError);
                 }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -46,12 +46,6 @@ interface SentMessage {
   resolve: (value: any) => void;
   reject: (reason?: any) => void;
   buffer: Uint8Array;
-  // How many times this message was re-sent over a freshly established
-  // connection. Used to give up instead of retrying forever.
-  resendCount: number;
-  // How many times this message was in flight when the connection died from a
-  // failure that can't be attributed to a single message.
-  fatalRounds: number;
 }
 
 export type QueryParameter = null | boolean | number | string | Buffer;
@@ -66,12 +60,9 @@ interface CubeStoreWebSocket extends WebSocket {
   readyPromise: Promise<CubeStoreWebSocket>;
   lastHeartBeat: Date;
   sentMessages: Record<number, SentMessage>;
-  sendAsync: (message: Uint8Array, messageId?: number) => Promise<void>;
-  // Set as soon as the 'close' handler has scheduled a re-send of the messages
-  // that are still in flight on this socket.
-  resendScheduled: boolean;
-  // A failure that killed this socket and that re-sending can't fix, so pending
-  // messages are rejected with it instead of being retried.
+  sendAsync: (message: Uint8Array) => Promise<void>;
+  // A failure that killed this socket and that re-sending can't fix, so the
+  // message that caused it is rejected instead of being re-sent.
   fatalError: Error | null;
 }
 
@@ -126,7 +117,7 @@ export class WebSocketConnection {
           }
         }, 5000);
 
-        webSocket.sendAsync = async (message: Uint8Array, messageId?: number) => new Promise<void>((resolveSend) => {
+        webSocket.sendAsync = async (message: Uint8Array) => new Promise<void>((resolveSend) => {
           // If socket is closing this message should be resent
           if (webSocket.readyState !== WebSocket.OPEN) {
             resolveSend();
@@ -136,11 +127,11 @@ export class WebSocketConnection {
           webSocket.send(message, (err) => {
             if (err) {
               // The write failed (EPIPE/ECONNRESET when Cube Store dropped the
-              // connection). The message stays registered in `sentMessages`, so
-              // it's re-sent once this socket is closed and a new one is
-              // established -- failing it here would surface a spurious
-              // `write EPIPE` to the user for a perfectly retryable query.
-              this.handleSendError(webSocket, err, messageId);
+              // connection). The message stays registered in `sentMessages` and
+              // terminating gets 'close' to re-send it over a new connection --
+              // failing it here would surface a spurious `write EPIPE` for a
+              // query that never reached Cube Store.
+              webSocket.terminate();
             }
 
             resolveSend();
@@ -196,7 +187,9 @@ export class WebSocketConnection {
         webSocket.on('close', (code: number) => {
           clearInterval(pingInterval);
 
-          if (Object.keys(webSocket.sentMessages).length) {
+          const pending = Object.keys(webSocket.sentMessages);
+
+          if (pending.length) {
             const fatalError = webSocket.fatalError || (
               // Cube Store refused a message that didn't fit into its limits.
               code === MESSAGE_TOO_BIG_CLOSE_CODE ? new MessageTooLargeError(
@@ -206,72 +199,29 @@ export class WebSocketConnection {
               ) : null
             );
 
-            if (fatalError) {
-              // The connection multiplexes messages, and an oversized one can't
-              // be attributed: `ws` drops the frame before its message id is
-              // read. A message that was alone in flight is certainly the one at
-              // fault. Otherwise every message gets one more round, which
-              // answers the innocent ones and usually leaves the offender alone
-              // on the connection, where the next round does attribute it. What
-              // is still in flight after that round is failed regardless, so an
-              // offender that keeps killing the connection before the others are
-              // answered can't turn into a re-send loop.
-              const pending = Object.keys(webSocket.sentMessages);
+            // The connection multiplexes messages and an oversized one can't be
+            // attributed -- `ws` drops the frame before its message id is read
+            // -- so only a message that was alone in flight can be failed with
+            // it. Anything else is re-sent as usual: answering the innocent
+            // messages leaves the offender alone, and the next round names it.
+            if (fatalError && pending.length === 1) {
+              webSocket.sentMessages[pending[0]].reject(fatalError);
+              delete webSocket.sentMessages[pending[0]];
 
-              // eslint-disable-next-line no-restricted-syntax
-              for (const key of pending) {
-                const sentMessage = webSocket.sentMessages[key];
-                sentMessage.fatalRounds += 1;
-
-                if (pending.length === 1 || sentMessage.fatalRounds > 1) {
-                  delete webSocket.sentMessages[key];
-                  sentMessage.reject(fatalError);
-                }
+              if (webSocket === this.webSocket) {
+                this.webSocket = null;
               }
 
-              if (!Object.keys(webSocket.sentMessages).length) {
-                if (webSocket === this.webSocket) {
-                  this.webSocket = null;
-                }
-
-                return;
-              }
+              return;
             }
-
-            webSocket.resendScheduled = true;
 
             setTimeout(async () => {
               try {
-                const nextWebSocket = await this.openSocket();
-                const resent: [string, SentMessage][] = [];
-
-                // Register the whole batch before writing any of it. Writing
-                // yields, and a socket that closes mid-batch must find every
-                // message of it in `sentMessages`: the ones not registered yet
-                // would end up on a socket whose 'close' has already been
-                // handled, with nobody left to write or to re-send them.
+                const nextWebSocket = await this.initWebSocket();
                 // eslint-disable-next-line no-restricted-syntax
                 for (const key of Object.keys(webSocket.sentMessages)) {
-                  const sentMessage = webSocket.sentMessages[key];
-
-                  if (sentMessage.resendCount >= this.maxConnectRetries) {
-                    sentMessage.reject(new ConnectionError(
-                      `CubeStore connection lost: message wasn't delivered after ${sentMessage.resendCount} retries`
-                    ));
-                  } else {
-                    sentMessage.resendCount += 1;
-                    nextWebSocket.sentMessages[key] = sentMessage;
-                    resent.push([key, sentMessage]);
-                  }
-                }
-
-                // eslint-disable-next-line no-restricted-syntax
-                for (const [key, sentMessage] of resent) {
-                  // Skip what was answered, or failed, while the batch was
-                  // being written.
-                  if (nextWebSocket.sentMessages[key] === sentMessage) {
-                    await nextWebSocket.sendAsync(sentMessage.buffer, Number(key));
-                  }
+                  nextWebSocket.sentMessages[key] = webSocket.sentMessages[key];
+                  await nextWebSocket.sendAsync(webSocket.sentMessages[key].buffer);
                 }
               } catch (e) {
                 // eslint-disable-next-line no-restricted-syntax
@@ -312,7 +262,6 @@ export class WebSocketConnection {
       });
 
       webSocket.sentMessages = {};
-      webSocket.resendScheduled = false;
       webSocket.fatalError = null;
       this.webSocket = webSocket;
     }
@@ -322,64 +271,6 @@ export class WebSocketConnection {
 
   private retryWaitTime() {
     return 1000 * (this.currentConnectionTry + 1);
-  }
-
-  /**
-   * Returns a socket that can still carry a message.
-   *
-   * `initWebSocket()` resolves as soon as a socket is open, but that socket may
-   * have been closed again by then. Registering a message on a closed socket
-   * would strand it: nothing writes it, and the re-send loop of that socket has
-   * already taken its snapshot, so the message would never settle.
-   */
-  private async openSocket(): Promise<CubeStoreWebSocket> {
-    // A closed socket is dropped from `this.webSocket` by its 'close' handler,
-    // so the next attempt establishes a new one.
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const socket = await this.initWebSocket();
-
-      if (socket.readyState !== WebSocket.CLOSED) {
-        return socket;
-      }
-    }
-
-    throw new ConnectionError('CubeStore connection is closed');
-  }
-
-  /**
-   * Handles a failed write to an already established socket, e.g. `write EPIPE`
-   * when Cube Store closed the connection between the `readyState` check and the
-   * actual write to the underlying TCP socket.
-   *
-   * Such a message is not lost: it stays registered in `sentMessages` and is
-   * re-sent by the 'close' handler over a freshly established connection, so it
-   * must not be rejected here. The socket is terminated to make sure that
-   * 'close' (and with it the re-send) really happens.
-   */
-  private handleSendError(webSocket: CubeStoreWebSocket, err: Error, messageId?: number) {
-    if (webSocket.readyState !== WebSocket.CLOSED) {
-      if (webSocket.readyState === WebSocket.OPEN) {
-        // The socket is broken, but `ws` doesn't know it yet. Terminating it
-        // emits 'close', which re-sends everything still pending on it.
-        webSocket.terminate();
-      }
-
-      // 'close' is still to come and will re-send pending messages.
-      return;
-    }
-
-    // The socket is already closed and the re-send loop is not going to pick
-    // this message up, so there's nothing left to wait for.
-    if (!webSocket.resendScheduled && messageId !== undefined) {
-      const sentMessage = webSocket.sentMessages[messageId];
-      if (sentMessage) {
-        delete webSocket.sentMessages[messageId];
-        sentMessage.reject(new ConnectionError(
-          `CubeStore connection error: ${err.message}`,
-          err
-        ));
-      }
-    }
   }
 
   private async sendMessage(messageId: number, buffer: Uint8Array): Promise<any> {
@@ -397,23 +288,24 @@ export class WebSocketConnection {
       );
     }
 
-    const socket = await this.openSocket();
+    const socket = await this.initWebSocket();
     return new Promise((resolve, reject) => {
-      socket.sentMessages[messageId] = {
-        resolve,
-        reject,
-        buffer,
-        resendCount: 0,
-        fatalRounds: 0,
-      };
+      socket.sentMessages[messageId] = { resolve, reject, buffer };
 
       // If socket is closing this message should be resent
       if (socket.readyState === WebSocket.OPEN) {
         socket.send(buffer, (err) => {
           if (err) {
-            this.handleSendError(socket, err, messageId);
+            // Leave the message registered and let 'close' re-send it over a
+            // new connection instead of failing it with the write error.
+            socket.terminate();
           }
         });
+      } else if (socket.readyState === WebSocket.CLOSED) {
+        // 'close' already fired for this socket, so no re-send is going to pick
+        // this message up and nothing would ever settle it.
+        delete socket.sentMessages[messageId];
+        reject(new ConnectionError('CubeStore connection is closed'));
       }
     });
   }

--- a/packages/cubejs-cubestore-driver/src/errors.ts
+++ b/packages/cubejs-cubestore-driver/src/errors.ts
@@ -13,6 +13,19 @@ export class ConnectionError extends CubeStoreError {
   }
 }
 
+/**
+ * A message didn't fit into the size limit of the connection. Unlike other
+ * connection errors this one is not worth retrying: the same message would be
+ * rejected again.
+ */
+export class MessageTooLargeError extends ConnectionError {
+  public constructor(message: string, cause?: Error) {
+    super(message, cause);
+
+    this.name = 'MessageTooLargeError';
+  }
+}
+
 export class QueryError extends CubeStoreError {
   public constructor(message: string) {
     super(message);

--- a/packages/cubejs-cubestore-driver/test/mock-cubestore-server.ts
+++ b/packages/cubejs-cubestore-driver/test/mock-cubestore-server.ts
@@ -2,7 +2,15 @@ import { AddressInfo, Socket } from 'net';
 import * as flatbuffers from 'flatbuffers';
 import WebSocket from 'ws';
 
-import { HttpCommand, HttpError, HttpMessage, HttpQuery } from '../codegen';
+import {
+  HttpCommand,
+  HttpError,
+  HttpMessage,
+  HttpQuery,
+  HttpQueryResult,
+  HttpQueryResultArrow,
+  HttpQueryResultData,
+} from '../codegen';
 
 export interface ReceivedMessage {
   connectionIndex: number;
@@ -29,6 +37,25 @@ export function buildErrorMessage(messageId: number, error: string): Buffer {
   const errorOffset = builder.createString(error);
   const commandOffset = HttpError.createHttpError(builder, errorOffset);
   const message = HttpMessage.createHttpMessage(builder, messageId, HttpCommand.HttpError, commandOffset, 0);
+  builder.finish(message);
+
+  return Buffer.from(builder.asUint8Array());
+}
+
+/**
+ * A successful answer. Its payload is decoded by the native result parser, so
+ * tests that use it stub that parser out.
+ */
+export function buildResultMessage(messageId: number, data: Buffer = Buffer.alloc(0)): Buffer {
+  const builder = new flatbuffers.Builder(1024);
+  const dataOffset = HttpQueryResultArrow.createDataVector(builder, data);
+  const arrowOffset = HttpQueryResultArrow.createHttpQueryResultArrow(builder, dataOffset, true);
+  const commandOffset = HttpQueryResult.createHttpQueryResult(
+    builder,
+    HttpQueryResultData.HttpQueryResultArrow,
+    arrowOffset
+  );
+  const message = HttpMessage.createHttpMessage(builder, messageId, HttpCommand.HttpQueryResult, commandOffset, 0);
   builder.finish(message);
 
   return Buffer.from(builder.asUint8Array());

--- a/packages/cubejs-cubestore-driver/test/mock-cubestore-server.ts
+++ b/packages/cubejs-cubestore-driver/test/mock-cubestore-server.ts
@@ -1,0 +1,137 @@
+import { AddressInfo, Socket } from 'net';
+import * as flatbuffers from 'flatbuffers';
+import WebSocket from 'ws';
+
+import { HttpCommand, HttpError, HttpMessage, HttpQuery } from '../codegen';
+
+export interface ReceivedMessage {
+  connectionIndex: number;
+  messageId: number;
+  query: string;
+}
+
+export interface MockConnection {
+  index: number;
+  ws: WebSocket;
+  socket: Socket;
+}
+
+export type MessageHandler = (message: ReceivedMessage, connection: MockConnection) => void;
+
+/**
+ * Cube Store answers a query either with a result set or with an error. Tests
+ * use the error variant, because it's the only answer that can be asserted
+ * without the native result parser, and it's enough to tell "the query reached
+ * Cube Store and was answered" from "the query failed on the transport".
+ */
+export function buildErrorMessage(messageId: number, error: string): Buffer {
+  const builder = new flatbuffers.Builder(1024);
+  const errorOffset = builder.createString(error);
+  const commandOffset = HttpError.createHttpError(builder, errorOffset);
+  const message = HttpMessage.createHttpMessage(builder, messageId, HttpCommand.HttpError, commandOffset, 0);
+  builder.finish(message);
+
+  return Buffer.from(builder.asUint8Array());
+}
+
+export function answeredBy(connectionIndex: number): string {
+  return `answered by connection #${connectionIndex}`;
+}
+
+/**
+ * A minimal Cube Store look-alike: it speaks the same WebSocket + flatbuffers
+ * protocol, so the driver talks to it over real TCP sockets, which can then be
+ * broken in the exact ways a real Cube Store restart breaks them.
+ */
+export class MockCubeStoreServer {
+  public readonly connections: MockConnection[] = [];
+
+  public readonly received: ReceivedMessage[] = [];
+
+  /**
+   * Replies to every query with an error naming the connection that received
+   * it, so a test can tell which connection answered. Can be replaced to
+   * emulate a Cube Store that goes away instead of answering.
+   */
+  public handler: MessageHandler = (message, connection) => {
+    connection.ws.send(buildErrorMessage(message.messageId, answeredBy(connection.index)));
+  };
+
+  protected constructor(protected readonly wss: WebSocket.Server) {
+    wss.on('connection', (ws: WebSocket, request: any) => {
+      const connection: MockConnection = {
+        index: this.connections.length,
+        ws,
+        socket: request.socket,
+      };
+      this.connections.push(connection);
+
+      ws.on('message', (raw: Buffer) => {
+        const httpMessage = HttpMessage.getRootAsHttpMessage(new flatbuffers.ByteBuffer(raw));
+        const message: ReceivedMessage = {
+          connectionIndex: connection.index,
+          messageId: httpMessage.messageId(),
+          query: httpMessage.command(new HttpQuery())?.query() || '',
+        };
+        this.received.push(message);
+        this.handler(message, connection);
+      });
+      // Connections are torn down by the tests on purpose, nothing to report.
+      ws.on('error', () => {
+        // noop
+      });
+    });
+  }
+
+  public static async start(): Promise<MockCubeStoreServer> {
+    const wss = new WebSocket.Server({ host: '127.0.0.1', port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      wss.once('listening', resolve);
+      wss.once('error', reject);
+    });
+
+    return new MockCubeStoreServer(wss);
+  }
+
+  public get url(): string {
+    return `ws://127.0.0.1:${(this.wss.address() as AddressInfo).port}`;
+  }
+
+  public connection(index: number): MockConnection {
+    if (!this.connections[index]) {
+      throw new Error(`Connection #${index} was never established`);
+    }
+
+    return this.connections[index];
+  }
+
+  public async waitForConnections(count: number, timeout: number = 20000): Promise<void> {
+    await this.waitFor(() => this.connections.length >= count, timeout, `${count} connection(s)`);
+  }
+
+  public async waitForMessages(count: number, timeout: number = 20000): Promise<void> {
+    await this.waitFor(() => this.received.length >= count, timeout, `${count} message(s)`);
+  }
+
+  protected async waitFor(condition: () => boolean, timeout: number, description: string): Promise<void> {
+    const deadline = Date.now() + timeout;
+
+    while (!condition()) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for ${description}`);
+      }
+
+      await new Promise((resolve) => { setTimeout(resolve, 25); });
+    }
+  }
+
+  public async stop(): Promise<void> {
+    for (const connection of this.connections) {
+      connection.ws.terminate();
+    }
+
+    await new Promise<void>((resolve) => {
+      this.wss.close(() => resolve());
+    });
+  }
+}

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -179,7 +179,7 @@ describe('WebSocketConnection', () => {
       delete process.env.CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE;
     });
 
-    it('reports a response that is over the limit instead of retrying it', async () => {
+    it('reports a response that is over the limit once its extra round is spent', async () => {
       connection = new WebSocketConnection(server.url);
 
       server.handler = (message, mockConnection) => {
@@ -195,8 +195,10 @@ describe('WebSocketConnection', () => {
         'or raise CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE.'
       );
 
-      // Re-running the query would only produce the same oversized response.
-      expect(server.received).toHaveLength(1);
+      // Re-sent once, since a fatal close on a sole in-flight query can just as
+      // well be an ordinary disconnect. The second oversized response spends
+      // its extra round and the size is reported rather than retried again.
+      expect(server.received).toHaveLength(2);
     }, JEST_TIMEOUT);
 
     it('resends the other queries in flight and attributes the limit to the offender', async () => {
@@ -351,7 +353,7 @@ describe('WebSocketConnection', () => {
       expect(server.connections).toHaveLength(0);
     }, JEST_TIMEOUT);
 
-    it('reports a request Cube Store refused as too big instead of retrying it', async () => {
+    it('reports a request Cube Store refused as too big once its extra round is spent', async () => {
       connection = new WebSocketConnection(server.url);
 
       server.handler = (message, mockConnection) => {
@@ -366,7 +368,9 @@ describe('WebSocketConnection', () => {
         'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts'
       );
 
-      expect(server.received).toHaveLength(1);
+      // Re-sent once before the size is reported, same as an over-limit
+      // response: one 1009 close is indistinguishable from a restart.
+      expect(server.received).toHaveLength(2);
     }, JEST_TIMEOUT);
   });
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -284,6 +284,60 @@ describe('WebSocketConnection', () => {
       await expect(small).rejects.toThrow(MessageTooLargeError);
     }, JEST_TIMEOUT);
 
+    it('gives a query its extra round back once an ordinary disconnect intervenes', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      const arrived = new Map<number, Set<string>>();
+      const longMessageIds = new Map<number, number>();
+      const sendOversized = (mockConnection: MockConnection) => {
+        mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2));
+      };
+
+      server.handler = (message, mockConnection) => {
+        const { index } = mockConnection;
+        const queries = arrived.get(index) || new Set<string>();
+        queries.add(message.query);
+        arrived.set(index, queries);
+
+        if (message.query === 'SELECT long') {
+          longMessageIds.set(index, message.messageId);
+        }
+
+        // Act once both are in flight, so the oversized response is never
+        // attributable to the query that caused it.
+        if (!queries.has('SELECT long') || !queries.has('SELECT big')) {
+          return;
+        }
+
+        if (index === 1) {
+          // An ordinary disconnect, unrelated to message size.
+          mockConnection.ws.terminate();
+          return;
+        }
+
+        const longMessageId = longMessageIds.get(index);
+        if (index >= 3 && longMessageId !== undefined) {
+          // The slow query finally answers, which leaves the offender alone.
+          mockConnection.ws.send(buildErrorMessage(longMessageId, answeredBy(index)));
+        }
+
+        sendOversized(mockConnection);
+      };
+
+      const long = query('SELECT long');
+      const big = query('SELECT big');
+      big.catch(() => {
+        // noop
+      });
+
+      // Two size incidents with an ordinary disconnect in between: the slow
+      // query is innocent in both, so the round it is owed has to survive the
+      // disconnect rather than being spent by the first incident.
+      await expectAnsweredBy(long, 3);
+
+      await expect(big).rejects.toThrow(MessageTooLargeError);
+    }, JEST_TIMEOUT);
+
     it('reports a request that is over the limit without sending it', async () => {
       connection = new WebSocketConnection(server.url);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -357,20 +357,45 @@ describe('WebSocketConnection', () => {
       connection = new WebSocketConnection(server.url);
 
       server.handler = (message, mockConnection) => {
-        // How Cube Store rejects a message that doesn't fit into its limits.
-        mockConnection.ws.close(1009, 'Message too big');
+        // How Cube Store rejects a message that doesn't fit into its limits,
+        // naming the size and the limit in the close reason.
+        mockConnection.ws.close(
+          1009,
+          'Message of 16452 bytes exceeds the maximum message size of 4096 bytes'
+        );
       };
 
       const promise = query('SELECT 1');
 
       await expect(promise).rejects.toThrow(MessageTooLargeError);
       await expect(promise).rejects.toThrow(
-        'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts'
+        'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
+        'Message of 16452 bytes exceeds the maximum message size of 4096 bytes. ' +
+        'Reduce the size of the query and of the inline tables it sends, or raise ' +
+        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
       );
 
       // Re-sent once before the size is reported, same as an over-limit
       // response: one 1009 close is indistinguishable from a restart.
       expect(server.received).toHaveLength(2);
+    }, JEST_TIMEOUT);
+
+    it('falls back to the generic wording when 1009 carries no reason', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      // An intermediary, or a Cube Store from before it sent a reason.
+      server.handler = (message, mockConnection) => {
+        mockConnection.ws.close(1009);
+      };
+
+      const promise = query('SELECT 1');
+
+      await expect(promise).rejects.toThrow(MessageTooLargeError);
+      await expect(promise).rejects.toThrow(
+        'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
+        'Reduce the size of the query and of the inline tables it sends, or raise ' +
+        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+      );
     }, JEST_TIMEOUT);
   });
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -368,11 +368,14 @@ describe('WebSocketConnection', () => {
       const promise = query('SELECT 1');
 
       await expect(promise).rejects.toThrow(MessageTooLargeError);
+      // The reason replaces the generic clause rather than being appended to
+      // it, so the sizes are stated once.
       await expect(promise).rejects.toThrow(
-        'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
+        'Cube Store closed the connection: ' +
         'Message of 16452 bytes exceeds the maximum message size of 4096 bytes. ' +
         'Reduce the size of the query and of the inline tables it sends, or raise ' +
-        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE or CUBESTORE_TRANSPORT_MAX_FRAME_SIZE ' +
+        'on the Cube Store side.'
       );
 
       // Re-sent once before the size is reported, same as an over-limit
@@ -394,7 +397,22 @@ describe('WebSocketConnection', () => {
       await expect(promise).rejects.toThrow(
         'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts. ' +
         'Reduce the size of the query and of the inline tables it sends, or raise ' +
-        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE on the Cube Store side.'
+        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE or CUBESTORE_TRANSPORT_MAX_FRAME_SIZE ' +
+        'on the Cube Store side.'
+      );
+    }, JEST_TIMEOUT);
+
+    it('does not double the full stop when 1009 carries a punctuated reason', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      server.handler = (message, mockConnection) => {
+        mockConnection.ws.close(1009, 'Message too big.');
+      };
+
+      const promise = query('SELECT 1');
+
+      await expect(promise).rejects.toThrow(
+        'Cube Store closed the connection: Message too big. Reduce the size of the query'
       );
     }, JEST_TIMEOUT);
   });

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -1,0 +1,136 @@
+import { Socket } from 'net';
+
+import { WebSocketConnection } from '../src/WebSocketConnection';
+import { QueryError } from '../src/errors';
+import { QueryResultFormat } from '../codegen';
+import { answeredBy, buildErrorMessage, MockCubeStoreServer } from './mock-cubestore-server';
+
+const JEST_TIMEOUT = 60 * 1000;
+
+/**
+ * The error Node hands to a pending write when the peer is gone, as seen in
+ * `ConnectionError: CubeStore connection error: write EPIPE`.
+ */
+const epipe = () => Object.assign(new Error('write EPIPE'), {
+  code: 'EPIPE',
+  errno: -32,
+  syscall: 'write',
+});
+
+const nextTurn = () => new Promise((resolve) => { setImmediate(resolve); });
+
+describe('WebSocketConnection', () => {
+  let server: MockCubeStoreServer;
+  let connection: WebSocketConnection | null = null;
+
+  beforeEach(async () => {
+    server = await MockCubeStoreServer.start();
+    connection = null;
+  });
+
+  afterEach(async () => {
+    connection?.close();
+    await server.stop();
+  });
+
+  const query = (sql: string) => connection!.query(sql, [], { responseFormat: QueryResultFormat.Legacy });
+
+  /**
+   * The mock answers every query with an error naming the connection that
+   * served it, so a rejection carrying that marker means the query made a full
+   * round trip. A rejection with anything else (`ConnectionError: ... write
+   * EPIPE`) means the driver dropped the query instead of delivering it.
+   */
+  const expectAnsweredBy = async (promise: Promise<any>, connectionIndex: number) => {
+    await expect(promise).rejects.toThrow(QueryError);
+    await expect(promise).rejects.toThrow(answeredBy(connectionIndex));
+  };
+
+  // The socket the driver is writing to right now.
+  const clientSocket = (): Socket => (connection as any).webSocket._socket;
+
+  it('resends a query when the write fails with EPIPE', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    // Establish the connection with a first, successfully answered query.
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    // Keep the outgoing frame in the socket write buffer, then break the socket
+    // the way Node does once Cube Store is gone: the buffered write fails with
+    // EPIPE while `ws` still reports the connection as OPEN.
+    const socket = clientSocket();
+    socket.cork();
+    const promise = query('SELECT 2');
+    await nextTurn();
+    socket.destroy(epipe());
+
+    // The query never reached Cube Store, so it has to be resent over a new
+    // connection instead of failing with the write error.
+    await expectAnsweredBy(promise, 1);
+
+    expect(server.received.map((message) => [message.connectionIndex, message.query])).toEqual([
+      [0, 'SELECT 1'],
+      [1, 'SELECT 2'],
+    ]);
+  }, JEST_TIMEOUT);
+
+  it('resends every query that was in flight when the write failed', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    const socket = clientSocket();
+    socket.cork();
+    const promises = [query('SELECT 2'), query('SELECT 3'), query('SELECT 4')];
+    await nextTurn();
+    socket.destroy(epipe());
+
+    await Promise.all(promises.map((promise) => expectAnsweredBy(promise, 1)));
+
+    expect(
+      server.received.filter((message) => message.connectionIndex === 1).map((message) => message.query).sort()
+    ).toEqual(['SELECT 2', 'SELECT 3', 'SELECT 4']);
+  }, JEST_TIMEOUT);
+
+  it('resends a query when the socket is no longer writable', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    // Half-close the socket: `ws` still reports OPEN, but the write fails.
+    clientSocket().end();
+
+    await expectAnsweredBy(query('SELECT 2'), 1);
+  }, JEST_TIMEOUT);
+
+  it('resends a query when Cube Store closes the connection without answering', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    server.handler = (message, mockConnection) => {
+      if (mockConnection.index === 0) {
+        // Cube Store went away in the middle of the query.
+        mockConnection.ws.close();
+        return;
+      }
+
+      mockConnection.ws.send(buildErrorMessage(message.messageId, answeredBy(mockConnection.index)));
+    };
+
+    await expectAnsweredBy(query('SELECT 1'), 1);
+  }, JEST_TIMEOUT);
+
+  it('rejects a query when the connection cannot be re-established', async () => {
+    process.env.CUBEJS_CUBESTORE_MAX_CONNECT_RETRIES = '2';
+
+    try {
+      const { url } = server;
+      await server.stop();
+
+      connection = new WebSocketConnection(url);
+
+      await expect(query('SELECT 1')).rejects.toThrow('CubeStore connection failed after 2 retries');
+    } finally {
+      delete process.env.CUBEJS_CUBESTORE_MAX_CONNECT_RETRIES;
+    }
+  }, JEST_TIMEOUT);
+});

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -3,7 +3,13 @@ import { Socket } from 'net';
 import { WebSocketConnection } from '../src/WebSocketConnection';
 import { MessageTooLargeError, QueryError } from '../src/errors';
 import { QueryResultFormat } from '../codegen';
-import { answeredBy, buildErrorMessage, buildResultMessage, MockCubeStoreServer } from './mock-cubestore-server';
+import {
+  answeredBy,
+  buildErrorMessage,
+  buildResultMessage,
+  MockConnection,
+  MockCubeStoreServer,
+} from './mock-cubestore-server';
 
 const QUERY_RESULT = [{ answer: 42 }];
 
@@ -41,6 +47,34 @@ const waitForBufferedWrite = async (socket: Socket) => {
     await new Promise((resolve) => { setImmediate(resolve); });
   }
 };
+
+/**
+ * Records which messages were registered on a socket when the re-send loop
+ * wrote the first message of a batch. `sendAsync` is only used to re-send, so
+ * its first call is that write.
+ */
+class ObservableConnection extends WebSocketConnection {
+  public registeredAtFirstResend: string[] | null = null;
+
+  protected async initWebSocket(): Promise<any> {
+    const socket: any = await super.initWebSocket();
+
+    if (!socket.sendAsyncObserved) {
+      socket.sendAsyncObserved = true;
+
+      const { sendAsync } = socket;
+      socket.sendAsync = async (message: Uint8Array, messageId?: number) => {
+        if (this.registeredAtFirstResend === null) {
+          this.registeredAtFirstResend = Object.keys(socket.sentMessages);
+        }
+
+        return sendAsync(message, messageId);
+      };
+    }
+
+    return socket;
+  }
+}
 
 describe('WebSocketConnection', () => {
   let server: MockCubeStoreServer;
@@ -135,6 +169,26 @@ describe('WebSocketConnection', () => {
     ).toEqual(['SELECT 2', 'SELECT 3', 'SELECT 4']);
   }, JEST_TIMEOUT);
 
+  it('registers the whole re-sent batch before writing any of it', async () => {
+    const observed = new ObservableConnection(server.url);
+    connection = observed;
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    const socket = clientSocket();
+    socket.cork();
+    const promises = [query('SELECT 2'), query('SELECT 3'), query('SELECT 4')];
+    await waitForBufferedWrite(socket);
+    socket.destroy(epipe());
+
+    await Promise.all(promises.map((promise) => expectAnsweredBy(promise, 1)));
+
+    // Writing yields, so the rest of the batch has to be registered before the
+    // first message of it is written: a connection dying in between would
+    // otherwise never see them, and they would never settle.
+    expect(observed.registeredAtFirstResend).toEqual(['2', '3', '4']);
+  }, JEST_TIMEOUT);
+
   it('resends a query when the socket is no longer writable', async () => {
     connection = new WebSocketConnection(server.url);
 
@@ -196,18 +250,40 @@ describe('WebSocketConnection', () => {
     it('resends the other queries in flight and attributes the limit to the offender', async () => {
       connection = new WebSocketConnection(server.url);
 
+      // Cube Store answers the small query before it is done producing the big
+      // one. Ordering the two sends rather than spacing them apart in time
+      // keeps the test independent of how fast the driver is scheduled: the
+      // answer to the small query is on the wire, and therefore processed,
+      // before the oversized frame that tears the connection down.
+      const answeredSmall = new Set<number>();
+      const deferredBig = new Map<number, MockConnection>();
+      const sendOversized = (mockConnection: MockConnection) => {
+        mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2));
+      };
+
       server.handler = (message, mockConnection) => {
         if (message.query === 'SELECT big') {
-          // A big result takes longer to produce than a small one.
-          setTimeout(() => mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2)), 50);
+          // On the first connection the small query is left in flight, so that
+          // the oversized response kills it along with the query it belongs to.
+          if (mockConnection.index === 0 || answeredSmall.has(mockConnection.index)) {
+            sendOversized(mockConnection);
+          } else {
+            deferredBig.set(mockConnection.index, mockConnection);
+          }
+
           return;
         }
 
         if (mockConnection.index > 0) {
           mockConnection.ws.send(buildErrorMessage(message.messageId, answeredBy(mockConnection.index)));
+          answeredSmall.add(mockConnection.index);
+
+          const deferred = deferredBig.get(mockConnection.index);
+          if (deferred) {
+            deferredBig.delete(mockConnection.index);
+            sendOversized(deferred);
+          }
         }
-        // On the first connection the small query is left in flight, so that
-        // the oversized response kills it along with the query it belongs to.
       };
 
       const big = query('SELECT big');

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -257,6 +257,33 @@ describe('WebSocketConnection', () => {
       await expect(big).rejects.toThrow('Cube Store response size exceeds the maximum message size of 1 MB');
     }, JEST_TIMEOUT);
 
+    it('gives up when an over-limit response keeps killing the connection', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      // The oversized response always wins the race against the small query's
+      // answer, so re-sending never shrinks the set of messages in flight and
+      // never leaves the offender alone to be attributed.
+      const arrived = new Map<number, Set<string>>();
+
+      server.handler = (message, mockConnection) => {
+        const queries = arrived.get(mockConnection.index) || new Set<string>();
+        queries.add(message.query);
+        arrived.set(mockConnection.index, queries);
+
+        if (queries.has('SELECT big') && queries.has('SELECT small')) {
+          mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2));
+        }
+      };
+
+      const big = query('SELECT big');
+      const small = query('SELECT small');
+
+      // Both have to settle rather than being re-sent forever, even at the cost
+      // of blaming the size on a query that never approached the limit.
+      await expect(big).rejects.toThrow(MessageTooLargeError);
+      await expect(small).rejects.toThrow(MessageTooLargeError);
+    }, JEST_TIMEOUT);
+
     it('reports a request that is over the limit without sending it', async () => {
       connection = new WebSocketConnection(server.url);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -415,6 +415,29 @@ describe('WebSocketConnection', () => {
         'Cube Store closed the connection: Message too big. Reduce the size of the query'
       );
     }, JEST_TIMEOUT);
+
+    it('does not send the user to the message limit when the frame limit refused it', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      // What Cube Store closes with when CUBESTORE_TRANSPORT_MAX_FRAME_SIZE is
+      // configured below the message limit and is the one that fired.
+      server.handler = (message, mockConnection) => {
+        mockConnection.ws.close(
+          1009,
+          'Message of 9437184 bytes exceeds the maximum frame size of 4194304 bytes'
+        );
+      };
+
+      const promise = query('SELECT 1');
+
+      await expect(promise).rejects.toThrow(
+        'Cube Store closed the connection: ' +
+        'Message of 9437184 bytes exceeds the maximum frame size of 4194304 bytes. ' +
+        'Reduce the size of the query and of the inline tables it sends, or raise ' +
+        'CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE or CUBESTORE_TRANSPORT_MAX_FRAME_SIZE ' +
+        'on the Cube Store side.'
+      );
+    }, JEST_TIMEOUT);
   });
 
   it('rejects a query when the connection cannot be re-established', async () => {

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -48,34 +48,6 @@ const waitForBufferedWrite = async (socket: Socket) => {
   }
 };
 
-/**
- * Records which messages were registered on a socket when the re-send loop
- * wrote the first message of a batch. `sendAsync` is only used to re-send, so
- * its first call is that write.
- */
-class ObservableConnection extends WebSocketConnection {
-  public registeredAtFirstResend: string[] | null = null;
-
-  protected async initWebSocket(): Promise<any> {
-    const socket: any = await super.initWebSocket();
-
-    if (!socket.sendAsyncObserved) {
-      socket.sendAsyncObserved = true;
-
-      const { sendAsync } = socket;
-      socket.sendAsync = async (message: Uint8Array, messageId?: number) => {
-        if (this.registeredAtFirstResend === null) {
-          this.registeredAtFirstResend = Object.keys(socket.sentMessages);
-        }
-
-        return sendAsync(message, messageId);
-      };
-    }
-
-    return socket;
-  }
-}
-
 describe('WebSocketConnection', () => {
   let server: MockCubeStoreServer;
   let connection: WebSocketConnection | null = null;
@@ -167,26 +139,6 @@ describe('WebSocketConnection', () => {
     expect(
       server.received.filter((message) => message.connectionIndex === 1).map((message) => message.query).sort()
     ).toEqual(['SELECT 2', 'SELECT 3', 'SELECT 4']);
-  }, JEST_TIMEOUT);
-
-  it('registers the whole re-sent batch before writing any of it', async () => {
-    const observed = new ObservableConnection(server.url);
-    connection = observed;
-
-    await expectAnsweredBy(query('SELECT 1'), 0);
-
-    const socket = clientSocket();
-    socket.cork();
-    const promises = [query('SELECT 2'), query('SELECT 3'), query('SELECT 4')];
-    await waitForBufferedWrite(socket);
-    socket.destroy(epipe());
-
-    await Promise.all(promises.map((promise) => expectAnsweredBy(promise, 1)));
-
-    // Writing yields, so the rest of the batch has to be registered before the
-    // first message of it is written: a connection dying in between would
-    // otherwise never see them, and they would never settle.
-    expect(observed.registeredAtFirstResend).toEqual(['2', '3', '4']);
   }, JEST_TIMEOUT);
 
   it('resends a query when the socket is no longer writable', async () => {

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -3,7 +3,16 @@ import { Socket } from 'net';
 import { WebSocketConnection } from '../src/WebSocketConnection';
 import { MessageTooLargeError, QueryError } from '../src/errors';
 import { QueryResultFormat } from '../codegen';
-import { answeredBy, buildErrorMessage, MockCubeStoreServer } from './mock-cubestore-server';
+import { answeredBy, buildErrorMessage, buildResultMessage, MockCubeStoreServer } from './mock-cubestore-server';
+
+const QUERY_RESULT = [{ answer: 42 }];
+
+// Decoding a result set is a native addon and is orthogonal to the transport
+// under test, so only that step is stubbed: the socket, the WebSocket framing
+// and the flatbuffers protocol stay real.
+jest.mock('@cubejs-backend/native', () => ({
+  parseCubestoreResultMessage: jest.fn(async () => [{ answer: 42 }]),
+}));
 
 const JEST_TIMEOUT = 60 * 1000;
 
@@ -17,7 +26,21 @@ const epipe = () => Object.assign(new Error('write EPIPE'), {
   syscall: 'write',
 });
 
-const nextTurn = () => new Promise((resolve) => { setImmediate(resolve); });
+/**
+ * Waits until the frame the driver just handed to `ws` has reached the socket
+ * write buffer, where a corked socket holds it.
+ */
+const waitForBufferedWrite = async (socket: Socket) => {
+  const deadline = Date.now() + 5000;
+
+  while (!socket.writableLength) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for a buffered write');
+    }
+
+    await new Promise((resolve) => { setImmediate(resolve); });
+  }
+};
 
 describe('WebSocketConnection', () => {
   let server: MockCubeStoreServer;
@@ -49,6 +72,26 @@ describe('WebSocketConnection', () => {
   // The socket the driver is writing to right now.
   const clientSocket = (): Socket => (connection as any).webSocket._socket;
 
+  it('resolves a query with the result Cube Store sent', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    server.handler = (message, mockConnection) => {
+      mockConnection.ws.send(buildResultMessage(message.messageId));
+    };
+
+    await expect(query('SELECT 1')).resolves.toEqual(QUERY_RESULT);
+
+    // And the same after the connection had to be re-established mid-query.
+    const socket = clientSocket();
+    socket.cork();
+    const promise = query('SELECT 2');
+    await waitForBufferedWrite(socket);
+    socket.destroy(epipe());
+
+    await expect(promise).resolves.toEqual(QUERY_RESULT);
+    expect(server.received.map((message) => message.query)).toEqual(['SELECT 1', 'SELECT 2']);
+  }, JEST_TIMEOUT);
+
   it('resends a query when the write fails with EPIPE', async () => {
     connection = new WebSocketConnection(server.url);
 
@@ -61,7 +104,7 @@ describe('WebSocketConnection', () => {
     const socket = clientSocket();
     socket.cork();
     const promise = query('SELECT 2');
-    await nextTurn();
+    await waitForBufferedWrite(socket);
     socket.destroy(epipe());
 
     // The query never reached Cube Store, so it has to be resent over a new
@@ -82,7 +125,7 @@ describe('WebSocketConnection', () => {
     const socket = clientSocket();
     socket.cork();
     const promises = [query('SELECT 2'), query('SELECT 3'), query('SELECT 4')];
-    await nextTurn();
+    await waitForBufferedWrite(socket);
     socket.destroy(epipe());
 
     await Promise.all(promises.map((promise) => expectAnsweredBy(promise, 1)));
@@ -148,6 +191,42 @@ describe('WebSocketConnection', () => {
 
       // Re-running the query would only produce the same oversized response.
       expect(server.received).toHaveLength(1);
+    }, JEST_TIMEOUT);
+
+    it('resends the other queries in flight and attributes the limit to the offender', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      server.handler = (message, mockConnection) => {
+        if (message.query === 'SELECT big') {
+          // A big result takes longer to produce than a small one.
+          setTimeout(() => mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2)), 50);
+          return;
+        }
+
+        if (mockConnection.index > 0) {
+          mockConnection.ws.send(buildErrorMessage(message.messageId, answeredBy(mockConnection.index)));
+        }
+        // On the first connection the small query is left in flight, so that
+        // the oversized response kills it along with the query it belongs to.
+      };
+
+      const big = query('SELECT big');
+      // Asserted below, handled here so that a rejection arriving earlier than
+      // expected is reported as a failed assertion and not as an unhandled one.
+      big.catch(() => {
+        // noop
+      });
+      const small = query('SELECT small');
+
+      // The small query is unrelated to the size limit: it gets resent and
+      // answered rather than failing with an error about a limit it never
+      // approached.
+      await expectAnsweredBy(small, 1);
+
+      // Which leaves the offending query alone on the connection, where the
+      // oversized response can be attributed to it.
+      await expect(big).rejects.toThrow(MessageTooLargeError);
+      await expect(big).rejects.toThrow('Cube Store response size exceeds the maximum message size of 1 MB');
     }, JEST_TIMEOUT);
 
     it('reports a request that is over the limit without sending it', async () => {

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -1,7 +1,7 @@
 import { Socket } from 'net';
 
 import { WebSocketConnection } from '../src/WebSocketConnection';
-import { QueryError } from '../src/errors';
+import { MessageTooLargeError, QueryError } from '../src/errors';
 import { QueryResultFormat } from '../codegen';
 import { answeredBy, buildErrorMessage, MockCubeStoreServer } from './mock-cubestore-server';
 
@@ -118,6 +118,69 @@ describe('WebSocketConnection', () => {
 
     await expectAnsweredBy(query('SELECT 1'), 1);
   }, JEST_TIMEOUT);
+
+  describe('message size limit', () => {
+    const MAX_MESSAGE_SIZE = 1024 * 1024;
+
+    beforeEach(() => {
+      process.env.CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE = String(MAX_MESSAGE_SIZE);
+    });
+
+    afterEach(() => {
+      delete process.env.CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE;
+    });
+
+    it('reports a response that is over the limit instead of retrying it', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      server.handler = (message, mockConnection) => {
+        mockConnection.ws.send(Buffer.alloc(MAX_MESSAGE_SIZE * 2));
+      };
+
+      const promise = query('SELECT 1');
+
+      await expect(promise).rejects.toThrow(MessageTooLargeError);
+      await expect(promise).rejects.toThrow(
+        'Cube Store response size exceeds the maximum message size of 1 MB. ' +
+        'Reduce the amount of data the query returns, e.g. by adding filters or a limit, ' +
+        'or raise CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE.'
+      );
+
+      // Re-running the query would only produce the same oversized response.
+      expect(server.received).toHaveLength(1);
+    }, JEST_TIMEOUT);
+
+    it('reports a request that is over the limit without sending it', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      const promise = query(`SELECT ${'x'.repeat(MAX_MESSAGE_SIZE + 1)}`);
+
+      await expect(promise).rejects.toThrow(MessageTooLargeError);
+      await expect(promise).rejects.toThrow(
+        /Cube Store request size of \d+(\.\d+)? MB exceeds the maximum message size of 1 MB/
+      );
+
+      expect(server.connections).toHaveLength(0);
+    }, JEST_TIMEOUT);
+
+    it('reports a request Cube Store refused as too big instead of retrying it', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      server.handler = (message, mockConnection) => {
+        // How Cube Store rejects a message that doesn't fit into its limits.
+        mockConnection.ws.close(1009, 'Message too big');
+      };
+
+      const promise = query('SELECT 1');
+
+      await expect(promise).rejects.toThrow(MessageTooLargeError);
+      await expect(promise).rejects.toThrow(
+        'Cube Store closed the connection: message size exceeds the maximum message size Cube Store accepts'
+      );
+
+      expect(server.received).toHaveLength(1);
+    }, JEST_TIMEOUT);
+  });
 
   it('rejects a query when the connection cannot be re-established', async () => {
     process.env.CUBEJS_CUBESTORE_MAX_CONNECT_RETRIES = '2';

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -82,21 +82,40 @@ const TRANSPORT_SIZE_HEADROOM: usize = 2;
 /// `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` or `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`,
 /// and renders it as a close reason. `warp` boxes the underlying `tungstenite`
 /// error, so it has to be recovered through `source()`.
-fn message_too_large_reason(e: &warp::Error) -> Option<String> {
+fn message_too_large_reason(
+    e: &warp::Error,
+    max_message_size: usize,
+    max_frame_size: usize,
+) -> Option<String> {
     match e.source()?.downcast_ref::<tungstenite::Error>()? {
         tungstenite::Error::Capacity(tungstenite::error::CapacityError::MessageTooLong {
             size,
             max_size,
-        }) => Some(format!(
-            "Message of {} bytes exceeds the maximum message size of {} bytes",
-            size,
+        }) => {
             // `max_size` is the backstop the transport was configured with,
             // which is the configured limit times the headroom. Report what
             // the operator actually set, since that is the number they can
-            // change -- and divide rather than naming the message limit, so
-            // that a frame limit configured below it reports itself.
-            max_size / TRANSPORT_SIZE_HEADROOM
-        )),
+            // change.
+            let configured = max_size / TRANSPORT_SIZE_HEADROOM;
+            // The same error covers both caps and doesn't say which one
+            // fired, so the value has to name the knob: a frame limit
+            // configured below the message limit would otherwise be reported
+            // as a message limit that never refused anything, sending an
+            // operator to the wrong environment variable. When the two are
+            // equal, as they are by default, the number is the same either
+            // way and the message limit is the one to name.
+            let limit = if configured == max_message_size {
+                "message"
+            } else if configured == max_frame_size {
+                "frame"
+            } else {
+                "transport"
+            };
+            Some(format!(
+                "Message of {} bytes exceeds the maximum {} size of {} bytes",
+                size, limit, configured
+            ))
+        }
         _ => None,
     }
 }
@@ -255,7 +274,7 @@ impl HttpServer {
                                         // reserved for this instead of dropping the connection
                                         // silently, so the client can report the size rather than
                                         // a bare disconnect it would otherwise retry.
-                                        match message_too_large_reason(&e) {
+                                        match message_too_large_reason(&e, max_message_size, max_frame_size) {
                                             Some(reason) => {
                                                 error!("Websocket message too large: {}", reason);
                                                 let send_res = web_socket.send(
@@ -2022,6 +2041,82 @@ mod tests {
                     frame.reason.contains(&format!(
                         "exceeds the maximum message size of {} bytes",
                         max_message_size
+                    )),
+                    "unexpected close reason: {}",
+                    frame.reason
+                );
+            }
+            msg => panic!("Close frame expected, got: {:?}", msg),
+        }
+
+        http_server.stop_processing().await;
+        Ok(())
+    }
+
+    /// The close reason names whichever limit refused the message. The same
+    /// capacity error covers both, so a frame limit configured below the
+    /// message limit would otherwise be reported as a message limit that never
+    /// refused anything.
+    #[tokio::test]
+    async fn ws_message_too_large_names_the_frame_limit_test() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let max_frame_size = 4 * 1024;
+        let max_message_size = max_frame_size * 4;
+        let mut auth = MockSqlAuthService::new();
+        auth.expect_authenticate().return_const(Ok(None));
+
+        let http_server = Arc::new(HttpServer::new(
+            "127.0.0.1:53035".to_string(),
+            Arc::new(auth),
+            Arc::new(SqlServiceMock {
+                message_counter: AtomicU64::new(0),
+            }),
+            Duration::from_millis(100),
+            Duration::from_millis(10000),
+            Duration::from_millis(1000),
+            max_message_size,
+            max_frame_size,
+        ));
+        {
+            let http_server = http_server.clone();
+            cube_ext::spawn(async move { http_server.run_server().await });
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let (mut socket, _) = connect_async(Url::parse("ws://127.0.0.1:53035/ws").unwrap())
+            .await
+            .unwrap();
+
+        // Past the frame backstop but inside the message one, so the frame
+        // limit is what refuses it.
+        socket
+            .send(Message::binary(
+                HttpMessage {
+                    message_id: 1,
+                    command: HttpCommand::Query {
+                        query: "s".repeat(max_frame_size * TRANSPORT_SIZE_HEADROOM * 2),
+                        inline_tables: vec![],
+                        trace_obj: None,
+                        parameters: None,
+                        response_format: QueryResultFormat::Legacy,
+                    },
+                    connection_id: Some("foo".to_string()),
+                }
+                .bytes(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = socket.next().await.unwrap().unwrap();
+        match msg {
+            Message::Close(Some(frame)) => {
+                assert_eq!(u16::from(frame.code), MESSAGE_TOO_BIG_CLOSE_CODE);
+                assert!(
+                    frame.reason.contains(&format!(
+                        "exceeds the maximum frame size of {} bytes",
+                        max_frame_size
                     )),
                     "unexpected close reason: {}",
                     frame.reason

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -89,7 +89,13 @@ fn message_too_large_reason(e: &warp::Error) -> Option<String> {
             max_size,
         }) => Some(format!(
             "Message of {} bytes exceeds the maximum message size of {} bytes",
-            size, max_size
+            size,
+            // `max_size` is the backstop the transport was configured with,
+            // which is the configured limit times the headroom. Report what
+            // the operator actually set, since that is the number they can
+            // change -- and divide rather than naming the message limit, so
+            // that a frame limit configured below it reports itself.
+            max_size / TRANSPORT_SIZE_HEADROOM
         )),
         _ => None,
     }
@@ -2010,8 +2016,13 @@ mod tests {
         match msg {
             Message::Close(Some(frame)) => {
                 assert_eq!(u16::from(frame.code), MESSAGE_TOO_BIG_CLOSE_CODE);
+                // The configured limit, not the backstop the transport is
+                // given: that is the number an operator set and can change.
                 assert!(
-                    frame.reason.contains("exceeds the maximum message size"),
+                    frame.reason.contains(&format!(
+                        "exceeds the maximum message size of {} bytes",
+                        max_message_size
+                    )),
                     "unexpected close reason: {}",
                     frame.reason
                 );
@@ -2089,7 +2100,10 @@ mod tests {
             .error()
             .unwrap_or_default();
         assert!(
-            error.contains("exceeds the maximum message size"),
+            error.contains(&format!(
+                "exceeds the maximum message size of {} bytes",
+                max_message_size
+            )),
             "unexpected error: {}",
             error
         );

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -33,6 +33,7 @@ use log::trace;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::error::Error as StdError;
 use std::net::SocketAddr;
 use std::time::{Duration, SystemTime};
 use tempfile::NamedTempFile;
@@ -40,10 +41,32 @@ use tokio::fs::File;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::tungstenite;
 use tokio_util::sync::CancellationToken;
 use warp::filters::ws::{Message, Ws};
 use warp::http::StatusCode;
 use warp::reject::Reject;
+
+/// Close code the WebSocket protocol reserves for a message a peer refuses to
+/// process because it is too large (RFC 6455 section 7.4.1, "Message Too Big").
+const MESSAGE_TOO_BIG_CLOSE_CODE: u16 = 1009;
+
+/// Recognizes the error raised when an incoming message exceeds
+/// `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` or `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`,
+/// and renders it as a close reason. `warp` boxes the underlying `tungstenite`
+/// error, so it has to be recovered through `source()`.
+fn message_too_large_reason(e: &warp::Error) -> Option<String> {
+    match e.source()?.downcast_ref::<tungstenite::Error>()? {
+        tungstenite::Error::Capacity(tungstenite::error::CapacityError::MessageTooLong {
+            size,
+            max_size,
+        }) => Some(format!(
+            "Message of {} bytes exceeds the maximum message size of {} bytes",
+            size, max_size
+        )),
+        _ => None,
+    }
+}
 
 pub struct HttpServer {
     bind_address: String,
@@ -190,7 +213,26 @@ impl HttpServer {
                             Some(msg) = web_socket.next() => {
                                 match msg {
                                     Err(e) => {
-                                        error!("Websocket error: {:?}", e);
+                                        // An over-limit message is reported before its payload is
+                                        // read, so the frame stream is left desynchronized and the
+                                        // message id is never seen: the connection can't be reused
+                                        // and an application level error can't be attributed to the
+                                        // query that caused it. Answer with the close code reserved
+                                        // for this instead of dropping the connection silently, so
+                                        // the client can report the size rather than a bare
+                                        // disconnect it would otherwise retry.
+                                        match message_too_large_reason(&e) {
+                                            Some(reason) => {
+                                                error!("Websocket message too large: {}", reason);
+                                                let send_res = web_socket.send(
+                                                    Message::close_with(MESSAGE_TOO_BIG_CLOSE_CODE, reason)
+                                                ).await;
+                                                if let Err(e) = send_res {
+                                                    error!("Websocket close send error: {:?}", e)
+                                                }
+                                            }
+                                            None => error!("Websocket error: {:?}", e),
+                                        }
                                         break;
                                     }
                                     Ok(msg) => {
@@ -1857,6 +1899,77 @@ mod tests {
                 .await
                 .expect("a header at the limit should be accepted");
         drop(socket);
+
+        http_server.stop_processing().await;
+        Ok(())
+    }
+    /// An incoming message over the transport size limit is answered with the
+    /// WebSocket "message too big" close code instead of the connection being
+    /// dropped without a word, which the client can only read as a bare
+    /// disconnect and retry.
+    #[tokio::test]
+    async fn ws_message_too_large_test() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let max_message_size = 4 * 1024;
+        let mut auth = MockSqlAuthService::new();
+        auth.expect_authenticate().return_const(Ok(None));
+
+        let http_server = Arc::new(HttpServer::new(
+            "127.0.0.1:53032".to_string(),
+            Arc::new(auth),
+            Arc::new(SqlServiceMock {
+                message_counter: AtomicU64::new(0),
+            }),
+            Duration::from_millis(100),
+            Duration::from_millis(10000),
+            Duration::from_millis(1000),
+            max_message_size,
+            max_message_size,
+        ));
+        {
+            let http_server = http_server.clone();
+            cube_ext::spawn(async move { http_server.run_server().await });
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let (mut socket, _) = connect_async(Url::parse("ws://127.0.0.1:53032/ws").unwrap())
+            .await
+            .unwrap();
+
+        // A query too long to fit, so that the server refuses the frame before
+        // it can read the message id back out of it.
+        socket
+            .send(Message::binary(
+                HttpMessage {
+                    message_id: 1,
+                    command: HttpCommand::Query {
+                        query: "s".repeat(max_message_size * 2),
+                        inline_tables: vec![],
+                        trace_obj: None,
+                        parameters: None,
+                        response_format: QueryResultFormat::Legacy,
+                    },
+                    connection_id: Some("foo".to_string()),
+                }
+                .bytes(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = socket.next().await.unwrap().unwrap();
+        match msg {
+            Message::Close(Some(frame)) => {
+                assert_eq!(u16::from(frame.code), MESSAGE_TOO_BIG_CLOSE_CODE);
+                assert!(
+                    frame.reason.contains("exceeds the maximum message size"),
+                    "unexpected close reason: {}",
+                    frame.reason
+                );
+            }
+            msg => panic!("Close frame expected, got: {:?}", msg),
+        }
 
         http_server.stop_processing().await;
         Ok(())

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -51,6 +51,20 @@ use warp::reject::Reject;
 /// process because it is too large (RFC 6455 section 7.4.1, "Message Too Big").
 const MESSAGE_TOO_BIG_CLOSE_CODE: u16 = 1009;
 
+/// How much room the transport is given above the configured message size.
+///
+/// The size limit is enforced here rather than by the transport, so that an
+/// over-limit request can be answered with an error naming the message it
+/// belongs to, on a connection that stays up for everything else multiplexed
+/// over it. That needs the message to arrive whole: `tungstenite` raises its
+/// capacity error as soon as the frame header is parsed, before the payload is
+/// read, which leaves the frame stream desynchronized and the message id
+/// unread. So the transport is configured a factor above the limit, and only
+/// enforces it as a backstop against a peer that would otherwise make the
+/// server buffer without bound. A message in between is what gets the readable
+/// error; past the backstop there is nothing to answer with but a close frame.
+const TRANSPORT_SIZE_HEADROOM: usize = 2;
+
 /// Recognizes the error raised when an incoming message exceeds
 /// `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` or `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`,
 /// and renders it as a close reason. `warp` boxes the underlying `tungstenite`
@@ -193,7 +207,7 @@ impl HttpServer {
             .and_then(move |tx: mpsc::Sender<(mpsc::Sender<Arc<HttpMessage>>, SqlQueryContext, HttpMessage)>, sql_query_context: SqlQueryContext, ws: Ws| async move {
                 let tx_to_move = tx.clone();
                 let sql_query_context = sql_query_context.clone();
-                let reply = ws.max_frame_size(max_frame_size).max_message_size(max_message_size).on_upgrade(async move |mut web_socket| {
+                let reply = ws.max_frame_size(max_frame_size.saturating_mul(TRANSPORT_SIZE_HEADROOM)).max_message_size(max_message_size.saturating_mul(TRANSPORT_SIZE_HEADROOM)).on_upgrade(async move |mut web_socket| {
                     let process_id = sql_query_context.process_id.as_deref().unwrap_or("None");
                     trace!("WebSocket connection established (process_id: {})", process_id);
                     let (response_tx, mut response_rx) = mpsc::channel::<Arc<HttpMessage>>(10000);
@@ -213,14 +227,15 @@ impl HttpServer {
                             Some(msg) = web_socket.next() => {
                                 match msg {
                                     Err(e) => {
-                                        // An over-limit message is reported before its payload is
-                                        // read, so the frame stream is left desynchronized and the
-                                        // message id is never seen: the connection can't be reused
-                                        // and an application level error can't be attributed to the
-                                        // query that caused it. Answer with the close code reserved
-                                        // for this instead of dropping the connection silently, so
-                                        // the client can report the size rather than a bare
-                                        // disconnect it would otherwise retry.
+                                        // Past the transport backstop the payload is refused
+                                        // before it is read, so the frame stream is left
+                                        // desynchronized and the message id is never seen: the
+                                        // connection can't be reused and the error can't be
+                                        // attributed to a query the way an over-limit request
+                                        // under the backstop is. Answer with the close code
+                                        // reserved for this instead of dropping the connection
+                                        // silently, so the client can report the size rather than
+                                        // a bare disconnect it would otherwise retry.
                                         match message_too_large_reason(&e) {
                                             Some(reason) => {
                                                 error!("Websocket message too large: {}", reason);
@@ -248,6 +263,25 @@ impl HttpServer {
 
                                             let message_id = http_message.message_id();
                                             let connection_id = http_message.connection_id().map(|s| s.to_string());
+
+                                            // Refused here rather than by the transport so the
+                                            // answer can name the message it belongs to and the
+                                            // connection survives for everything else in flight
+                                            // on it. See TRANSPORT_SIZE_HEADROOM.
+                                            if message_buffer.len() > max_message_size {
+                                                let error = format!(
+                                                    "Request of {} bytes exceeds the maximum message size of {} bytes. Reduce the size of the query, e.g. by sending fewer or smaller inline tables, or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE",
+                                                    message_buffer.len(), max_message_size
+                                                );
+                                                error!("Websocket message too large: {}", error);
+                                                let send_res = web_socket.send(
+                                                    Message::binary(HttpMessage { message_id, connection_id, command: HttpCommand::Error { error } }.bytes())
+                                                ).await;
+                                                if let Err(e) = send_res {
+                                                    error!("Websocket message send error: {:?}", e)
+                                                }
+                                                continue;
+                                            }
 
                                             match HttpMessage::read(http_message).await {
                                                 Err(e) => {
@@ -1903,7 +1937,7 @@ mod tests {
         http_server.stop_processing().await;
         Ok(())
     }
-    /// An incoming message over the transport size limit is answered with the
+    /// An incoming message past the transport backstop is answered with the
     /// WebSocket "message too big" close code instead of the connection being
     /// dropped without a word, which the client can only read as a bare
     /// disconnect and retry.
@@ -1938,14 +1972,14 @@ mod tests {
             .await
             .unwrap();
 
-        // A query too long to fit, so that the server refuses the frame before
-        // it can read the message id back out of it.
+        // Clear of the headroom the graceful path is given, so that the server
+        // refuses the frame before it can read the message id back out of it.
         socket
             .send(Message::binary(
                 HttpMessage {
                     message_id: 1,
                     command: HttpCommand::Query {
-                        query: "s".repeat(max_message_size * 2),
+                        query: "s".repeat(max_message_size * TRANSPORT_SIZE_HEADROOM * 2),
                         inline_tables: vec![],
                         trace_obj: None,
                         parameters: None,
@@ -1969,6 +2003,114 @@ mod tests {
                 );
             }
             msg => panic!("Close frame expected, got: {:?}", msg),
+        }
+
+        http_server.stop_processing().await;
+        Ok(())
+    }
+
+    /// An over-limit request that still fits within the transport headroom is
+    /// answered with an error naming the message it belongs to, and the
+    /// connection carries on serving the queries multiplexed over it.
+    #[tokio::test]
+    async fn ws_message_too_large_reports_the_message_test() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let max_message_size = 4 * 1024;
+        let mut auth = MockSqlAuthService::new();
+        auth.expect_authenticate().return_const(Ok(None));
+
+        let http_server = Arc::new(HttpServer::new(
+            "127.0.0.1:53034".to_string(),
+            Arc::new(auth),
+            Arc::new(SqlServiceMock {
+                message_counter: AtomicU64::new(0),
+            }),
+            Duration::from_millis(100),
+            Duration::from_millis(10000),
+            Duration::from_millis(1000),
+            max_message_size,
+            max_message_size,
+        ));
+        {
+            let http_server = http_server.clone();
+            cube_ext::spawn(async move { http_server.run_server().await });
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let (mut socket, _) = connect_async(Url::parse("ws://127.0.0.1:53034/ws").unwrap())
+            .await
+            .unwrap();
+
+        // Over the limit, but inside the headroom the transport is given, so it
+        // arrives whole and can be attributed to message 7.
+        socket
+            .send(Message::binary(
+                HttpMessage {
+                    message_id: 7,
+                    command: HttpCommand::Query {
+                        query: "s".repeat(max_message_size + max_message_size / 2),
+                        inline_tables: vec![],
+                        trace_obj: None,
+                        parameters: None,
+                        response_format: QueryResultFormat::Legacy,
+                    },
+                    connection_id: Some("foo".to_string()),
+                }
+                .bytes(),
+            ))
+            .await
+            .unwrap();
+
+        // Read off the flatbuffer directly: `HttpMessage::read` only decodes the
+        // commands a client sends, and an error is not one of them.
+        let msg = socket.next().await.unwrap().unwrap();
+        let data = msg.into_data();
+        let message = root_as_http_message(&data).unwrap();
+        assert_eq!(message.message_id(), 7);
+        let error = message
+            .command_as_http_error()
+            .expect("an error was expected")
+            .error()
+            .unwrap_or_default();
+        assert!(
+            error.contains("exceeds the maximum message size"),
+            "unexpected error: {}",
+            error
+        );
+
+        // The point of answering instead of closing: the connection is still
+        // usable for everything that wasn't oversized.
+        socket
+            .send(Message::binary(
+                HttpMessage {
+                    message_id: 8,
+                    command: HttpCommand::Query {
+                        query: "foo".to_string(),
+                        inline_tables: vec![],
+                        trace_obj: None,
+                        parameters: None,
+                        response_format: QueryResultFormat::Legacy,
+                    },
+                    connection_id: Some("foo".to_string()),
+                }
+                .bytes(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = socket.next().await.unwrap().unwrap();
+        let message = HttpMessage::read(root_as_http_message(&msg.into_data()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(message.message_id, 8);
+        match message.command {
+            HttpCommand::ResultSet { data_frame } => assert_eq!(
+                data_frame.get_rows()[0].values()[0],
+                TableValue::String("0".to_string())
+            ),
+            command => panic!("Result set expected, got: {:?}", command),
         }
 
         http_server.stop_processing().await;

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -1916,7 +1916,7 @@ mod tests {
         auth.expect_authenticate().return_const(Ok(None));
 
         let http_server = Arc::new(HttpServer::new(
-            "127.0.0.1:53032".to_string(),
+            "127.0.0.1:53033".to_string(),
             Arc::new(auth),
             Arc::new(SqlServiceMock {
                 message_counter: AtomicU64::new(0),
@@ -1934,7 +1934,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let (mut socket, _) = connect_async(Url::parse("ws://127.0.0.1:53032/ws").unwrap())
+        let (mut socket, _) = connect_async(Url::parse("ws://127.0.0.1:53033/ws").unwrap())
             .await
             .unwrap();
 

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -51,7 +51,7 @@ use warp::reject::Reject;
 /// process because it is too large (RFC 6455 section 7.4.1, "Message Too Big").
 const MESSAGE_TOO_BIG_CLOSE_CODE: u16 = 1009;
 
-/// How much room the transport is given above the configured message size.
+/// How much room the transport is given above the configured sizes.
 ///
 /// The size limit is enforced here rather than by the transport, so that an
 /// over-limit request can be answered with an error naming the message it
@@ -63,6 +63,19 @@ const MESSAGE_TOO_BIG_CLOSE_CODE: u16 = 1009;
 /// enforces it as a backstop against a peer that would otherwise make the
 /// server buffer without bound. A message in between is what gets the readable
 /// error; past the backstop there is nothing to answer with but a close frame.
+///
+/// The frame limit is given the same headroom, and has to be: a client sends a
+/// query as a single frame, so an exact frame limit would refuse an over-limit
+/// message at the transport before the handler ever saw it, and at the default
+/// configuration — where `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` and
+/// `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` are both `64 << 20` — that is every
+/// over-limit message, leaving the readable error unreachable.
+///
+/// Frame size is not re-checked in the handler, because reassembly happens
+/// below `warp` and individual frames are never visible up here. So with the
+/// two knobs configured apart, `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` bounds a
+/// single allocation at the headroom multiple of its configured value, and the
+/// message limit is what actually enforces the policy.
 const TRANSPORT_SIZE_HEADROOM: usize = 2;
 
 /// Recognizes the error raised when an incoming message exceeds
@@ -270,7 +283,7 @@ impl HttpServer {
                                             // on it. See TRANSPORT_SIZE_HEADROOM.
                                             if message_buffer.len() > max_message_size {
                                                 let error = format!(
-                                                    "Request of {} bytes exceeds the maximum message size of {} bytes. Reduce the size of the query, e.g. by sending fewer or smaller inline tables, or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE",
+                                                    "Request of {} bytes exceeds the maximum message size of {} bytes. Reduce the size of the query, e.g. by sending fewer or smaller inline tables, or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.",
                                                     message_buffer.len(), max_message_size
                                                 );
                                                 error!("Websocket message too large: {}", error);
@@ -1937,6 +1950,7 @@ mod tests {
         http_server.stop_processing().await;
         Ok(())
     }
+
     /// An incoming message past the transport backstop is answered with the
     /// WebSocket "message too big" close code instead of the connection being
     /// dropped without a word, which the client can only read as a bare


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Fixes two ways a healthy query could fail with an unhelpful error:

```
Internal Error: Error during processing PostgreSQL message: DataFusionError: Arrow error:
External error: Database Execution Error: ConnectionError: CubeStore connection error: write EPIPE
    at /node_modules/@cubejs-backend/cubestore-driver/src/WebSocketConnection.ts:193:20
```

**1. `write EPIPE` failed queries that were never delivered**

`WebSocketConnection` already knows how to survive Cube Store going away: the `'close'` handler resends everything still pending in `sentMessages` over a freshly established connection, reusing the same `messageId` and `connectionId` so that Cube Store can de-duplicate it (`messages_state` in `rust/cubestore/cubestore/src/http/mod.rs` — a resend attaches to the still-running execution, or gets the cached result). But when Cube Store dropped a connection the driver hadn't noticed yet, `readyState` was still `OPEN`, the write went into a dead socket, and the `send` callback got `EPIPE` — at which point `sendMessage` deleted the message and rejected it. The reconnect still happened and still resent the query, but the promise was already rejected, so the user saw `write EPIPE` for a query that never reached Cube Store. `sendAsync` (used by the resend loop itself) had the same flaw, plus it never settled when the socket wasn't `OPEN`, stalling the loop.

A failed write now leaves the message registered and terminates the socket, which is exactly the event the existing resend loop already handles — no second retry path. The loop itself is unchanged except that it registers a batch before writing it, so a socket dying mid-batch can't strand the rest. A message registered on a socket whose `'close'` has already fired re-establishes the connection instead of waiting for a resend that will never come, since there is no timeout in this class.

**2. An over-limit response retried instead of saying it was too big**

A result bigger than the connection accepts (`ws` `maxPayload`, 100 MB by default, never set explicitly before) makes `ws` tear the connection down with close code 1009. Combined with the resend above, the query was retried on a fresh connection, produced the same oversized response, and repeated. Real Cube Store de-duplicates a resend by `(connection_id, message_id)`, but handing back a cached result also drops the entry, so the loop alternates between re-sending the cached oversized result and genuinely re-executing, and the error it eventually surfaces says nothing about size. Now the failure is reported and bounded:

```
MessageTooLargeError: Cube Store response size exceeds the maximum message size of 100 MB.
Reduce the amount of data the query returns, e.g. by adding filters or a limit,
or raise CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE.
```

`MessageTooLargeError` is distinguished from a retryable `ConnectionError` precisely because resending cannot help indefinitely. The limit becomes explicit and configurable through the new `CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE`, defaulting to the same 100 MB `ws` used implicitly, so behaviour is unchanged for anyone not hitting it. It applies to outgoing messages too: a query over the limit is rejected before being sent, since Cube Store would close the connection on it and that surfaces as an unrelated `write EPIPE`. A peer closing with 1009 is reported the same way, and the close reason Cube Store sends — which names the size and the limit that refused it — replaces the generic wording when there is one.

The connection multiplexes messages and `ws` drops the oversized frame before its message id is read, so the close says an oversized message arrived on this socket, not which query produced it. Every message in flight therefore gets exactly one more round. That includes a message that was alone in flight: it can be the response to a query already rejected on an earlier round that was still on the wire, so being the only one pending is not proof of being the offender. The round answers the innocent queries and usually leaves the offender alone on the connection, where the next one names it. Whatever is still in flight after its round is failed regardless, so an offender whose response keeps arriving ahead of the other answers can't be re-sent forever; only consecutive unattributable failures count towards that, so an ordinary disconnect in between doesn't spend a query's round. The cost is that the sole-message case pays a reconnect and a re-transfer of the oversized payload before being reported. Outside the over-limit case the resends stay bounded by the connection-level retry only, as before this PR.

**3. Cube Store dropped the connection on an over-limit request without a word**

The other half of the same problem, on the server. A request over `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` or `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` (both `64 << 20`) surfaced as a capacity error from the WebSocket stream, and the handler's catch-all in `rust/cubestore/cubestore/src/http/mod.rs` logged it and `break`'d out of the loop. That drops the connection with no close frame, so the client cannot tell an oversized request from Cube Store restarting, and falls back to resending the query that caused it. The size limit itself is `warp`/`tungstenite` behaviour; the silent drop was ours.

The limit is now enforced a layer up, in the message handler rather than by the transport. Once the message has arrived its id is known, so the answer is an ordinary `HttpCommand::Error` naming the request that was too big — and the connection stays up for every other query multiplexed over it, which a close frame would have taken down along with the offender:

```
Request of 70000000 bytes exceeds the maximum message size of 67108864 bytes.
Reduce the size of the query, e.g. by sending fewer or smaller inline tables,
or raise CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE.
```

That needs the message to actually arrive: `tungstenite` raises its capacity error as soon as the frame header is parsed and before the payload is read, which leaves the frame stream desynchronized and the id unread. So the transport is configured a factor above the configured limits and keeps enforcing them only as a backstop, so a peer still cannot make the server buffer without bound. Past that backstop there is nothing left to answer with but a close frame, and that is now sent explicitly with code 1009 and the size as its reason — which is what the client-side handling above turns into a readable `MessageTooLargeError`, instead of the bare disconnect it would otherwise retry. Every other `break` in that loop is unchanged.

The reported number is the configured limit, not the backstop: `tungstenite` hands back the size it was configured with, which is the configured value times the headroom, so it is divided back out. The same capacity error covers both caps and does not say which fired, so the divided value is compared against each and names the one it matches — otherwise a `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` configured below the message limit would be reported under the message limit's name, sending an operator to a knob that changes nothing.

The frame limit gets the same headroom as the message limit and needs it: a query arrives as a single frame, so an exact frame limit would refuse an over-limit message at the transport before the handler saw it, and with the two defaults equal that is every over-limit message, leaving the readable error unreachable. Frame size can't be re-checked in the handler, since reassembly happens below `warp`, so when the two knobs are configured apart the frame knob bounds a single allocation at the headroom multiple of its value and the message limit is what enforces the policy. This is spelled out on `TRANSPORT_SIZE_HEADROOM`.

**Docs**

#11655 landed on master while this was in flight and documents the transport size limits, including the behaviour above as a known limitation — a message over the transport limit closing the connection and surfacing as `write EPIPE`. That is what this PR removes, so the page is updated to the error-and-survive behaviour, along with where that stops: past twice whichever transport limit is lower, the message is refused before it can be attributed and the connection is closed after all. `CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE` is documented next to the Cube Store side limits it is independent of.

**Tests**

`packages/cubejs-cubestore-driver/test/` runs the driver against a Cube Store mock that speaks the real WebSocket + flatbuffers protocol over real TCP sockets, and breaks the connection in the ways that produce these errors — a buffered write failed with `EPIPE` (the exact `errorBuffer` path from the report), a non-writable socket, a close mid-query, an over-limit response, an over-limit request, a 1009 close carrying Cube Store's sizes, a 1009 close with no reason, a 1009 close whose reason is punctuated, a 1009 close whose reason names the *frame* limit, a small query in flight alongside an over-limit response, an over-limit response that always beats the other answer and so can never be attributed, and a slow query spanning two size incidents with an ordinary disconnect between them.

A successful result round trip is asserted too, both fresh and after a mid-query reconnect, with only the native result decoder stubbed. All 15 pass; `tsc` and `eslint` are clean. Wired into CI through a `unit` script on the package, which `yarn lerna run unit` picks up.

Every test was checked against the source it fixes: 10 of the original 12 fail against `master`, the `EPIPE` ones with exactly the reported error. The two that only a later commit fixes were checked against that commit rather than `master` — the unattributable-loop one hung to the jest timeout against `5219a9d`, and the extra-round one failed with `MessageTooLargeError` on the innocent query against `e7a5bd5`.

On the Cube Store side, three tests drive the paths over a real socket against a server with a 4 KB limit. `ws_message_too_large_reports_the_message_test` sends an over-limit request, asserts the error comes back on that request's message id, and then runs an ordinary query on the same connection to show it survived; it fails without the handler-level check. `ws_message_too_large_test` covers the backstop, asserting the close frame and its reason; against the code before this PR it fails with the reported `Connection reset by peer`. `ws_message_too_large_names_the_frame_limit_test` configures the frame limit below the message limit and asserts the close names the frame limit. All three assert the configured size rather than a prefix, which is what catches the limit being reported as the backstop. All 11 `http::tests` pass, and `cargo fmt` is clean.

**Notes for the reviewer**

- The client-side error text deliberately does not mention `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` for the *response* direction: in tungstenite 0.20 `max_frame_size`/`max_message_size` are only checked on the read path, so Cube Store puts no limit on what it sends and those knobs do nothing for response size. The client's `maxPayload` is the only limit that applies to a response. The 1009 path, which is the request direction, does name both.
- `CUBEJS_CUBESTORE_MAX_MESSAGE_SIZE` (100 MB) and Cube Store's `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` (64 MB) are independent, so the driver's outgoing check only catches what is over the client's own limit; a query between the two is refused by Cube Store, and is the case section 3 now reports readably.
- The transport headroom means a request between the configured limit and the backstop is buffered before being refused, so the worst-case memory a single connection can tie up goes up by that factor. It is a cap only an over-limit peer reaches, and it is what buys the error message and the surviving connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPf8PuEMdZ6RE7BusNGWej