### PR TITLE
docs: "dashboards as code" guide for programmatic dashboards (CUB-3521)

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -118,6 +118,7 @@
                     ]
                   },
                   "docs/explore-analyze/dashboards/styling",
+                  "docs/explore-analyze/dashboards/dashboards-as-code",
                   "docs/explore-analyze/dashboards/dashboard-agent"
                 ]
               },

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboards-as-code.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboards-as-code.mdx
@@ -1,0 +1,359 @@
+---
+title: Dashboards as code
+description: Define dashboards and charts as versioned YAML in your Cube project — deployed with your data model, reviewed in Git, and rendered read-only in the workspace.
+---
+
+<Note>
+
+Dashboards as code is in **preview**. Contact your Cube representative to enable
+it for a deployment.
+
+</Note>
+
+**Dashboards as code** lets you define dashboards and their charts as YAML files
+that live in your Cube project's source tree, right next to your data model.
+They are versioned in Git, reviewed through pull requests, and deployed with the
+rest of your project — so the same dashboard definition can be promoted across
+environments (staging → production) or reused across deployments the same way
+your data model is.
+
+This is the source-owned counterpart to building dashboards interactively in the
+[dashboard builder][ref-dashboards]. A deployment with dashboards as code enabled
+reads its dashboards from the source tree and renders them **read-only** in the
+[workspace][ref-workbooks]: the repository is the owner, so there are no
+create, move, or edit affordances in the UI — you change a dashboard by editing
+its file and deploying.
+
+## When to use it
+
+Reach for dashboards as code when you want to:
+
+- **Review dashboard changes in Git** — treat a dashboard edit like any other
+  code change, with diffs, pull requests, and approvals.
+- **Promote across environments** — apply the same definitions to staging and
+  production, or to many deployments, from one CI/CD pipeline.
+- **Keep dashboards reproducible** — the definition is the source of truth, not
+  a database row, so a deployment rebuilt from the repository has the same
+  dashboards.
+
+If you instead want business users to create and edit dashboards interactively,
+use the [dashboard builder][ref-dashboards] — the two models are independent.
+
+## How it works
+
+Dashboards as code builds on [Git-based continuous
+deployment][ref-continuous-deployment]. You add a `dashboards/` directory to your
+project (alongside `model/`), commit dashboard and chart YAML files to it, and
+deploy your project as usual. Cube Cloud reads that directory at build time and
+serves the dashboards to the workspace.
+
+- **Folders come from the directory structure.** A file at
+  `dashboards/finance/emea/revenue.yaml` places its dashboard in the
+  `finance → emea` folder of the workspace. You organize dashboards by moving
+  files between directories.
+- **Nothing is persisted separately.** The definitions are read live from the
+  deployed source and are versioned and redeployed with your model — there is no
+  separate database copy to keep in sync.
+- **Everything is read-only in the UI.** Source-owned dashboards render through
+  the same viewer as published dashboards, but the workspace exposes no editing
+  for them. Charts still run their queries live, so the data is current.
+
+The directory Cube reads defaults to `dashboards/` at the project root. To use a
+different location, set the `CUBE_CLOUD_DASHBOARDS_CONFIG_PATH` environment
+variable to the path you want.
+
+## Project layout
+
+```
+my-cube-project/
+├── model/
+│   └── ...                          # your data model
+└── dashboards/
+    ├── revenue-overview.yaml        # a dashboard (root folder)
+    ├── charts/
+    │   ├── revenue_by_month.yaml    # a chart referenced by a dashboard widget
+    │   └── revenue_by_status.yaml
+    └── finance/
+        └── emea/
+            └── emea-revenue.yaml     # a dashboard in the finance → emea folder
+```
+
+There are two kinds of file, distinguished by their `apiVersion`:
+
+| File | `apiVersion` | Purpose |
+| --- | --- | --- |
+| **Dashboard** | `cube.dev/dashboard/v1` | Layout: which widgets appear, where, and which chart each one shows |
+| **Chart** | `cube.dev/chart/v1` | A chart's query and visualization spec, referenced by dashboards via its `publicId` |
+
+Both kinds can live anywhere under `dashboards/`; Cube routes each file by its
+`apiVersion`. Only a dashboard file's directory affects the folder tree — chart
+files are referenced by id, so their location is up to you (grouping them under
+`charts/` is a convention, not a requirement).
+
+## Dashboard files
+
+A dashboard file describes the layout and the widgets on the canvas.
+
+```yaml title="dashboards/revenue-overview.yaml"
+apiVersion: cube.dev/dashboard/v1
+slug: revenue-overview
+name: Revenue Overview
+widgets:
+  - id: w1
+    type: CHART
+    position: { x: 0, y: 0, w: 6, h: 8 }
+    chart: revqZ1x8Kp0a          # references a chart file by its publicId
+  - id: w2
+    type: CHART
+    position: { x: 6, y: 0, w: 6, h: 8 }
+    chart: statP4hQ2mN7
+  - id: w3
+    type: TEXT
+    position: { x: 0, y: 8, w: 12, h: 2 }
+    config:
+      content: "## Notes\nRevenue excludes refunds."
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `apiVersion` | yes | Must be `cube.dev/dashboard/v1`. |
+| `slug` | yes | Stable, human-readable identifier, unique across the deployment. Used to address the dashboard and as the target of [drill-in links][ref-dashboard-slug]. |
+| `name` | no | Display name shown in the workspace. Defaults to the slug. |
+| `widgets` | no | The widgets on the canvas (see below). |
+
+### Widgets
+
+Each widget is an object with an `id`, a `type`, and a `position`:
+
+| Field | Description |
+| --- | --- |
+| `id` | Stable identifier for the widget, unique within the dashboard. |
+| `type` | One of `CHART`, `TEXT`, `FILTER`, `TIME_GRAIN`, `AI_SUMMARY`, `TABS_CONTAINER`. |
+| `position` | Grid placement: `{ x, y, w, h }` in grid units (columns run 0–11). |
+| `chart` | For `CHART` widgets: the `publicId` of the chart file this widget renders. |
+| `config` | Type-specific configuration (for example, `content` holds the Markdown of a `TEXT` widget). Carried through as authored. |
+| `tabs` | For `TABS_CONTAINER` widgets: nested tabs, each with its own child widgets (see below). |
+
+The widget types mirror the ones in the [dashboard builder][ref-widgets]: charts
+visualize a report, text adds Markdown, controls (`FILTER` / `TIME_GRAIN`) let
+viewers filter or change the time granularity, and AI summaries generate
+narrative text.
+
+#### Tabbed widgets
+
+A `TABS_CONTAINER` groups widgets into tabs. Each tab has an `id`, a `title`, and
+its own `children` — which are ordinary widgets, including nested charts:
+
+```yaml
+- id: w4
+  type: TABS_CONTAINER
+  position: { x: 0, y: 10, w: 12, h: 10 }
+  tabs:
+    - id: t1
+      title: By month
+      children:
+        - id: w4a
+          type: CHART
+          position: { x: 0, y: 0, w: 12, h: 8 }
+          chart: revqZ1x8Kp0a
+    - id: t2
+      title: By status
+      children:
+        - id: w4b
+          type: CHART
+          position: { x: 0, y: 0, w: 12, h: 8 }
+          chart: statP4hQ2mN7
+```
+
+## Chart files
+
+A chart file holds a chart's query and its visualization spec. It is referenced
+by dashboard widgets through its `publicId`, so the same chart can appear on more
+than one dashboard.
+
+```yaml title="dashboards/charts/revenue_by_month.yaml"
+apiVersion: cube.dev/chart/v1
+publicId: revqZ1x8Kp0a
+name: Revenue by month
+query:
+  sql: >
+    SELECT MEASURE(orders.revenue), orders.created_at
+    FROM orders
+    GROUP BY 2
+chart:
+  chartCategory: table
+  tableChartSpec:
+    columns:
+      - orders.created_at
+      - orders.revenue
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `apiVersion` | yes | Must be `cube.dev/chart/v1`. |
+| `publicId` | yes | Stable identifier, unique across the deployment. Widgets reference the chart by this value. |
+| `name` | no | Display name for the chart. |
+| `query.sql` | no | The chart's query, written against the [Cube SQL API][ref-sql-api]. Datasets are referenced by cube or view name in the `FROM` clause, so a query is portable across deployments that share the same data model. |
+| `pivot` | no | Pivot configuration (`rows`, `columns`, `measures`, `filters`). |
+| `chart` | no | The visualization spec (see below). |
+
+### Chart `publicId`
+
+The `publicId` is the chart's portable identity: dashboards reference it, and it
+is what keeps a reference stable across deployments and edits. Choose a
+12-character alphanumeric id (`[0-9A-Za-z]`) and keep it fixed for the life of the
+chart. It must be unique within the deployment — two chart files with the same
+`publicId` fail the build.
+
+### Visualization spec
+
+The `chart` block holds the visualization spec. Its shape mirrors what the
+[dashboard builder][ref-charts] produces:
+
+- `chartCategory` names the chart type.
+- The spec itself lives in a matching field: `tableChartSpec`, `vegaSpec`,
+  `kpiChartSpec`, `htmlChartSpec`, or `mapChartSpec`. The render type is one of
+  `table`, `vega`, `kpi`, `html`, or `map`.
+
+A table chart (above) is the simplest to author by hand — it just lists the
+columns to show. Richer visualizations (Vega-Lite charts, KPIs, maps) carry a
+correspondingly richer spec; the easiest way to get one right is to model it on a
+chart built in the UI. Any additional fields you include are preserved, so a
+chart definition is not silently truncated.
+
+<Note>
+
+`query.sql` is the source of truth for a chart's query. The chart is rendered by
+running that SQL live in the browser, so the data is always current — the file
+stores the definition, never a cached result.
+
+</Note>
+
+## Referencing charts from widgets
+
+A `CHART` widget names the chart it renders with `chart: <publicId>`:
+
+```yaml
+- id: w1
+  type: CHART
+  position: { x: 0, y: 0, w: 6, h: 8 }
+  chart: revqZ1x8Kp0a       # must match a chart file's publicId
+```
+
+Because widgets reference charts by `publicId` (not by a per-deployment numeric
+id), a dashboard and its charts move together across environments unchanged. A
+widget whose `chart` id has no matching chart file simply renders nothing.
+
+## Folders
+
+The directory a dashboard file lives in becomes its folder in the workspace, and
+the directory tree becomes the folder tree. A dashboard at the root of
+`dashboards/` appears at the top level; one at `dashboards/finance/emea/` appears
+under `finance → emea`. Ancestor folders (`finance`) are created automatically
+even if they contain no dashboard file of their own.
+
+## A complete example
+
+```
+dashboards/
+├── revenue-overview.yaml
+└── charts/
+    ├── revenue_by_month.yaml
+    └── revenue_by_status.yaml
+```
+
+```yaml title="dashboards/revenue-overview.yaml"
+apiVersion: cube.dev/dashboard/v1
+slug: revenue-overview
+name: Revenue Overview
+widgets:
+  - id: w1
+    type: CHART
+    position: { x: 0, y: 0, w: 6, h: 8 }
+    chart: revqZ1x8Kp0a
+  - id: w2
+    type: CHART
+    position: { x: 6, y: 0, w: 6, h: 8 }
+    chart: statP4hQ2mN7
+```
+
+```yaml title="dashboards/charts/revenue_by_month.yaml"
+apiVersion: cube.dev/chart/v1
+publicId: revqZ1x8Kp0a
+name: Revenue by month
+query:
+  sql: >
+    SELECT MEASURE(orders.revenue), orders.created_at
+    FROM orders
+    GROUP BY 2
+chart:
+  chartCategory: table
+  tableChartSpec:
+    columns:
+      - orders.created_at
+      - orders.revenue
+```
+
+```yaml title="dashboards/charts/revenue_by_status.yaml"
+apiVersion: cube.dev/chart/v1
+publicId: statP4hQ2mN7
+name: Revenue by status
+query:
+  sql: >
+    SELECT MEASURE(orders.revenue), orders.status
+    FROM orders
+    GROUP BY 2
+chart:
+  chartCategory: table
+  tableChartSpec:
+    columns:
+      - orders.status
+      - orders.revenue
+```
+
+Committing these files and deploying makes a **Revenue Overview** dashboard
+appear at the top level of the workspace, with two table charts side by side.
+
+## Deploying
+
+Dashboards as code is deployed like the rest of your project:
+
+1. Add the dashboard and chart files under `dashboards/` in your repository.
+2. Open a pull request and review the change like any other code change.
+3. Merge and deploy — with [Git-based deployment][ref-continuous-deployment], the
+   production branch builds automatically; with CLI deployment, run your usual
+   deploy command.
+
+After the build, the dashboards appear in the workspace, read-only. To change a
+dashboard, edit its file and deploy again.
+
+## Validation and rules
+
+Cube validates the source tree at build time. A problem fails the load with a
+message naming the file, so you catch it in your build rather than at runtime:
+
+- **`apiVersion` is required and must match.** Files without a recognized
+  `apiVersion` are ignored; a recognized one with an invalid body fails
+  validation.
+- **Slugs are unique.** Two dashboards with the same `slug` are rejected.
+- **Chart `publicId`s are unique.** Two chart files with the same `publicId` are
+  rejected.
+- **YAML must parse.** A malformed file fails with a parse error naming the file.
+- **Unknown fields are preserved.** Fields beyond the documented ones round-trip
+  untouched, so a newer authoring field is never dropped by the runtime.
+
+## Relationship to builder-authored dashboards
+
+Source-owned dashboards and dashboards created in the [builder][ref-dashboards]
+are independent. When dashboards as code is enabled, the workspace shows the
+source-owned dashboards and treats them as read-only — the repository owns them.
+Manage those dashboards through your Git workflow; use the builder for
+dashboards you want business users to create and edit interactively.
+
+[ref-dashboards]: /docs/explore-analyze/dashboards
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-widgets]: /docs/explore-analyze/dashboards/widgets
+[ref-charts]: /docs/explore-analyze/dashboards/widgets/charts
+[ref-dashboard-slug]: /docs/explore-analyze/dashboards#dashboard-slug
+[ref-continuous-deployment]: /admin/deployment/continuous-deployment
+[ref-sql-api]: /reference/core-data-apis/sql-api

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboards-as-code.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboards-as-code.mdx
@@ -1,359 +1,200 @@
 ---
 title: Dashboards as code
-description: Define dashboards and charts as versioned YAML in your Cube project — deployed with your data model, reviewed in Git, and rendered read-only in the workspace.
+description: Manage workbooks, dashboards, and reports as code with idempotent REST endpoints keyed by portable identifiers, so a CI/CD pipeline can apply the same definitions across deployments.
 ---
 
-<Note>
+**Dashboards as code** lets you manage the reporting assets in a deployment —
+[workbooks][ref-workbooks], their [dashboards][ref-dashboards], and the
+[reports][ref-reports] the dashboard widgets render — from source control instead
+of only through the UI. You keep each asset's definition in Git and apply it to a
+deployment with the [Cube Cloud REST API][ref-api], the same way you might manage
+Superset assets with `preset-cli` or infrastructure with Terraform.
 
-Dashboards as code is in **preview**. Contact your Cube representative to enable
-it for a deployment.
+Two **idempotent upsert** endpoints make this possible. Instead of tracking the
+per-deployment numeric id that a `POST` returns, you address each asset by a
+**portable identifier you choose** and re-apply its definition as often as you
+like:
 
-</Note>
-
-**Dashboards as code** lets you define dashboards and their charts as YAML files
-that live in your Cube project's source tree, right next to your data model.
-They are versioned in Git, reviewed through pull requests, and deployed with the
-rest of your project — so the same dashboard definition can be promoted across
-environments (staging → production) or reused across deployments the same way
-your data model is.
-
-This is the source-owned counterpart to building dashboards interactively in the
-[dashboard builder][ref-dashboards]. A deployment with dashboards as code enabled
-reads its dashboards from the source tree and renders them **read-only** in the
-[workspace][ref-workbooks]: the repository is the owner, so there are no
-create, move, or edit affordances in the UI — you change a dashboard by editing
-its file and deploying.
-
-## When to use it
-
-Reach for dashboards as code when you want to:
-
-- **Review dashboard changes in Git** — treat a dashboard edit like any other
-  code change, with diffs, pull requests, and approvals.
-- **Promote across environments** — apply the same definitions to staging and
-  production, or to many deployments, from one CI/CD pipeline.
-- **Keep dashboards reproducible** — the definition is the source of truth, not
-  a database row, so a deployment rebuilt from the repository has the same
-  dashboards.
-
-If you instead want business users to create and edit dashboards interactively,
-use the [dashboard builder][ref-dashboards] — the two models are independent.
-
-## How it works
-
-Dashboards as code builds on [Git-based continuous
-deployment][ref-continuous-deployment]. You add a `dashboards/` directory to your
-project (alongside `model/`), commit dashboard and chart YAML files to it, and
-deploy your project as usual. Cube Cloud reads that directory at build time and
-serves the dashboards to the workspace.
-
-- **Folders come from the directory structure.** A file at
-  `dashboards/finance/emea/revenue.yaml` places its dashboard in the
-  `finance → emea` folder of the workspace. You organize dashboards by moving
-  files between directories.
-- **Nothing is persisted separately.** The definitions are read live from the
-  deployed source and are versioned and redeployed with your model — there is no
-  separate database copy to keep in sync.
-- **Everything is read-only in the UI.** Source-owned dashboards render through
-  the same viewer as published dashboards, but the workspace exposes no editing
-  for them. Charts still run their queries live, so the data is current.
-
-The directory Cube reads defaults to `dashboards/` at the project root. To use a
-different location, set the `CUBE_CLOUD_DASHBOARDS_CONFIG_PATH` environment
-variable to the path you want.
-
-## Project layout
-
-```
-my-cube-project/
-├── model/
-│   └── ...                          # your data model
-└── dashboards/
-    ├── revenue-overview.yaml        # a dashboard (root folder)
-    ├── charts/
-    │   ├── revenue_by_month.yaml    # a chart referenced by a dashboard widget
-    │   └── revenue_by_status.yaml
-    └── finance/
-        └── emea/
-            └── emea-revenue.yaml     # a dashboard in the finance → emea folder
-```
-
-There are two kinds of file, distinguished by their `apiVersion`:
-
-| File | `apiVersion` | Purpose |
+| Endpoint | Keyed by | Upserts |
 | --- | --- | --- |
-| **Dashboard** | `cube.dev/dashboard/v1` | Layout: which widgets appear, where, and which chart each one shows |
-| **Chart** | `cube.dev/chart/v1` | A chart's query and visualization spec, referenced by dashboards via its `publicId` |
+| [`PUT /deployments/{deploymentId}/workbooks/by-slug/{slug}`][ref-upsert-workbook] | a deployment-scoped **slug** | a workbook (and its dashboard draft) |
+| [`PUT /deployments/{deploymentId}/reports/by-public-id/{publicId}`][ref-upsert-report] | an account-unique **`publicId`** | a report |
 
-Both kinds can live anywhere under `dashboards/`; Cube routes each file by its
-`apiVersion`. Only a dashboard file's directory affects the folder tree — chart
-files are referenced by id, so their location is up to you (grouping them under
-`charts/` is a convention, not a requirement).
-
-## Dashboard files
-
-A dashboard file describes the layout and the widgets on the canvas.
-
-```yaml title="dashboards/revenue-overview.yaml"
-apiVersion: cube.dev/dashboard/v1
-slug: revenue-overview
-name: Revenue Overview
-widgets:
-  - id: w1
-    type: CHART
-    position: { x: 0, y: 0, w: 6, h: 8 }
-    chart: revqZ1x8Kp0a          # references a chart file by its publicId
-  - id: w2
-    type: CHART
-    position: { x: 6, y: 0, w: 6, h: 8 }
-    chart: statP4hQ2mN7
-  - id: w3
-    type: TEXT
-    position: { x: 0, y: 8, w: 12, h: 2 }
-    config:
-      content: "## Notes\nRevenue excludes refunds."
-```
-
-| Field | Required | Description |
-| --- | --- | --- |
-| `apiVersion` | yes | Must be `cube.dev/dashboard/v1`. |
-| `slug` | yes | Stable, human-readable identifier, unique across the deployment. Used to address the dashboard and as the target of [drill-in links][ref-dashboard-slug]. |
-| `name` | no | Display name shown in the workspace. Defaults to the slug. |
-| `widgets` | no | The widgets on the canvas (see below). |
-
-### Widgets
-
-Each widget is an object with an `id`, a `type`, and a `position`:
-
-| Field | Description |
-| --- | --- |
-| `id` | Stable identifier for the widget, unique within the dashboard. |
-| `type` | One of `CHART`, `TEXT`, `FILTER`, `TIME_GRAIN`, `AI_SUMMARY`, `TABS_CONTAINER`. |
-| `position` | Grid placement: `{ x, y, w, h }` in grid units (columns run 0–11). |
-| `chart` | For `CHART` widgets: the `publicId` of the chart file this widget renders. |
-| `config` | Type-specific configuration (for example, `content` holds the Markdown of a `TEXT` widget). Carried through as authored. |
-| `tabs` | For `TABS_CONTAINER` widgets: nested tabs, each with its own child widgets (see below). |
-
-The widget types mirror the ones in the [dashboard builder][ref-widgets]: charts
-visualize a report, text adds Markdown, controls (`FILTER` / `TIME_GRAIN`) let
-viewers filter or change the time granularity, and AI summaries generate
-narrative text.
-
-#### Tabbed widgets
-
-A `TABS_CONTAINER` groups widgets into tabs. Each tab has an `id`, a `title`, and
-its own `children` — which are ordinary widgets, including nested charts:
-
-```yaml
-- id: w4
-  type: TABS_CONTAINER
-  position: { x: 0, y: 10, w: 12, h: 10 }
-  tabs:
-    - id: t1
-      title: By month
-      children:
-        - id: w4a
-          type: CHART
-          position: { x: 0, y: 0, w: 12, h: 8 }
-          chart: revqZ1x8Kp0a
-    - id: t2
-      title: By status
-      children:
-        - id: w4b
-          type: CHART
-          position: { x: 0, y: 0, w: 12, h: 8 }
-          chart: statP4hQ2mN7
-```
-
-## Chart files
-
-A chart file holds a chart's query and its visualization spec. It is referenced
-by dashboard widgets through its `publicId`, so the same chart can appear on more
-than one dashboard.
-
-```yaml title="dashboards/charts/revenue_by_month.yaml"
-apiVersion: cube.dev/chart/v1
-publicId: revqZ1x8Kp0a
-name: Revenue by month
-query:
-  sql: >
-    SELECT MEASURE(orders.revenue), orders.created_at
-    FROM orders
-    GROUP BY 2
-chart:
-  chartCategory: table
-  tableChartSpec:
-    columns:
-      - orders.created_at
-      - orders.revenue
-```
-
-| Field | Required | Description |
-| --- | --- | --- |
-| `apiVersion` | yes | Must be `cube.dev/chart/v1`. |
-| `publicId` | yes | Stable identifier, unique across the deployment. Widgets reference the chart by this value. |
-| `name` | no | Display name for the chart. |
-| `query.sql` | no | The chart's query, written against the [Cube SQL API][ref-sql-api]. Datasets are referenced by cube or view name in the `FROM` clause, so a query is portable across deployments that share the same data model. |
-| `pivot` | no | Pivot configuration (`rows`, `columns`, `measures`, `filters`). |
-| `chart` | no | The visualization spec (see below). |
-
-### Chart `publicId`
-
-The `publicId` is the chart's portable identity: dashboards reference it, and it
-is what keeps a reference stable across deployments and edits. Choose a
-12-character alphanumeric id (`[0-9A-Za-z]`) and keep it fixed for the life of the
-chart. It must be unique within the deployment — two chart files with the same
-`publicId` fail the build.
-
-### Visualization spec
-
-The `chart` block holds the visualization spec. Its shape mirrors what the
-[dashboard builder][ref-charts] produces:
-
-- `chartCategory` names the chart type.
-- The spec itself lives in a matching field: `tableChartSpec`, `vegaSpec`,
-  `kpiChartSpec`, `htmlChartSpec`, or `mapChartSpec`. The render type is one of
-  `table`, `vega`, `kpi`, `html`, or `map`.
-
-A table chart (above) is the simplest to author by hand — it just lists the
-columns to show. Richer visualizations (Vega-Lite charts, KPIs, maps) carry a
-correspondingly richer spec; the easiest way to get one right is to model it on a
-chart built in the UI. Any additional fields you include are preserved, so a
-chart definition is not silently truncated.
+Because the identifier is stable and lives in your repository, applying the same
+definition twice is a no-op, and applying it to a second deployment (staging →
+production) reproduces the same assets there.
 
 <Note>
 
-`query.sql` is the source of truth for a chart's query. The chart is rendered by
-running that SQL live in the browser, so the data is always current — the file
-stores the definition, never a cached result.
+This page covers the REST primitives available today. They are the building
+blocks for an as-code workflow you assemble in your own pipeline — Cube does not
+yet ship a single bundle export/apply command that wraps them.
 
 </Note>
 
-## Referencing charts from widgets
+## How the pieces fit
 
-A `CHART` widget names the chart it renders with `chart: <publicId>`:
+Three assets are involved, each with its own identity:
 
-```yaml
-- id: w1
-  type: CHART
-  position: { x: 0, y: 0, w: 6, h: 8 }
-  chart: revqZ1x8Kp0a       # must match a chart file's publicId
+- A **report** is a saved query plus its visualization. Its portable identity is
+  a **`publicId`**: a 12-character alphanumeric (`[0-9A-Za-z]`) id that is unique
+  across your account. You mint it when you author the report and keep it fixed
+  for the report's lifetime.
+- A **workbook** is the container that holds a dashboard. Its portable identity
+  is a **slug**: a human-readable, deployment-scoped id (the same slug a data
+  model targets with `links: [{ dashboard: <slug> }]` for drill-in).
+- A **dashboard** is the layout — which widgets sit where. It is stored on its
+  workbook as `meta.dashboardDraft` and is made visible by **publishing** the
+  workbook. Each chart widget references a report.
+
+The identifiers you control (`publicId`, `slug`) are what make a definition
+portable. The numeric ids that `POST` responses return are per-deployment and are
+resolved at apply time — you never store them in Git.
+
+## Authenticating
+
+These are public REST endpoints. Authenticate with a deployment API key exactly
+as for the rest of the [REST API][ref-api] — see [Authentication][ref-auth] for
+how to create a key and pass it. The examples below assume:
+
+```bash
+export CUBE_API_URL="https://<your-cube-cloud-host>"
+export CUBE_API_TOKEN="<your-api-key>"
+export DEPLOYMENT_ID="<your-deployment-id>"
 ```
 
-Because widgets reference charts by `publicId` (not by a per-deployment numeric
-id), a dashboard and its charts move together across environments unchanged. A
-widget whose `chart` id has no matching chart file simply renders nothing.
+## The apply flow
 
-## Folders
+An as-code pipeline applies a dashboard bottom-up: reports first, then the
+workbook that lays them out, then publish.
 
-The directory a dashboard file lives in becomes its folder in the workspace, and
-the directory tree becomes the folder tree. A dashboard at the root of
-`dashboards/` appears at the top level; one at `dashboards/finance/emea/` appears
-under `finance → emea`. Ancestor folders (`finance`) are created automatically
-even if they contain no dashboard file of their own.
+### 1. Author once, then export
 
-## A complete example
+The report and dashboard-draft definitions are large and are not meant to be
+hand-written. Build the reports and dashboard once in the UI, then read them back
+over the API and commit the results:
 
-```
-dashboards/
-├── revenue-overview.yaml
-└── charts/
-    ├── revenue_by_month.yaml
-    └── revenue_by_status.yaml
-```
+- [`GET /deployments/{deploymentId}/reports/{reportId}`][ref-get-report] returns a
+  report's definition.
+- [`GET /deployments/{deploymentId}/workbooks/{workbookId}`][ref-get-workbook]
+  returns the workbook, including its `dashboardDraft`.
 
-```yaml title="dashboards/revenue-overview.yaml"
-apiVersion: cube.dev/dashboard/v1
-slug: revenue-overview
-name: Revenue Overview
-widgets:
-  - id: w1
-    type: CHART
-    position: { x: 0, y: 0, w: 6, h: 8 }
-    chart: revqZ1x8Kp0a
-  - id: w2
-    type: CHART
-    position: { x: 6, y: 0, w: 6, h: 8 }
-    chart: statP4hQ2mN7
+Assign each report a `publicId` and the workbook a `slug` of your choosing, store
+those alongside the exported definitions in your repository, and treat that as the
+source of truth.
+
+### 2. Upsert each report
+
+For every report, [upsert it by `publicId`][ref-upsert-report]. If a report with
+that `publicId` already exists in the deployment it is updated with the fields you
+send (same semantics as [`PUT /reports/{reportId}`][ref-update-report]);
+otherwise it is created with that `publicId`.
+
+```bash
+curl -X PUT \
+  "$CUBE_API_URL/api/v1/deployments/$DEPLOYMENT_ID/reports/by-public-id/revqZ1x8Kp0a" \
+  -H "Authorization: $CUBE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @report-revenue-by-month.json
 ```
 
-```yaml title="dashboards/charts/revenue_by_month.yaml"
-apiVersion: cube.dev/chart/v1
-publicId: revqZ1x8Kp0a
-name: Revenue by month
-query:
-  sql: >
-    SELECT MEASURE(orders.revenue), orders.created_at
-    FROM orders
-    GROUP BY 2
-chart:
-  chartCategory: table
-  tableChartSpec:
-    columns:
-      - orders.created_at
-      - orders.revenue
+The path `publicId` is the report's identity; the request body is the report
+definition you exported (its query in `sqlQuery` / `jsonQuery`, pivot in
+`pivotItems`, and visualization config in `meta`). Keep track of the numeric
+`id` each response returns — the dashboard draft references reports by that
+per-deployment id.
+
+### 3. Upsert the workbook and its dashboard
+
+[Upsert the workbook by `slug`][ref-upsert-workbook], carrying the dashboard
+layout in `meta.dashboardDraft`. Only the fields you send are changed, and `meta`
+is **merged** into the existing metadata rather than replacing it. The
+`dashboardDraft` is validated the same way the builder validates it.
+
+```bash
+curl -X PUT \
+  "$CUBE_API_URL/api/v1/deployments/$DEPLOYMENT_ID/workbooks/by-slug/revenue-overview" \
+  -H "Authorization: $CUBE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Revenue Overview",
+    "meta": { "dashboardDraft": { "...": "the exported dashboard config" } }
+  }'
 ```
 
-```yaml title="dashboards/charts/revenue_by_status.yaml"
-apiVersion: cube.dev/chart/v1
-publicId: statP4hQ2mN7
-name: Revenue by status
-query:
-  sql: >
-    SELECT MEASURE(orders.revenue), orders.status
-    FROM orders
-    GROUP BY 2
-chart:
-  chartCategory: table
-  tableChartSpec:
-    columns:
-      - orders.status
-      - orders.revenue
-```
+Because each chart widget inside `dashboardDraft` points at a report by its
+per-deployment numeric id, rewrite those references to the ids returned in
+step&nbsp;2 before applying the workbook to a **new** deployment. Re-applying to
+the same deployment needs no rewriting — the ids are stable there.
 
-Committing these files and deploying makes a **Revenue Overview** dashboard
-appear at the top level of the workspace, with two table charts side by side.
+### 4. Publish
 
-## Deploying
+Upserting the workbook writes the dashboard **draft**. Publish it to make it
+visible to viewers with [`POST /workbooks/{workbookId}/publish`][ref-publish],
+using the workbook id returned in step&nbsp;3. Publishing is itself idempotent per
+workbook, so it is safe to run on every apply.
 
-Dashboards as code is deployed like the rest of your project:
+## Idempotency and conflicts
 
-1. Add the dashboard and chart files under `dashboards/` in your repository.
-2. Open a pull request and review the change like any other code change.
-3. Merge and deploy — with [Git-based deployment][ref-continuous-deployment], the
-   production branch builds automatically; with CLI deployment, run your usual
-   deploy command.
+Re-applying an unchanged definition is a no-op — that is the property that makes
+these endpoints safe to run on every pipeline execution. When something does go
+wrong, both upserts fail with a `409` rather than guessing, and the report upsert
+distinguishes three cases by a `code` field in the response body so your pipeline
+can react correctly:
 
-After the build, the dashboards appear in the workspace, read-only. To change a
-dashboard, edit its file and deploy again.
+| Endpoint | `code` | Meaning | What to do |
+| --- | --- | --- | --- |
+| workbook & report | `upsert_branch_changed` | A concurrent writer created or deleted the asset between the access check and the write, so the request would have applied under the wrong permission check. | **Retry.** Transient; happens only under concurrent applies of the same key. |
+| report | _(none)_ | The `publicId` already belongs to a report in a **different** deployment. `publicId` is unique across the account. | **Permanent.** Use a different `publicId`. |
+| report | `ambiguous_legacy_id` | The id matches more than one legacy report (see below), so it can't identify one. | **Permanent.** Give the intended report a `publicId` of your own (see below), then key on that. |
 
-## Validation and rules
+The upserts serialize per key (per slug, per `publicId`), so two pipeline runs
+applying the same bundle at once can't create a duplicate — the loser gets a
+retryable `upsert_branch_changed` instead.
 
-Cube validates the source tree at build time. A problem fails the load with a
-message naming the file, so you catch it in your build rather than at runtime:
+## Choosing and adopting `publicId`s
 
-- **`apiVersion` is required and must match.** Files without a recognized
-  `apiVersion` are ignored; a recognized one with an invalid body fails
-  validation.
-- **Slugs are unique.** Two dashboards with the same `slug` are rejected.
-- **Chart `publicId`s are unique.** Two chart files with the same `publicId` are
-  rejected.
-- **YAML must parse.** A malformed file fails with a parse error naming the file.
-- **Unknown fields are preserved.** Fields beyond the documented ones round-trip
-  untouched, so a newer authoring field is never dropped by the runtime.
+A report's `publicId` is **write-once**: you can assign one to a report that
+doesn't have one yet, but a report's existing `publicId` can never be changed,
+because clients may already have stored it. You can supply a `publicId`:
 
-## Relationship to builder-authored dashboards
+- **On create** — pass it in the body to [`POST /reports`][ref-create-report], or
+  just call the [upsert endpoint][ref-upsert-report] with the id in the path.
+- **On an existing report** — assign one with
+  [`PUT /reports/{reportId}`][ref-update-report]. This is how you bring a report
+  that was authored in the UI under as-code management.
 
-Source-owned dashboards and dashboards created in the [builder][ref-dashboards]
-are independent. When dashboards as code is enabled, the workspace shows the
-source-owned dashboards and treats them as read-only — the repository owns them.
-Manage those dashboards through your Git workflow; use the builder for
-dashboards you want business users to create and edit interactively.
+Pick any distinct 12-character `[0-9A-Za-z]` id. The auto-generated placeholder
+ids shown for reports that don't have a stable id yet are a reserved, non-unique
+shape and are rejected with `400` — you must choose your own.
+
+### Reports created before stable ids
+
+Reports created before `publicId` existed don't store one; the API **synthesizes**
+one from the report's internal id so every report has an id on the wire. These
+synthesized ids are **not unique** — several reports can share one. The upsert
+endpoint resolves a synthesized id only when it is unambiguous, adopting it as the
+report's real `publicId` at that point; if it matches more than one report it
+returns the `ambiguous_legacy_id` conflict above. For anything you manage as code,
+don't rely on a synthesized id — assign a `publicId` you chose and key on that.
+
+## Reference
+
+- [Create or update a workbook by slug][ref-upsert-workbook]
+- [Create or update a report by publicId][ref-upsert-report]
+- [Create a report][ref-create-report] · [Update a report][ref-update-report]
+- [Publish dashboard][ref-publish]
+- [Building dashboards in the UI][ref-dashboards]
 
 [ref-dashboards]: /docs/explore-analyze/dashboards
 [ref-workbooks]: /docs/explore-analyze/workbooks
-[ref-widgets]: /docs/explore-analyze/dashboards/widgets
-[ref-charts]: /docs/explore-analyze/dashboards/widgets/charts
-[ref-dashboard-slug]: /docs/explore-analyze/dashboards#dashboard-slug
-[ref-continuous-deployment]: /admin/deployment/continuous-deployment
-[ref-sql-api]: /reference/core-data-apis/sql-api
+[ref-reports]: /docs/explore-analyze/workbooks/querying-data
+[ref-api]: /api-reference/introduction
+[ref-auth]: /api-reference/authentication
+[ref-upsert-workbook]: /api-reference/workbooks/create-or-update-a-workbook-by-slug
+[ref-upsert-report]: /api-reference/reports/create-or-update-a-report-by-publicid
+[ref-create-report]: /api-reference/reports/create-a-report
+[ref-update-report]: /api-reference/reports/update-a-report
+[ref-get-report]: /api-reference/reports/get-report
+[ref-get-workbook]: /api-reference/workbooks/get-workbook
+[ref-publish]: /api-reference/workbooks/publish-dashboard

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -18,6 +18,9 @@ Dashboards enable you to:
 
 In the dashboard builder inside your [workbook][ref-workbooks], select the reports you want to include and arrange them on the canvas alongside other [widgets][ref-widgets] to tell your data story, then publish the dashboard. This gives stakeholders direct access to the insights that matter most, without the complexity of the underlying analysis.
 
+Prefer to manage dashboards in Git instead? You can also define them as versioned
+YAML in your Cube project — see [Dashboards as code](/docs/explore-analyze/dashboards/dashboards-as-code).
+
 ## Data freshness
 
 Each widget shows a [freshness](/docs/explore-analyze/workbooks/querying-data#result-freshness-and-provenance) leaf indicating how recently its data was refreshed. The dashboard's own leaf reflects its least-recently-refreshed widget, so you can see at a glance whether everything on the dashboard is up to date.

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -18,8 +18,9 @@ Dashboards enable you to:
 
 In the dashboard builder inside your [workbook][ref-workbooks], select the reports you want to include and arrange them on the canvas alongside other [widgets][ref-widgets] to tell your data story, then publish the dashboard. This gives stakeholders direct access to the insights that matter most, without the complexity of the underlying analysis.
 
-Prefer to manage dashboards in Git instead? You can also define them as versioned
-YAML in your Cube project — see [Dashboards as code](/docs/explore-analyze/dashboards/dashboards-as-code).
+Prefer to manage dashboards from source control? You can also apply dashboards,
+workbooks, and reports to a deployment through the REST API and keep their
+definitions in Git — see [Dashboards as code](/docs/explore-analyze/dashboards/dashboards-as-code).
 
 ## Data freshness
 


### PR DESCRIPTION
## Dashboards as code guide (CUB-3521)

Documents the **idempotent REST upsert API** for managing workbooks, dashboards, and reports as code — Phase 1 of programmatic dashboards, shipped in cubedevinc/cubejs-enterprise#13361.

New page: `docs-mintlify/docs/explore-analyze/dashboards/dashboards-as-code.mdx`, in the Dashboards nav group, with a discovery cross-link from the dashboards index.

### What the merged API is

Two public REST endpoints, keyed by a portable identifier you choose (so a CI/CD pipeline can re-apply the same definitions across deployments without tracking per-environment numeric ids):

- `PUT /deployments/{deploymentId}/workbooks/by-slug/{slug}` — upsert a workbook (and its dashboard draft in `meta.dashboardDraft`, merged into existing metadata)
- `PUT /deployments/{deploymentId}/reports/by-public-id/{publicId}` — upsert a report keyed by its account-unique, write-once `publicId`

Supporting changes in the same PR: `POST /reports` accepts a client-supplied `publicId`; `PUT /reports/{reportId}` accepts a write-once `publicId` (so a UI-authored report can be adopted into as-code management).

### Covers

- How the pieces fit — report (`publicId`) / workbook (`slug`) / dashboard (`meta.dashboardDraft`, made visible by publishing)
- The apply flow: author in the UI → export via `GET` → upsert each report → upsert the workbook → publish
- Idempotency and the three `409` conflict cases distinguished by `code` (`upsert_branch_changed` = retry; cross-deployment = permanent; `ambiguous_legacy_id` = permanent)
- `publicId` rules: 12-char `[0-9A-Za-z]`, write-once, client-suppliable; reserved placeholder shape rejected with `400`
- Legacy reports with synthesized ids and how to adopt a real `publicId`
- Cross-links to the auto-generated endpoint reference pages under `/api-reference/{reports,workbooks}/…`

### What changed from the first draft

The original draft documented a **runtime-owned YAML-in-project** model (dashboards as `cube.dev/dashboard/v1` YAML in a `dashboards/` directory, read at build time, rendered read-only behind `useRuntimeDashboards`). That feature did not ship in #13361 — it's a different, unmerged design. This revision replaces that page wholesale with documentation of the REST upsert API that actually merged, and drops the "preview / do not merge" gating since these endpoints are shipped public API.

### Accuracy

Every fact checked against the merged source and the public OpenAPI spec (`open-api-spec-public-v3.1.yaml`) — endpoint paths, request bodies (`CreateReportInput` / `CreateWorkbookInput`), the `409` `code` values, `publicId` validation, and that dashboard-draft widgets reference reports by per-deployment numeric id (hence the export-then-rewrite step). The endpoint reference pages already exist in `api-reference/api.yaml` on master; all internal links resolve.

Linear: CUB-3521
