### PR TITLE
fix(schema-compiler): quote scaffolded YAML values that would not round-trip

### DIFF
--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -8,13 +8,15 @@ import { BaseSchemaFormatter } from './BaseSchemaFormatter';
 /**
  * Plain scalars that a YAML loader resolves to something other than a string — null, a
  * boolean, a number or a timestamp — so a title or member name of this shape has to be
- * quoted to stay a string. Includes the YAML 1.1 integer forms loaders still accept
- * (binary, octal), since resolution is what matters here, not which spec version
- * nominally applies. `yes`/`on`/`off` are strings and stay unquoted.
+ * quoted to stay a string. Covers the YAML 1.1 binary and octal integers loaders still
+ * accept, since resolution is what matters here, not which spec version nominally
+ * applies; sexagesimal (`1:30`) is left out because js-yaml 4 — the loader
+ * `YamlCompiler` uses — dropped it. `yes`/`on`/`off` are strings and stay unquoted.
  */
 const YAML_TYPE_SHAPED = new RegExp(
   [
     '^(?:',
+    // The empty alternative is deliberate: a bare empty scalar loads as null.
     '|~|null|Null|NULL|true|True|TRUE|false|False|FALSE',
     // Decimal, with an optional fraction and exponent.
     '|[-+]?(?:\\d[\\d_]*(?:\\.[\\d_]*)?|\\.[\\d_]+)(?:[eE][-+]?\\d+)?',
@@ -47,7 +49,13 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
   protected renderFile(fileDescriptor: Record<string, unknown>): string {
     const { cube, sql, preAggregations: _, ...descriptor } = fileDescriptor;
 
-    return `cubes:\n  - name: ${cube}${this.render(
+    // The cube name is interpolated rather than rendered, so it needs the predicate
+    // applied by hand — it comes from the table name the same way a member name comes
+    // from a column, and a cube that names itself `2024` (a number) is not the cube
+    // another file's join refers to as `"2024"` (a string).
+    return `cubes:\n  - name: ${this.escapedValue(
+      cube as string
+    )}${this.render(
       {
         ...(sql ? { sql } : null),
         ...descriptor,
@@ -67,7 +75,10 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       .reduce((memo) => `${memo} `, '');
 
     if (value instanceof MemberReference) {
-      return value.member;
+      // Quote on the same rule as the member name this points at, or the two stop
+      // denoting the same member — see the drill-member cases in
+      // `scaffolding-template.test.ts`.
+      return this.escapedValue(value.member, flow);
     } else if (value instanceof ValueWithComments) {
       const comments = `\n${value.comments
         .map((comment) => `${indent}# ${comment}`)
@@ -151,9 +162,13 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       return value;
     }
 
-    return this.needsQuotes(value, flow)
-      ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
-      : value;
+    // YAML's double-quoted style is a superset of JSON's string escaping, so
+    // `JSON.stringify` is exactly the escaper this needs — including the quotes. Quoting
+    // alone would not be enough: a raw line break inside the quotes is folded to a space
+    // (so the value does not come back as the string that went in) and the other C0
+    // controls make js-yaml reject the file outright. Escaping is what keeps a value one
+    // line and one string.
+    return this.needsQuotes(value, flow) ? JSON.stringify(value) : value;
   }
 
   /**
@@ -163,8 +178,10 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
    * a column named `revenue: usd` must not be allowed to turn the generated file into
    * something YAML parses differently, or fails to parse at all.
    *
-   * Each test below is a case that demonstrably does not round-trip; anything else stays
-   * unquoted, so ordinary member names and SQL expressions are unaffected.
+   * Each test below is a case that does not round-trip, except the first-position set,
+   * which over-quotes on purpose: `-abc` and `?abc` are legal plain scalars in YAML 1.2,
+   * but quoting is the safe direction and the rule stays one character wide. Anything
+   * else stays unquoted, so ordinary member names and SQL expressions are unaffected.
    */
   private needsQuotes(value: string, flow: boolean): boolean {
     return (
@@ -177,9 +194,13 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       // A `#` after whitespace starts a comment and truncates the rest of the line.
       // A bare `a#b` is a legal plain scalar, so it stays unquoted.
       /\s#/.test(value) ||
-      // Surrounding whitespace is stripped from a plain scalar, and a tab or newline
-      // cannot appear in one at all.
-      /^\s|\s$|[\n\t]/.test(value) ||
+      // Surrounding whitespace is stripped from a plain scalar. A control character has
+      // to be escaped rather than merely quoted: a line break — a lone CR is one — would
+      // otherwise fold to a space, and the C0/C1 controls and an unpaired surrogate are
+      // rejected outright by the loader as non-printable. The surrogate range also
+      // matches a well-formed astral pair, which only costs that value a pair of quotes.
+      // eslint-disable-next-line no-control-regex
+      /^\s|\s$|[\x00-\x1f\x7f-\x9f]|[\uD800-\uDFFF]/.test(value) ||
       // A plain scalar matching a YAML type resolves to that type, not to a string.
       YAML_TYPE_SHAPED.test(value) ||
       // `{` opens a flow mapping, and a `"` would be read as a quoted scalar.

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -5,6 +5,29 @@ import {
 } from '../ScaffoldingTemplate';
 import { BaseSchemaFormatter } from './BaseSchemaFormatter';
 
+/**
+ * Plain scalars that a YAML loader resolves to something other than a string — null, a
+ * boolean, a number or a timestamp — so a title or member name of this shape has to be
+ * quoted to stay a string. Includes the YAML 1.1 integer forms loaders still accept
+ * (binary, octal), since resolution is what matters here, not which spec version
+ * nominally applies. `yes`/`on`/`off` are strings and stay unquoted.
+ */
+const YAML_TYPE_SHAPED = new RegExp(
+  [
+    '^(?:',
+    '|~|null|Null|NULL|true|True|TRUE|false|False|FALSE',
+    // Decimal, with an optional fraction and exponent.
+    '|[-+]?(?:\\d[\\d_]*(?:\\.[\\d_]*)?|\\.[\\d_]+)(?:[eE][-+]?\\d+)?',
+    // Hex, octal (both spellings) and binary.
+    '|[-+]?0[xX][0-9a-fA-F_]+|[-+]?0o?[0-7_]+|[-+]?0[bB][01_]+',
+    // Infinity and not-a-number.
+    '|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN)',
+    // A date or date-time resolves to a Date, not to a string.
+    '|\\d{4}-\\d{1,2}-\\d{1,2}(?:[Tt\\s].*)?',
+    ')$',
+  ].join('')
+);
+
 function isPlainObject(value) {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -128,10 +151,41 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       return value;
     }
 
-    // `,` and `]` end an item inside a flow sequence, so a value carrying either
-    // has to be quoted there even though it is harmless in a block scalar.
-    const needsQuotes = flow ? /[{}",[\]]/ : /[{}"]/;
+    return this.needsQuotes(value, flow)
+      ? `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+      : value;
+  }
 
-    return value.match(needsQuotes) ? `"${value.replace(/"/g, '\\"')}"` : value;
+  /**
+   * Whether a plain scalar has to be quoted to survive a YAML round-trip.
+   *
+   * Values reach here from the warehouse — `title` is the titleized column name — so
+   * a column named `revenue: usd` must not be allowed to turn the generated file into
+   * something YAML parses differently, or fails to parse at all.
+   *
+   * Each test below is a case that demonstrably does not round-trip; anything else stays
+   * unquoted, so ordinary member names and SQL expressions are unaffected.
+   */
+  private needsQuotes(value: string, flow: boolean): boolean {
+    return (
+      // An indicator character only has meaning in the first position: it would start a
+      // sequence entry, an alias, a tag, a block scalar, a quoted string or a comment.
+      // `-` also covers the bare `-`, which is an empty sequence entry.
+      /^[-?:,[\]{}#&*!|>'"%@`]/.test(value) ||
+      // `key: value` inside a scalar makes it a mapping; a trailing colon does the same.
+      /:(?:\s|$)/.test(value) ||
+      // A `#` after whitespace starts a comment and truncates the rest of the line.
+      // A bare `a#b` is a legal plain scalar, so it stays unquoted.
+      /\s#/.test(value) ||
+      // Surrounding whitespace is stripped from a plain scalar, and a tab or newline
+      // cannot appear in one at all.
+      /^\s|\s$|[\n\t]/.test(value) ||
+      // A plain scalar matching a YAML type resolves to that type, not to a string.
+      YAML_TYPE_SHAPED.test(value) ||
+      // `{` opens a flow mapping, and a `"` would be read as a quoted scalar.
+      /[{}"]/.test(value) ||
+      // Inside a flow sequence these end the item; in a block scalar they are literal.
+      (flow && /[,[\]]/.test(value))
+    );
   }
 }

--- a/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
+++ b/packages/cubejs-schema-compiler/src/scaffolding/formatters/YamlSchemaFormatter.ts
@@ -194,13 +194,19 @@ export class YamlSchemaFormatter extends BaseSchemaFormatter {
       // A `#` after whitespace starts a comment and truncates the rest of the line.
       // A bare `a#b` is a legal plain scalar, so it stays unquoted.
       /\s#/.test(value) ||
-      // Surrounding whitespace is stripped from a plain scalar. A control character has
-      // to be escaped rather than merely quoted: a line break — a lone CR is one — would
-      // otherwise fold to a space, and the C0/C1 controls and an unpaired surrogate are
-      // rejected outright by the loader as non-printable. The surrogate range also
-      // matches a well-formed astral pair, which only costs that value a pair of quotes.
+      // Surrounding whitespace is stripped from a plain scalar, and the loader rejects
+      // the whole stream — not just the one value — over a non-printable character.
+      //
+      // The two halves of the fix do different work here, so neither collapses into the
+      // other. Below `\x20`, `JSON.stringify` escapes, which is what a line break needs:
+      // quoting alone would leave a real break that YAML folds back to a space. From
+      // `\x7f` up it does not escape, so those survive on the *quoting* — js-yaml admits
+      // them inside a double-quoted scalar but not in a plain one. Hence the wide class:
+      // C0, C1, the U+FFFE/U+FFFF noncharacters and unpaired surrogates all reach here.
+      // The surrogate range also matches a well-formed astral pair, which only costs
+      // that value a pair of quotes.
       // eslint-disable-next-line no-control-regex
-      /^\s|\s$|[\x00-\x1f\x7f-\x9f]|[\uD800-\uDFFF]/.test(value) ||
+      /^\s|\s$|[\x00-\x1f\x7f-\x9f\ufffe\uffff]|[\uD800-\uDFFF]/.test(value) ||
       // A plain scalar matching a YAML type resolves to that type, not to a string.
       YAML_TYPE_SHAPED.test(value) ||
       // `{` opens a flow mapping, and a `"` would be read as a quoted scalar.

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -1,3 +1,4 @@
+import YAML from 'js-yaml';
 import {
   ScaffoldingTemplate,
   SchemaFormat,
@@ -557,6 +558,95 @@ describe('ScaffoldingTemplate', () => {
       expect(render(['a]'])).toContain('tags: ["a]"]');
       // Nothing structural: still unquoted.
       expect(render(['plain', 'ok'])).toContain('tags: [plain, ok]');
+    });
+
+    describe('quoting values that are structural in YAML', () => {
+      // Titles come from the warehouse — `title` is the titleized column name — so a
+      // column name decides whether the generated file parses. Assertions read the
+      // PARSED document rather than the rendered text: the defect is that the output
+      // parses as something other than the string that went in, which a text
+      // assertion cannot see.
+      const renderColumn = (columnName: string) => new ScaffoldingTemplate(
+        {
+          public: {
+            orders: [
+              { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              { name: columnName, type: 'character varying', attributes: [] },
+            ],
+          },
+        },
+        driver,
+        { format: SchemaFormat.Yaml, snakeCase: true }
+      ).generateFilesByTableNames(['public.orders'])[0].content;
+
+      // The non-`id` dimension, read back from the parsed document.
+      const dimensionOf = (columnName: string) => {
+        const parsed: any = YAML.load(renderColumn(columnName));
+
+        return parsed.cubes[0].dimensions.find((d: any) => d.name !== 'id');
+      };
+
+      it.each([
+        // A colon-space makes the scalar a mapping; in a block context it fails to parse.
+        ['revenue: usd', 'Revenue: Usd'],
+        // A space-hash starts a comment and truncates the rest of the line.
+        ['price # net', 'Price # Net'],
+        // An indicator character only bites in first position.
+        ['*starred', '*starred'],
+        ['- leading dash', '- Leading Dash'],
+        // Everything structural at once.
+        ['weird: name # with [everything]', 'Weird: Name # with [everything]'],
+      ])(
+        'keeps the title a string for a column named %p',
+        (columnName, title) => {
+          expect(dimensionOf(columnName).title).toBe(title);
+        }
+      );
+
+      it.each([
+        // A type-shaped member name resolves to null or a number rather than to a
+        // string, leaving the cube with a dimension that has no usable name.
+        ['null'],
+        ['0x1f'],
+        ['123'],
+        ['0b101'],
+      ])('keeps the member name a string for a column named %p', (columnName) => {
+        expect(dimensionOf(columnName).name).toBe(columnName);
+      });
+
+      it('keeps a date-shaped title a string rather than a Date', () => {
+        // The member name loses the dashes to snake_case, but the title keeps them and
+        // would otherwise resolve to a Date.
+        expect(dimensionOf('2026-08-06').title).toBe('2026-08-06');
+      });
+
+      it.each([
+        // Only a `#` after whitespace starts a comment, and a colon binds as a mapping
+        // only before whitespace or end-of-scalar, so these need no quotes. Quoting
+        // them would be noise.
+        ['order#status', 'Order#status'],
+        ['a:b', 'A:b'],
+      ])('leaves %p unquoted, needing no escape', (columnName, title) => {
+        expect(renderColumn(columnName)).toContain(`title: ${title}`);
+      });
+
+      it('leaves a name YAML 1.2 reads as a string unquoted', () => {
+        // `yes`/`on`/`off` are booleans only under YAML 1.1.
+        expect(renderColumn('yes')).toContain('name: yes');
+      });
+
+      it('emits a file that parses whatever the column name is', () => {
+        for (const columnName of [
+          'revenue: usd',
+          'price # net',
+          'null',
+          '*starred',
+          'c:\\path',
+          'weird: name # with [everything]',
+        ]) {
+          expect(() => YAML.load(renderColumn(columnName))).not.toThrow();
+        }
+      });
     });
 
     it('uses the camelCase key and member names when snakeCase is off', () => {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -631,8 +631,85 @@ describe('ScaffoldingTemplate', () => {
       });
 
       it('leaves a name YAML 1.2 reads as a string unquoted', () => {
-        // `yes`/`on`/`off` are booleans only under YAML 1.1.
+        // `yes`/`on`/`off` are booleans only under YAML 1.1. Assert the parse too: the
+        // rendered text reads the same under a 1.1 loader that returns `true`.
         expect(renderColumn('yes')).toContain('name: yes');
+        expect(dimensionOf('yes').name).toBe('yes');
+      });
+
+      it.each([
+        // `memberName()` strips the structural characters but not the type-shaped ones,
+        // so a drill reference renders through the same predicate as the name it points
+        // at — otherwise `name: "2024"` is a string and `drill_members: [2024]` a number,
+        // and the drill dead-ends at click time.
+        ['2024'],
+        ['null'],
+        ['true'],
+        ['0x1f'],
+        ['1e5'],
+        // The underscores a snake_cased date leaves behind are digit separators in YAML.
+        ['2026-08-06'],
+      ])('keeps every drill member denoting a dimension for a column named %p', (columnName) => {
+        const parsed: any = YAML.load(renderColumn(columnName));
+        const [cube] = parsed.cubes;
+        const names = cube.dimensions.map((d: any) => d.name);
+
+        // Order differs — dimensions sort the primary key first — so compare as sets.
+        // Tag each with its type: a bare `2024` and a quoted `"2024"` are the same
+        // string once sorted, and telling them apart is the whole point here.
+        const typed = (list: any[]) => list
+          .map((v) => `${typeof v}:${String(v)}`)
+          .sort();
+
+        expect(typed(cube.measures[0].drill_members)).toEqual(typed(names));
+      });
+
+      it.each([
+        // A double-quoted scalar may span lines, but YAML folds the break to a space and
+        // an unindented continuation fails the document — so the break has to be escaped,
+        // not merely quoted. A lone CR is a line break to YAML too, and the remaining C0
+        // controls make the loader reject the file outright.
+        ['line1\nline2', 'Line1\nline2'],
+        ['a\rb', 'A\rb'],
+        ['tab\there', 'Tab\there'],
+        ['bell\x07here', 'Bell\x07here'],
+        ['esc\x1bhere', 'Esc\x1bhere'],
+      ])('round-trips a control character in a column named %p', (columnName, title) => {
+        expect(dimensionOf(columnName).title).toBe(title);
+      });
+
+      it.each([
+        // A C1 control or an unpaired surrogate is non-printable to the loader, which
+        // rejects the whole stream rather than the one value.
+        ['\x80'],
+        ['\x9f'],
+        ['\ud800'],
+        ['\udc00'],
+      ])('emits a file that parses around the non-printable %j', (char) => {
+        expect(() => YAML.load(renderColumn(`pri${char}ce`))).not.toThrow();
+      });
+
+      it.each([
+        // A cube name comes from the table name the way a member name comes from a
+        // column, and it is interpolated rather than rendered — so it needs the same
+        // predicate, or a join naming `"2024"` misses the cube calling itself `2024`.
+        ['2024'],
+        ['null'],
+        ['true'],
+      ])('keeps the cube name a string for a table named %p', (tableName) => {
+        const [{ content }] = new ScaffoldingTemplate(
+          {
+            public: {
+              [tableName]: [
+                { name: 'id', type: 'integer', attributes: ['primaryKey'] },
+              ],
+            },
+          },
+          driver,
+          { format: SchemaFormat.Yaml, snakeCase: true }
+        ).generateFilesByTableNames([`public.${tableName}`]);
+
+        expect((YAML.load(content) as any).cubes[0].name).toBe(tableName);
       });
 
       it('emits a file that parses whatever the column name is', () => {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-template.test.ts
@@ -685,6 +685,8 @@ describe('ScaffoldingTemplate', () => {
         ['\x9f'],
         ['\ud800'],
         ['\udc00'],
+        ['\ufffe'],
+        ['\uffff'],
       ])('emits a file that parses around the non-printable %j', (char) => {
         expect(() => YAML.load(renderColumn(`pri${char}ce`))).not.toThrow();
       });


### PR DESCRIPTION
## Summary

- `escapedValue` decided quoting from `/[{}"]/` (plus `,[]` inside a flow sequence), which leaves several characters that change how YAML parses a scalar emitted bare. This is reachable from ordinary warehouse data, not just from a cast: a dimension's `title` is `inflection.titleize(column.name)`, so a column named `revenue: usd` renders `title: Revenue: Usd` and **the generated model file fails to parse at all**, while `price # net` silently truncates the title to `Price`.
- Replaces the character blocklist with a `needsQuotes` predicate covering the cases that demonstrably do not round-trip: a leading indicator character, `: ` or a trailing colon, ` #`, surrounding whitespace, a tab or newline, and a scalar YAML would resolve to null / a boolean / a number / a `Date` rather than a string. The existing `{}"` rule and the flow-sequence `,[]` rule are kept.
- Also escapes backslashes in the quoted form. `C:\path` used to be emitted as `"C:\path"`, which is an invalid escape and a parse error; `tab\there` became a real tab.
- Deliberately narrow in the other direction — `a#b`, `a:b`, `COUNT(*)`, `users.id`, `Order Status` and `yes` stay unquoted, so ordinary member names, titles and SQL expressions are untouched. All 18 existing snapshots are unchanged.

Stacked on the `drill_members` branch, which introduced the flow-context flag this extends; it targets that branch rather than `master`.

## Test plan

- [x] 11 new unit tests in `scaffolding-template.test.ts`, asserting the **parsed** document rather than the rendered text — the defect is that the output parses as something other than the string that went in, which a text assertion cannot see
- [x] Each new test verified red against the previous rule and green with the fix
- [x] Round-trip probe over 44 hostile values across all three emitted contexts (block scalar, flow sequence, block sequence)
- [x] Existing scaffolding snapshots unchanged (18/18), full file suite 42/42
- [x] `tsc --noEmit` and `eslint` clean on both changed files
- [ ] CI must pass
