### PR TITLE
fix(cubesql): preserve literal ORDER BY aliases

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -1759,11 +1759,44 @@ impl WrappedSelectNode {
         )
         .await?;
 
+        // Sort pushdown can replace a grouped literal's alias with the literal expression.
+        // Integer literals in ORDER BY are interpreted as select-list positions by some SQL
+        // dialects, so restore the generated alias when the literal is selected in this query.
+        let order_expr = self
+            .order_expr
+            .iter()
+            .map(|order_expr| match order_expr {
+                Expr::Sort {
+                    expr,
+                    asc,
+                    nulls_first,
+                } => {
+                    let literal_alias = flat_group_expr.iter().zip(group_by.iter()).find_map(
+                        |(selected_expr, (aliased_column, _))| {
+                            (matches!(selected_expr, Expr::Literal(_))
+                                && selected_expr == expr.as_ref())
+                            .then(|| aliased_column.alias.clone())
+                        },
+                    );
+
+                    match literal_alias {
+                        Some(alias) => Expr::Sort {
+                            expr: Box::new(Expr::Column(Column::from_name(alias))),
+                            asc: *asc,
+                            nulls_first: *nulls_first,
+                        },
+                        None => order_expr.clone(),
+                    }
+                }
+                _ => order_expr.clone(),
+            })
+            .collect::<Vec<_>>();
+
         // Sort expressions can reference window expressions computed in this same select
         // by their full DataFusion name. Those columns don't exist in the source SQL, so
         // rewrite them to the generated window aliases, which ORDER BY can reference by name.
         let order_expr = if window.is_empty() {
-            self.order_expr.clone()
+            order_expr
         } else {
             let window_columns = self
                 .window_expr
@@ -1777,9 +1810,9 @@ impl WrappedSelectNode {
                 })
                 .collect::<result::Result<HashMap<_, _>, CubeError>>()?;
             let window_columns_ref = window_columns.iter().collect();
-            self.order_expr
-                .iter()
-                .map(|e| replace_col(e.clone(), &window_columns_ref))
+            order_expr
+                .into_iter()
+                .map(|e| replace_col(e, &window_columns_ref))
                 .collect::<Result<Vec<_>>>()?
         };
 

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2048,8 +2048,8 @@ impl WrappedSelectNode {
             }
             expr
         }
-        // Push-to-Cube builds its order separately from self.order_expr. Generated SQL
-        // aliases are not scan members and cannot be resolved on that path.
+        // Push-to-Cube discards this `order` and builds its own from `self.order_expr`, so
+        // there is nothing to fix there, and a generated alias is not a scan member.
         let literal_aliases = if push_to_cube_context.is_some() {
             vec![]
         } else {

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2048,16 +2048,21 @@ impl WrappedSelectNode {
             }
             expr
         }
-        let literal_aliases = self
-            .projection_expr
-            .iter()
-            .zip(projection.iter())
-            .chain(flat_group_expr.iter().zip(group_by.iter()))
-            .filter_map(|(selected_expr, (aliased_column, _))| {
-                let expr = unalias(selected_expr);
-                matches!(expr, Expr::Literal(_)).then(|| (expr, &aliased_column.alias))
-            })
-            .collect::<Vec<_>>();
+        // Push-to-Cube builds its order separately from self.order_expr. Generated SQL
+        // aliases are not scan members and cannot be resolved on that path.
+        let literal_aliases = if push_to_cube_context.is_some() {
+            vec![]
+        } else {
+            self.projection_expr
+                .iter()
+                .zip(projection.iter())
+                .chain(flat_group_expr.iter().zip(group_by.iter()))
+                .filter_map(|(selected_expr, (aliased_column, _))| {
+                    let expr = unalias(selected_expr);
+                    matches!(expr, Expr::Literal(_)).then(|| (expr, &aliased_column.alias))
+                })
+                .collect::<Vec<_>>()
+        };
         let order_expr = if literal_aliases.is_empty() {
             self.order_expr.clone()
         } else {

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2039,38 +2039,53 @@ impl WrappedSelectNode {
         )
         .await?;
 
-        // Sort pushdown can replace a grouped literal's alias with the literal expression.
+        // Sort pushdown can replace a select-list alias with the literal expression.
         // Integer literals in ORDER BY are interpreted as select-list positions by some SQL
         // dialects, so restore the generated alias when the literal is selected in this query.
-        let order_expr = self
-            .order_expr
+        fn unalias(mut expr: &Expr) -> &Expr {
+            while let Expr::Alias(inner, _) = expr {
+                expr = inner;
+            }
+            expr
+        }
+        let literal_aliases = self
+            .projection_expr
             .iter()
-            .map(|order_expr| match order_expr {
-                Expr::Sort {
-                    expr,
-                    asc,
-                    nulls_first,
-                } => {
-                    let literal_alias = flat_group_expr.iter().zip(group_by.iter()).find_map(
-                        |(selected_expr, (aliased_column, _))| {
-                            (matches!(selected_expr, Expr::Literal(_))
-                                && selected_expr == expr.as_ref())
-                            .then(|| aliased_column.alias.clone())
-                        },
-                    );
-
-                    match literal_alias {
-                        Some(alias) => Expr::Sort {
-                            expr: Box::new(Expr::Column(Column::from_name(alias))),
-                            asc: *asc,
-                            nulls_first: *nulls_first,
-                        },
-                        None => order_expr.clone(),
-                    }
-                }
-                _ => order_expr.clone(),
+            .zip(projection.iter())
+            .chain(flat_group_expr.iter().zip(group_by.iter()))
+            .filter_map(|(selected_expr, (aliased_column, _))| {
+                let expr = unalias(selected_expr);
+                matches!(expr, Expr::Literal(_)).then(|| (expr, &aliased_column.alias))
             })
             .collect::<Vec<_>>();
+        let order_expr = if literal_aliases.is_empty() {
+            self.order_expr.clone()
+        } else {
+            self.order_expr
+                .iter()
+                .map(|order_expr| {
+                    let Expr::Sort {
+                        expr,
+                        asc,
+                        nulls_first,
+                    } = order_expr
+                    else {
+                        return order_expr.clone();
+                    };
+                    let Some((_, alias)) = literal_aliases
+                        .iter()
+                        .find(|(literal, _)| *literal == unalias(expr))
+                    else {
+                        return order_expr.clone();
+                    };
+                    Expr::Sort {
+                        expr: Box::new(Expr::Column(Column::from_name(*alias))),
+                        asc: *asc,
+                        nulls_first: *nulls_first,
+                    }
+                })
+                .collect()
+        };
 
         // Sort expressions can reference window expressions computed in this same select
         // by their full DataFusion name. Those columns don't exist in the source SQL, so

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2039,11 +2039,44 @@ impl WrappedSelectNode {
         )
         .await?;
 
+        // Sort pushdown can replace a grouped literal's alias with the literal expression.
+        // Integer literals in ORDER BY are interpreted as select-list positions by some SQL
+        // dialects, so restore the generated alias when the literal is selected in this query.
+        let order_expr = self
+            .order_expr
+            .iter()
+            .map(|order_expr| match order_expr {
+                Expr::Sort {
+                    expr,
+                    asc,
+                    nulls_first,
+                } => {
+                    let literal_alias = flat_group_expr.iter().zip(group_by.iter()).find_map(
+                        |(selected_expr, (aliased_column, _))| {
+                            (matches!(selected_expr, Expr::Literal(_))
+                                && selected_expr == expr.as_ref())
+                            .then(|| aliased_column.alias.clone())
+                        },
+                    );
+
+                    match literal_alias {
+                        Some(alias) => Expr::Sort {
+                            expr: Box::new(Expr::Column(Column::from_name(alias))),
+                            asc: *asc,
+                            nulls_first: *nulls_first,
+                        },
+                        None => order_expr.clone(),
+                    }
+                }
+                _ => order_expr.clone(),
+            })
+            .collect::<Vec<_>>();
+
         // Sort expressions can reference window expressions computed in this same select
         // by their full DataFusion name. Those columns don't exist in the source SQL, so
         // rewrite them to the generated window aliases, which ORDER BY can reference by name.
         let order_expr = if window.is_empty() {
-            self.order_expr.clone()
+            order_expr
         } else {
             let window_columns = self
                 .window_expr
@@ -2057,9 +2090,9 @@ impl WrappedSelectNode {
                 })
                 .collect::<result::Result<HashMap<_, _>, CubeError>>()?;
             let window_columns_ref = window_columns.iter().collect();
-            self.order_expr
-                .iter()
-                .map(|e| replace_col(e.clone(), &window_columns_ref))
+            order_expr
+                .into_iter()
+                .map(|e| replace_col(e, &window_columns_ref))
                 .collect::<Result<Vec<_>>>()?
         };
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17577,6 +17577,78 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_sort_by_literal_aliases_sql_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            WITH with_rate AS (
+                SELECT
+                    customer_gender,
+                    notes,
+                    SUM(taxful_total_price) AS hourly_rate
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1, 2
+            )
+            SELECT
+                customer_gender,
+                19 AS hour_slot,
+                8 AS minute_slot,
+                SUM(hourly_rate) AS total_price
+            FROM with_rate
+            GROUP BY 1, 2, 3
+            ORDER BY hour_slot ASC, minute_slot DESC, customer_gender ASC
+            LIMIT 50000
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        let hour_slot_alias = &Regex::new(r#"19 "([^"]+)""#)
+            .unwrap()
+            .captures(&sql)
+            .unwrap_or_else(|| {
+                panic!(
+                    "literal expression with alias must be present in generated SQL: {}",
+                    sql
+                )
+            })[1];
+        let minute_slot_alias = &Regex::new(r#"8 "([^"]+)""#)
+            .unwrap()
+            .captures(&sql)
+            .unwrap_or_else(|| {
+                panic!(
+                    "literal expression with alias must be present in generated SQL: {}",
+                    sql
+                )
+            })[1];
+        let expected_order =
+            format!(r#"ORDER BY "{hour_slot_alias}" ASC, "{minute_slot_alias}" DESC"#);
+        assert!(
+            sql.contains(&expected_order),
+            "unexpected ORDER BY: {}",
+            sql
+        );
+        assert!(
+            sql.contains(r#", "with_rate"."customer_gender" ASC"#),
+            "ordinary sort expression must be preserved: {}",
+            sql
+        );
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
+
+    #[tokio::test]
     async fn test_date_filter_with_or_and() {
         init_testing_logger();
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17574,6 +17574,78 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_sort_by_literal_aliases_sql_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            WITH with_rate AS (
+                SELECT
+                    customer_gender,
+                    notes,
+                    SUM(taxful_total_price) AS hourly_rate
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1, 2
+            )
+            SELECT
+                customer_gender,
+                19 AS hour_slot,
+                8 AS minute_slot,
+                SUM(hourly_rate) AS total_price
+            FROM with_rate
+            GROUP BY 1, 2, 3
+            ORDER BY hour_slot ASC, minute_slot DESC, customer_gender ASC
+            LIMIT 50000
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        let hour_slot_alias = &Regex::new(r#"19 "([^"]+)""#)
+            .unwrap()
+            .captures(&sql)
+            .unwrap_or_else(|| {
+                panic!(
+                    "literal expression with alias must be present in generated SQL: {}",
+                    sql
+                )
+            })[1];
+        let minute_slot_alias = &Regex::new(r#"8 "([^"]+)""#)
+            .unwrap()
+            .captures(&sql)
+            .unwrap_or_else(|| {
+                panic!(
+                    "literal expression with alias must be present in generated SQL: {}",
+                    sql
+                )
+            })[1];
+        let expected_order =
+            format!(r#"ORDER BY "{hour_slot_alias}" ASC, "{minute_slot_alias}" DESC"#);
+        assert!(
+            sql.contains(&expected_order),
+            "unexpected ORDER BY: {}",
+            sql
+        );
+        assert!(
+            sql.contains(r#", "with_rate"."customer_gender" ASC"#),
+            "ordinary sort expression must be preserved: {}",
+            sql
+        );
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
+
+    #[tokio::test]
     async fn test_date_filter_with_or_and() {
         init_testing_logger();
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17687,6 +17687,40 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_sort_by_projected_literal_alias_push_to_cube() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            SELECT customer_gender, 19 AS hour_slot, taxful_total_price
+            FROM KibanaSampleDataEcommerce
+            ORDER BY hour_slot ASC
+            LIMIT 100
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let request = logical_plan.find_cube_scan_wrapped_sql().request;
+        assert_eq!(
+            request.order,
+            Some(vec![vec!["hour_slot".to_string(), "asc".to_string()]])
+        );
+        assert_eq!(request.limit, Some(100));
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
+
+    #[tokio::test]
     async fn test_date_filter_with_or_and() {
         init_testing_logger();
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17607,21 +17607,21 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
 
         let logical_plan = query_plan.as_logical_plan();
         let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-        let hour_slot_alias = &Regex::new(r#"19 "([^"]+)""#)
+        let hour_slot_alias = &Regex::new(r#"\b19 "([^"]+)""#)
             .unwrap()
             .captures(&sql)
             .unwrap_or_else(|| {
                 panic!(
-                    "literal expression with alias must be present in generated SQL: {}",
+                    "aliased literal 19 must be present in generated SQL: {}",
                     sql
                 )
             })[1];
-        let minute_slot_alias = &Regex::new(r#"8 "([^"]+)""#)
+        let minute_slot_alias = &Regex::new(r#"\b8 "([^"]+)""#)
             .unwrap()
             .captures(&sql)
             .unwrap_or_else(|| {
                 panic!(
-                    "literal expression with alias must be present in generated SQL: {}",
+                    "aliased literal 8 must be present in generated SQL: {}",
                     sql
                 )
             })[1];
@@ -17635,6 +17635,47 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
         assert!(
             sql.contains(r#", "with_rate"."customer_gender" ASC"#),
             "ordinary sort expression must be preserved: {}",
+            sql
+        );
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sort_by_projected_literal_alias_sql_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            WITH with_rate AS (
+                SELECT
+                    customer_gender,
+                    SUM(taxful_total_price) AS hourly_rate
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1
+            )
+            SELECT customer_gender, 19 AS hour_slot, hourly_rate
+            FROM with_rate
+            ORDER BY hour_slot ASC, customer_gender ASC
+            LIMIT 100
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        assert!(
+            sql.contains(r#"ORDER BY "hour_slot" ASC, "with_rate"."customer_gender" ASC"#),
+            "literal sort expression must reference the projected alias: {}",
             sql
         );
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

CubeSQL sort pushdown can replace an aliased integer literal with the literal itself. Databases that interpret integers in ORDER BY as positional ordinals can then reject the generated SQL when the ordinal exceeds the select-list width.

- Restore the generated select-list alias when an ORDER BY expression matches a projected or grouped literal, after stripping aliases from both expressions
- Preserve sort direction, null ordering, ordinary column sorts, and existing window-expression alias handling
- Cover grouped literals with two sort keys, a projected literal without an outer GROUP BY, and literal sorting through Cube load requests

**Risk Assessment**

Low. The rewrite applies only when generating SQL text, not when building Cube load requests. It is limited to ORDER BY expressions that exactly match literal expressions in the same select after stripping aliases; all other sort expressions retain their existing behavior.

**Validation**

- cargo test -p cubesql --lib: 778 passed, 6 ignored
- cargo clippy -p cubesql --lib --tests
- cargo fmt --all -- --check

---
**Update Sep 6:** Cover projected literals and alias-wrapped expressions, and collect literal candidates once per select. Add the projected-literal regression test and tighten the grouped test’s alias matching and failure messages.


---
**Update Sep 8:** Skip literal alias rewriting on the push-to-Cube path, where generated aliases cannot resolve against scan members. Add a regression test for a projected literal with `taxful_total_price` and `LIMIT 100`; it verifies the load request keeps `hour_slot ASC` and the limit. The test fails before the guard and passes afterward.
