### PR TITLE
docs: correct the small multiples grid maximum to 5 × 5

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -23,7 +23,7 @@ These options appear once a **Split by** dimension is chosen.
 
 | Option | What it does |
 |---|---|
-| **Grid** | Columns × rows, up to 5 × 4. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
+| **Grid** | Columns × rows, up to 5 × 5. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
 | **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
@@ -38,7 +38,7 @@ Switch to **Independent** when the question is about the *shape* of each series 
 
 ### How many panels are drawn
 
-The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 4, or twenty panels.
+The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 5, or twenty-five panels.
 
 When a dimension has more values than the grid has tiles, the chart draws the first ones in the current sort order. The underlying query is unaffected, so no data is lost — a bigger grid simply shows more of it.
 


### PR DESCRIPTION
The small multiples page says the grid goes up to 5 × 4 and that the largest grid is twenty panels. Both maxima are 5: `MAX_GRID_COLUMNS = 5` and `MAX_GRID_ROWS = 5`, and the control renders a fifth row segment.

Since the grid is also the panel cap (`columns × rows` tiles, no separate cap), the largest grid is 5 × 5 — twenty-five panels, not twenty.

Two spots corrected: the **Grid** row of the options table, and the "How many panels are drawn" section.
