### PR TITLE
feat(cubesql): Support `WIDTH_BUCKET` SQL pushdown

### DIFF
--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -254,6 +254,16 @@ of the PostgreSQL documentation.
 | `SIGN` | Sign of the argument (`-1`, `0`, or `+1`) | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 | `SQRT` | Square root | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 | `TRUNC` | Truncates to integer (towards zero) | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>✅ Inner (selections)</nobr><br/><nobr>❌ Inner (projections)</nobr> |
+| `WIDTH_BUCKET` | Assigns a value to a bucket in an equal-width histogram | ✅ Yes | ❌ No |
+
+<Note>
+
+`WIDTH_BUCKET` pushdown is only available on data sources whose SQL dialect
+supports it. It is not supported with Apache Pinot, BigQuery, CrateDB, Cube Store,
+Dremio, Druid, DuckDB, Firebolt, Hive, ksqlDB, Microsoft SQL Server, MySQL,
+QuestDB, or SQLite.
+
+</Note>
 
 ### Trigonometric functions
 

--- a/packages/cubejs-dremio-driver/driver/DremioQuery.js
+++ b/packages/cubejs-dremio-driver/driver/DremioQuery.js
@@ -167,6 +167,7 @@ class DremioQuery extends BaseQuery {
     templates.expressions.interval_single_date_part = 'CAST({{ num }} as INTERVAL {{ date_part }})';
     templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     delete templates.expressions.ilike;
+    delete templates.functions.WIDTH_BUCKET;
     templates.quotes.identifiers = '"';
     return templates;
   }

--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -68,6 +68,7 @@ export class DruidQuery extends BaseQuery {
     // Druid evaluates CURRENT_TIMESTAMP in the sqlTimeZone query context, which
     // defaults to UTC — assumes the connection does not override sqlTimeZone
     templates.functions.UTCTIMESTAMP = 'CURRENT_TIMESTAMP';
+    delete templates.functions.WIDTH_BUCKET;
 
     return templates;
   }

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -67,6 +67,7 @@ export class DuckDBQuery extends BaseQuery {
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
     templates.functions.STRING_AGG = 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}, COALESCE({{ args[1] }}, \'\'))';
+    delete templates.functions.WIDTH_BUCKET;
     templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     templates.expressions.ilike = '{{ expr }} {% if negated %}NOT {% endif %}ILIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     // DuckDB `/` performs float division even for integer operands (since v0.8);

--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -57,6 +57,7 @@ export class FireboltQuery extends BaseQuery {
     // value bare, which is invalid syntax
     templates.expressions.timestamp_literal = 'TIMESTAMPTZ \'{{ value }}\'';
     templates.tesseract.bool_param_cast = 'CAST({{ expr }} AS BOOLEAN)';
+    delete templates.functions.WIDTH_BUCKET;
     return templates;
   }
 

--- a/packages/cubejs-ksql-driver/src/KsqlQuery.ts
+++ b/packages/cubejs-ksql-driver/src/KsqlQuery.ts
@@ -78,6 +78,7 @@ export class KsqlQuery extends BaseQuery {
     // ksqlDB does not support positional GROUP BY — group by the full
     // expressions instead of column ordinals.
     templates.statements.group_by_exprs = '{{ group_by | map(attribute=\'expr\') | join(\', \') }}';
+    delete templates.functions.WIDTH_BUCKET;
     return templates;
   }
 

--- a/packages/cubejs-pinot-driver/src/PinotQuery.ts
+++ b/packages/cubejs-pinot-driver/src/PinotQuery.ts
@@ -216,6 +216,7 @@ export class PinotQuery extends BaseQuery {
     // epoch-millis representation produced by the timestamp_literal template
     templates.functions.UTCTIMESTAMP = 'NOW()';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
+    delete templates.functions.WIDTH_BUCKET;
     templates.statements.select = '{% if ctes %} WITH \n' +
       '{{ ctes | join(\',\n\') }}\n' +
       '{% endif %}' +

--- a/packages/cubejs-questdb-driver/src/QuestQuery.ts
+++ b/packages/cubejs-questdb-driver/src/QuestQuery.ts
@@ -309,6 +309,8 @@ export class QuestQuery extends BaseQuery {
       '{% elif offset is not none %}\nLIMIT {{ offset }}, 2147483647' +
       '{% elif limit is not none %}\nLIMIT {{ limit }}{% endif %}';
 
+    delete templates.functions.WIDTH_BUCKET;
+
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4565,6 +4565,7 @@ export class BaseQuery {
         DATE: 'DATE({{ args_concat }})',
 
         PERCENTILECONT: 'PERCENTILE_CONT({{ args_concat }})',
+        WIDTH_BUCKET: 'WIDTH_BUCKET({{ args_concat }})',
       },
       statements: {
         select: '{% if ctes %} WITH {% if recursive %}RECURSIVE {% endif %}\n' +

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -335,6 +335,7 @@ export class BigqueryQuery extends BaseQuery {
     templates.functions.UTCTIMESTAMP = 'CURRENT_TIMESTAMP()';
     delete templates.functions.TO_CHAR;
     delete templates.functions.PERCENTILECONT;
+    delete templates.functions.WIDTH_BUCKET;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
     templates.expressions.interval = 'INTERVAL {{ interval }}';
     // BigQuery `/` on INT64 operands returns FLOAT64; DIV() is integer division

--- a/packages/cubejs-schema-compiler/src/adapter/CrateQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/CrateQuery.ts
@@ -13,4 +13,10 @@ export class CrateQuery extends PostgresQuery {
   public countDistinctApprox(sql: string): string {
     return `hyperloglog_distinct(${sql})`;
   }
+
+  public sqlTemplates() {
+    const templates = super.sqlTemplates();
+    delete templates.functions.WIDTH_BUCKET;
+    return templates;
+  }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/CubeStoreQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/CubeStoreQuery.ts
@@ -363,6 +363,7 @@ export class CubeStoreQuery extends BaseQuery {
     // across partitioned tables is unsafe. Don't push those join types down to CubeStore.
     delete templates.join_types.full;
     delete templates.join_types.right;
+    delete templates.functions.WIDTH_BUCKET;
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/HiveQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/HiveQuery.ts
@@ -109,4 +109,10 @@ export class HiveQuery extends BaseQuery {
   public defaultRefreshKeyRenewalThreshold() {
     return 120;
   }
+
+  public sqlTemplates() {
+    const templates = super.sqlTemplates();
+    delete templates.functions.WIDTH_BUCKET;
+    return templates;
+  }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -275,6 +275,7 @@ export class MssqlQuery extends BaseQuery {
     delete templates.functions.STRING_AGG;
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
+    delete templates.functions.WIDTH_BUCKET;
     templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     delete templates.expressions.ilike;
     // MSSQL uses + for string concatenation instead of ||

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -189,6 +189,7 @@ export class MysqlQuery extends BaseQuery {
     templates.functions.UTCTIMESTAMP = 'UTC_TIMESTAMP()';
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
+    delete templates.functions.WIDTH_BUCKET;
     templates.quotes.identifiers = '`';
     templates.quotes.escape = '\\`';
     // NOTE: this template contains a comma; two order expressions are being generated

--- a/packages/cubejs-schema-compiler/src/adapter/SqliteQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SqliteQuery.ts
@@ -81,4 +81,10 @@ export class SqliteQuery extends BaseQuery {
     // eslint-disable-next-line quotes
     return `strftime('%s','now')`;
   }
+
+  public sqlTemplates() {
+    const templates = super.sqlTemplates();
+    delete templates.functions.WIDTH_BUCKET;
+    return templates;
+  }
 }

--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -5382,10 +5382,16 @@ pub fn register_fun_stubs(mut ctx: SessionContext) -> SessionContext {
         vol = Stable
     );
     register_fun_stub!(udf, "unistr", tsig = [Utf8], rettyp = Utf8);
+    // In Postgres the bucket count is int4, but integer literals are parsed as Int64 here,
+    // and Int64 is never coerced down to Int32. Accept both so that a plain literal count
+    // like "width_bucket(x, 0, 100, 10)" plans.
     register_fun_stub!(
         udf,
         "width_bucket",
-        tsig = [Float64, Float64, Float64, Int32],
+        tsigs = [
+            [Float64, Float64, Float64, Int32],
+            [Float64, Float64, Float64, Int64],
+        ],
         rettyp = Int32
     );
     // TODO: "width_bucket" also has a two-arg variant with anyarray args

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -15127,6 +15127,64 @@ ORDER BY "source"."str0" ASC
     }
 
     #[tokio::test]
+    async fn test_width_bucket_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        // The bucket count is an Int64 literal here, while Postgres types it as int4:
+        // the stub signature has to accept both, otherwise planning fails on coercion.
+        let query_plan = convert_select_to_query_plan(
+            "
+            SELECT WIDTH_BUCKET(k.taxful_total_price, -301, 2200, 36) AS b, COUNT(1)
+            FROM KibanaSampleDataEcommerce AS k
+            GROUP BY 1
+            "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+
+        let logical_plan = query_plan.as_logical_plan();
+        assert!(logical_plan
+            .find_cube_scan_wrapped_sql()
+            .wrapped_sql
+            .sql
+            .contains(
+                "WIDTH_BUCKET(${KibanaSampleDataEcommerce.taxful_total_price}, -301, 2200, 36)"
+            ));
+
+        // Same call with an Int32 bucket count, which matches the other arm of the
+        // stub signature. It has to render identically.
+        let query_plan = convert_select_to_query_plan(
+            "
+            SELECT WIDTH_BUCKET(k.taxful_total_price, -301, 2200, CAST(36 AS INT)) AS b, COUNT(1)
+            FROM KibanaSampleDataEcommerce AS k
+            GROUP BY 1
+            "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        assert!(query_plan
+            .as_logical_plan()
+            .find_cube_scan_wrapped_sql()
+            .wrapped_sql
+            .sql
+            .contains(
+                "WIDTH_BUCKET(${KibanaSampleDataEcommerce.taxful_total_price}, -301, 2200, 36)"
+            ));
+    }
+
+    #[tokio::test]
     async fn test_datetrunc_push_down() {
         if !Rewriter::sql_push_down_enabled() {
             return;

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -704,6 +704,7 @@ pub fn sql_generator(
                     ("functions/LOWER".to_string(), "LOWER({{ args_concat }})".to_string()),
                     ("functions/UPPER".to_string(), "UPPER({{ args_concat }})".to_string()),
                     ("functions/PERCENTILECONT".to_string(), "PERCENTILE_CONT({{ args_concat }})".to_string()),
+                    ("functions/WIDTH_BUCKET".to_string(), "WIDTH_BUCKET({{ args_concat }})".to_string()),
                     ("expressions/query_aliased".to_string(), "{{ query }} AS {{ quoted_alias }}".to_string()),
                     ("expressions/extract".to_string(), "EXTRACT({{ date_part }} FROM {{ expr }})".to_string()),
                     (


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

This PR adds `WIDTH_BUCKET` SQL push down support. Related test is included.
