### PR TITLE
fix(tesseract): Resolve join for hint-less member expressions on views

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/join_hints.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/join_hints.rs
@@ -1,9 +1,17 @@
 use crate::cube_bridge::join_hints::JoinHintItem;
 
-/// Ordered list of cube-join hints. Adjacent redundant entries are
-/// silently dropped on `push` / `extend` — a `Single` is skipped when
-/// it duplicates either the previous `Single` or the tail of the
-/// previous `Vector`.
+/// Ordered list of cube-join hints. `push` / `extend` drop an entry that
+/// is redundant against the one before it — an item repeating the previous
+/// one verbatim, or a `Single` duplicating either the previous `Single` or
+/// the tail of the previous `Vector`.
+///
+/// That is a local rule, not a normal form. `from_items` stores what it is
+/// given as-is, and nothing collapses a `Vector` that is a strict prefix of
+/// another (`[V[customers], V[customers, orders]]`) or a repeat that is not
+/// adjacent. So two hint lists that resolve to the same join tree can still
+/// differ — which matters, since `JoinHints` is a join tree cache key:
+/// equal hints hit the same entry, but unequal ones are not proof of
+/// different trees.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct JoinHints {
     items: Vec<JoinHintItem>,
@@ -19,13 +27,12 @@ impl JoinHints {
     }
 
     pub fn push(&mut self, item: JoinHintItem) {
-        if let JoinHintItem::Single(ref name) = item {
-            if let Some(last) = self.items.last() {
-                let redundant = match last {
-                    JoinHintItem::Single(s) => s == name,
-                    JoinHintItem::Vector(v) => v.last() == Some(name),
-                };
-                if redundant {
+        if let Some(last) = self.items.last() {
+            if last == &item {
+                return;
+            }
+            if let (JoinHintItem::Single(name), JoinHintItem::Vector(v)) = (&item, last) {
+                if v.last() == Some(name) {
                     return;
                 }
             }
@@ -159,6 +166,28 @@ mod tests {
 
         hints.push(s("abc"));
         assert_eq!(hints.len(), 3, "Different Single is added");
+    }
+
+    #[test]
+    fn test_push_skips_repeated_vector() {
+        let mut hints = JoinHints::new();
+        hints.push(v(&["customers", "orders"]));
+        hints.push(v(&["customers", "orders"]));
+        assert_eq!(
+            hints.len(),
+            1,
+            "Vector repeating the previous one is skipped"
+        );
+
+        hints.push(v(&["customers", "returns"]));
+        assert_eq!(hints.len(), 2, "Different Vector is added");
+
+        hints.push(v(&["customers", "orders"]));
+        assert_eq!(
+            hints.len(),
+            3,
+            "Only adjacent repeats are dropped, not every earlier occurrence"
+        );
     }
 
     #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -57,7 +57,7 @@ impl MeasuresJoinHintsBuilder {
             base_hints.extend(&collect_join_hints(sym)?);
         }
 
-        MeasuresJoinHints::from_base_hints(base_hints, measures)
+        MeasuresJoinHints::from_base_hints(base_hints, measures, None)
     }
 }
 
@@ -68,10 +68,25 @@ impl MeasuresJoinHintsBuilder {
 /// - `measure_hints` — per-measure incremental hints, one entry per
 ///   non-multi-stage measure. Multi-stage measures plan their joins
 ///   separately and are skipped here.
+/// - `hints_by_cube` — the hints the measures of the whole query collected,
+///   grouped by the cube the measure itself belongs to, which for a measure of a
+///   view is that view. Multi-stage measures are included. Only used to resolve a
+///   measure that carries no hints of its own and sits on a view (see
+///   `MultiFactJoinGroups::fallback_hints_for_measure`), which is why the
+///   grouping matters: such a measure may only borrow from members of its own
+///   view. It is inherited as-is when regrouping over a measure subset, so the
+///   measure stays in the join tree of the query it came from.
+///
+///   Dimensions, filters and query-level join hints are deliberately absent: they
+///   land in `base_hints`, so a measure of a query that has any of them never
+///   reaches the fallback in the first place. That also means the view grouping
+///   only guards the case where `base_hints` is empty - a dimension of an
+///   unrelated view still pulls a hint-less member expression into its join.
 #[derive(Clone, Debug)]
 pub struct MeasuresJoinHints {
     base_hints: JoinHints,
     measure_hints: Vec<MeasureJoinHints>,
+    hints_by_cube: HashMap<String, JoinHints>,
 }
 
 impl MeasuresJoinHints {
@@ -85,37 +100,59 @@ impl MeasuresJoinHints {
     }
 
     /// Reuse the existing `base_hints` to produce a new
-    /// `MeasuresJoinHints` over a different measure subset.
+    /// `MeasuresJoinHints` over a different measure subset. `hints_by_cube`
+    /// keeps describing the whole query, not the subset.
     pub fn for_measures(&self, measures: &[Rc<MemberSymbol>]) -> Result<Self, CubeError> {
-        Self::from_base_hints(self.base_hints.clone(), measures)
+        Self::from_base_hints(
+            self.base_hints.clone(),
+            measures,
+            Some(self.hints_by_cube.clone()),
+        )
     }
 
+    /// `inherited_hints_by_cube` describes the whole query these measures were
+    /// taken from, so the measures add nothing to it; without it they are grouped
+    /// from scratch.
     fn from_base_hints(
         base_hints: JoinHints,
         measures: &[Rc<MemberSymbol>],
+        inherited_hints_by_cube: Option<HashMap<String, JoinHints>>,
     ) -> Result<Self, CubeError> {
-        let mut filtered_measures = Vec::new();
-        for m in measures {
-            if !has_multi_stage_members(m, true)? {
-                filtered_measures.push(m.clone());
-            }
-        }
+        let inherited = inherited_hints_by_cube.is_some();
+        let mut hints_by_cube = inherited_hints_by_cube.unwrap_or_default();
 
-        let measure_hints: Vec<MeasureJoinHints> = filtered_measures
-            .iter()
-            .map(|m| -> Result<_, CubeError> {
-                let mut hints = base_hints.clone();
-                hints.extend(&collect_join_hints(m)?);
-                Ok(MeasureJoinHints {
-                    measure: m.clone(),
-                    hints,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut measure_hints: Vec<MeasureJoinHints> = Vec::new();
+        for m in measures {
+            // Multi-stage measures plan their joins separately, so they get no
+            // entry of their own - but their hints still count towards their
+            // cube's. With inherited hints there is nothing left to collect
+            // them for.
+            let is_multi_stage = has_multi_stage_members(m, true)?;
+            if is_multi_stage && inherited {
+                continue;
+            }
+            let own_hints = collect_join_hints(m)?;
+            if !inherited {
+                hints_by_cube
+                    .entry(m.cube_name())
+                    .or_insert_with(JoinHints::new)
+                    .extend(&own_hints);
+            }
+            if is_multi_stage {
+                continue;
+            }
+            let mut hints = base_hints.clone();
+            hints.extend(&own_hints);
+            measure_hints.push(MeasureJoinHints {
+                measure: m.clone(),
+                hints,
+            });
+        }
 
         Ok(Self {
             base_hints,
             measure_hints,
+            hints_by_cube,
         })
     }
 
@@ -209,10 +246,20 @@ impl MultiFactJoinGroups {
                 .iter()
                 .map(|mh| -> Result<_, CubeError> {
                     let measure_hints = if mh.hints.is_empty() {
-                        Self::fallback_hints_for_measure(query_tools, &mh.measure)?
+                        Self::fallback_hints_for_measure(query_tools, &mh.measure, hints)?
                     } else {
                         mh.hints.clone()
                     };
+                    if measure_hints.is_empty() {
+                        return Err(CubeError::user(format!(
+                            "Can't resolve the cube to query for '{}': the member references no \
+                             members of '{}', and neither the rest of the query nor the join map \
+                             of '{}' gives a cube to join from",
+                            mh.measure.full_name(),
+                            mh.measure.cube_name(),
+                            mh.measure.cube_name()
+                        )));
+                    }
                     let (key, join_tree) = resolve(&measure_hints)?;
                     Ok((vec![mh.measure.clone()], key, join_tree))
                 })
@@ -237,23 +284,117 @@ impl MultiFactJoinGroups {
     }
 
     /// Hints to use for a measure whose own hint set resolved to empty.
-    /// Seeds the measure's owning cube when it is a real, joinable cube;
-    /// returns empty for views (resolved via the query's other members).
+    /// Seeds the measure's owning cube when it is a real, joinable cube.
+    ///
+    /// A view is not a joinable cube, so it can't seed anything. Such a measure
+    /// borrows the hints of the other members **of that same view** instead, and
+    /// lands in the same join group as the members it borrowed from. Members of
+    /// another view or of a bare cube are not borrowed from: their cubes need not
+    /// appear in this view at all, and counting rows of a join tree the view is
+    /// not built on would answer a different question than the one asked.
+    ///
+    /// Borrowing at all is what the legacy planner does, but it borrows wider: it
+    /// unions the join hints of every query member into one join tree, with no
+    /// notion of which view a member came from. Narrowing that union to the
+    /// measure's own view is the difference here.
+    ///
+    /// When there is nothing to borrow from either, the view's own join map is
+    /// the last resort: its paths start at the cube the view is rooted at, so
+    /// that cube is the one to query. This is what makes a query built only from
+    /// such member expressions, like `COUNT(*)` over a view, resolvable. It only
+    /// covers views that have a join map at all: a view over a single directly
+    /// joinable cube records no path, and such a query is rejected - see
+    /// `test_expr_measure_count_star_only_member_on_view`.
+    ///
+    /// Note that borrowing makes the meaning of such a measure depend on the rest
+    /// of the query: `COUNT(*)` over a view with two facts counts the rows of the
+    /// cube the view is rooted at when selected alone, and the rows of the fanned
+    /// out join tree when selected together with measures from both facts. The
+    /// legacy planner behaves the same way, since it pools the hints of all query
+    /// members into one join tree.
+    ///
+    /// Known hole, kept for legacy parity: the same-view rule only reaches
+    /// measures. Dimensions, filters and query-level hints land in `base_hints`,
+    /// which is not view-scoped, and a measure whose `base_hints` are non-empty
+    /// never gets here at all. So a dimension of an *unrelated* view still drags a
+    /// hint-less member expression into that view's join and yields a number for a
+    /// join tree its own view is not built on - see
+    /// `test_expr_measure_count_star_no_hints_beside_other_view_dimension`, which
+    /// pins that behaviour. Closing it means resolving from the view bucket
+    /// whenever the measure's *own* hints are empty, which would also make the
+    /// ordinary shape - a view dimension next to `COUNT(*)` on the same view -
+    /// depend on that bucket carrying dimensions, so it is a larger change than
+    /// this fix.
     fn fallback_hints_for_measure(
         query_tools: &Rc<State>,
         measure: &Rc<MemberSymbol>,
+        all_hints: &MeasuresJoinHints,
     ) -> Result<JoinHints, CubeError> {
         let cube_name = measure.cube_name();
-        let is_view = query_tools
+        let cube_definition = query_tools
             .cube_evaluator()
             .cube_from_path(cube_name.clone())
-            .ok()
+            .ok();
+        let is_view = cube_definition
+            .as_ref()
             .and_then(|cube| cube.static_data().is_view)
             .unwrap_or(false);
-        if is_view {
-            Ok(JoinHints::new())
-        } else {
-            Ok(JoinHints::from_items(vec![JoinHintItem::Single(cube_name)]))
+        if !is_view {
+            return Ok(JoinHints::from_items(vec![JoinHintItem::Single(cube_name)]));
+        }
+
+        match all_hints.hints_by_cube.get(&cube_name) {
+            Some(hints) if !hints.is_empty() => return Ok(hints.clone()),
+            _ => {}
+        }
+
+        let join_map = cube_definition
+            .and_then(|cube| cube.static_data().join_map.clone())
+            .unwrap_or_default();
+        if join_map.is_empty() {
+            return Ok(JoinHints::new());
+        }
+        // A cube that heads one path but is reached from another one is not a
+        // root of the view - the path it heads is just the tail of a longer walk.
+        // Only the heads that nothing else reaches are candidates.
+        let reached = join_map
+            .iter()
+            .flat_map(|path| path.iter().skip(1))
+            .collect::<HashSet<_>>();
+        let roots = join_map
+            .iter()
+            .filter_map(|path| path.first())
+            .filter(|head| !reached.contains(*head))
+            .unique()
+            .collect_vec();
+
+        let no_single_root = |detail: String| {
+            CubeError::user(format!(
+                "Can't resolve the cube to query for '{}': the member references no members of \
+                 '{}', and {detail}",
+                measure.full_name(),
+                cube_name,
+            ))
+        };
+
+        match roots.as_slice() {
+            [root_cube] => Ok(JoinHints::from_items(vec![JoinHintItem::Single(
+                (*root_cube).clone(),
+            )])),
+            // Every path of the join map is headed by a cube some other path
+            // reaches, so the paths lead in a circle and none of them starts at
+            // the view's root.
+            [] => Err(no_single_root(format!(
+                "the join paths of that view are cyclic: {}",
+                join_map.iter().map(|path| path.join(".")).join(", ")
+            ))),
+            // The join map is ordered by the order the view lists its cubes, so
+            // picking one root out of several would make the answer depend on
+            // that order with nothing to hint at it.
+            _ => Err(no_single_root(format!(
+                "that view is built on cubes that don't share a single root: {}",
+                roots.iter().join(", ")
+            ))),
         }
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
@@ -645,9 +645,38 @@ impl MockViewBuilder {
             }
         }
 
+        // Like the schema compiler, only multi-hop join paths land in the join
+        // map: a direct cube needs no path to be reached. Note this is what makes
+        // a root cube member of a view carry `Vector([cube])` rather than
+        // `Single(cube)` - `collect_join_hints` enriches a hint into the prefix of
+        // the path it sits on - and both forms are distinct join tree cache keys.
+        //
+        // The schema compiler fills the map in `CubeSymbols.prepareIncludes`,
+        // inside the pass over `dimensions`, but it pushes the entry for an
+        // included cube before looking at that cube's includes - so a cube
+        // contributing no dimension still gets one. `customer_overview` includes
+        // only measures from `customers.orders` and is mapped all the same.
+        // Emitting one entry per view cube here matches that. What the compiler
+        // does differently is evaluate the join path as a reference instead of
+        // splitting the raw string, so a fixture would only diverge with a join
+        // path that is not a literal.
+        let join_map = self
+            .view_cubes
+            .iter()
+            .map(|view_cube| {
+                view_cube
+                    .join_path
+                    .split('.')
+                    .map(|part| part.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|path| path.len() > 1)
+            .collect::<Vec<_>>();
+
         let view_def = MockCubeDefinition::builder()
             .name(self.view_name.clone())
             .is_view(Some(true))
+            .join_map(Some(join_map))
             .default_filters(self.default_filters)
             .build();
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_views.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_views.yaml
@@ -52,6 +52,18 @@ cubes:
           - name: total_amount
             type: sum
             sql: amount
+          - name: total_amount_by_status
+            type: number
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            add_group_by:
+                - orders.status
+          # Not multi-stage itself, but depends on a multi-stage measure, so it
+          # is skipped when building per-measure hints while still counting
+          # towards the hints of the view it is included in.
+          - name: amount_share
+            type: number
+            sql: "{CUBE.total_amount} / NULLIF({CUBE.total_amount_by_status}, 0)"
       segments:
           - name: completed_orders
             sql: "{CUBE}.status = 'completed'"
@@ -89,6 +101,7 @@ views:
                 - status
                 - count
                 - total_amount
+                - amount_share
 
     - name: orders_with_customers
       cubes:
@@ -104,6 +117,43 @@ views:
                 - name
                 - city
                 - ny_customers
+
+    # Join paths whose heads differ, but where one head is reached from the
+    # other, so `returns` is the single root. Real view YAML anchors every path
+    # at the view root and cannot produce this, but the root rule should not
+    # depend on that.
+    # The reached cube heads the *first* path on purpose, so that taking the first
+    # head instead of the unreached one picks the wrong cube.
+    - name: nested_root_view
+      cubes:
+          - join_path: customers.orders
+            includes:
+                - status
+          - join_path: returns.customers
+            includes:
+                - city
+
+    # Join paths that lead in a circle, so every head is reached from another
+    # path and none of them is the view's root.
+    - name: cyclic_paths_view
+      cubes:
+          - join_path: orders.customers
+            includes:
+                - city
+          - join_path: customers.orders
+            includes:
+                - status
+
+    # Join paths under two different roots, so the join map alone does not say
+    # which cube a member expression with no hints of its own should query.
+    - name: two_roots_view
+      cubes:
+          - join_path: orders.customers
+            includes:
+                - city
+          - join_path: returns.customers
+            includes:
+                - name
 
     - name: customer_overview
       cubes:

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/member_expressions.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/member_expressions.rs
@@ -40,6 +40,12 @@ fn make_measure_expression(name: &str, cube: &str, sql: &str) -> OptionsMember {
     OptionsMember::MemberExpression(Rc::new(expr))
 }
 
+// Collapses whitespace so an assertion on the shape of a query does not pin the
+// renderer's spacing.
+fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 // Mirrors a SQL-API `subqueryJoins` entry: opaque sub-query `sql`, a join type
 // and alias, and an `on` condition expressed as a member expression (the alias
 // arrives pre-quoted and is referenced verbatim inside `on`).
@@ -201,6 +207,350 @@ async fn test_expr_measure_count_star_no_hints() {
     if let Some(result) = ctx.try_execute_pg_from_options(options, SEED).await {
         insta::assert_snapshot!(result);
     }
+}
+
+// Same hint-less `COUNT(*)` case, but the member expression belongs to a view.
+// The view is not a joinable cube, so the fallback cannot seed it as a hint; the
+// join must be taken from the other measures of the query (here the
+// `COUNT(DISTINCT {orders_view.status})` expression, which pulls in `orders`).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_expr_measure_count_star_no_hints_on_view() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let distinct_status = make_measure_expression(
+        "distinct_status",
+        "orders_view",
+        "COUNT(DISTINCT {orders_view.status})",
+    );
+    let total_count = make_measure_expression("total_count", "orders_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![distinct_status, total_count]))
+            .build(),
+    );
+
+    ctx.build_sql_from_options(options.clone()).unwrap();
+
+    if let Some(result) = ctx
+        .try_execute_pg_from_options(options, "integration_multi_fact_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// The only other measure of the query is `amount_share`, which depends on a
+// multi-stage measure. Such a measure plans its joins separately and so gets no
+// per-measure hints entry, but its hints still count towards its view's - which
+// is the only thing that gives the hint-less `COUNT(*)` a cube to query here,
+// since `orders_view` has no join map to fall back to.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_expr_measure_count_star_no_hints_beside_multi_stage_measure() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "orders_view", "COUNT(*)");
+    let mut measures = members_from_strings(vec!["orders_view.amount_share"]);
+    measures.push(total_count);
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(measures))
+            .build(),
+    );
+
+    ctx.build_sql_from_options(options.clone()).unwrap();
+
+    if let Some(result) = ctx
+        .try_execute_pg_from_options(options, "integration_multi_fact_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// Hint-less `COUNT(*)` on a view in a genuinely multi-fact query: `orders_count`
+// and `returns_count` sit on two different facts that fan out from `customers`.
+// Both are members of this view, so its hints are the union over both facts, and
+// the member expression forms a third group over the fan-out tree, counting the
+// joined row set of the view -
+// which is what `COUNT(*)` over a view means. The legacy planner renders the
+// whole query over that same fan-out tree, so it counts the same rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_expr_measure_count_star_no_hints_on_multi_fact_view() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "customer_overview", "COUNT(*)");
+    let mut measures = members_from_strings(vec![
+        "customer_overview.orders_count",
+        "customer_overview.returns_count",
+    ]);
+    measures.push(total_count);
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(measures))
+            .build(),
+    );
+
+    ctx.build_sql_from_options(options.clone()).unwrap();
+
+    if let Some(result) = ctx
+        .try_execute_pg_from_options(options, "integration_multi_fact_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// A hint-less `COUNT(*)` member expression on a view as the *only* query member,
+// where the view has a join map: every path in it starts at `customers`, so that
+// is the cube to query. BI tools send such member-less profiling queries against
+// a view, so they must resolve.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_expr_measure_count_star_only_member_on_view_with_join_map() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "customer_overview", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .build(),
+    );
+
+    ctx.build_sql_from_options(options.clone()).unwrap();
+
+    if let Some(result) = ctx
+        .try_execute_pg_from_options(options, "integration_multi_fact_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// The join map of `nested_root_view` holds paths headed by different cubes, but
+// `customers` heads one path only because it is reached from `returns` in
+// another - so `returns` is the single root and the query resolves against it.
+#[test]
+fn test_expr_measure_count_star_only_member_on_view_with_nested_join_map() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "nested_root_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .build(),
+    );
+
+    let sql = normalize_sql(&ctx.build_sql_from_options(options).unwrap());
+    // Anchored on the join structure rather than on a cube name being absent from
+    // the text: the point is that the tree is `returns` by itself. A rule that
+    // took the first head instead of the unreached one would root at `customers`
+    // and join `orders` onto it.
+    assert!(
+        sql.contains("FROM returns AS") && !sql.contains("JOIN"),
+        "expected the query to resolve against the root cube `returns` alone, got: {sql}"
+    );
+}
+
+// The same shape as the test below, but with a *dimension* of the other view
+// instead of a measure - and it is not rejected. Dimensions land in `base_hints`,
+// which is not view-scoped, so the member expression never reaches the same-view
+// fallback and counts rows of `customers`, a cube `orders_view` is not built on.
+//
+// This pins a known hole rather than desired behaviour: the legacy planner does
+// the same, and closing it is a wider change than this fix (see the note on
+// `MultiFactJoinGroups::fallback_hints_for_measure`). If it is ever closed, this
+// test flips to expecting the same rejection as the one below.
+#[test]
+fn test_expr_measure_count_star_no_hints_beside_other_view_dimension() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "orders_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .dimensions(Some(members_from_strings(vec!["customer_overview.city"])))
+            .build(),
+    );
+
+    let sql = normalize_sql(&ctx.build_sql_from_options(options).unwrap());
+    assert!(
+        sql.contains("FROM customers AS") && !sql.contains("JOIN"),
+        "expected the hole to stand: the count resolves against `customers` alone, got: {sql}"
+    );
+}
+
+// A hint-less `COUNT(*)` on `orders_view` next to a measure of a *different*
+// view. `customer_overview.returns_count` pulls in `customers` and `returns`,
+// neither of which `orders_view` is built on, so those hints must not be
+// borrowed - counting rows of `customers` joined to `returns` would answer a
+// question nobody asked. Nothing is left to resolve from, so the query is
+// rejected.
+#[test]
+fn test_expr_measure_count_star_no_hints_beside_other_view_measure() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "orders_view", "COUNT(*)");
+    let mut measures = members_from_strings(vec!["customer_overview.returns_count"]);
+    measures.push(total_count);
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(measures))
+            .build(),
+    );
+
+    let err = ctx
+        .build_sql_from_options(options)
+        .expect_err("a view member expression must not borrow the join of an unrelated view");
+    assert!(
+        err.message.contains("Can't resolve the cube to query"),
+        "expected a clear unresolvable-cube error, got: {}",
+        err.message
+    );
+}
+
+// The join map of `two_roots_view` holds paths under two different roots, so
+// there is no one cube the view is rooted at. Which one gets counted would come
+// down to the order the view lists its cubes, so the query is rejected instead.
+#[test]
+fn test_expr_measure_count_star_only_member_on_view_with_ambiguous_join_map() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "two_roots_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .build(),
+    );
+
+    let err = ctx
+        .build_sql_from_options(options)
+        .expect_err("a view whose join map has several roots should be rejected");
+    assert!(
+        err.message.contains("don't share a single root")
+            && err.message.contains("orders")
+            && err.message.contains("returns"),
+        "expected an ambiguous-root error naming both roots, got: {}",
+        err.message
+    );
+}
+
+// Every path of `cyclic_paths_view` is headed by a cube another path reaches, so
+// the paths lead in a circle. That is a different fault from several roots and
+// says so, rather than degrading into the generic nothing-to-join-from error.
+#[test]
+fn test_expr_measure_count_star_only_member_on_view_with_cyclic_join_map() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "cyclic_paths_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .build(),
+    );
+
+    let err = ctx
+        .build_sql_from_options(options)
+        .expect_err("a view whose join paths are cyclic should be rejected");
+    assert!(
+        err.message.contains("join paths of that view are cyclic")
+            && err.message.contains("orders.customers"),
+        "expected a cyclic-join-map error listing the paths, got: {}",
+        err.message
+    );
+}
+
+// A hint-less `COUNT(*)` member expression on a view as the *only* query member:
+// the view is not a joinable cube, nothing else seeds the join, and the view has
+// no join map to fall back to, because a view over a single directly joinable cube
+// records no path. So there is no cube to query.
+//
+// This is a known limitation, not the desired end state: a one-cube view is the
+// most common shape, and the cube is knowable - the view does record `orders` as
+// an included cube, it is just dropped from the join map as "no path needed".
+// Lifting it means either exposing the view's included cubes on the cube bridge or
+// keeping single-element paths in the join map, and the latter turns every root
+// cube hint from `Single` into `Vector` across both planners - too wide to carry
+// here. The legacy planner fails on this query too, so nothing regresses; what
+// this test locks in is a clear error instead of a bridge deserialization failure
+// on the null join tree.
+#[test]
+fn test_expr_measure_count_star_only_member_on_view() {
+    let schema = MockSchema::from_yaml_file("common/integration_views.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let total_count = make_measure_expression("total_count", "orders_view", "COUNT(*)");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![total_count]))
+            .build(),
+    );
+
+    let err = ctx
+        .build_sql_from_options(options)
+        .expect_err("a view member expression with nothing to join from should be rejected");
+    assert!(
+        err.message.contains("Can't resolve the cube to query"),
+        "expected a clear unresolvable-cube error, got: {}",
+        err.message
+    );
 }
 
 // Multiplied dim-only ME: a measure expression evaluating to a

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_beside_multi_stage_measure.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_beside_multi_stage_measure.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/src/tests/integration/member_expressions.rs
+expression: result
+---
+orders_view__amount_share | total_count
+--------------------------+------------
+1.1956521739130435        | 8          
+6.1111111111111111        | 8

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_on_multi_fact_view.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_on_multi_fact_view.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/src/tests/integration/member_expressions.rs
+expression: result
+---
+customer_overview__orders_count | customer_overview__returns_count | total_count
+--------------------------------+----------------------------------+------------
+8                               | 5                                | 13

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_on_view.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_no_hints_on_view.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/src/tests/integration/member_expressions.rs
+expression: result
+---
+distinct_status | total_count
+----------------+------------
+2               | 8

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_only_member_on_view_with_join_map.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__member_expressions__expr_measure_count_star_only_member_on_view_with_join_map.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/src/tests/integration/member_expressions.rs
+expression: result
+---
+total_count
+-----------
+4

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
@@ -52,16 +52,18 @@ fn test_collect_join_hints_view_symbols() {
     assert_eq!(hints.len(), 1);
     assert_eq!(hints.items(), &[v(&["cube_a", "cube_b", "cube_c"])]);
 
+    // Members of the root cube of the view are enriched with the view join map
+    // into the prefix of the path they sit on, so they come back as a vector.
     let dim = ctx.create_dimension("a_with_b_and_c.name").unwrap();
     let hints = collect_join_hints(&dim).unwrap();
     assert_eq!(hints.len(), 1);
-    assert_eq!(hints.items(), &[s("cube_a")]);
+    assert_eq!(hints.items(), &[v(&["cube_a"])]);
 
     // View measure from root join_path
     let measure = ctx.create_measure("a_with_b_and_c.total_value").unwrap();
     let hints = collect_join_hints(&measure).unwrap();
     assert_eq!(hints.len(), 1);
-    assert_eq!(hints.items(), &[s("cube_a")]);
+    assert_eq!(hints.items(), &[v(&["cube_a"])]);
 }
 
 #[test]
@@ -95,7 +97,8 @@ fn test_join_hints_many_to_one_view_root_dim() {
     let dim = ctx.create_dimension("many_to_one_view.root_dim").unwrap();
     let hints = collect_join_hints(&dim).unwrap();
     assert_eq!(hints.len(), 1);
-    assert_eq!(hints.items(), &[s("many_to_one_root")]);
+    // Enriched with the view join map into the prefix of the path it sits on.
+    assert_eq!(hints.items(), &[v(&["many_to_one_root"])]);
 }
 
 #[test]
@@ -116,7 +119,8 @@ fn test_join_hints_many_to_one_view_root_measure() {
     let measure = ctx.create_measure("many_to_one_view.root_val_avg").unwrap();
     let hints = collect_join_hints(&measure).unwrap();
     assert_eq!(hints.len(), 1);
-    assert_eq!(hints.items(), &[s("many_to_one_root")]);
+    // Enriched with the view join map into the prefix of the path it sits on.
+    assert_eq!(hints.items(), &[v(&["many_to_one_root"])]);
 }
 
 #[test]


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes the `invalid type: unit value, expected struct JoinDefinitionStatic` error for queries whose member expressions on a view carry no join hints of their own, such as `count(*)` alongside `count(distinct <view dimension>)`. Related tests are included.
