### PR TITLE
docs: document per-deployment agent space scope

### DIFF
--- a/docs-mintlify/admin/ai/memory-isolation.mdx
+++ b/docs-mintlify/admin/ai/memory-isolation.mdx
@@ -11,7 +11,9 @@ Memories are scoped and enforced at the Tenant/Space boundary. Cube applies both
 
 ### Space-Scoped Memories
 
-Cube memories are stored at the Space level. Agents only learn from and retrieve memories within the current Space, ensuring no cross-Space exposure by design. 
+Cube memories are stored at the Space level. Agents only learn from and retrieve memories within the current Space, ensuring no cross-Space exposure by design.
+
+Because a Space can be [scoped globally or to a single deployment](/admin/ai/multi-agent#space-scope), that boundary also decides whether memories are shared across deployments: agents in different deployments that use the same global Space share its memories, while a Space scoped to one deployment keeps them to that deployment.
 
 ### Tenant-Aware Security Context
 

--- a/docs-mintlify/admin/ai/multi-agent.mdx
+++ b/docs-mintlify/admin/ai/multi-agent.mdx
@@ -128,6 +128,29 @@ spaces:
 
 Each agent must reference exactly one space via its `space` property. Multiple agents can share the same space and inherit its rules, certified queries, and memories.
 
+## Space scope
+
+Spaces live at the account level, so one space can be used by agents in more than one deployment. When a space is created, you choose its scope:
+
+- **Global** — one space that agents in every deployment can use.
+- **A specific deployment** — the space is available to that deployment only.
+
+You pick the scope when you create a space in the UI (**Agents** → **Spaces** → **Create space**), and when you create the spaces declared in `agents/config.yml` from the reconcile panel — the **Create Spaces** control there offers **Global** and **Per deployment**. Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. You can change the scope of an existing space later on the space's page.
+
+Choose per-deployment scope when the same `spaces:` entry is declared in several deployments — typically development, staging, and production fed from branches of one data model — and you don't want them sharing what the space stores.
+
+<Warning>
+  Reconciling again does not split a space that was created as global: a global space counts as reconciled for every deployment, so no new space is created. To split one, re-scope it to a deployment on its space page, then reconcile the other deployments.
+</Warning>
+
+Spaces created before this option existed have no scope stored. Cube infers the deployment they belong to from the agents linked to them, and the Spaces list shows them as **Not scoped**. Set the scope explicitly on the space page to replace that guess with an answer.
+
+### Scope affects storage, not configuration
+
+Scope never changes where configuration comes from. Agents always belong to a single deployment, and the `spaces:` and `agents:` entries, rules, and certified queries that shape an agent are read from the `agents/` directory of the data model of that deployment, on that deployment's branch. A global space does not merge the configuration of the deployments that use it.
+
+What a global space shares is storage: the space itself and the data held against it — memories in particular. Two deployments using the same global space read and write the same memories, while each of them still applies its own `agents/` configuration. Scope a space to a deployment when that shared storage is what you want to avoid.
+
 ## Attaching rules and certified queries to a space
 
 In the single-agent setup, [rules](/admin/ai/rules) and [certified queries](/admin/ai/certified-queries) belong to the implicit `auto` space. In a multi-agent setup, you must attach each rule and certified query to a specific space using the `space` property in the Markdown frontmatter:

--- a/docs-mintlify/admin/ai/multi-agent.mdx
+++ b/docs-mintlify/admin/ai/multi-agent.mdx
@@ -145,7 +145,7 @@ Spaces created per deployment are named after it, for example `Product (producti
 Choose per-deployment scope when the same `spaces:` entry is declared in several deployments — typically development, staging, and production fed from branches of one data model — and you don't want them sharing what the space stores.
 
 <Warning>
-  Reconciling again does not split a space that was created as global: a global space counts as reconciled for every deployment, so no new space is created. To split one, re-scope it to a deployment on its space page, then reconcile the other deployments.
+  Creating the spaces again does not split a space that was created as global: it already counts as created for every deployment, so **Create All** creates nothing new. To split one, re-scope it to a deployment on its space page, then run **Create All** for the other deployments.
 </Warning>
 
 Spaces created before this option existed have no scope stored. Cube infers the deployment they belong to from the agents linked to them, and the Spaces list shows them as **Not scoped**. Set the scope explicitly on the space page to make it definite.

--- a/docs-mintlify/admin/ai/multi-agent.mdx
+++ b/docs-mintlify/admin/ai/multi-agent.mdx
@@ -133,14 +133,14 @@ Each agent must reference exactly one space via its `space` property. Multiple a
 Spaces live at the account level, so one space can be used by agents in more than one deployment. When a space is created, you choose its scope:
 
 - **Global** — one space that agents in every deployment can use.
-- **A specific deployment** — the space is available to that deployment only.
+- **Per deployment** — the space is available to a single deployment only.
 
 You pick the scope on the **Agents** → **Spaces** page, in two places:
 
 - **Create space**, when you create a space by hand.
 - The **Create All** panel, shown for spaces and agents declared in `agents/config.yml` that don't exist yet. Its **Create Spaces** control offers **Global** and **Per deployment**.
 
-Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. Only the displayed name changes — the space stays linked to the space `name` declared in `agents/config.yml`, so the YAML entry keeps matching. You can change the scope of an existing space later on the space's page.
+Spaces created per deployment are named after the deployment, for example `Product (production)` and `Product (staging)`. Only the displayed name changes — the space stays linked to the space `name` declared in `agents/config.yml`, so the YAML entry keeps matching. You can change the scope of an existing space later on the space's page.
 
 Choose per-deployment scope when the same `spaces:` entry is declared in several deployments — typically development, staging, and production fed from branches of one data model — and you don't want them sharing what the space stores.
 

--- a/docs-mintlify/admin/ai/multi-agent.mdx
+++ b/docs-mintlify/admin/ai/multi-agent.mdx
@@ -135,7 +135,12 @@ Spaces live at the account level, so one space can be used by agents in more tha
 - **Global** — one space that agents in every deployment can use.
 - **A specific deployment** — the space is available to that deployment only.
 
-You pick the scope on the **Agents** → **Spaces** page: with **Create space**, and with the **Create All** panel that page shows for spaces and agents declared in `agents/config.yml` that don't exist yet — its **Create Spaces** control offers **Global** and **Per deployment**. Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. You can change the scope of an existing space later on the space's page.
+You pick the scope on the **Agents** → **Spaces** page, in two places:
+
+- **Create space**, when you create a space by hand.
+- The **Create All** panel, shown for spaces and agents declared in `agents/config.yml` that don't exist yet. Its **Create Spaces** control offers **Global** and **Per deployment**.
+
+Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. Only the displayed name changes — the space stays linked to the space `name` declared in `agents/config.yml`, so the YAML entry keeps matching. You can change the scope of an existing space later on the space's page.
 
 Choose per-deployment scope when the same `spaces:` entry is declared in several deployments — typically development, staging, and production fed from branches of one data model — and you don't want them sharing what the space stores.
 

--- a/docs-mintlify/admin/ai/multi-agent.mdx
+++ b/docs-mintlify/admin/ai/multi-agent.mdx
@@ -19,7 +19,7 @@ Multi-agent is useful when:
 
 A multi-agent setup introduces one new concept on top of the single-agent model: **spaces**.
 
-- A **deployment** can contain one or more **spaces**.
+- A **space** belongs to the account and is used by one or more **deployments** — see [Space scope](#space-scope).
 - A **space** is an isolated context. It owns its **rules**, **certified queries**, and **memories** — they are not shared across spaces.
 - Each **agent** belongs to exactly one space and inherits everything that space owns. Multiple agents can live in the same space and share the same rules, certified queries, and memories.
 
@@ -48,8 +48,8 @@ flowchart LR
     SMM[Memories]:::resource
     A3[Agent<br/>marketing-analyst]:::agent
 
-    D --> SA
-    D --> SM
+    D -->|uses| SA
+    D -->|uses| SM
 
     SA --- SAR
     SA --- SAC
@@ -135,7 +135,7 @@ Spaces live at the account level, so one space can be used by agents in more tha
 - **Global** — one space that agents in every deployment can use.
 - **A specific deployment** — the space is available to that deployment only.
 
-You pick the scope when you create a space in the UI (**Agents** → **Spaces** → **Create space**), and when you create the spaces declared in `agents/config.yml` from the reconcile panel — the **Create Spaces** control there offers **Global** and **Per deployment**. Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. You can change the scope of an existing space later on the space's page.
+You pick the scope on the **Agents** → **Spaces** page: with **Create space**, and with the **Create All** panel that page shows for spaces and agents declared in `agents/config.yml` that don't exist yet — its **Create Spaces** control offers **Global** and **Per deployment**. Spaces created per deployment are named after it, for example `Product (production)` and `Product (staging)`. You can change the scope of an existing space later on the space's page.
 
 Choose per-deployment scope when the same `spaces:` entry is declared in several deployments — typically development, staging, and production fed from branches of one data model — and you don't want them sharing what the space stores.
 
@@ -143,13 +143,13 @@ Choose per-deployment scope when the same `spaces:` entry is declared in several
   Reconciling again does not split a space that was created as global: a global space counts as reconciled for every deployment, so no new space is created. To split one, re-scope it to a deployment on its space page, then reconcile the other deployments.
 </Warning>
 
-Spaces created before this option existed have no scope stored. Cube infers the deployment they belong to from the agents linked to them, and the Spaces list shows them as **Not scoped**. Set the scope explicitly on the space page to replace that guess with an answer.
+Spaces created before this option existed have no scope stored. Cube infers the deployment they belong to from the agents linked to them, and the Spaces list shows them as **Not scoped**. Set the scope explicitly on the space page to make it definite.
 
 ### Scope affects storage, not configuration
 
 Scope never changes where configuration comes from. Agents always belong to a single deployment, and the `spaces:` and `agents:` entries, rules, and certified queries that shape an agent are read from the `agents/` directory of the data model of that deployment, on that deployment's branch. A global space does not merge the configuration of the deployments that use it.
 
-What a global space shares is storage: the space itself and the data held against it — memories in particular. Two deployments using the same global space read and write the same memories, while each of them still applies its own `agents/` configuration. Scope a space to a deployment when that shared storage is what you want to avoid.
+What a global space shares is storage: the space itself and the data held against it — memories in particular. Two deployments using the same global space read and write the same memories, while each of them still applies its own `agents/` configuration.
 
 ## Attaching rules and certified queries to a space
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Agent spaces can now be created either globally or scoped to a single deployment. Documents that option and what it does — and does not — change.

`docs-mintlify/admin/ai/multi-agent.mdx` — new `## Space scope` section:

- Spaces live at the account level; scope is chosen at creation — **Global** or **Per deployment**. The Architecture section and its diagram, which previously described a deployment as containing its spaces, were reconciled with that.
- Where the choice is made: on the **Agents** → **Spaces** page, via **Create space** and via the **Create All** panel shown for `agents/config.yml` entries that don't exist yet. Per-deployment spaces are named after the deployment (`Product (production)`, `Product (staging)`) — only the displayed name changes, so the space stays linked to the `name` declared in the YAML and the entry keeps matching. Scope can be changed later on the space page.
- A callout for the footgun: a space created as global already counts as created for every deployment, so **Create All** will not split it later — it has to be re-scoped by hand, then **Create All** run for the other deployments.
- Spaces predating the option have no stored scope; the deployment is inferred from their linked agents and the list shows them as **Not scoped**.
- Subsection **Scope affects storage, not configuration**: agents always belong to one deployment, and the `spaces:`/`agents:` entries, rules, and certified queries are read from that deployment's `agents/` directory on its own branch. A global space merges no configuration — what it shares is storage, memories in particular, so two deployments on one global space read and write the same memories while each applies its own config.

`docs-mintlify/admin/ai/memory-isolation.mdx` — a paragraph under "Space-Scoped Memories" tying the Space memory boundary to the scope choice, linking to the new section.

Prose-only edits to existing pages; no `docs.json` navigation changes needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAPQ46S1v4ocPEWxvDNDuZ)_