### PR TITLE
docs: cover MCP standalone reports, calendar-period filters, sheets scale, and more

### DIFF
--- a/docs-mintlify/admin/ai/skills.mdx
+++ b/docs-mintlify/admin/ai/skills.mdx
@@ -97,6 +97,9 @@ its complete instructions on demand.
   instruction body stays server-side and is never sent to the browser.
 - Skills are surfaced through a viewer-accessible deployment endpoint, so they work for
   any configured agent as well as the default `auto` agent.
+- Skills are also available when the agent is used through the [MCP server](/docs/integrations/mcp-server),
+  not just the in-app chat surface. Skills remain unavailable to viewers chatting on a
+  published or embedded dashboard, where the agent is limited to read-only Q&A.
 - Because the agent matches against `description`, a well-written description makes
   automatic matching more reliable.
 

--- a/docs-mintlify/admin/customization/dashboard-themes.mdx
+++ b/docs-mintlify/admin/customization/dashboard-themes.mdx
@@ -62,6 +62,8 @@ Custom themes are saved from the dashboard builder's **Styling** tab.
 
 The new theme appears in the **Admin → Customization → Dashboard Themes** list and becomes selectable in the **Styling** tab on every other dashboard in the account.
 
+You can also rename the currently selected custom theme without leaving the dashboard builder: open the theme menu (**...**) in the **Styling** tab and choose **Rename**.
+
 ## Apply a theme to a dashboard
 
 1. Open the dashboard in the dashboard builder.

--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -91,6 +91,12 @@ button next to the branch switcher. It copies the current URL with
 `?branch=<branch-name>` appended; opening that link switches the recipient to
 the same branch.
 
+On the **Changes** tab, the diff is always shown against an explicit base branch,
+defaulting to the branch's fork point (with the deploy branch offered as an
+alternative when it isn't already the fork point). The selected base is carried
+in the link via `?base=<branch-name>`, so a review link is shareable and shows
+the same comparison to whoever opens it.
+
 ## Generating data model files
 
 You can generate data model files when [creating a new

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -20,7 +20,7 @@ The available operators depend on the type of the underlying dimension:
 |---|---|
 | **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null` |
 | **Number** | `is`, `is not`, `greater than`, `greater than or equal`, `less than`, `less than or equal`, `is null`, `is not null` |
-| **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `is null`, `is not null` |
+| **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `in the month`, `not in the month`, `in the quarter`, `not in the quarter`, `in the year`, `not in the year`, `is null`, `is not null` |
 
 ### Single vs. multiple selection
 
@@ -67,6 +67,8 @@ How the attribute value is matched to the filter:
 Empty, `null`, or unresolvable attribute values are skipped — the filter falls back to whatever static default it has, or no default if none is set.
 
 The user attribute default only seeds the filter's *initial* value. Viewers can still change the filter unless its [visibility](#visibility) is set to **Disabled**, in which case the resolved attribute value is locked in for that viewer. Values passed via URL parameters also take precedence over user attribute defaults, so deep links continue to work.
+
+When a viewer changes a filter's value on the dashboard builder or a published dashboard, the change is written back into the URL as well, so a manually picked filter value is bookmarkable and shareable — not just the values a link was originally opened with.
 
 ### Faceted filters
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -214,12 +214,16 @@ the comparison to all measures at once.
 </Frame>
 
 The menu is available when the query includes a time dimension with a year,
-quarter, month, week, or day granularity. The presets depend on that
-granularity — a month grain offers **Previous period**, **Same period
-previous quarter**, and **Same period previous year** — so the comparison
-period always aligns exactly with the current buckets. A measure can have
-several comparisons active at once, such as month over month and year over
-year side by side.
+quarter, month, week, or day granularity — either one it groups by, or one it
+only filters. Grouping gives presets read off the granularity — a month grain
+offers **Previous period**, **Same period previous quarter**, and **Same
+period previous year** — so the comparison period always aligns exactly with
+the current buckets. Filtering without grouping gives a comparison anchored to
+the filter's own date window instead (for example, **Previous period** shifts
+back by exactly the filtered window's length), which lets a report with no
+time column still compare against a prior period. A measure can have several
+comparisons active at once, such as month over month and year over year side
+by side.
 
 Each comparison adds derived columns next to the measure. Choose which ones
 to show under **Comparison columns** in the same menu:
@@ -237,7 +241,10 @@ Comparisons are saved with the report and apply everywhere it appears —
 charts, totals, and [dashboards][ref-dashboards]. Cube fetches the
 comparison values with a companion query whose date filters are shifted back
 by the comparison offset; you can [inspect it](#inspecting-queries) to check
-the math.
+the math. On a dashboard, the comparison follows whatever the viewer has the
+widget filtered to — narrowing the dashboard's filters also narrows the
+comparison window, so the two periods being compared always stay the same
+length.
 
 ## Inspecting queries
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -127,6 +127,16 @@ their header, both when the report is inserted and after **Refresh**.
 You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
 in Cube Cloud.
 
+## Number formatting
+
+A measure's [`format`][ref-measure-format] from the data model — including `abbr`
+(compact notation, e.g. `1.2M`) — is applied as a native spreadsheet number format,
+so the cell keeps its numeric value and stays usable in `SUM`, pivots, and charts.
+
+To pin every measure column in a report to a fixed magnitude regardless of the data
+model's format, open the sidebar's **Display** tab and set **Scale** to **Model
+default**, **Absolute**, **Thousands (K)**, **Millions (M)**, or **Billions (B)**.
+The setting is session-local to the current report.
 
 [link-google-sheets]: https://workspace.google.com/products/sheets/
 [link-marketplace-listing]: https://workspace.google.com/u/0/marketplace/app/cube_cloud_for_sheets/641460343379
@@ -135,3 +145,4 @@ in Cube Cloud.
 [ref-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
 [ref-saved-reports]: /docs/workspace/saved-reports
+[ref-measure-format]: /reference/data-modeling/measures#format

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -255,7 +255,7 @@ programmatically. Creating and editing workbooks requires the Explorer role or h
 | --- | --- | --- |
 | `readWorkbook` | Reads a workbook — its name and its current dashboard draft and published configs. | Read-only |
 | `createWorkbook` | Creates a new empty workbook, the container that holds reports and a dashboard. | Write |
-| `createReport` | Saves a query plus its visualization as a report inside a workbook, and returns the `reportId` a chart widget references. | Write |
+| `createReport` | Saves a query plus its visualization as a report, and returns the `reportId` a chart widget references. `workbookId` is optional: pass it to add the report as a tab of that workbook (referenceable by a CHART widget there); omit it (optionally passing `folderId`) to save a standalone exploration reachable from the workspace browser and the [Google Sheets][ref-google-sheets] / [Excel][ref-excel] add-in's saved reports list instead. | Write |
 | `updateDashboard` | Saves the dashboard layout to the workbook **draft**. Replaces the full widget set and does not go live. | Destructive — prompts |
 | `publishDashboard` | Publishes the current draft to make it live. Idempotent — republishing an unchanged draft is a no-op. | Destructive — prompts |
 
@@ -362,3 +362,5 @@ publish it.
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-dashboards]: /docs/explore-analyze/dashboards
 [ref-dev-mode]: /docs/data-modeling/dev-mode
+[ref-google-sheets]: /docs/integrations/google-sheets
+[ref-excel]: /docs/integrations/microsoft-excel

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -135,6 +135,16 @@ their header, both when the report is inserted and after **Refresh**.
 You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
 in Cube Cloud.
 
+## Number formatting
+
+A measure's [`format`][ref-measure-format] from the data model — including `abbr`
+(compact notation, e.g. `1.2M`) — is applied as a native spreadsheet number format,
+so the cell keeps its numeric value and stays usable in `SUM`, pivots, and charts.
+
+To pin every measure column in a report to a fixed magnitude regardless of the data
+model's format, open the sidebar's **Display** tab and set **Scale** to **Model
+default**, **Absolute**, **Thousands (K)**, **Millions (M)**, or **Billions (B)**.
+The setting is session-local to the current report.
 
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576
@@ -145,3 +155,4 @@ in Cube Cloud.
 [link-excel-addins]: https://support.microsoft.com/en-us/office/add-or-remove-add-ins-in-excel-0af570c4-5cf3-4fa9-9b88-403625a0b460
 [link-ms-appsource]: https://appsource.microsoft.com/en-us/product/office/WA200008486
 [ref-saved-reports]: /docs/workspace/saved-reports
+[ref-measure-format]: /reference/data-modeling/measures#format


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change)
- [ ] Linter has been run for changed code (docs-only change)
- [ ] Tests for the changes have been added if not covered yet (docs-only change)

**Description of Changes Made**

Routine audit of `cubejs-enterprise` (Cube Cloud) commits merged since the prior daily audit ([#11497](https://github.com/cube-js/cube/pull/11497)), cross-checked against `docs-mintlify` and the [customer-facing criteria](https://github.com/cubedevinc/cubejs-enterprise/blob/master/.claude/shared/customer-facing-criteria.md). Eight small doc gaps found and fixed, each verified against the actual diff (not just the commit subject):

1. **`docs/integrations/mcp-server.mdx`** — MCP's `createReport` tool now takes an optional `workbookId`; omitting it (optionally with `folderId`) saves a standalone exploration reachable from the workspace browser and the Sheets/Excel add-ins, instead of only a workbook-tab report.
2. **`docs/explore-analyze/dashboards/widgets/controls.mdx`** — new time-filter operators (`in the month`/`not in the month`, `in the quarter`/`not in the quarter`, `in the year`/`not in the year`) on the report bar, dashboard Filter widget, and embedded dashboards. Also: manually changing a dashboard filter now writes the value back into the URL, so it's bookmarkable/shareable (previously URL → filter was one-way).
3. **`docs/explore-analyze/workbooks/querying-data.mdx`** — a period-over-period comparison can now anchor to a time dimension the query only *filters* (not just one it groups by), so a report with no time column can still compare periods. Also documents that a comparison on a dashboard now correctly follows the viewer's active filter window rather than the report's original saved window.
4. **`docs/integrations/google-sheets.mdx`, `docs/integrations/microsoft-excel.mdx`** — new "Number formatting" section: compact measure formats (e.g. `abbr`) now write as real numbers rather than text (so `SUM`/pivots/charts keep working), and a new **Display → Scale** control (Model default / Absolute / Thousands (K) / Millions (M) / Billions (B)) lets a user pin every measure column to a fixed magnitude.
5. **`admin/customization/dashboard-themes.mdx`** — a **Rename** action was added to the Styling tab's theme "..." menu, so a custom theme can be renamed from the dashboard builder directly, not only from the Admin themes list.
6. **`admin/ai/skills.mdx`** — skills now work when the agent is used through the MCP server, not just in-app chat (previously silently unavailable over MCP); still unavailable on published/embedded dashboards, which stay read-only Q&A.
7. **`docs/data-modeling/data-model-ide.mdx`** — the Data Model IDE's Changes view now always names an explicit comparison base (defaulting to the branch's fork point, with the deploy branch offered as an alternative), carried in a shareable `?base=<branch-name>` link parameter alongside the existing `?branch=`.

Prose-only edits to existing pages; no `docs.json` navigation changes needed.

**Dropped after verification:**
- A candidate "centralized `/mcp` endpoint" (`feat(cloud-router): centralized MCP endpoint at /mcp`) turned out to be gated behind a tenant flag *and* opt-in even when the flag is on (`regional` stays the default) — not shipped per the customer-facing criteria's "wait until on by default" rule, so left undocumented for now.

**Not a doc gap — filed as a Linear ticket instead:**
- A tenant-wide time-zone policy with personal and per-embed-tenant overrides (CUB-852) is a genuinely new, multi-surface feature (Admin Settings, Preferences, Embedding tenant settings) with no existing doc home. It warrants a new dedicated page rather than a surgical edit, and its tracking issue (CUB-852) is still "In Progress" with a small follow-up PR in flight, so a documentation ticket was opened in Linear instead of drafting a full page in this PR.

Also checked the 3 `cube-js/cube` Tesseract fixes merged in this window (FILTER_PARAMS column callbacks, multi-stage filter row-set bug, ungrouped-query/rollup matching) — all are internal correctness fixes that make previously-wrong results correct without changing any documented option or contract, so none needed a doc change.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LEfUVvGy8HbJ4BnCJ2V9jY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEfUVvGy8HbJ4BnCJ2V9jY)_