### PR TITLE
docs: document recent chart, filter, and MCP features from cubejs-enterprise

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -28,8 +28,8 @@ Displays a single value from your query result.
 | **Field** | The measure or dimension to display |
 | **Row** | Which row of the result to read from |
 | **Format** | Number formatting (currency, percent, etc.) |
-| **Font size / color** | Text appearance |
-| **Alignment** | Left, center, or right |
+
+See [Styling blocks](#styling-blocks) below for font size, color, background, and alignment.
 
 {/* TODO screenshot: Number block (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -42,7 +42,8 @@ Displays a current value alongside a previous value with a calculated difference
 | **Current field / row** | The primary value |
 | **Previous field / row** | The value to compare against — can be a different column or a different row from the same column |
 | **Difference format** | Absolute, percentage, or both |
-| **Positive color / Negative color** | Colors applied based on whether the change is positive or negative |
+
+See [Styling blocks](#styling-blocks) below for the positive/negative/neutral colors applied based on the direction of change.
 
 To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field.
 
@@ -63,6 +64,8 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
 </Tip>
 
+See [Styling blocks](#styling-blocks) below for background and alignment.
+
 {/* TODO screenshot: Progress bar block (bar style) and circle style (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ### Sparkline
@@ -78,6 +81,8 @@ Renders a compact trend chart — either a bar or line — within the KPI tile. 
 | **Max points** | Limits the number of data points rendered |
 | **Colors** | Line/fill colors |
 
+See [Styling blocks](#styling-blocks) below for background and alignment.
+
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ### Text
@@ -92,7 +97,25 @@ Use text blocks for short labels and headings inside the KPI. For complex layout
 
 A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support.
 
+See [Styling blocks](#styling-blocks) below for background and alignment.
+
 {/* TODO screenshot: HTML block with custom content (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Styling blocks
+
+Every block has a **Style** panel with alignment controls — horizontal (left, center, right) and vertical (top, middle, bottom) — for positioning its content within the block's space.
+
+Most block types also get a **Background** color, painted behind that block only; leave it unset to show the tile's own background through. Some block types add colors of their own:
+
+| Block | Style controls |
+|---|---|
+| **Number** | Value color and background (linked as a pair), font size |
+| **Comparison** | Positive / negative change colors, and a neutral color paired with the background |
+| **Progress bar** | Background |
+| **Sparkline** | Background (the sparkline's own line/fill colors are set in the Fields tab) |
+| **HTML** | Background |
+
+Text blocks don't have a background or color control — style them directly with Markdown/HTML.
 
 ## Layout controls
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -5,25 +5,36 @@ description: Show how a single measure is distributed across a small number of c
 
 Pie charts divide a circle into slices proportional to each category's share of the total. Best for communicating part-to-whole proportions to a broad audience when you have a small number of clearly distinct categories (typically five or fewer).
 
-## Variants
+## Shape
 
-### Pie
+In the Style tab, toggle **Shape** between **Pie** and **Donut**. Donut cuts a hollow center out of the circle, which can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
 
-Standard filled circle. Each slice's arc length is proportional to its value.
+{/* Screenshot: pie and donut shape toggle side by side, same data. Place directly below this heading. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-{/* Screenshot: pie chart — total revenue split by product category (5 slices with a legend). Place directly below this heading, half-width centered or side-by-side with donut. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+## Data labels
 
-### Donut
+In the Style tab's **Data labels** section, toggle any combination of **Value**, **Category**, and **Percent** to show them directly on each slice. Percent is each slice's share of the total. Value and Percent each have their own number format, set from the format button next to their toggle.
 
-A pie with a hollow center. Increase the **Inner radius** value in the Style tab to any non-zero value to switch to a donut. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
+Once a label is on, you can also set:
 
-{/* Screenshot: donut chart — same data as the pie variant, with inner radius applied. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+- **Position** — **Inside** the slice or **Outside** it, with a leader line
+- **Font size**
 
-## Inner radius
+{/* Screenshot: pie chart with Value + Percent labels shown outside the slices. Place directly below this heading. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-Drag the **Inner radius** slider in the Style tab or enter a pixel value. Setting it to `0` returns to a full pie.
+## Concentric rings
 
-{/* Screenshot: Style tab with the Inner radius control highlighted. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+A pie can only size its slices by one dimension. When your query has two or more dimensions, every dimension past the first draws as its own ring — one ring per dimension, nested outward from the center, each ring broken down by the ring inside it — instead of being dropped.
+
+Reorder rings by dragging them in the **Rings** section of the Fields tab; the innermost ring also sets each slice's color. Only the outermost ring's measure total is exact — a measure that isn't additive (e.g. a count distinct) can't be summed correctly across inner rings, and the builder shows a warning when that's the case.
+
+Data labels on a multi-ring chart can be limited to the **Outer ring** or shown on **All rings**, from the **Rings** control next to Position and Font size in the Style tab. Inner rings only ever show the Category label — Value and Percent at inner depths would need per-ring aggregation.
+
+{/* Screenshot: a two-dimension pie rendered as concentric rings (e.g. region outer ring, product category inner ring). Place directly below this heading. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Tooltips
+
+By default, hovering a slice shows every column from your query. Use the **Tooltips** control in the Fields tab to show all fields, one field, or none.
 
 ## Color and slice ordering
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -20,7 +20,9 @@ The available operators depend on the type of the underlying dimension:
 |---|---|
 | **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null` |
 | **Number** | `is`, `is not`, `greater than`, `greater than or equal`, `less than`, `less than or equal`, `is null`, `is not null` |
-| **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `is null`, `is not null` |
+| **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `in`/`not in the month`, `in`/`not in the quarter`, `in`/`not in the year`, `is null`, `is not null` |
+
+The `in the month` / `in the quarter` / `in the year` operators (and their negations) match a fixed calendar period — pick a month, quarter, or year and every row in that period matches, regardless of when the dashboard is viewed. This differs from `relative date` values like `this month`, which resolve against the current date each time the dashboard loads.
 
 ### Single vs. multiple selection
 
@@ -67,6 +69,10 @@ How the attribute value is matched to the filter:
 Empty, `null`, or unresolvable attribute values are skipped — the filter falls back to whatever static default it has, or no default if none is set.
 
 The user attribute default only seeds the filter's *initial* value. Viewers can still change the filter unless its [visibility](#visibility) is set to **Disabled**, in which case the resolved attribute value is locked in for that viewer. Values passed via URL parameters also take precedence over user attribute defaults, so deep links continue to work.
+
+### Bookmarking and sharing
+
+On a published dashboard, changing a filter's value updates the page URL to match. A viewer can bookmark or share that URL, and opening it re-applies the same filter values — no extra setup required.
 
 ### Faceted filters
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -221,6 +221,13 @@ period always aligns exactly with the current buckets. A measure can have
 several comparisons active at once, such as month over month and year over
 year side by side.
 
+The menu is also available when the query has no time dimension in its
+results, as long as exactly one time dimension is used as a filter with a
+start and end date. Cube reads the comparison period from that filter's own
+date range instead of from a grouped column — a query filtered to `Q1 2026`
+offers **Previous period** as `Q4 2025`, for example — so a report with no
+time column can still compare against the preceding window.
+
 Each comparison adds derived columns next to the measure. Choose which ones
 to show under **Comparison columns** in the same menu:
 
@@ -268,7 +275,7 @@ Two indicators next to each result describe the data behind it.
 
 ## Editing Semantic SQL by hand
 
-You can edit the Semantic SQL directly in the editor to refine a query — for example, to add a `WHERE` clause, change `GROUP BY` order, or apply a different sort. After making changes, click **Save and Run** to apply them to the query and refresh the results, or **Discard** to revert.
+You can edit the Semantic SQL directly in the editor to refine a query — for example, to add a `WHERE` clause, change `GROUP BY` order, or apply a different sort. After making changes, click **Save and Run** to apply them to the query and refresh the results, or **Discard** to revert. **Save and Run** also reformats the SQL for readability.
 
 <Frame>
   <img src="https://static.cube.dev/docs/explore-analyze/workbooks/edit-semantic-sql-v2.png" />

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -22,6 +22,11 @@ Model Context Protocol (MCP) is an open standard that enables AI assistants to s
 Cube hosts an MCP server endpoint for your tenant. MCP clients connect over HTTPS and authenticate via OAuth.
 
 - **Endpoint:** `https://<cube-mcp-server-host>/api/mcp`
+- **Centralized endpoint:** `https://<console-domain>/mcp` — one fixed URL, on the Cube
+  Cloud console domain rather than your tenant's own host, that proxies to the same
+  server. Use it for MCP connector directories and clients that require one server URL
+  registered up front, since the per-tenant endpoint above can vary by region or BYOC
+  domain.
 - **OAuth discovery:** `https://<cube-mcp-server-host>/.well-known/oauth`
 - **OAuth flow:** Authorization Code + PKCE, `client_id` = `cube-mcp-client`, scope = `mcp-agent-access`
 - **Deployment selection:** On connect, the client lands on the tenant **default deployment** set by your admin (or the first deployment you can access). Clients can also target a specific deployment and agent per request — see [Select a deployment and agent](#select-a-deployment-and-agent).
@@ -211,7 +216,7 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 
 ## Available actions
 
-The MCP server exposes 16 tools, grouped below.
+The MCP server exposes 20 tools, grouped below.
 
 Every tool runs as the authenticated user. Queries respect the same
 [permissions][ref-roles] as the rest of Cube, including row-level security — MCP is a new
@@ -232,6 +237,7 @@ a dashboard or your data model happens without an explicit approval.
 | `listDeployments` | Lists the deployments and agents you can reach over MCP. |
 | `chat` | Asks a question of a Cube agent, optionally targeting a specific deployment and agent. |
 | `loadQueryResults` | Paginates through the results of a previous query. |
+| `getDeploymentEnv` | Lists a deployment's environment variables, with secret-looking values redacted. Read-only — it cannot change them. |
 
 See [Select a deployment and agent](#select-a-deployment-and-agent) for how these three
 work together.
@@ -245,6 +251,13 @@ work together.
 
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
 guessing them.
+
+### Pre-aggregations
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `getPreAggregationStatus` | Lists the data model's pre-aggregations with their definitions and, for each, how many partitions exist, how many have been built, when the newest build landed, and the error if a build failed. | Read-only |
+| `buildPreAggregation` | Queues an on-demand build of one pre-aggregation and returns once it's accepted; poll `getPreAggregationStatus` for the result. Runs real queries against your data source, so it consumes warehouse resources. | Write |
 
 ### Dashboard authoring
 
@@ -277,6 +290,7 @@ default. Users without it never see them.
 | `writeDataModelFile` | Creates or overwrites a model source file on the dev branch (whole-file replacement). Recompiles the model and reports `valid` plus any `validationError`. | Destructive — prompts |
 | `deleteDataModelFile` | Deletes a model source file on the dev branch. | Destructive — prompts |
 | `getDataModelChanges` | Shows the diff of the dev branch against its parent — the pending changes, for review before committing. | Read-only |
+| `getBranchDiff` | Shows what any branch changed against an arbitrary base (the deploy branch by default) — the changed-file list with insertion/deletion counts plus the unified diff. Broader than `getDataModelChanges`, which only compares your own dev branch to its immediate parent. | Read-only |
 
 #### How model edits stay safe
 

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -380,6 +380,14 @@ value's grain, not a range — `is yesterday` matches yesterday only (e.g.
 `is this month` matches the current month. For a rolling window, use `between`
 with two bounds.
 
+A date or time member also accepts `in the month`, `in the quarter`, `in the
+year`, and their negations `not in the month`, `not in the quarter`, `not in
+the year`. These take a single fixed date (e.g. `"2026-03-01"`) and match
+every row whose value falls in that date's calendar month, quarter, or year —
+`DATE_TRUNC('quarter', created_at) = DATE_TRUNC('quarter', DATE '2026-03-01')`.
+Unlike `is this month`, the reference date is fixed rather than resolved
+against the current date on every run.
+
 ##### Relative date values
 
 A `between` filter always takes an explicit two-element `[start, end]` pair.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required (this PR is docs-only)
- [ ] Tests have been run in packages where changes have been made if available (N/A — no code changes)
- [ ] Linter has been run for changed code (N/A — no code changes)
- [ ] Tests for the changes have been added if not covered yet (N/A — no code changes)

**Description of Changes Made**

Routine sweep cross-checking recently shipped Cube Cloud (cubejs-enterprise) features against docs-mintlify, per the customer-facing-criteria bar. These were shipped and already announced in the in-app changelog but had no docs-mintlify coverage (or stale coverage). One larger cross-cutting feature (tenant-wide time zone policy, CUB-852) was filed as a Linear ticket instead, since it needs its own page rather than a surgical edit.

- `docs/explore-analyze/charts/chart-types/pie.mdx` — the Style tab's inner-radius slider was replaced by a Pie/Donut shape toggle; added sections for data labels (value/percent/category, position, font size), concentric rings (rendered when a query has 2+ dimensions), and the tooltips control.
- `docs/explore-analyze/charts/chart-types/kpi.mdx` — added a "Styling blocks" section covering the Style tab's per-block alignment, background, and color controls (previously only vaguely described on the Number block).
- `docs/explore-analyze/dashboards/widgets/controls.mdx` — added the new calendar-period filter operators (`in`/`not in the month`/`quarter`/`year`) and a note that filter changes on a published dashboard are now reflected in (and restorable from) the URL.
- `docs/explore-analyze/workbooks/querying-data.mdx` — period-over-period comparison can now anchor to a time dimension the query only filters on (not just one it groups by); "Save and Run" now reformats hand-edited Semantic SQL.
- `reference/data-modeling/view.mdx` — documented the same new calendar-period operators as accepted values for `default_ui_filters`.
- `docs/integrations/mcp-server.mdx` — added the new centralized `/mcp` endpoint and four MCP tools that existed in the server but weren't listed (`getBranchDiff`, `getDeploymentEnv`, `getPreAggregationStatus`, `buildPreAggregation`).

Verified each change against the current cubejs-enterprise source (component code, i18n strings, MCP tool registrations) rather than relying on commit subjects alone.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_019bMVxieG2qCBLtaD6MGP8d

---
_Generated by [Claude Code](https://claude.ai/code/session_019bMVxieG2qCBLtaD6MGP8d)_