### PR TITLE
fix(tesseract): report multi-stage reads of out-of-grain dimensions

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -228,6 +228,10 @@ impl MultiStageQueryPlanner {
         resolved_multi_stage_dimensions: &mut HashSet<String>,
         scope: &mut PlanningScope,
     ) -> Result<(), CubeError> {
+        // The CASE-SWITCH path plans every branch dependency as its own CTE,
+        // dimensions included, so each one is a column of the source rather than
+        // something the stage grain has to carry. It deliberately skips the
+        // reachability check `default_make_childs` applies.
         if let Some(Case::CaseSwitch(case_switch)) = member.case() {
             if self.try_make_childs_for_case_switch(
                 case_switch,
@@ -339,7 +343,12 @@ impl MultiStageQueryPlanner {
         resolved_multi_stage_dimensions: &mut HashSet<String>,
         scope: &mut PlanningScope,
     ) -> Result<(), CubeError> {
-        let rendered: HashSet<String> = rendered_dependencies(&member)
+        let is_masked = |m: &Rc<MemberSymbol>| {
+            self.query_tools
+                .query_tools()
+                .is_member_masked(&m.full_name())
+        };
+        let rendered: HashSet<String> = rendered_dependencies(&member, &is_masked)
             .into_iter()
             .map(|d| d.resolve_reference_chain().full_name())
             .collect();
@@ -359,7 +368,7 @@ impl MultiStageQueryPlanner {
                     result.push(description);
                 }
             } else if dep.is_dimension() && rendered.contains(&dep.full_name()) {
-                Self::check_dimension_is_reachable(&member, dep, &new_state, parent_state)?;
+                self.check_dimension_is_reachable(&member, dep, &new_state, parent_state)?;
             }
         }
         if !has_inputs {
@@ -392,12 +401,17 @@ impl MultiStageQueryPlanner {
     /// all — the fallback is its own cube alias, and no cube is part of a CTE
     /// built from subqueries.
     fn check_dimension_is_reachable(
+        &self,
         member: &Rc<MemberSymbol>,
         dimension: &Rc<MemberSymbol>,
         grain_state: &QueryProperties,
         parent_state: &QueryProperties,
     ) -> Result<(), CubeError> {
-        if dimension_is_reachable(dimension, grain_state, parent_state) {
+        if dimension_is_reachable(dimension, grain_state, parent_state, &|m| {
+            self.query_tools
+                .query_tools()
+                .is_member_masked(&m.full_name())
+        }) {
             return Ok(());
         }
         Err(CubeError::user(format!(
@@ -1156,6 +1170,7 @@ fn dimension_is_reachable(
     dimension: &Rc<MemberSymbol>,
     grain_state: &QueryProperties,
     parent_state: &QueryProperties,
+    is_masked: &dyn Fn(&Rc<MemberSymbol>) -> bool,
 ) -> bool {
     let target = dimension.full_name();
     let carries = |state: &QueryProperties| {
@@ -1168,28 +1183,41 @@ fn dimension_is_reachable(
     if carries(grain_state) || carries(parent_state) {
         return true;
     }
-    let deps = rendered_dependencies(dimension);
+    let deps = rendered_dependencies(dimension, is_masked);
     !deps.is_empty()
-        && !reads_raw_cube_column(dimension)
+        && !reads_raw_cube_column(dimension, is_masked)
         && deps.iter().all(|dep| {
             dimension_is_reachable(
                 &dep.clone().resolve_reference_chain(),
                 grain_state,
                 parent_state,
+                is_masked,
             )
         })
 }
 
 // The slots of a member that reach its rendered SQL. `drill_filters` are carried
-// by the symbol but never emitted, and a `mask` is emitted only for members the
-// security context actually masks — neither can put a column requirement on the
-// CTE. Both the member deps and the cube refs have to be read through this, or an
-// excluded slot leaks back in through the side that isn't filtered.
+// by the symbol but never emitted, so they never put a column requirement on the
+// CTE. A `mask` is emitted only for the members it applies to, so it is included
+// for those and excluded otherwise. Both the member deps and the cube refs have to
+// be read through this, or an excluded slot leaks back in through the side that
+// isn't filtered.
 //
 // `iter_sql_calls` is the neighbouring accessor and is deliberately not reused:
 // on the measure side it covers `kind` and `case` only, missing `measure_filters`
 // and `measure_order_by`.
-fn visit_rendered_slots(member: &Rc<MemberSymbol>, visit: &mut dyn FnMut(&dyn SymbolDeps)) {
+fn visit_rendered_slots(
+    member: &Rc<MemberSymbol>,
+    is_masked: &dyn Fn(&Rc<MemberSymbol>) -> bool,
+    visit: &mut dyn FnMut(&dyn SymbolDeps),
+) {
+    // A mask reaches the SQL exactly for the members it is applied to, so it
+    // counts as rendered only for those.
+    if is_masked(member) {
+        if let Some(mask) = member.mask_sql() {
+            visit(mask);
+        }
+    }
     if let Ok(measure) = member.as_measure() {
         visit(measure.kind());
         for filter in measure.measure_filters() {
@@ -1207,21 +1235,29 @@ fn visit_rendered_slots(member: &Rc<MemberSymbol>, visit: &mut dyn FnMut(&dyn Sy
         // A time dimension is a view of its base: the granularity renders around
         // whatever the base renders, so both contribute.
         visit(time_dimension.granularity_obj());
-        visit_rendered_slots(time_dimension.base_symbol(), visit);
+        visit_rendered_slots(time_dimension.base_symbol(), is_masked, visit);
     } else {
         visit(member.as_ref());
     }
 }
 
-fn rendered_dependencies(member: &Rc<MemberSymbol>) -> Vec<Rc<MemberSymbol>> {
+fn rendered_dependencies(
+    member: &Rc<MemberSymbol>,
+    is_masked: &dyn Fn(&Rc<MemberSymbol>) -> bool,
+) -> Vec<Rc<MemberSymbol>> {
     let mut result = vec![];
-    visit_rendered_slots(member, &mut |slot| result.extend(collect_deps(slot)));
+    visit_rendered_slots(member, is_masked, &mut |slot| {
+        result.extend(collect_deps(slot))
+    });
     result
 }
 
-fn reads_raw_cube_column(member: &Rc<MemberSymbol>) -> bool {
+fn reads_raw_cube_column(
+    member: &Rc<MemberSymbol>,
+    is_masked: &dyn Fn(&Rc<MemberSymbol>) -> bool,
+) -> bool {
     let mut found = false;
-    visit_rendered_slots(member, &mut |slot| {
+    visit_rendered_slots(member, is_masked, &mut |slot| {
         found = found || !collect_cube_refs(slot).is_empty()
     });
     found

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -1212,7 +1212,11 @@ fn visit_rendered_slots(
     visit: &mut dyn FnMut(&dyn SymbolDeps),
 ) {
     // A mask reaches the SQL exactly for the members it is applied to, so it
-    // counts as rendered only for those.
+    // counts as rendered only for those. The member's own slots below stay
+    // required even then: an unconditional mask replaces the original render
+    // rather than wrapping it, so strictly they are not emitted for a masked
+    // member — but the same model is broken for every unmasked one, and the
+    // narrower rule would only move where that surfaces.
     if is_masked(member) {
         if let Some(mask) = member.mask_sql() {
             visit(mask);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -14,6 +14,7 @@ use crate::planner::filter::BaseFilter;
 use crate::planner::filter::FilterItem;
 use crate::planner::filter::FilterOperator;
 use crate::planner::state::State;
+use crate::planner::symbols::deps::{collect_cube_refs, collect_deps, SymbolDeps};
 use crate::planner::symbols::transforms;
 use crate::planner::symbols::AggregationType;
 use crate::planner::Case;
@@ -221,6 +222,7 @@ impl MultiStageQueryPlanner {
         &self,
         member: Rc<MemberSymbol>,
         new_state: Rc<QueryProperties>,
+        parent_state: &Rc<QueryProperties>,
         result: &mut Vec<Rc<MultiStageQueryDescription>>,
         descriptions: &mut Vec<Rc<MultiStageQueryDescription>>,
         resolved_multi_stage_dimensions: &mut HashSet<String>,
@@ -241,6 +243,7 @@ impl MultiStageQueryPlanner {
         self.default_make_childs(
             member,
             new_state,
+            parent_state,
             result,
             descriptions,
             resolved_multi_stage_dimensions,
@@ -330,11 +333,16 @@ impl MultiStageQueryPlanner {
         &self,
         member: Rc<MemberSymbol>,
         new_state: Rc<QueryProperties>,
+        parent_state: &Rc<QueryProperties>,
         result: &mut Vec<Rc<MultiStageQueryDescription>>,
         descriptions: &mut Vec<Rc<MultiStageQueryDescription>>,
         resolved_multi_stage_dimensions: &mut HashSet<String>,
         scope: &mut PlanningScope,
     ) -> Result<(), CubeError> {
+        let rendered: HashSet<String> = rendered_dependencies(&member)
+            .into_iter()
+            .map(|d| d.resolve_reference_chain().full_name())
+            .collect();
         let mut has_inputs = false;
         for dep in member.get_dependencies() {
             let dep = &dep.resolve_reference_chain();
@@ -350,6 +358,8 @@ impl MultiStageQueryPlanner {
                 if !description.is_multi_stage_dimension() || member.as_dimension().is_ok() {
                     result.push(description);
                 }
+            } else if dep.is_dimension() && rendered.contains(&dep.full_name()) {
+                Self::check_dimension_is_reachable(&member, dep, &new_state, parent_state)?;
             }
         }
         if !has_inputs {
@@ -372,6 +382,31 @@ impl MultiStageQueryPlanner {
             descriptions.push(description.clone());
         }
         Ok(())
+    }
+
+    /// A dimension read by a multi-stage member's SQL is rendered against the
+    /// CTE that computes the member, so it has to be a column of it. Two grains
+    /// can supply one: the stage's own (`grain_state`) and, when the assembly
+    /// broadcasts a narrowed measure back onto the query grid, the keys side
+    /// built from `parent_state`. Beyond those the dimension has no rendering at
+    /// all — the fallback is its own cube alias, and no cube is part of a CTE
+    /// built from subqueries.
+    fn check_dimension_is_reachable(
+        member: &Rc<MemberSymbol>,
+        dimension: &Rc<MemberSymbol>,
+        grain_state: &QueryProperties,
+        parent_state: &QueryProperties,
+    ) -> Result<(), CubeError> {
+        if dimension_is_reachable(dimension, grain_state, parent_state) {
+            return Ok(());
+        }
+        Err(CubeError::user(format!(
+            "Multi-stage member {member} reads dimension {dimension}, which is not part of the \
+             grain it is computed at. Add {dimension} to `grain.include` of {member}, or remove \
+             it from the member's sql.",
+            member = member.full_name(),
+            dimension = dimension.full_name(),
+        )))
     }
 
     /// Plans CASE-SWITCH dependencies: collects, per dependency, the
@@ -640,6 +675,7 @@ impl MultiStageQueryPlanner {
             self.make_childs(
                 member.clone(),
                 new_state.clone(),
+                &state,
                 &mut input,
                 descriptions,
                 resolved_multi_stage_dimensions,
@@ -678,6 +714,7 @@ impl MultiStageQueryPlanner {
                     self.make_childs(
                         member.clone(),
                         state.clone(),
+                        &state,
                         &mut keys_input,
                         descriptions,
                         resolved_multi_stage_dimensions,
@@ -1101,6 +1138,93 @@ impl MultiStageQueryPlanner {
 
         Ok((Rc::new(new_state), new_time_dimension))
     }
+}
+
+// Mirrors how references are resolved when the CTE is rendered: a member the
+// source exposes as a column stops the walk, and anything else is reachable only
+// if every member its own SQL reads is. A dimension that also reads a raw cube
+// column is unreachable whatever its member deps resolve to — that column renders
+// against the cube alias, which such a CTE never has in scope.
+//
+// A leaf outside both grains is reported as well. `sql: category` and a constant
+// `sql: "'x'"` are indistinguishable here — neither carries a cube ref — so the
+// constant is reported too, and declaring it in `grain.include` resolves that the
+// same way. The same ambiguity runs the other way: a bare identifier inside a
+// larger expression (`UPPER({CUBE.status}) || category`) carries no cube ref
+// either, so it passes and fails at the database instead.
+fn dimension_is_reachable(
+    dimension: &Rc<MemberSymbol>,
+    grain_state: &QueryProperties,
+    parent_state: &QueryProperties,
+) -> bool {
+    let target = dimension.full_name();
+    let carries = |state: &QueryProperties| {
+        state
+            .dimensions()
+            .iter()
+            .chain(state.time_dimensions().iter())
+            .any(|d| d.clone().resolve_reference_chain().full_name() == target)
+    };
+    if carries(grain_state) || carries(parent_state) {
+        return true;
+    }
+    let deps = rendered_dependencies(dimension);
+    !deps.is_empty()
+        && !reads_raw_cube_column(dimension)
+        && deps.iter().all(|dep| {
+            dimension_is_reachable(
+                &dep.clone().resolve_reference_chain(),
+                grain_state,
+                parent_state,
+            )
+        })
+}
+
+// The slots of a member that reach its rendered SQL. `drill_filters` are carried
+// by the symbol but never emitted, and a `mask` is emitted only for members the
+// security context actually masks — neither can put a column requirement on the
+// CTE. Both the member deps and the cube refs have to be read through this, or an
+// excluded slot leaks back in through the side that isn't filtered.
+//
+// `iter_sql_calls` is the neighbouring accessor and is deliberately not reused:
+// on the measure side it covers `kind` and `case` only, missing `measure_filters`
+// and `measure_order_by`.
+fn visit_rendered_slots(member: &Rc<MemberSymbol>, visit: &mut dyn FnMut(&dyn SymbolDeps)) {
+    if let Ok(measure) = member.as_measure() {
+        visit(measure.kind());
+        for filter in measure.measure_filters() {
+            visit(filter);
+        }
+        for order_by in measure.measure_order_by() {
+            visit(order_by);
+        }
+        if let Some(case) = measure.case() {
+            visit(case);
+        }
+    } else if let Ok(dimension) = member.as_dimension() {
+        visit(dimension.kind());
+    } else if let Ok(time_dimension) = member.as_time_dimension() {
+        // A time dimension is a view of its base: the granularity renders around
+        // whatever the base renders, so both contribute.
+        visit(time_dimension.granularity_obj());
+        visit_rendered_slots(time_dimension.base_symbol(), visit);
+    } else {
+        visit(member.as_ref());
+    }
+}
+
+fn rendered_dependencies(member: &Rc<MemberSymbol>) -> Vec<Rc<MemberSymbol>> {
+    let mut result = vec![];
+    visit_rendered_slots(member, &mut |slot| result.extend(collect_deps(slot)));
+    result
+}
+
+fn reads_raw_cube_column(member: &Rc<MemberSymbol>) -> bool {
+    let mut found = false;
+    visit_rendered_slots(member, &mut |slot| {
+        found = found || !collect_cube_refs(slot).is_empty()
+    });
+    found
 }
 
 fn multi_stage_filter_directive(member: &Rc<MemberSymbol>) -> Option<MultiStageFilter> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -131,6 +131,30 @@ cubes:
             type: string
             sql: "NULLIF(category, 'books')"
 
+          # Reads a member and a raw cube column in one expression: the member
+          # half can resolve against a CTE column, the raw half never can.
+          - name: status_and_category
+            type: string
+            sql: "UPPER({CUBE.status}) || {CUBE}.category"
+
+          # Clean sql, with the raw cube column confined to the mask. Reading the
+          # cube refs unfiltered would treat it as a raw read of the dimension.
+          - name: status_upper_masked_by_column
+            type: string
+            sql: "UPPER({CUBE.status})"
+            mask:
+                sql: "{CUBE}.category"
+
+          # Multi-stage time dimension carrying a mask: the mask is not rendered
+          # unless the member is masked, so the dimension it names must not be
+          # required of the CTE.
+          - name: created_at_masked_multi_stage
+            type: time
+            sql: "{CUBE.created_at}"
+            multi_stage: true
+            mask:
+                sql: "{CUBE.category}"
+
           - name: customer_name
             type: string
             sql: "{customers.name}"
@@ -370,6 +394,87 @@ cubes:
                 - interval: "1 month"
                   type: prior
                   timeDimension: orders.created_at
+
+          # Reads a plain dimension of its own cube alongside an aggregated
+          # dependency, without declaring it. At month grain the raw
+          # `created_at` value is no column of the CTE this measure is computed
+          # from, and the only rendering left would be the cube alias, which
+          # that CTE's FROM does not contain — the planner rejects it.
+          - name: amount_first_half_of_month
+            type: sum
+            sql: "CASE WHEN EXTRACT(DAY FROM {CUBE.created_at}) <= 15 THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+
+          # The same read, with the grain the sql needs declared.
+          - name: amount_first_half_of_month_with_grain
+            type: sum
+            sql: "CASE WHEN EXTRACT(DAY FROM {CUBE.created_at}) <= 15 THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+            grain:
+                include:
+                    - orders.created_at
+
+          # Undeclared read one stage further out: the dimension is read by a
+          # measure whose aggregated dependency is itself multi-stage.
+          - name: amount_prev_month_first_half
+            type: sum
+            sql: "CASE WHEN EXTRACT(DAY FROM {CUBE.created_at}) <= 15 THEN {CUBE.amount_prev_month} ELSE 0 END"
+            multi_stage: true
+
+          # Undeclared read of a non-time dimension.
+          - name: completed_amount_multi_stage
+            type: sum
+            sql: "CASE WHEN {CUBE.status} = 'completed' THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+
+          # Reads the very dimension its own `reduce_by` drops from the stage
+          # grain. The dimension still reaches the CTE from the keys side the
+          # JOIN-model builds on the parent grain, so this one plans.
+          - name: amount_reduce_status_reading_status
+            type: sum
+            sql: "CASE WHEN {CUBE.status} = 'completed' THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+            reduce_by:
+                - orders.status
+
+          # Reads a dimension built out of another one. It is no column of the
+          # CTE itself, but renders from the column its own sql reads.
+          - name: amount_by_category_label
+            type: sum
+            sql: "CASE WHEN {CUBE.category_label} = 'Literature' THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+
+          # `drill_filters` are held on the symbol and never rendered, so the
+          # dimension this one names puts no column requirement on the CTE.
+          - name: amount_with_drill_filters
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            drill_filters:
+                - sql: "{CUBE.category} = 'books'"
+
+          # A mask is rendered only for members the security context masks, so
+          # the dimension it reads puts no column requirement on the CTE either.
+          - name: amount_with_masked_dimension_read
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            mask:
+                sql: "CASE WHEN {CUBE.category} = 'books' THEN 0 ELSE 1 END"
+
+          # The read resolves through a member, but the same expression also
+          # reaches a raw cube column that no CTE column can stand in for.
+          - name: amount_by_status_and_category
+            type: sum
+            sql: "CASE WHEN {CUBE.status_and_category} = 'X' THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+
+          # The dimension read here is clean; only its unrendered mask names a
+          # raw cube column.
+          - name: amount_by_status_upper_masked
+            type: sum
+            sql: "CASE WHEN {CUBE.status_upper_masked_by_column} = 'X' THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
 
           - name: amount_mom_diff
             type: number

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -473,8 +473,21 @@ cubes:
           # raw cube column.
           - name: amount_by_status_upper_masked
             type: sum
-            sql: "CASE WHEN {CUBE.status_upper_masked_by_column} = 'X' THEN {CUBE.total_amount} ELSE 0 END"
+            sql: "CASE WHEN {CUBE.status_upper_masked_by_column} = 'COMPLETED' THEN {CUBE.total_amount} ELSE 0 END"
             multi_stage: true
+
+          # Masked, with the dimension the mask reads declared. Pins that an
+          # applied mask is rendered inside the multi-stage CTE and therefore
+          # reads its dimension as a column of it.
+          - name: amount_masked_by_category_in_grain
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            grain:
+                include:
+                    - orders.category
+            mask:
+                sql: "CASE WHEN {CUBE.category} = 'books' THEN -1 ELSE 0 END"
 
           # Declares a grain its own leaf is computed at.
           - name: amount_with_status_in_leaf_grain

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -476,6 +476,23 @@ cubes:
             sql: "CASE WHEN {CUBE.status_upper_masked_by_column} = 'X' THEN {CUBE.total_amount} ELSE 0 END"
             multi_stage: true
 
+          # Declares a grain its own leaf is computed at.
+          - name: amount_with_status_in_leaf_grain
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            grain:
+                include:
+                    - orders.status
+
+          # Reads the dimension the measure below it declared. A declared grain
+          # widens that measure's own leaf, not the columns its CTE projects, so
+          # this read still has nowhere to come from.
+          - name: amount_reading_a_child_leaf_grain
+            type: sum
+            sql: "CASE WHEN {CUBE.status} = 'completed' THEN {CUBE.amount_with_status_in_leaf_grain} ELSE 0 END"
+            multi_stage: true
+
           - name: amount_mom_diff
             type: number
             sql: "{CUBE.total_amount} - {CUBE.amount_prev_month}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
@@ -1,0 +1,356 @@
+//! Multi-stage members whose SQL reads a plain dimension of their own cube.
+//!
+//! Such a member is rendered against the CTE that computes its aggregated
+//! dependency, so the dimension has to be one of that CTE's columns. When no
+//! grain supplies it, rendering would fall back to the dimension's own cube
+//! alias — a table name nothing in the CTE's FROM brings into scope — and the
+//! planner reports the member instead.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_multi_stage.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+fn month_query(measure: &str) -> String {
+    format!(
+        indoc! {r#"
+            measures:
+              - orders.{}
+            time_dimensions:
+              - dimension: orders.created_at
+                granularity: month
+                dateRange:
+                  - "2024-01-01"
+                  - "2024-03-31"
+        "#},
+        measure
+    )
+}
+
+fn expect_error(measure: &str) -> String {
+    let ctx = create_context();
+    match ctx.build_sql(&month_query(measure)) {
+        Ok(sql) => panic!("Expected a planning error for orders.{measure}, got SQL:\n{sql}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undeclared_time_dimension_read_is_reported() {
+    let message = expect_error("amount_first_half_of_month");
+
+    assert!(
+        message.contains("orders.amount_first_half_of_month")
+            && message.contains("orders.created_at"),
+        "The error must name both the member and the dimension it reads:\n{}",
+        message
+    );
+    assert!(
+        message.contains("grain.include"),
+        "The error must point at the declaration that fixes the model:\n{}",
+        message
+    );
+}
+
+/// The reading member consumes a time-shifted multi-stage measure, so its own
+/// grain is settled one stage above the leaf that would have to carry the
+/// dimension.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undeclared_read_by_a_consumer_of_a_shifted_measure_is_reported() {
+    let message = expect_error("amount_prev_month_first_half");
+
+    assert!(
+        message.contains("orders.amount_prev_month_first_half")
+            && message.contains("orders.created_at"),
+        "The error must name both the member and the dimension it reads:\n{}",
+        message
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_undeclared_string_dimension_read_is_reported() {
+    let message = expect_error("completed_amount_multi_stage");
+
+    assert!(
+        message.contains("orders.completed_amount_multi_stage")
+            && message.contains("orders.status"),
+        "The error must name both the member and the dimension it reads:\n{}",
+        message
+    );
+}
+
+/// Declaring the grain the sql needs is what makes the model plan: the leaf
+/// carries the raw dimension, and the measure reads it as a CTE column.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_declared_grain_plans_and_reads_the_cte_column() {
+    let ctx = create_context();
+
+    let sql = ctx
+        .build_sql(&month_query("amount_first_half_of_month_with_grain"))
+        .unwrap();
+
+    // The trailing quote is what keeps this from matching `orders__created_at_month`.
+    assert!(
+        sql.contains("\"orders__created_at\""),
+        "Expected the raw time dimension to be materialized as a CTE column:\n{}",
+        sql
+    );
+    assert!(
+        !sql.contains("EXTRACT(DAY FROM \"orders\".created_at)"),
+        "The measure must not read the dimension off the cube alias:\n{}",
+        sql
+    );
+}
+
+/// The declared grain widens the leaf only — the query still reports months.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_declared_grain_keeps_the_query_grain() {
+    let ctx = create_context();
+
+    let sql = ctx
+        .build_sql(&month_query("amount_first_half_of_month_with_grain"))
+        .unwrap();
+
+    let (_, final_select) = sql
+        .rsplit_once("\nSELECT")
+        .expect("the plan must end in a top-level SELECT");
+    assert!(
+        !final_select.contains("\"orders__created_at\""),
+        "The raw time dimension must not reach the query projection:\n{}",
+        sql
+    );
+    assert!(
+        final_select.contains("orders__created_at_month"),
+        "Expected the month grain in the query projection:\n{}",
+        sql
+    );
+}
+
+/// A dimension the stage's own `reduce_by` drops is still reachable from the
+/// keys side, so reading it must not be reported.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dimension_reachable_from_the_keys_side_is_not_reported() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_reduce_status_reading_status
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.status
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("\"fk_aggregate_keys\".\"orders__status\" = 'completed'"),
+        "Expected the measure to read the dimension off the keys side:\n{}",
+        sql
+    );
+}
+
+/// A dimension the query itself groups by is part of the stage grain, so it
+/// resolves without any declaration.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dimension_in_the_query_grain_is_not_reported() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.completed_amount_multi_stage
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.status
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("\"fk_aggregate\".\"orders__status\" = 'completed'"),
+        "Expected the measure to read the dimension off the stage grain:\n{}",
+        sql
+    );
+}
+
+/// A dimension built out of another one is no column of the CTE itself, but
+/// renders from the column its own sql reads — the reachability walk has to
+/// follow that, the way reference resolution does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dimension_derived_from_a_grain_dimension_is_not_reported() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_category_label
+        dimensions:
+          - orders.category
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.category
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    // The label's own branch condition, which only the derived dimension emits —
+    // the bare column appears in the projection either way.
+    assert!(
+        sql.contains("\"fk_aggregate\".\"orders__category\" = 'books'"),
+        "Expected the derived dimension to render from the grain column:\n{}",
+        sql
+    );
+}
+
+/// The read resolves through a member, but the same expression also reaches a
+/// raw cube column, and no CTE column can stand in for that.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_read_mixing_a_member_and_a_raw_column_is_reported() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_status_and_category
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.status
+    "#};
+
+    match ctx.build_sql(query) {
+        Ok(sql) => panic!("Expected a planning error, got SQL:\n{sql}"),
+        Err(e) => assert!(
+            e.to_string().contains("orders.status_and_category"),
+            "The error must name the dimension that reads the raw column:\n{}",
+            e
+        ),
+    }
+}
+
+/// `drill_filters` never reach the rendered SQL, so a dimension named only
+/// there puts no column requirement on the CTE.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dimension_read_only_by_drill_filters_is_not_reported() {
+    let ctx = create_context();
+
+    let sql = ctx
+        .build_sql(&month_query("amount_with_drill_filters"))
+        .unwrap();
+
+    assert!(
+        !sql.contains("\"orders\".category"),
+        "The drill filter must not put a cube-qualified column into the CTE:\n{}",
+        sql
+    );
+}
+
+/// A mask is rendered only for members the security context masks, so a
+/// dimension read from an inactive mask puts no column requirement either.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dimension_read_only_by_an_inactive_mask_is_not_reported() {
+    let ctx = create_context();
+
+    let sql = ctx
+        .build_sql(&month_query("amount_with_masked_dimension_read"))
+        .unwrap();
+
+    assert!(
+        !sql.contains("\"orders\".category"),
+        "The inactive mask must not put a cube-qualified column into the CTE:\n{}",
+        sql
+    );
+}
+
+/// The exclusion has to hold for the cube refs of a mask as well: a dimension
+/// whose own sql is clean must not be rejected because its mask names a raw
+/// column.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_raw_column_read_only_by_a_mask_is_not_reported() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_status_upper_masked
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.status
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("UPPER(\"fk_aggregate\".\"orders__status\")"),
+        "Expected the dimension to render from the grain column:\n{}",
+        sql
+    );
+    assert!(
+        !sql.contains("\"orders\".category"),
+        "The inactive mask must not put a cube-qualified column into the CTE:\n{}",
+        sql
+    );
+}
+
+/// The same exclusion has to hold when the masked member is a multi-stage time
+/// dimension, which reaches its slots through the base symbol it is a view of.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_masked_multi_stage_time_dimension_is_not_reported() {
+    let ctx = create_context();
+
+    // `orders.created_at` is grouped by so that the dimension's own sql dep is
+    // reachable — otherwise this would report for that reason and stop guarding
+    // the mask.
+    let query = indoc! {r#"
+        measures:
+          - orders.total_amount
+        dimensions:
+          - orders.created_at
+        time_dimensions:
+          - dimension: orders.created_at_masked_multi_stage
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        !sql.contains("\"orders\".category"),
+        "The inactive mask must not put a cube-qualified column into the CTE:\n{}",
+        sql
+    );
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
@@ -15,6 +15,8 @@ fn create_context() -> TestContext {
     TestContext::new(schema).unwrap()
 }
 
+const SEED: &str = "integration_multi_stage_tables.sql";
+
 fn month_query(measure: &str) -> String {
     format!(
         indoc! {r#"
@@ -89,9 +91,8 @@ async fn test_undeclared_string_dimension_read_is_reported() {
 async fn test_declared_grain_plans_and_reads_the_cte_column() {
     let ctx = create_context();
 
-    let sql = ctx
-        .build_sql(&month_query("amount_first_half_of_month_with_grain"))
-        .unwrap();
+    let query = month_query("amount_first_half_of_month_with_grain");
+    let sql = ctx.build_sql(&query).unwrap();
 
     // The trailing quote is what keeps this from matching `orders__created_at_month`.
     assert!(
@@ -104,6 +105,10 @@ async fn test_declared_grain_plans_and_reads_the_cte_column() {
         "The measure must not read the dimension off the cube alias:\n{}",
         sql
     );
+
+    if let Some(result) = ctx.try_execute_pg(&query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// The declared grain widens the leaf only — the query still reports months.
@@ -132,6 +137,11 @@ async fn test_declared_grain_keeps_the_query_grain() {
 
 /// A dimension the stage's own `reduce_by` drops is still reachable from the
 /// keys side, so reading it must not be reported.
+///
+/// The values are the whole month against the `completed` row rather than the
+/// `completed` total: `reduce_by` collapses the measure to a grain without
+/// `status`, and the CASE then reads the status of the broadcast row. That is
+/// what this shape means, not a defect in the reachability check.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dimension_reachable_from_the_keys_side_is_not_reported() {
     let ctx = create_context();
@@ -158,6 +168,10 @@ async fn test_dimension_reachable_from_the_keys_side_is_not_reported() {
         "Expected the measure to read the dimension off the keys side:\n{}",
         sql
     );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// A `grain.include` on the measure below widens *that* measure's leaf, not the
@@ -204,6 +218,10 @@ async fn test_dimension_in_the_query_grain_is_not_reported() {
         "Expected the measure to read the dimension off the stage grain:\n{}",
         sql
     );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// A dimension built out of another one is no column of the CTE itself, but
@@ -237,6 +255,10 @@ async fn test_dimension_derived_from_a_grain_dimension_is_not_reported() {
         "Expected the derived dimension to render from the grain column:\n{}",
         sql
     );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// The read resolves through a member, but the same expression also reaches a
@@ -285,6 +307,13 @@ async fn test_dimension_read_only_by_drill_filters_is_not_reported() {
         "The drill filter must not put a cube-qualified column into the CTE:\n{}",
         sql
     );
+
+    if let Some(result) = ctx
+        .try_execute_pg(&month_query("amount_with_drill_filters"), SEED)
+        .await
+    {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// A mask is rendered only for members the security context masks, so a
@@ -338,6 +367,10 @@ async fn test_raw_column_read_only_by_a_mask_is_not_reported() {
         "The inactive mask must not put a cube-qualified column into the CTE:\n{}",
         sql
     );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
 }
 
 /// The exclusion is conditional on the mask not being applied. Once the query

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
@@ -159,6 +159,7 @@ async fn test_dimension_reachable_from_the_keys_side_is_not_reported() {
               - "2024-03-31"
         order:
           - id: orders.status
+          - id: orders.created_at
     "#};
 
     let sql = ctx.build_sql(query).unwrap();
@@ -209,6 +210,7 @@ async fn test_dimension_in_the_query_grain_is_not_reported() {
               - "2024-03-31"
         order:
           - id: orders.status
+          - id: orders.created_at
     "#};
 
     let sql = ctx.build_sql(query).unwrap();
@@ -244,6 +246,7 @@ async fn test_dimension_derived_from_a_grain_dimension_is_not_reported() {
               - "2024-03-31"
         order:
           - id: orders.category
+          - id: orders.created_at
     "#};
 
     let sql = ctx.build_sql(query).unwrap();
@@ -280,6 +283,7 @@ async fn test_read_mixing_a_member_and_a_raw_column_is_reported() {
               - "2024-03-31"
         order:
           - id: orders.status
+          - id: orders.created_at
     "#};
 
     match ctx.build_sql(query) {
@@ -298,9 +302,8 @@ async fn test_read_mixing_a_member_and_a_raw_column_is_reported() {
 async fn test_dimension_read_only_by_drill_filters_is_not_reported() {
     let ctx = create_context();
 
-    let sql = ctx
-        .build_sql(&month_query("amount_with_drill_filters"))
-        .unwrap();
+    let query = month_query("amount_with_drill_filters");
+    let sql = ctx.build_sql(&query).unwrap();
 
     assert!(
         !sql.contains("\"orders\".category"),
@@ -308,10 +311,7 @@ async fn test_dimension_read_only_by_drill_filters_is_not_reported() {
         sql
     );
 
-    if let Some(result) = ctx
-        .try_execute_pg(&month_query("amount_with_drill_filters"), SEED)
-        .await
-    {
+    if let Some(result) = ctx.try_execute_pg(&query, SEED).await {
         insta::assert_snapshot!(result);
     }
 }
@@ -322,9 +322,8 @@ async fn test_dimension_read_only_by_drill_filters_is_not_reported() {
 async fn test_dimension_read_only_by_an_inactive_mask_is_not_reported() {
     let ctx = create_context();
 
-    let sql = ctx
-        .build_sql(&month_query("amount_with_masked_dimension_read"))
-        .unwrap();
+    let query = month_query("amount_with_masked_dimension_read");
+    let sql = ctx.build_sql(&query).unwrap();
 
     assert!(
         !sql.contains("\"orders\".category"),
@@ -353,6 +352,7 @@ async fn test_raw_column_read_only_by_a_mask_is_not_reported() {
               - "2024-03-31"
         order:
           - id: orders.status
+          - id: orders.created_at
     "#};
 
     let sql = ctx.build_sql(query).unwrap();
@@ -396,6 +396,57 @@ async fn test_active_mask_reading_an_out_of_grain_dimension_is_reported() {
             "The error must name the dimension the mask reads:\n{}",
             e
         ),
+    }
+}
+
+/// The accept side of the same rule, and the premise the mask branch rests on:
+/// an applied mask is rendered inside the multi-stage CTE, so its dimension read
+/// resolves against a column of that CTE rather than the cube alias.
+///
+/// The dimension is grouped by in the query, not merely declared in
+/// `grain.include`. An unconditional mask replaces the member's aggregate, so its
+/// read sits outside any aggregate and has to be in the stage's own GROUP BY; a
+/// declared leaf grain puts the column in the source but not in that GROUP BY,
+/// and the database rejects the result. The reachability check does not tell the
+/// two apart — it asks only whether a column exists — so that shape still plans
+/// and fails at the database.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_active_mask_reading_a_grouped_dimension_plans() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_masked_by_category_in_grain
+        dimensions:
+          - orders.category
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-03-31"
+        order:
+          - id: orders.category
+          - id: orders.created_at
+        maskedMembers:
+          - member: orders.amount_masked_by_category_in_grain
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("\"fk_aggregate\".\"orders__category\" = 'books'"),
+        "Expected the mask to render against the CTE column:\n{}",
+        sql
+    );
+    assert!(
+        !sql.contains("\"orders\".category = 'books'"),
+        "The mask must not read the dimension off the cube alias:\n{}",
+        sql
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
@@ -160,6 +160,22 @@ async fn test_dimension_reachable_from_the_keys_side_is_not_reported() {
     );
 }
 
+/// A `grain.include` on the measure below widens *that* measure's leaf, not the
+/// columns its own CTE projects, so a member reading the dimension one stage up
+/// still has nowhere to read it from. Pinned because the difference between
+/// widening a leaf and projecting a column is easy to mistake for an oversight.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_grain_declared_by_a_child_does_not_satisfy_the_parent() {
+    let message = expect_error("amount_reading_a_child_leaf_grain");
+
+    assert!(
+        message.contains("orders.amount_reading_a_child_leaf_grain")
+            && message.contains("orders.status"),
+        "The error must name both the member and the dimension it reads:\n{}",
+        message
+    );
+}
+
 /// A dimension the query itself groups by is part of the stage grain, so it
 /// resolves without any declaration.
 #[tokio::test(flavor = "multi_thread")]
@@ -322,6 +338,32 @@ async fn test_raw_column_read_only_by_a_mask_is_not_reported() {
         "The inactive mask must not put a cube-qualified column into the CTE:\n{}",
         sql
     );
+}
+
+/// The exclusion is conditional on the mask not being applied. Once the query
+/// masks the member, the mask does reach the SQL, and the dimension it reads has
+/// to be reachable like any other.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_active_mask_reading_an_out_of_grain_dimension_is_reported() {
+    let ctx = create_context();
+
+    let query = format!(
+        "{}{}",
+        month_query("amount_with_masked_dimension_read"),
+        indoc! {"
+            maskedMembers:
+              - member: orders.amount_with_masked_dimension_read
+        "},
+    );
+
+    match ctx.build_sql(&query) {
+        Ok(sql) => panic!("Expected a planning error, got SQL:\n{sql}"),
+        Err(e) => assert!(
+            e.to_string().contains("orders.category"),
+            "The error must name the dimension the mask reads:\n{}",
+            e
+        ),
+    }
 }
 
 /// The same exclusion has to hold when the masked member is a multi-stage time

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
@@ -2,6 +2,7 @@ mod add_group_by;
 mod bucketing;
 mod calculated;
 mod case_switch;
+mod dimension_deps;
 mod dimensions;
 mod edge_cases;
 mod filter_directive;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__active_mask_reading_a_grouped_dimension_plans.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__active_mask_reading_a_grouped_dimension_plans.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__category | orders__created_at_month | orders__amount_masked_by_category_in_grain
+-----------------+--------------------------+-------------------------------------------
+books            | 2024-01-01 00:00:00      | -1                                        
+books            | 2024-02-01 00:00:00      | -1                                        
+books            | 2024-03-01 00:00:00      | -1                                        
+clothing         | 2024-01-01 00:00:00      | 0                                         
+clothing         | 2024-02-01 00:00:00      | 0                                         
+clothing         | 2024-03-01 00:00:00      | 0                                         
+electronics      | 2024-01-01 00:00:00      | 0                                         
+electronics      | 2024-02-01 00:00:00      | 0                                         
+electronics      | 2024-03-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__declared_grain_plans_and_reads_the_cte_column.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__declared_grain_plans_and_reads_the_cte_column.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__created_at_month | orders__amount_first_half_of_month_with_grain
+-------------------------+----------------------------------------------
+2024-01-01 00:00:00      | 420.00                                       
+2024-02-01 00:00:00      | 650.00                                       
+2024-03-01 00:00:00      | 850.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_derived_from_a_grain_dimension_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_derived_from_a_grain_dimension_is_not_reported.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__category | orders__created_at_month | orders__amount_by_category_label
+-----------------+--------------------------+---------------------------------
+books            | 2024-02-01 00:00:00      | 150.00                          
+books            | 2024-01-01 00:00:00      | 230.00                          
+books            | 2024-03-01 00:00:00      | 500.00                          
+clothing         | 2024-02-01 00:00:00      | 0                               
+clothing         | 2024-01-01 00:00:00      | 0                               
+clothing         | 2024-03-01 00:00:00      | 0                               
+electronics      | 2024-01-01 00:00:00      | 0                               
+electronics      | 2024-03-01 00:00:00      | 0                               
+electronics      | 2024-02-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_derived_from_a_grain_dimension_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_derived_from_a_grain_dimension_is_not_reported.snap
@@ -4,12 +4,12 @@ expression: result
 ---
 orders__category | orders__created_at_month | orders__amount_by_category_label
 -----------------+--------------------------+---------------------------------
-books            | 2024-02-01 00:00:00      | 150.00                          
 books            | 2024-01-01 00:00:00      | 230.00                          
+books            | 2024-02-01 00:00:00      | 150.00                          
 books            | 2024-03-01 00:00:00      | 500.00                          
-clothing         | 2024-02-01 00:00:00      | 0                               
 clothing         | 2024-01-01 00:00:00      | 0                               
+clothing         | 2024-02-01 00:00:00      | 0                               
 clothing         | 2024-03-01 00:00:00      | 0                               
 electronics      | 2024-01-01 00:00:00      | 0                               
-electronics      | 2024-03-01 00:00:00      | 0                               
-electronics      | 2024-02-01 00:00:00      | 0
+electronics      | 2024-02-01 00:00:00      | 0                               
+electronics      | 2024-03-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_in_the_query_grain_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_in_the_query_grain_is_not_reported.snap
@@ -4,12 +4,12 @@ expression: result
 ---
 orders__status | orders__created_at_month | orders__completed_amount_multi_stage
 ---------------+--------------------------+-------------------------------------
-cancelled      | 2024-02-01 00:00:00      | 0                                   
 cancelled      | 2024-01-01 00:00:00      | 0                                   
+cancelled      | 2024-02-01 00:00:00      | 0                                   
 cancelled      | 2024-03-01 00:00:00      | 0                                   
-completed      | 2024-02-01 00:00:00      | 500.00                              
 completed      | 2024-01-01 00:00:00      | 300.00                              
+completed      | 2024-02-01 00:00:00      | 500.00                              
 completed      | 2024-03-01 00:00:00      | 600.00                              
 pending        | 2024-01-01 00:00:00      | 0                                   
-pending        | 2024-03-01 00:00:00      | 0                                   
-pending        | 2024-02-01 00:00:00      | 0
+pending        | 2024-02-01 00:00:00      | 0                                   
+pending        | 2024-03-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_in_the_query_grain_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_in_the_query_grain_is_not_reported.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__status | orders__created_at_month | orders__completed_amount_multi_stage
+---------------+--------------------------+-------------------------------------
+cancelled      | 2024-02-01 00:00:00      | 0                                   
+cancelled      | 2024-01-01 00:00:00      | 0                                   
+cancelled      | 2024-03-01 00:00:00      | 0                                   
+completed      | 2024-02-01 00:00:00      | 500.00                              
+completed      | 2024-01-01 00:00:00      | 300.00                              
+completed      | 2024-03-01 00:00:00      | 600.00                              
+pending        | 2024-01-01 00:00:00      | 0                                   
+pending        | 2024-03-01 00:00:00      | 0                                   
+pending        | 2024-02-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_reachable_from_the_keys_side_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_reachable_from_the_keys_side_is_not_reported.snap
@@ -4,12 +4,12 @@ expression: result
 ---
 orders__status | orders__created_at_month | orders__amount_reduce_status_reading_status
 ---------------+--------------------------+--------------------------------------------
-cancelled      | 2024-02-01 00:00:00      | 0                                          
 cancelled      | 2024-01-01 00:00:00      | 0                                          
+cancelled      | 2024-02-01 00:00:00      | 0                                          
 cancelled      | 2024-03-01 00:00:00      | 0                                          
-completed      | 2024-02-01 00:00:00      | 750.00                                     
 completed      | 2024-01-01 00:00:00      | 500.00                                     
+completed      | 2024-02-01 00:00:00      | 750.00                                     
 completed      | 2024-03-01 00:00:00      | 1000.00                                    
 pending        | 2024-01-01 00:00:00      | 0                                          
-pending        | 2024-03-01 00:00:00      | 0                                          
-pending        | 2024-02-01 00:00:00      | 0
+pending        | 2024-02-01 00:00:00      | 0                                          
+pending        | 2024-03-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_reachable_from_the_keys_side_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_reachable_from_the_keys_side_is_not_reported.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__status | orders__created_at_month | orders__amount_reduce_status_reading_status
+---------------+--------------------------+--------------------------------------------
+cancelled      | 2024-02-01 00:00:00      | 0                                          
+cancelled      | 2024-01-01 00:00:00      | 0                                          
+cancelled      | 2024-03-01 00:00:00      | 0                                          
+completed      | 2024-02-01 00:00:00      | 750.00                                     
+completed      | 2024-01-01 00:00:00      | 500.00                                     
+completed      | 2024-03-01 00:00:00      | 1000.00                                    
+pending        | 2024-01-01 00:00:00      | 0                                          
+pending        | 2024-03-01 00:00:00      | 0                                          
+pending        | 2024-02-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_read_only_by_drill_filters_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__dimension_read_only_by_drill_filters_is_not_reported.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__created_at_month | orders__amount_with_drill_filters
+-------------------------+----------------------------------
+2024-01-01 00:00:00      | 500.00                           
+2024-02-01 00:00:00      | 750.00                           
+2024-03-01 00:00:00      | 1000.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__raw_column_read_only_by_a_mask_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__raw_column_read_only_by_a_mask_is_not_reported.snap
@@ -4,12 +4,12 @@ expression: result
 ---
 orders__status | orders__created_at_month | orders__amount_by_status_upper_masked
 ---------------+--------------------------+--------------------------------------
-cancelled      | 2024-02-01 00:00:00      | 0                                    
 cancelled      | 2024-01-01 00:00:00      | 0                                    
+cancelled      | 2024-02-01 00:00:00      | 0                                    
 cancelled      | 2024-03-01 00:00:00      | 0                                    
-completed      | 2024-02-01 00:00:00      | 0                                    
-completed      | 2024-01-01 00:00:00      | 0                                    
-completed      | 2024-03-01 00:00:00      | 0                                    
+completed      | 2024-01-01 00:00:00      | 300.00                               
+completed      | 2024-02-01 00:00:00      | 500.00                               
+completed      | 2024-03-01 00:00:00      | 600.00                               
 pending        | 2024-01-01 00:00:00      | 0                                    
-pending        | 2024-03-01 00:00:00      | 0                                    
-pending        | 2024-02-01 00:00:00      | 0
+pending        | 2024-02-01 00:00:00      | 0                                    
+pending        | 2024-03-01 00:00:00      | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__raw_column_read_only_by_a_mask_is_not_reported.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__dimension_deps__raw_column_read_only_by_a_mask_is_not_reported.snap
@@ -1,0 +1,15 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+expression: result
+---
+orders__status | orders__created_at_month | orders__amount_by_status_upper_masked
+---------------+--------------------------+--------------------------------------
+cancelled      | 2024-02-01 00:00:00      | 0                                    
+cancelled      | 2024-01-01 00:00:00      | 0                                    
+cancelled      | 2024-03-01 00:00:00      | 0                                    
+completed      | 2024-02-01 00:00:00      | 0                                    
+completed      | 2024-01-01 00:00:00      | 0                                    
+completed      | 2024-03-01 00:00:00      | 0                                    
+pending        | 2024-01-01 00:00:00      | 0                                    
+pending        | 2024-03-01 00:00:00      | 0                                    
+pending        | 2024-02-01 00:00:00      | 0


### PR DESCRIPTION
## Summary

A multi-stage member whose SQL reads a dimension that is not part of the grain it is computed at emitted SQL referencing the dimension's own cube alias — a table nothing in the CTE's `FROM` brings into scope. Postgres rejects it with `missing FROM-clause entry`, and nothing reported it at plan time. This PR reports the member and the dimension instead, naming the declaration that fixes the model.

This is a regression. Through v1.3.11 the planner raised `member X has no source`; `1deddcc4e3` (#9434, pre-aggregations) commented out that guard, and v1.3.12 onward produced broken SQL silently. Restoring the original guard is not an option — it recognises only `SingleSource::Cube`, so pre-aggregation sources fail it (verified: 607 of 1191 tests break on ordinary queries).

Broken output, Postgres dialect:

```sql
cte_1 AS (
  SELECT "fk_aggregate"."base__metric_ts_quarter" ...,
         sum(CASE WHEN EXTRACT(MONTH FROM "base".metric_ts) IN (1,4,7,10)
                  THEN "fk_aggregate"."base__total" ELSE 0 END) ...
  FROM cte_0 AS "fk_aggregate")   -- "base" is not in scope
```

Now:

```
Multi-stage member orders.amount_first_half_of_month reads dimension orders.created_at,
which is not part of the grain it is computed at. Add orders.created_at to
`grain.include` of orders.amount_first_half_of_month, or remove it from the member's sql.
```

Declaring `grain.include` is both the fix and a workaround that already works on released versions — no upgrade needed to unblock a model.

## Changes

- Check dimension reachability in `default_make_childs`, where a multi-stage member's deps are decomposed into children. `CubeError::user` — this is a model error, not a planner failure.
- Reachability mirrors reference resolution: a member the source exposes as a column stops the walk; anything else is reachable only if every member its own SQL reads is; a dimension that also reads a raw cube column is unreachable regardless of what its member deps resolve to.
- `visit_rendered_slots` is the single slot list both the dependency walk and the cube-ref test read, so the two cannot drift. `drill_filters` are never emitted, so they never constrain the CTE; a `mask` is emitted only for the members it is applied to, so it counts for those and is excluded otherwise.
- A dimension the stage's own `reduce_by` drops still reaches the CTE from the keys side, and is not reported.
- 16 tests in `dimension_deps.rs`: reported / plans with `grain.include` / not reported falsely (derived dimensions, `drill_filters`, inactive masks, keys side, query grain). Seven of them execute against Postgres and pin the result sets.

## Testing

| run | result |
| -- | -- |
| `cargo test -p cubesqlplanner --features integration-postgres` | 1206 passed, 0 failed |
| `cargo test -p cubesqlplanner` | 1206 passed, 0 failed |
| `cargo clippy --all-targets --features integration-postgres` | clean |

**Executed against Postgres.** Seven plans the guard lets through now run on a live database, and every pinned result set was recomputed by hand from `integration_multi_stage_tables.sql` — e.g. the declared-grain measure returns 420 / 650 / 850 for day ≤ 15 (Jan 100+200+120, Feb 300+200+150, Mar 400+200+250). `try_execute_pg` panics with the full SQL on a failed statement, so these tests now fail loudly on a `missing FROM-clause entry` regression instead of passing a substring assertion.

Every behavioural change was checked against a negative control: reverting it individually makes the corresponding test fail with the expected broken SQL. Snapshot row order is pinned by naming every grouped dimension in `order:`, so the result sets do not depend on hash-aggregate output order.

Semantics were taken from the legacy planner rather than invented — it materialises the same dimension into the leaf grain, so the intended shape is not in doubt.

Reviewed over five adversarial rounds; each round found a false-positive class that would have rejected working models (derived dimensions, `drill_filters`/`mask` slots, expressions mixing a member with a raw column, unfiltered cube refs). All closed and pinned by tests.

## Known limitations

Documented in the code, and worth a release note for the first one:

- **Constant dimensions are reported.** At symbol level `sql: category` and `sql: "'x'"` are indistinguishable — neither carries a cube ref — so a constant dimension read by a multi-stage member now needs a `grain.include` entry it did not need before. A model that worked for years starts failing; declaring the dimension resolves it.
- **A bare identifier inside a larger expression passes through.** `UPPER({CUBE.status}) || category` carries no cube ref either, so it plans and fails at the database. Same ambiguity, opposite direction.
- **An unconditional mask replaces the member's aggregate**, so its dimension read sits outside any aggregate and has to be in the stage's own `GROUP BY`. A declared leaf grain puts the column in the source but not in that `GROUP BY`. The check asks only whether a column exists and does not tell the two apart, so that shape plans and the database rejects it. Pinned and explained on `test_active_mask_reading_a_grouped_dimension_plans`.
- **`rolling_window` measures are not covered** — they take a different planning path (`try_plan_rolling_window`) and keep their pre-existing defect, where the dimension lands outside both the aggregate and the `GROUP BY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
