### PR TITLE
fix(schema-compiler): promote DATE columns in Trino/Presto convertTz

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -53,12 +53,19 @@ export class PrestodbQuery extends BaseQuery {
    * Lifts a DATE expression to a timestamp so that timezone arithmetic accepts
    * it. `COALESCE` with a NULL timestamp resolves to the common supertype,
    * which triggers the implicit DATE -> TIMESTAMP coercion while leaving both
-   * timestamp types intact. An explicit `CAST(... AS TIMESTAMP)` would instead
-   * strip the zone off a `timestamp with time zone` expression, so the
-   * subsequent `AT TIME ZONE` would reinterpret its wall clock in the session
-   * timezone and shift the result.
+   * timestamp types intact. Deliberately not `CAST(... AS TIMESTAMP)`: that
+   * strips the zone off a `timestamp with time zone` expression, so the
+   * subsequent `AT TIME ZONE` reinterprets its wall clock in the session
+   * timezone and shifts the result.
+   *
+   * A promoted DATE lands on midnight and is then converted like any other
+   * naive timestamp, which moves its calendar date under a negative offset:
+   * `DATE '2024-01-15'` day-truncates to `2024-01-14` for `America/Los_Angeles`.
+   * That is what every other dialect does with a date column — `PostgresQuery`
+   * reaches the same bucket via `::timestamptz AT TIME ZONE` — so treating DATE
+   * specially here would diverge instead.
    */
-  protected coerceToTimestamp(field: string): string {
+  protected promoteDateToTimestamp(field: string): string {
     return `COALESCE(${field}, CAST(NULL AS TIMESTAMP))`;
   }
 
@@ -67,7 +74,7 @@ export class PrestodbQuery extends BaseQuery {
       return field;
     }
 
-    const timestampField = this.coerceToTimestamp(field);
+    const timestampField = this.promoteDateToTimestamp(field);
     const atTimezone = `${timestampField} AT TIME ZONE '${this.timezone}'`;
     return `CAST(date_add('minute', timezone_minute(${atTimezone}), date_add('hour', timezone_hour(${atTimezone}), ${timestampField})) AS TIMESTAMP)`;
   }

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -49,11 +49,27 @@ export class PrestodbQuery extends BaseQuery {
     return `from_iso8601_timestamp(${value})`;
   }
 
+  /**
+   * Lifts a DATE expression to a timestamp so that timezone arithmetic accepts
+   * it. `COALESCE` with a NULL timestamp resolves to the common supertype,
+   * which triggers the implicit DATE -> TIMESTAMP coercion while leaving both
+   * timestamp types intact. An explicit `CAST(... AS TIMESTAMP)` would instead
+   * strip the zone off a `timestamp with time zone` expression, so the
+   * subsequent `AT TIME ZONE` would reinterpret its wall clock in the session
+   * timezone and shift the result.
+   */
+  protected coerceToTimestamp(field: string): string {
+    return `COALESCE(${field}, CAST(NULL AS TIMESTAMP))`;
+  }
+
   public override convertTz(field) {
-    const atTimezone = `${field} AT TIME ZONE '${this.timezone}'`;
-    return this.timezone ?
-      `CAST(date_add('minute', timezone_minute(${atTimezone}), date_add('hour', timezone_hour(${atTimezone}), ${field})) AS TIMESTAMP)` :
-      field;
+    if (!this.timezone) {
+      return field;
+    }
+
+    const timestampField = this.coerceToTimestamp(field);
+    const atTimezone = `${timestampField} AT TIME ZONE '${this.timezone}'`;
+    return `CAST(date_add('minute', timezone_minute(${atTimezone}), date_add('hour', timezone_hour(${atTimezone}), ${timestampField})) AS TIMESTAMP)`;
   }
 
   /**

--- a/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
@@ -4,6 +4,6 @@ export class TrinoQuery extends PrestodbQuery {
   // Trino doesn't require odd prestodb manual datetime offset calculations
   // as it uses mature timestamps models
   public override convertTz(field) {
-    return this.timezone ? `CAST((${field} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
+    return this.timezone ? `CAST((${this.coerceToTimestamp(field)} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
@@ -4,6 +4,6 @@ export class TrinoQuery extends PrestodbQuery {
   // Trino doesn't require odd prestodb manual datetime offset calculations
   // as it uses mature timestamps models
   public override convertTz(field) {
-    return this.timezone ? `CAST((${this.coerceToTimestamp(field)} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
+    return this.timezone ? `CAST((${this.promoteDateToTimestamp(field)} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
   }
 }

--- a/packages/cubejs-schema-compiler/test/unit/trino-presto-date-time-dimension.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/trino-presto-date-time-dimension.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable no-restricted-syntax, quotes */
+import { PrestodbQuery } from '../../src/adapter/PrestodbQuery';
+import { TrinoQuery } from '../../src/adapter/TrinoQuery';
+import { prepareJsCompiler } from './PrepareCompiler';
+
+// Trino/Presto reject timezone arithmetic over DATE:
+// "Type of value must be a time or timestamp with/without time zone (actual date)".
+// Scaffolding maps DATE columns to `type: time` without a cast, so `convertTz`
+// has to promote the field to a timestamp itself. The promotion must not be a
+// plain `CAST(... AS TIMESTAMP)`: that strips the zone off a
+// `timestamp with time zone` column and shifts the converted value.
+describe('Trino/Presto time dimensions over DATE columns', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+    cube('events', {
+      sql: \`
+        SELECT
+          1 AS id,
+          CAST('2024-01-15' AS DATE) AS d,
+          CAST('2024-01-15 10:20:30' AS TIMESTAMP) AS ts,
+          CAST('2024-01-15 10:20:30 UTC' AS TIMESTAMP WITH TIME ZONE) AS tstz
+      \`,
+      dimensions: {
+        id: {
+          sql: 'id',
+          type: 'number',
+          primaryKey: true
+        },
+        d: {
+          sql: 'd',
+          type: 'time'
+        },
+        ts: {
+          sql: 'ts',
+          type: 'time'
+        },
+        tstz: {
+          sql: 'tstz',
+          type: 'time'
+        }
+      },
+      measures: {
+        count: {
+          type: 'count'
+        }
+      }
+    });
+  `);
+
+  const timezone = 'America/Los_Angeles';
+
+  const buildSql = (QueryClass: any, column: string) => {
+    const query = new QueryClass({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['events.count'],
+      timeDimensions: [{
+        dimension: `events.${column}`,
+        granularity: 'day'
+      }],
+      timezone
+    });
+
+    return query.buildSqlAndParams()[0];
+  };
+
+  const promoted = (column: string) => `COALESCE("events".${column}, CAST(NULL AS TIMESTAMP))`;
+
+  const dialects = [
+    {
+      name: 'TrinoQuery',
+      QueryClass: TrinoQuery,
+      convertTz: (column: string) => `CAST((${promoted(column)} AT TIME ZONE '${timezone}') AS TIMESTAMP)`
+    },
+    {
+      name: 'PrestodbQuery',
+      QueryClass: PrestodbQuery,
+      convertTz: (column: string) => {
+        const atTimezone = `${promoted(column)} AT TIME ZONE '${timezone}'`;
+        return `CAST(date_add('minute', timezone_minute(${atTimezone}), ` +
+          `date_add('hour', timezone_hour(${atTimezone}), ${promoted(column)})) AS TIMESTAMP)`;
+      }
+    }
+  ] as const;
+
+  for (const { name, QueryClass, convertTz } of dialects) {
+    describe(name, () => {
+      // `d` is the column that used to fail outright; `ts`/`tstz` guard the
+      // promotion against changing what already worked.
+      for (const column of ['d', 'ts', 'tstz']) {
+        it(`promotes the ${column} column instead of feeding it to AT TIME ZONE`, async () => {
+          await compiler.compile();
+
+          const sql = buildSql(QueryClass, column);
+
+          expect(sql).not.toMatch(new RegExp(`"events"\\.${column} AT TIME ZONE`));
+          expect(sql).toContain(convertTz(column));
+        });
+      }
+    });
+  }
+});

--- a/packages/cubejs-schema-compiler/test/unit/trino-presto-date-time-dimension.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/trino-presto-date-time-dimension.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax, quotes */
+import { AthenaQuery } from '../../src/adapter/AthenaQuery';
 import { PrestodbQuery } from '../../src/adapter/PrestodbQuery';
 import { TrinoQuery } from '../../src/adapter/TrinoQuery';
 import { prepareJsCompiler } from './PrepareCompiler';
@@ -63,27 +64,25 @@ describe('Trino/Presto time dimensions over DATE columns', () => {
 
   const promoted = (column: string) => `COALESCE("events".${column}, CAST(NULL AS TIMESTAMP))`;
 
+  const trinoConvertTz = (column: string) => `CAST((${promoted(column)} AT TIME ZONE '${timezone}') AS TIMESTAMP)`;
+
+  const prestoConvertTz = (column: string) => {
+    const atTimezone = `${promoted(column)} AT TIME ZONE '${timezone}'`;
+    return `CAST(date_add('minute', timezone_minute(${atTimezone}), ` +
+      `date_add('hour', timezone_hour(${atTimezone}), ${promoted(column)})) AS TIMESTAMP)`;
+  };
+
   const dialects = [
-    {
-      name: 'TrinoQuery',
-      QueryClass: TrinoQuery,
-      convertTz: (column: string) => `CAST((${promoted(column)} AT TIME ZONE '${timezone}') AS TIMESTAMP)`
-    },
-    {
-      name: 'PrestodbQuery',
-      QueryClass: PrestodbQuery,
-      convertTz: (column: string) => {
-        const atTimezone = `${promoted(column)} AT TIME ZONE '${timezone}'`;
-        return `CAST(date_add('minute', timezone_minute(${atTimezone}), ` +
-          `date_add('hour', timezone_hour(${atTimezone}), ${promoted(column)})) AS TIMESTAMP)`;
-      }
-    }
+    { name: 'TrinoQuery', QueryClass: TrinoQuery, convertTz: trinoConvertTz },
+    { name: 'PrestodbQuery', QueryClass: PrestodbQuery, convertTz: prestoConvertTz },
+    // Athena has no convertTz of its own; pin that it keeps inheriting the fix.
+    { name: 'AthenaQuery', QueryClass: AthenaQuery, convertTz: prestoConvertTz }
   ] as const;
 
   for (const { name, QueryClass, convertTz } of dialects) {
     describe(name, () => {
-      // `d` is the column that used to fail outright; `ts`/`tstz` guard the
-      // promotion against changing what already worked.
+      // `d` is the column the engine rejects; `ts`/`tstz` pin that the
+      // promotion leaves the types that already work alone.
       for (const column of ['d', 'ts', 'tstz']) {
         it(`promotes the ${column} column instead of feeding it to AT TIME ZONE`, async () => {
           await compiler.compile();
@@ -94,6 +93,17 @@ describe('Trino/Presto time dimensions over DATE columns', () => {
           expect(sql).toContain(convertTz(column));
         });
       }
+
+      it('leaves the field untouched without a timezone', async () => {
+        await compiler.compile();
+
+        const query = new QueryClass({ joinGraph, cubeEvaluator, compiler }, {
+          measures: ['events.count'],
+          timezone: null
+        });
+
+        expect(query.convertTz('"events".d')).toBe('"events".d');
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary

Time dimensions over `DATE` columns fail outright on Trino and Presto. Scaffolding maps any column whose type name contains `date` to `type: time` without emitting a cast, and both dialects then apply `AT TIME ZONE` directly to the field — which Trino and Presto reject:

```
TYPE_MISMATCH: Type of value must be a time or timestamp with/without time zone (actual date)
```

This makes `convertTz` promote the field to a timestamp itself, so hand-written and already-generated models are fixed too, not just newly scaffolded ones.

Fixes #11494 (CORE-748).

## Changes

- `PrestodbQuery.promoteDateToTimestamp()` lifts the field to a timestamp; `PrestodbQuery.convertTz` and `TrinoQuery.convertTz` both route the field through it.
- New unit test `trino-presto-date-time-dimension.test.ts`: 12 cases covering Trino / Presto / Athena × `date` / `timestamp` / `timestamp with time zone` columns, each pinning the full expected `convertTz` expression and guarding that a bare column is never fed to `AT TIME ZONE`, plus the no-timezone early return.

### Why `COALESCE` and not `CAST(... AS TIMESTAMP)`

The obvious fix is `CAST(${field} AS TIMESTAMP) AT TIME ZONE …`, described as a no-op for columns that are already timestamps. That holds for `timestamp`, but **not** for `timestamp with time zone` — common in Trino via Iceberg `timestamptz`. Verified on Trino: `CAST(tstz AS TIMESTAMP)` simply drops the zone and keeps the value's own wall clock, which the following `AT TIME ZONE` then reinterprets in the *session* timezone. With `session = Europe/Berlin` and query timezone `America/Los_Angeles`, that silently shifts the result:

```sql
-- session tz = Europe/Berlin
CAST(TIMESTAMP '2024-01-15 10:20:30 UTC' AT TIME ZONE 'America/Los_Angeles' AS TIMESTAMP)
-- 2024-01-15 02:20:30.000   (correct, current behaviour)

CAST(CAST(TIMESTAMP '2024-01-15 10:20:30 UTC' AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles' AS TIMESTAMP)
-- 2024-01-15 01:20:30.000   (wrong, off by the session offset)
```

`COALESCE(field, CAST(NULL AS TIMESTAMP))` resolves to the common supertype instead: that triggers the implicit `DATE -> TIMESTAMP` coercion while leaving both timestamp types — zone and precision — untouched. `COALESCE(x, NULL)` is `x`, so the value is unchanged by construction.

| input type | `typeof COALESCE(x, CAST(NULL AS TIMESTAMP))` |
| --- | --- |
| `date` | `timestamp(3)` — promoted |
| `timestamp(6)` | `timestamp(6)` — unchanged |
| `timestamp(6) with time zone` | `timestamp(6) with time zone` — unchanged |

### Behaviour change: a DATE time dimension can move by a day

A promoted `DATE` lands on midnight and is then converted like any other naive timestamp, so under a negative offset its calendar date moves — `DATE '2024-01-15'` day-truncates to `2024-01-14` for `America/Los_Angeles`, and the range filter shifts with it. Previously these queries did not run at all, so nothing regresses, but the bucket a `DATE` column lands in is worth knowing about.

This is deliberately *not* special-cased: it is what the other dialects already do with a date column. Verified by generating the same model through three dialects and executing each against its own engine:

| dialect | emitted expression | bucket |
| --- | --- | --- |
| Postgres | `date_trunc('day', ("events".d::timestamptz AT TIME ZONE 'America/Los_Angeles'))` | `2024-01-14` |
| Trino | `date_trunc('day', CAST((COALESCE("events".d, …) AT TIME ZONE …) AS TIMESTAMP))` | `2024-01-14` |
| Presto | `date_trunc('day', CAST(date_add('minute', timezone_minute(…), …) AS TIMESTAMP))` | `2024-01-14` |

Giving `DATE` its own treatment on Trino/Presto would introduce a *new* cross-dialect divergence rather than remove one, so the day shift is documented on `promoteDateToTimestamp` instead.

## Testing

Executed against real engines — `trinodb/trino:latest` and `prestodb/presto:latest` in Docker — using the SQL actually emitted by Tesseract:

- **Before:** both engines, both dialect forms, `DATE` column → `TYPE_MISMATCH … (actual date)`, reproducing the issue.
- **After:** all 6 generated queries (2 dialects × `date` / `timestamp` / `timestamptz`) execute and return sensible values.
- **No behaviour change for timestamps:** `before = after` compared as SQL under `session tz = Europe/Berlin` → `true` for both `timestamp` and `timestamp with time zone`, on both engines.

Unit tests:

- New test: 12/12 green under Tesseract; reverting the two source files turns the promotion cases red, confirming the guard bites.
- Full `schema-compiler` unit suite under Tesseract: 726 passed. The only failure is `error-reporter.test.ts` (3 snapshots differing in ANSI colour codes) — pre-existing and unrelated. `athena-query.test.ts` and `prestodb-query.test.ts` pass.
- A value-level test for Trino/Presto is not possible in CI today: `cubejs-schema-compiler` has integration contours for Postgres/MySQL/MSSQL/ClickHouse only, and `cubejs-testing-drivers` has no Trino or Presto fixture. The generated expression is pinned in full instead, so any special-casing of `DATE` fails the test.
- Lint clean.

## Blast radius

Wider than Trino alone: `TrinoDriver.dialectClass()` returns `PrestodbQuery`, and `AthenaQuery` is an empty subclass of it, so this one change covers Trino, Presto and Athena. The existing Athena guard against exposing `timestamp with time zone` to an export bucket is unaffected — the outer `CAST(… AS TIMESTAMP)` is still there.

**Note for operators:** `convertTz` feeds pre-aggregation `loadSql`, which `getStructureVersion` hashes, so existing Presto/Trino/Athena pre-aggregations with a time dimension will be rebuilt once on upgrade.
