### PR TITLE
docs: fix a batch of undocumented/stale Cube Cloud features found in a doc audit

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -124,7 +124,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
           - Controls 
             - Filter widget
             - Time grain switcher
-          - AI summary
+          - Analysis
     - **Dashboard**
       - Scheduled refresh
     - **Semantic Model**

--- a/docs-mintlify/admin/ai/index.mdx
+++ b/docs-mintlify/admin/ai/index.mdx
@@ -90,6 +90,8 @@ To pin a specific model, set the `llm` property to one of the predefined models:
 - `gpt_5_mini`
 - `gpt_5_3`
 - `gpt_5_4`
+- `gpt_5_6_sol`
+- `gpt_5_6_terra`
 - `o3`
 - `o4_mini`
 

--- a/docs-mintlify/admin/customization/dashboard-themes.mdx
+++ b/docs-mintlify/admin/customization/dashboard-themes.mdx
@@ -77,6 +77,8 @@ After tweaking styling on a dashboard that uses a custom theme, you can push tho
 1. From the dashboard's **Styling** tab, make your changes.
 2. Click **Save** to write the current effective styles back into the theme.
 
+You can also **rename** a custom theme directly from the **Styling** tab's theme menu, next to **Save as new** and **Reset** — this is equivalent to renaming it from the **Admin → Customization → Dashboard Themes** list.
+
 <Warning>
 
 Saving a theme updates **every dashboard** that uses it. Already-published dashboard snapshots keep their previous styling until they are re-published.

--- a/docs-mintlify/admin/monitoring/audit-log.mdx
+++ b/docs-mintlify/admin/monitoring/audit-log.mdx
@@ -39,6 +39,9 @@ You can click on any event to view extended information:
 - IP address from which an event was initiated.
 - Event-specific attributes.
 
+For `Created group via SCIM`, `Updated group via SCIM`, and `Deleted group via SCIM`
+events, event-specific attributes also include the list of members added to or
+removed from the group, by email.
 
 #### Sanitization
 

--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -74,6 +74,12 @@ in the popup:
   <img src="https://ucarecdn.com/15ea528f-4a54-40a1-83c7-2f67738a3e8b/" alt="Create a new branch" />
 </Frame>
 
+By default, the new branch forks off whichever branch you currently have
+checked out. To fork from a different one instead, choose **Create branch
+from…** in the branch switcher, name the new branch, and pick its source —
+any of Cube's branches, or a remote-only branch that hasn't been checked out
+in Cube yet.
+
 These branches are shared, meaning everyone who has access to the deployment can
 see and edit them. This makes them extremely useful for out-of-band experiments
 where you can quickly test things in Cube Cloud without having to go through a

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -36,9 +36,10 @@ are never saved to the dashboard — see
     [workbook][ref-workbooks]: creating reports, building and editing
     dashboards, and running analysis.
 
-  The published Dashboard Agent can adjust **your own view** — filters and time
-  granularity, for your session only — but intentionally cannot author or change
-  the **saved** dashboard.
+  Any viewer can adjust **their own view** — filters and time granularity, for
+  their session only. Authoring the **saved** dashboard through this panel
+  depends on the viewer's permissions — see
+  [What the Dashboard Agent can and can't do](#what-the-dashboard-agent-can-and-cant-do).
 </Note>
 
 ## Opening the agent
@@ -116,8 +117,20 @@ contents — text, PDF, ZIP, and image files are supported.
 
 ## What the Dashboard Agent can and can't do
 
-The published Dashboard Agent can answer questions and adjust your own view, but
-it never changes the **saved** dashboard.
+The published Dashboard Agent can answer questions and adjust your own view.
+Whether it can also author the **saved** dashboard depends on your permissions
+on the workbook that owns it:
+
+- **If you have edit permission on the dashboard**, asking the agent to change
+  it edits the workbook's **draft** directly — the agent never publishes for
+  you; review the draft and use the dashboard's **Edit** action to publish it.
+- **If you don't have edit permission but can create workbooks**, asking the
+  agent to change the dashboard duplicates it into a new workbook you own,
+  applies the change there, and hands off to the new dashboard. The original
+  dashboard is never touched.
+- **If you have neither**, the agent stays read-only: it can't create reports,
+  workbooks, or a duplicate dashboard, and it explains that instead of applying
+  a change.
 
 **It can:**
 
@@ -132,16 +145,21 @@ it never changes the **saved** dashboard.
 - Explain how a metric or dimension is defined
 - Look up the values available for a dimension
 - Read the contents of [attachments](#attachments) you add to the chat
+- Edit the dashboard's draft in place, or duplicate it into a new dashboard you
+  own, depending on your permissions (see above)
 
 **It can't:**
 
-- Save its filter or time-granularity changes to the dashboard — they apply to
-  your session only and never change what other viewers see
-- Edit the dashboard, or add/remove widgets
-- Create reports or workbooks
+- Publish a draft it edited — you review and publish yourself via the
+  dashboard's **Edit** action
+- Save filter or time-granularity changes applied via
+  [Changing filters and time granularity](#changing-filters-and-time-granularity)
+  to the dashboard — those always apply to your session only, regardless of
+  your permissions
 - Change the data model
 
-If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
+For full authoring — building dashboards from scratch, editing any report, or
+changing the data model — use the [Workbook Agent][ref-workbook-agent] instead.
 
 ## Limitations
 
@@ -151,9 +169,10 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
   applies to your session only — it is never saved to the dashboard. If you ask
   it to change something with no control on the dashboard, it explains the
   current state instead of applying a change.
-- **No authoring on published dashboards.** The published Dashboard Agent
-  cannot create reports or build dashboards, edit the saved dashboard, or change
-  the data model. Those live in the [Workbook Agent][ref-workbook-agent].
+- **Draft edits and duplication need permission.** Editing the saved dashboard
+  (as a draft) or duplicating it requires, respectively, edit permission on the
+  workbook or permission to create workbooks. A viewer with neither stays
+  read-only and the agent explains why instead of applying a change.
 - **Report search covers published reports only.** When the agent searches for
   existing reports, it sees published reports.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
@@ -1,13 +1,13 @@
 ---
-title: AI summary
+title: Analysis
 description: Generate natural-language summaries of dashboard data on demand using an AI agent.
 ---
 
-AI summary widgets generate a natural-language summary of the data shown on the dashboard. Write a prompt — for example, _"Summarize the key trends and call out anything unusual"_ — and the configured [AI agent][ref-agents] produces a Markdown narrative based on the current dashboard state, including the data behind every chart and the values of any active [controls][ref-controls].
+Analysis widgets generate a natural-language summary of the data shown on the dashboard. Write a prompt — for example, _"Summarize the key trends and call out anything unusual"_ — and the configured [AI agent][ref-agents] produces a Markdown narrative based on the current dashboard state, including the data behind every chart and the values of any active [controls][ref-controls].
 
-## Adding an AI summary
+## Adding an Analysis widget
 
-In the [dashboard builder][ref-workbooks], click **Add AI Summary** in the toolbar. The widget opens with a prompt editor — write your prompt and click **Generate Summary** to produce the first response.
+In the [dashboard builder][ref-workbooks], click **Analysis** in the toolbar. The widget opens with a prompt editor — write your prompt and click **Run** to produce the first response.
 
 ## Use cases
 
@@ -28,11 +28,11 @@ Once generated, the summary is **cached** with the widget. Viewers loading the d
 
 The widget keeps a checksum of the dashboard state at the time of generation: the queries behind each chart, the active control values, and the chart configuration. When any of those change, the widget marks the cached summary as **stale** and shows a refresh prompt so viewers know the narrative may no longer match the data.
 
-Click the refresh icon (or open the widget menu and choose **Refresh**) to regenerate using the saved prompt against the latest state.
+Click the refresh icon (or open the widget menu and choose **Re-run**) to regenerate using the saved prompt against the latest state.
 
 ## Choosing the agent
 
-By default, AI summaries use the agent configured at the dashboard level. You can override the agent per widget when you need a particular [agent's][ref-agents] tooling, model, or guardrails for a specific summary.
+By default, Analysis widgets use the agent configured at the dashboard level. You can override the agent per widget when you need a particular [agent's][ref-agents] tooling, model, or guardrails for a specific summary.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-agents]: /admin/ai

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -27,7 +27,12 @@ Each chart shows the name of the underlying workbook tab as its title. To rename
 
 Use **Hide Title** in the widget's settings menu to suppress the title on the dashboard — useful when the chart's content already makes the subject obvious, or when an adjacent [text widget][ref-text] provides its own heading. Choose **Show Title** in the same menu to bring it back.
 
+## Downloading a chart
+
+Open a chart widget's menu (`⋮`) on a published dashboard and choose **Download as CSV**, **Download as PNG**, or **Download as PDF** to export that chart on its own, without downloading the whole dashboard. This uses the same server-rendered snapshot mechanism as the dashboard-level [Download as PNG or PDF][ref-dashboard-download] action, scoped to a single widget, and requires the same **Manage** permission on the workbook that owns the dashboard.
+
 [ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-dashboard-download]: /docs/explore-analyze/dashboards#download-as-png-or-pdf
 [ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
 [ref-incompatible-controls]: /docs/explore-analyze/dashboards/widgets/controls#incompatible-controls
 [ref-text]: /docs/explore-analyze/dashboards/widgets/text

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -104,6 +104,10 @@ Each control has a **Visibility** setting that determines how it appears on the 
 
 Set the visibility from the **Visibility** dropdown when editing the control. **Hidden** controls remain visible in the dashboard builder so editors can reconfigure them, but disappear from the published view.
 
+## Bookmarking and sharing
+
+On a published dashboard, changing a control's value updates the dashboard's URL (`?f_<View>.<member>=…` for filters). This makes your current filter and time-granularity selections bookmarkable and shareable — anyone opening the link sees the same values you had set. This applies to viewer-made changes on published dashboards only; picking a value in the dashboard builder sets the widget's saved default instead.
+
 ## Interaction with charts
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -12,8 +12,8 @@ The dashboard builder supports the following widget types:
 - [Charts](/docs/explore-analyze/dashboards/widgets/charts) — Visualize reports from your workbook
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data or switch the time granularity
-- [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
+- [Analysis](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
 
-In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, click **Add Text** or **Add AI Summary**, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
+In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, click **Add Text** or **Analysis**, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/explore.mdx
+++ b/docs-mintlify/docs/explore-analyze/explore.mdx
@@ -41,7 +41,7 @@ Navigate to the **Explore** page in the sidebar. From here, you can select any s
 
 The functionality in Explore is similar to when working with semantic views in workbooks. You can build visualizations, pivot tables, and tables by selecting measures and dimensions from your semantic views, apply filters, group and aggregate data.
 
-Explore state is also saved in the URL, making it easy to share your exploration with other users by simply copying and sharing the link.
+Explore state is also saved in the URL, making it easy to share your exploration with other users by simply copying and sharing the link. If you're chatting with the AI agent while exploring, the chat thread is preserved in the URL too, so reopening or sharing the link restores the same conversation alongside the exploration.
 
 If you have developer or admin access, you can [apply a security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context) to an exploration to verify what a specific end user—or an AI agent querying on their behalf—would see.
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -221,6 +221,12 @@ period always aligns exactly with the current buckets. A measure can have
 several comparisons active at once, such as month over month and year over
 year side by side.
 
+A query with no grouped time dimension can still anchor a comparison to a
+time dimension it only **filters** — the comparison window derives from the
+filter's own bounds instead of a granularity preset. Menu rows explain why an
+anchor isn't offered when it can't produce one — for example, an open-ended
+filter or a filter inside an `OR` group.
+
 Each comparison adds derived columns next to the measure. Choose which ones
 to show under **Comparison columns** in the same menu:
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
@@ -30,6 +30,13 @@ and dimension definitions), the Workbook Agent can:
   time-grain, and text widgets
 - **Publish dashboards**
 
+## Saving into an attached empty tab
+
+If you attach an empty tab to your question, the agent saves the first query
+behind its answer directly into that tab instead of creating a new report —
+useful when you've already created a placeholder tab you want the result to
+land in.
+
 ## How charts get added to a dashboard
 
 When the agent adds a chart to a dashboard, the chart widget references a

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -211,7 +211,7 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 
 ## Available actions
 
-The MCP server exposes 16 tools, grouped below.
+The MCP server exposes 20 tools, grouped below.
 
 Every tool runs as the authenticated user. Queries respect the same
 [permissions][ref-roles] as the rest of Cube, including row-level security — MCP is a new
@@ -277,6 +277,19 @@ default. Users without it never see them.
 | `writeDataModelFile` | Creates or overwrites a model source file on the dev branch (whole-file replacement). Recompiles the model and reports `valid` plus any `validationError`. | Destructive — prompts |
 | `deleteDataModelFile` | Deletes a model source file on the dev branch. | Destructive — prompts |
 | `getDataModelChanges` | Shows the diff of the dev branch against its parent — the pending changes, for review before committing. | Read-only |
+| `getBranchDiff` | Diffs any branch against an arbitrary base (the deploy branch by default) — unlike `getDataModelChanges`, which only diffs a dev branch against its immediate parent. | Read-only |
+| `getDeploymentEnv` | Lists the deployment's environment variables, with secret-named values redacted. Useful for checking configuration (e.g., an export bucket) when a pre-aggregation build fails. | Read-only |
+
+### Pre-aggregations
+
+These tools verify that pre-aggregations defined in the data model actually build — including on an un-deployed dev branch, which `runQuery` can't reach since it only hits the deployed SQL API. Gated the same way as [Data model editing](#data-model-editing).
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `getPreAggregationStatus` | Lists pre-aggregations with their partitions, how many have built, the newest build time, and the exact error for any that failed. | Read-only |
+| `buildPreAggregation` | Triggers an on-demand build of one pre-aggregation. | Write |
+
+Both tools target the deploy branch by default; pass a dev `branchName` from `startDataModelEdit` to target that branch's dev worker instead.
 
 #### How model edits stay safe
 
@@ -293,7 +306,7 @@ into the MCP server:
   from the Cube UI, as described in [Development mode][ref-dev-mode]. The MCP server
   deliberately exposes no commit tool — an AI client can prepare changes, but only a
   person can ship them.
-- **Registration is permission-gated.** The six tools above are only offered to users
+- **Registration is permission-gated.** The tools above are only offered to users
   whose role allows editing the semantic model.
 
 Review pending work with `getDataModelChanges` before you commit.

--- a/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
+++ b/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
@@ -35,6 +35,11 @@ From the IDE, users can pull semantic views from Snowflake and turn them into cu
 
 This allows you to leverage existing Snowflake semantic views in Cube without manual conversion, ensuring consistency between your Snowflake and Cube definitions.
 
+To scope the pull to specific views, enter a comma-separated list of view names or
+`*`-wildcard patterns (e.g., `SALES_*`) in the **Views** field — matching is
+case-insensitive. Leave it empty to pull every semantic view in the selected schema.
+A name or pattern that matches nothing fails the sync rather than silently skipping it.
+
 ## Push Integration
 
 Alternatively, you can push Cube views into Snowflake as native semantic views. The push integration creates DDL from Cube's definitions and executes it in Snowflake, creating Snowflake Semantic Views that match your Cube schema.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -40,7 +40,7 @@ To set up default dashboards:
 3. Embed users in Creator Mode now see the shared items at the root of their workspace as soon as they open the app.
 
 <Note>
-  **All embed users** is a system group: it can't be renamed or deleted, and it can only be granted read-only (**Can view**) access. It appears automatically in **Admin → User Groups** and in the share dialog once Creator Mode is enabled for your workspace.
+  **All embed users** is a system group: it can't be renamed or deleted, and it can only be granted read-only (**Can view**) access. It's created automatically once Creator Mode is enabled for your workspace, and appears in the share dialog right away. In **Admin → User Groups**, system groups are hidden by default — use the **user | system | all** filter in the toolbar to reveal it.
 </Note>
 
 Keep the following behavior in mind:

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -369,7 +369,9 @@ Operators use the same labels data consumers see in the workbook filter bar —
 what you see in the filter bar is what you type: `is`, `is not`, `after date`,
 `after or on date`, `before date`, `before or on date`, `between`, `contains`,
 `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`,
-`is null`, `is not null`.
+`is null`, `is not null`. Time dimensions also accept `in the month`, `not in
+the month`, `in the quarter`, `not in the quarter`, `in the year`, and `not in
+the year`, which filter to a specific calendar period.
 
 Operators are case-insensitive and whitespace-tolerant. Internal type names and
 REST API aliases (e.g. `equals`, `gte`, `inDateRange`) are also accepted.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Found via a routine audit cross-checking recent `cubejs-enterprise` (Cube Cloud product) changes against `docs-mintlify`. Each item below is a small, surgical edit — no new pages. Grouped by area:

**Audit Log**
- SCIM group create/update/delete audit events now include the resolved membership delta (members added/removed by email) — documented in the Extended view section (`admin/monitoring/audit-log.mdx`).

**Dashboards & widgets**
- Chart widget menu gained per-widget CSV/PNG/PDF download, alongside the existing whole-dashboard export (`widgets/charts.mdx`).
- The "AI summary" widget was renamed to "Analysis" throughout the UI ("Generate Summary" → "Run", "Regenerate" → "Re-run") — updated `widgets/ai-summary.mdx`, `widgets/index.mdx`, and the taxonomy in `docs-mintlify/CLAUDE.md`.
- Manually changing a filter or time-granularity control on a published dashboard now syncs to the URL, making it bookmarkable/shareable (`widgets/controls.mdx`).
- Custom dashboard themes can now be renamed directly from the Styling tab's theme menu, not just the admin list (`admin/customization/dashboard-themes.mdx`).
- The Dashboard Agent can now edit a dashboard's draft in place (for users with edit permission) or duplicate it into a new dashboard before editing (for users who can create workbooks but lack edit permission on that dashboard) — the page previously claimed the agent can't author dashboards at all, which is now inaccurate (`dashboard-agent.mdx`).

**MCP & AI-engineer**
- MCP server gained 4 tools — `getBranchDiff`, `getDeploymentEnv`, `getPreAggregationStatus`, `buildPreAggregation` — bumping the documented tool count from 16 to 20 (`docs/integrations/mcp-server.mdx`).
- Snowflake Semantic Views pull integration supports scoping by comma-separated view names or `*`-glob patterns (`docs/integrations/snowflake-semantic-views.mdx`).
- New `gpt_5_6_sol` / `gpt_5_6_terra` predefined models available for agent LLM selection (`admin/ai/index.mdx`).
- Workbook Agent saves a data question's result into an attached empty tab instead of always creating a new report (`workbook-agent.mdx`).
- Explore's shareable URL now preserves the chat thread alongside query state (`explore.mdx`).

**Data modeling & filters**
- Time dimension filters gained six calendar-period operators: `in`/`not in the month`, `quarter`, `year` (`reference/data-modeling/view.mdx`).
- Period-over-period comparison can now anchor to a time dimension that's only filtered, not just grouped (`querying-data.mdx`).
- Data Model IDE's branch switcher gained "Create branch from…" to fork from an explicitly chosen source, including remote-only branches (`data-model-ide.mdx`).
- Admin → User Groups now hides system groups (e.g., the auto-created `all_embed_users` group) by default behind a user/system/all filter (`embedding/iframe/creator-mode.mdx`).

A separate, larger tenant-wide time-zone policy feature (admin default zone, personal override, embed override) was also found undocumented; given its scope it's being tracked as a Linear ticket for a dedicated docs page rather than bundled into this PR.
