### PR TITLE
docs: correct the donut shape control and document the center total

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -19,11 +19,11 @@ A pie with a hollow center. Select **Donut** under **Shape** in the Style tab to
 
 {/* Screenshot: donut chart — same data as the pie variant. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-## Show total
+## Center total
 
-Turn on **Show total** in the Style tab to render the measure's grand total in the donut's hole. The total uses the measure's own number format, so changing the format of the measure changes the total with it.
+Turn on **Show total** in the Style tab to render the measure's grand total in the donut's hole. The total uses the measure's number format.
 
-The option appears only for a donut, since a pie has no hollow center to fill. Switching back to a pie hides the total and remembers the setting, so returning to a donut restores it.
+The option appears only for a donut, since a pie has no hollow center to fill.
 
 {/* Screenshot: donut chart with the center total visible, Style tab showing the Show total switch. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -25,7 +25,7 @@ A donut shows the measure's grand total in its hole by default, using the measur
 
 The button appears only for a donut, since a pie has no hollow center to fill.
 
-The total is styled like the slice labels: it uses the font size set in the Data labels section. When labels include **Percentage**, the total shows `100%` on a second line, since the whole is the entire circle.
+The total uses the font size set in the Data labels section, the same as the slice labels. If you turn on the **Percentage** label, the total also shows `100%` on a second line, since the whole is the entire circle.
 
 {/* Screenshot: donut chart with the center total visible, Style tab showing the Show total button. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -15,17 +15,17 @@ Standard filled circle. Each slice's arc length is proportional to its value.
 
 ### Donut
 
-A pie with a hollow center. Increase the **Inner radius** value in the Style tab to any non-zero value to switch to a donut. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
+A pie with a hollow center. Select **Donut** under **Shape** in the Style tab to switch; select **Pie** to switch back.
 
-By default, a donut also shows the measure's total in the hole, formatted with the measure's own number format. Toggle it with **Show total**, next to the **Data labels** controls in the Style tab.
+{/* Screenshot: donut chart — same data as the pie variant. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-{/* Screenshot: donut chart — same data as the pie variant, with inner radius applied. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+## Show total
 
-## Inner radius
+Turn on **Show total** in the Style tab to render the measure's grand total in the donut's hole. The total uses the measure's own number format, so changing the format of the measure changes the total with it.
 
-Drag the **Inner radius** slider in the Style tab or enter a pixel value. Setting it to `0` returns to a full pie.
+The option appears only for a donut, since a pie has no hollow center to fill. Switching back to a pie hides the total and remembers the setting, so returning to a donut restores it.
 
-{/* Screenshot: Style tab with the Inner radius control highlighted. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+{/* Screenshot: donut chart with the center total visible, Style tab showing the Show total switch. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Color and slice ordering
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -21,11 +21,13 @@ A pie with a hollow center. Select **Donut** under **Shape** in the Style tab to
 
 ## Center total
 
-Turn on **Show total** in the Style tab to render the measure's grand total in the donut's hole. The total uses the measure's number format.
+A donut shows the measure's grand total in its hole by default, using the measure's number format. Use the **Show total** button in the Data labels section of the Style tab to turn it off or on again.
 
-The option appears only for a donut, since a pie has no hollow center to fill.
+The button appears only for a donut, since a pie has no hollow center to fill.
 
-{/* Screenshot: donut chart with the center total visible, Style tab showing the Show total switch. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+The total is styled like the slice labels: it uses the font size set in the Data labels section. When labels include **Percentage**, the total shows `100%` on a second line, since the whole is the entire circle.
+
+{/* Screenshot: donut chart with the center total visible, Style tab showing the Show total button. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Color and slice ordering
 


### PR DESCRIPTION
The pie & donut page describes an **Inner radius** slider that no longer exists — the control is now a **Pie / Donut** shape selector in the Style tab, and the hole is a fixed fraction of the chart rather than a pixel value a user drags.

It also suggested overlaying a KPI tile on a dashboard to get a summary value in the hole. The donut now renders the measure's grand total itself, behind a **Show total** switch, so that workaround is no longer the answer.

Updates both sections to what the product actually does. No new pages; the screenshot placeholders are carried over and re-worded to match.
