### PR TITLE
fix(cubesql): Resolve data source for synthetic-only queries

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -962,6 +962,13 @@ impl CubeScanWrapperNode {
                 })
                 .map(|mem| mem.member.as_str()),
         )
+        // A scan can have no members to resolve from, like when it selects only
+        // synthetic fields, so fall back to the cubes it scans.
+        .and_then(|data_source| {
+            data_source.or_else_try(|| {
+                meta.data_source_for_cube_names(node.used_cubes.iter().map(|c| c.as_str()))
+            })
+        })
         .map_err(|err| {
             CubeError::internal(format!(
                 "Can't generate SQL for node; error: {err}; node: {node:?}"
@@ -3643,6 +3650,15 @@ impl WrappedSelectNode {
             }
 
             meta.data_source_for_member_names(every_used_member.iter().map(|m| m.as_str()))
+                // A query can reference no members to resolve from, like when it
+                // selects only synthetic fields, so fall back to the cubes it scans.
+                .and_then(|data_source| {
+                    data_source.or_else_try(|| {
+                        meta.data_source_for_cube_names(
+                            ungrouped_scan_node.used_cubes.iter().map(|c| c.as_str()),
+                        )
+                    })
+                })
                 .map_err(|err| {
                     CubeError::internal(format!("Could not determine data source: {err}"))
                 })?
@@ -4490,6 +4506,125 @@ impl<'ctx, 'mem> ExpressionVisitor for CollectMembersVisitor<'ctx, 'mem> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        compile::engine::df::scan::CubeScanOptions,
+        sql::HttpAuthContext,
+        transport::{CubeMeta, CubeMetaDimension, CubeMetaType},
+    };
+    use datafusion::logical_plan::DFField;
+    use std::collections::HashMap;
+
+    /// Each entry is a cube with one dimension, on a data source of its own.
+    fn meta_context_with_cubes(cubes: &[(&str, &str, &str)]) -> MetaContext {
+        MetaContext::new(
+            cubes
+                .iter()
+                .map(|(cube_name, member, _)| CubeMeta {
+                    name: cube_name.to_string(),
+                    description: None,
+                    title: None,
+                    r#type: CubeMetaType::Cube,
+                    dimensions: vec![CubeMetaDimension::new(
+                        member.to_string(),
+                        "string".to_string(),
+                    )],
+                    measures: vec![],
+                    segments: vec![],
+                    joins: None,
+                    folders: None,
+                    nested_folders: None,
+                    hierarchies: None,
+                    meta: None,
+                })
+                .collect(),
+            cubes
+                .iter()
+                .map(|(_, member, data_source)| (member.to_string(), data_source.to_string()))
+                .collect(),
+            HashMap::new(),
+            uuid::Uuid::new_v4(),
+        )
+    }
+
+    fn cube_scan_node(member_fields: Vec<MemberField>, used_cubes: Vec<String>) -> CubeScanNode {
+        let schema = Arc::new(
+            DFSchema::new_with_metadata(
+                member_fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| DFField::new(None, &format!("c{i}"), DataType::Utf8, true))
+                    .collect::<Vec<_>>(),
+                HashMap::new(),
+            )
+            .unwrap(),
+        );
+
+        CubeScanNode::new(
+            schema,
+            member_fields,
+            V1LoadRequestQuery::new(),
+            Arc::new(HttpAuthContext {
+                access_token: "token".to_string(),
+                base_path: "path".to_string(),
+            }),
+            CubeScanOptions {
+                change_user: None,
+                max_records: None,
+                cache_mode: None,
+                throw_continue_wait: false,
+            },
+            used_cubes,
+            None,
+        )
+    }
+
+    /// A plain wrapped `CubeScan` whose columns are all literals has no member to
+    /// resolve a data source from, so it falls back to the cubes it scans. The
+    /// push-to-cube path has `test_wrapper_only_system_fields` for this; the SQL
+    /// surface never reaches this one, so it is covered here directly.
+    #[test]
+    fn test_data_source_for_cube_scan_without_members() {
+        let meta = meta_context_with_cubes(&[("Orders", "Orders.status", "warehouse")]);
+        let node = cube_scan_node(
+            vec![MemberField::Literal(ScalarValue::Utf8(Some(
+                "anything".to_string(),
+            )))],
+            vec!["Orders".to_string()],
+        );
+
+        let data_source = CubeScanWrapperNode::data_source_for_cube_scan(&meta, &node).unwrap();
+        assert!(matches!(data_source, DataSource::Specific("warehouse")));
+    }
+
+    /// With a member to resolve from, that member decides and the fallback must not
+    /// take over. `used_cubes` holds a second cube on another data source, so
+    /// falling back would merge the two into a conflict instead - that is what
+    /// makes the precedence observable rather than assumed.
+    #[test]
+    fn test_data_source_for_cube_scan_with_members() {
+        let meta = meta_context_with_cubes(&[
+            ("Orders", "Orders.status", "warehouse"),
+            ("Visits", "Visits.url", "analytics"),
+        ]);
+        let node = cube_scan_node(
+            vec![MemberField::regular("Orders.status".to_string())],
+            vec!["Orders".to_string(), "Visits".to_string()],
+        );
+
+        let data_source = CubeScanWrapperNode::data_source_for_cube_scan(&meta, &node).unwrap();
+        assert!(matches!(data_source, DataSource::Specific("warehouse")));
+    }
+
+    /// Literal-only columns and no cubes to fall back to: nothing restricts the
+    /// data source, and the caller raises its own error.
+    #[test]
+    fn test_data_source_for_cube_scan_without_members_or_cubes() {
+        let meta = meta_context_with_cubes(&[("Orders", "Orders.status", "warehouse")]);
+        let node = cube_scan_node(vec![MemberField::Literal(ScalarValue::Utf8(None))], vec![]);
+
+        let data_source = CubeScanWrapperNode::data_source_for_cube_scan(&meta, &node).unwrap();
+        assert!(matches!(data_source, DataSource::Unrestricted));
+    }
 
     #[test]
     fn test_member_expression_sql() {

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -2809,3 +2809,47 @@ async fn test_case_wrapper_sum_case_date_only_string() {
         displayable(physical_plan.as_ref()).indent()
     );
 }
+
+/// Query can reference no members at all, only synthetic fields.
+/// Data source is resolved from cubes of the scan node in that case.
+#[tokio::test]
+async fn test_wrapper_only_system_fields() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        SELECT COUNT(DISTINCT "F0"."__user") AS "user_count",
+               COUNT(1) AS "row_count",
+               MIN("F0"."__user") AS "user_min",
+               MAX("F0"."__user") AS "user_max",
+               COUNT(DISTINCT "F0"."__cubeJoinField") AS "join_field_count",
+               MIN("F0"."__cubeJoinField") AS "join_field_min",
+               MAX("F0"."__cubeJoinField") AS "join_field_max"
+        FROM (
+            SELECT "T1"."__user" AS "__user", "T1"."__cubeJoinField" AS "__cubeJoinField"
+            FROM KibanaSampleDataEcommerce AS "T1"
+        ) AS "F0"
+        LIMIT 1
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains(r#"\"cubeName\":\"KibanaSampleDataEcommerce\""#),
+        "SQL contains member expressions for the scanned cube: {}",
+        sql
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+}

--- a/rust/cubesql/cubesql/src/transport/ctx.rs
+++ b/rust/cubesql/cubesql/src/transport/ctx.rs
@@ -49,6 +49,10 @@ pub enum DataSourceError {
     Conflict(String, String),
     #[error("Data source not found for member '{0}'")]
     Missing(String),
+    #[error("Data source not found for cube '{0}'")]
+    MissingForCube(String),
+    #[error("Data source not found for any of the cubes: {0}")]
+    MissingForEveryCube(String),
 }
 
 impl<'meta> DataSource<'meta> {
@@ -56,6 +60,14 @@ impl<'meta> DataSource<'meta> {
         match self {
             DataSource::Unrestricted => Err(err),
             DataSource::Specific(data_source) => Ok(data_source),
+        }
+    }
+
+    /// Resolve again with `f` when nothing has restricted the data source yet.
+    pub fn or_else_try<E>(self, f: impl FnOnce() -> Result<Self, E>) -> Result<Self, E> {
+        match self {
+            Self::Unrestricted => f(),
+            specific => Ok(specific),
         }
     }
 
@@ -136,6 +148,57 @@ impl MetaContext {
             .into_iter()
             .map(|member| self.data_source_for_member_name(member))
             .try_fold(DataSource::Unrestricted, |l, r| l.merge(&r?))
+    }
+
+    /// Data source for a cube or a view as a whole.
+    /// A query can reference a cube without referencing any of its members,
+    /// like when it selects only synthetic fields (`__user`, `__cubeJoinField`).
+    /// Members of a single view can come from different data sources,
+    /// so the first member with a known data source wins.
+    pub fn data_source_for_cube_name(
+        &self,
+        cube_name: &str,
+    ) -> Result<DataSource<'_>, DataSourceError> {
+        let cube = self
+            .find_cube_with_name(cube_name)
+            .ok_or_else(|| DataSourceError::MissingForCube(cube_name.to_string()))?;
+
+        cube.dimensions
+            .iter()
+            .map(|dimension| &dimension.name)
+            .chain(cube.measures.iter().map(|measure| &measure.name))
+            .chain(cube.segments.iter().map(|segment| &segment.name))
+            .find_map(|member| self.member_to_data_source.get(member))
+            .map(|data_source| DataSource::Specific(data_source.as_ref()))
+            .ok_or_else(|| DataSourceError::MissingForCube(cube_name.to_string()))
+    }
+
+    /// Data source shared by `cube_names`, as a fallback for a query that
+    /// references no members at all. Cubes without a data source of their own are
+    /// skipped, so that one unresolvable cube does not mask a resolvable one; the
+    /// rest are merged, which reports two different data sources as a conflict
+    /// like every other resolution path here. An empty `cube_names` is
+    /// `Unrestricted`; `cube_names` where nothing at all resolves names them all,
+    /// since the caller has no other way to tell what was tried.
+    pub fn data_source_for_cube_names<'names>(
+        &self,
+        cube_names: impl IntoIterator<Item = &'names str>,
+    ) -> Result<DataSource<'_>, DataSourceError> {
+        let mut tried = Vec::new();
+        let data_source = cube_names
+            .into_iter()
+            .filter_map(|cube_name| {
+                tried.push(cube_name);
+                self.data_source_for_cube_name(cube_name).ok()
+            })
+            .try_fold(DataSource::Unrestricted, |l, r| l.merge(&r))?;
+
+        match data_source {
+            DataSource::Unrestricted if !tried.is_empty() => {
+                Err(DataSourceError::MissingForEveryCube(tried.join(", ")))
+            }
+            data_source => Ok(data_source),
+        }
     }
 
     pub fn find_cube_with_name(&self, name: &str) -> Option<&CubeMeta> {
@@ -309,5 +372,138 @@ mod tests {
             Some(table) => assert_eq!(18005, table.oid),
             _ => panic!("wrong name!"),
         }
+    }
+
+    fn cube_with_members(name: &str, members: &[&str]) -> CubeMeta {
+        CubeMeta {
+            name: name.to_string(),
+            description: None,
+            title: None,
+            r#type: CubeMetaType::Cube,
+            dimensions: members
+                .iter()
+                .map(|member| CubeMetaDimension::new(member.to_string(), "string".to_string()))
+                .collect(),
+            measures: vec![],
+            segments: vec![],
+            joins: None,
+            folders: None,
+            nested_folders: None,
+            hierarchies: None,
+            meta: None,
+        }
+    }
+
+    /// `orders` resolves through its member, `logs` has a member with no data
+    /// source of its own, and `events` is not in the schema at all.
+    fn data_source_test_context() -> MetaContext {
+        MetaContext::new(
+            vec![
+                cube_with_members("orders", &["orders.status"]),
+                cube_with_members("logs", &["logs.line"]),
+            ],
+            HashMap::from([("orders.status".to_string(), "warehouse".to_string())]),
+            HashMap::new(),
+            Uuid::new_v4(),
+        )
+    }
+
+    #[test]
+    fn test_data_source_for_cube_name() {
+        let ctx = data_source_test_context();
+
+        assert!(matches!(
+            ctx.data_source_for_cube_name("orders"),
+            Ok(DataSource::Specific("warehouse"))
+        ));
+        assert!(matches!(
+            ctx.data_source_for_cube_name("logs"),
+            Err(DataSourceError::MissingForCube(cube)) if cube == "logs"
+        ));
+        assert!(matches!(
+            ctx.data_source_for_cube_name("events"),
+            Err(DataSourceError::MissingForCube(cube)) if cube == "events"
+        ));
+    }
+
+    #[test]
+    fn test_data_source_for_cube_names() {
+        let ctx = data_source_test_context();
+
+        // Nothing to resolve from leaves the data source open, so that the caller
+        // can raise its own error.
+        assert!(matches!(
+            ctx.data_source_for_cube_names(Vec::<&str>::new()),
+            Ok(DataSource::Unrestricted)
+        ));
+        // A cube without a data source of its own does not mask a cube that has
+        // one, whichever order they come in.
+        assert!(matches!(
+            ctx.data_source_for_cube_names(vec!["logs", "orders"]),
+            Ok(DataSource::Specific("warehouse"))
+        ));
+        assert!(matches!(
+            ctx.data_source_for_cube_names(vec!["orders", "logs"]),
+            Ok(DataSource::Specific("warehouse"))
+        ));
+        // When nothing resolves, the error names everything that was tried.
+        let err = ctx
+            .data_source_for_cube_names(vec!["logs", "events"])
+            .expect_err("neither cube has a data source");
+        assert!(
+            matches!(&err, DataSourceError::MissingForEveryCube(cubes) if cubes == "logs, events"),
+            "expected every tried cube to be named, got: {}",
+            err
+        );
+    }
+
+    /// A view can include members from cubes on different data sources. There is
+    /// no single right answer then, and resolving a whole cube is only ever a
+    /// fallback for a query that names no members, so the first member that has a
+    /// data source wins. This pins that choice rather than endorsing it.
+    #[test]
+    fn test_data_source_for_cube_name_of_multi_data_source_view() {
+        let mut view = cube_with_members("everything", &["everything.url", "everything.status"]);
+        view.r#type = CubeMetaType::View;
+
+        let ctx = MetaContext::new(
+            vec![view],
+            HashMap::from([
+                ("everything.url".to_string(), "analytics".to_string()),
+                ("everything.status".to_string(), "warehouse".to_string()),
+            ]),
+            HashMap::new(),
+            Uuid::new_v4(),
+        );
+
+        assert!(matches!(
+            ctx.data_source_for_cube_name("everything"),
+            Ok(DataSource::Specific("analytics"))
+        ));
+    }
+
+    #[test]
+    fn test_data_source_for_cube_names_reports_conflict() {
+        let ctx = MetaContext::new(
+            vec![
+                cube_with_members("orders", &["orders.status"]),
+                cube_with_members("visits", &["visits.url"]),
+            ],
+            HashMap::from([
+                ("orders.status".to_string(), "warehouse".to_string()),
+                ("visits.url".to_string(), "analytics".to_string()),
+            ]),
+            HashMap::new(),
+            Uuid::new_v4(),
+        );
+
+        let err = ctx
+            .data_source_for_cube_names(vec!["orders", "visits"])
+            .expect_err("two data sources should conflict");
+        assert!(
+            matches!(&err, DataSourceError::Conflict(..)),
+            "expected a conflict, got: {}",
+            err
+        );
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes the "Can't generate SQL for push-to-Cube CubeScan without specific data source" error for queries that reference no members at all, such as a BI profiling query over only synthetic fields like `__user` or `__cubeJoinField`. Related test is included.
