### PR TITLE
fix(cubestore): bump lru to 0.18.2 to clear two use-after-free advisories

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -97,17 +97,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
-dependencies = [
- "getrandom 0.2.14",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -254,7 +243,7 @@ name = "arrow-array"
 version = "54.2.1"
 source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube-46.0.1#008ff5b21afa64ec7dfd6c2c41526fff4b37db7b"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -390,7 +379,7 @@ name = "arrow-select"
 version = "54.2.1"
 source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube-46.0.1#008ff5b21afa64ec7dfd6c2c41526fff4b37db7b"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1853,7 +1842,7 @@ name = "datafusion-common"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "arrow-ipc",
  "base64 0.22.1",
@@ -2003,7 +1992,7 @@ name = "datafusion-functions-aggregate"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2023,7 +2012,7 @@ name = "datafusion-functions-aggregate-common"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2123,7 +2112,7 @@ name = "datafusion-physical-expr"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2144,7 +2133,7 @@ name = "datafusion-physical-expr-common"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2175,7 +2164,7 @@ name = "datafusion-physical-plan"
 version = "46.0.1"
 source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube-46.0.1#ea204976c12c057d7c315ae13040264258b23131"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -2593,6 +2582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,20 +2897,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.4",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -2924,6 +2910,17 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -3772,11 +3769,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.6"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4626,7 +4623,7 @@ version = "54.2.1"
 source = "git+https://github.com/cube-js/arrow-rs.git?branch=cube-46.0.1#008ff5b21afa64ec7dfd6c2c41526fff4b37db7b"
 dependencies = [
  "aes-gcm",
- "ahash 0.8.11",
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
@@ -4977,7 +4974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -6815,8 +6812,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.7.3",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -92,7 +92,7 @@ opentelemetry-otlp = { version = "0.26.0", default-features = false, features = 
     "trace", "metrics", "logs", "http-proto", "http-json", "reqwest-client", "tokio"
 ] }
 opentelemetry-http = { version = "0.26.0", features = ["reqwest"] }
-lru = "0.6.5"
+lru = "0.18.2"
 moka = { version = "0.10.1", features = ["future"] }
 ctor = "0.1.20"
 json = "0.12.4"

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -9,6 +9,7 @@ use futures::Future;
 use log::trace;
 use moka::future::{Cache, ConcurrentCacheExt, Iter};
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{watch, Mutex};
@@ -120,7 +121,10 @@ impl SqlResultCache {
         });
 
         Self {
-            queue_cache: Mutex::new(lru::LruCache::new(queue_cache_max_capacity as usize)),
+            // `LruCache::new` takes NonZeroUsize since lru 0.9; a configured 0 would panic.
+            queue_cache: Mutex::new(lru::LruCache::new(
+                NonZeroUsize::new(queue_cache_max_capacity as usize).unwrap_or(NonZeroUsize::MIN),
+            )),
             result_cache: cache_builder
                 .max_capacity(capacity_bytes)
                 .weigher(sql_result_cache_sizeof)
@@ -419,6 +423,14 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
+
+    /// A configured capacity of 0 must not panic on startup.
+    #[test]
+    fn queue_cache_capacity_zero_does_not_panic() {
+        let cache = SqlResultCache::new(1 << 20, Some(120), 0, None);
+
+        assert_eq!(cache.queue_cache.blocking_lock().cap().get(), 1);
+    }
 
     #[tokio::test]
     async fn simple() -> Result<(), CubeError> {


### PR DESCRIPTION
`lru = "0.6.5"` resolved to **0.6.6**, affected by two HIGH use-after-free advisories, both fixed in **0.7.1**:

- [`GHSA-qqmc-hwqp-8g2w`](https://github.com/advisories/GHSA-qqmc-hwqp-8g2w) — Use after free in lru crate
- [`GHSA-v362-2895-h9r2`](https://github.com/advisories/GHSA-v362-2895-h9r2) — Use After Free in lru

Went to **0.18.2** rather than the minimum 0.7.1 to land on a maintained line.

## Change

The only API difference that affects us is the constructor: `LruCache::new` takes a `NonZeroUsize` as of lru 0.9. A configured capacity of 0 would panic there, so it's clamped to 1, with a test covering it. `cargo check -p cubestore` needed no other adjustments — `contains` / `get` / `pop` are unchanged.

## Verification

```
running 5 tests
test sql::cache::tests::queue_cache_capacity_zero_does_not_panic ... ok
test sql::cache::tests::stale_while_revalidate_background_failure ... ok
test sql::cache::tests::simple ... ok
test sql::cache::tests::stale_while_revalidate ... ok
test sql::cache::tests::stale_while_revalidate_timeout_expiry ... ok

test result: ok. 5 passed; 0 failed
```

`Cargo.lock` carries one `lru` entry at 0.18.2, with no 0.6.x remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)