### PR TITLE
docs: document time zones across account, user, dashboard, and embed

### DIFF
--- a/docs-mintlify/admin/time-zones.mdx
+++ b/docs-mintlify/admin/time-zones.mdx
@@ -1,0 +1,138 @@
+---
+title: Time zones
+description: Run queries in the time zone your readers actually work in — account-wide, per user, and per dashboard.
+---
+
+By default, every query Cube runs buckets time in the deployment's Account Time Zone
+(the [`CUBEJS_DEFAULT_TIMEZONE`](/reference/configuration/environment-variables#cubejs_default_timezone)
+environment variable, `UTC` unless you change it). That means "orders today" answers the
+same question for everyone, regardless of where they sit — which is wrong by up to a day
+for anyone outside that zone.
+
+Turning on **user time zones** lets a zone be resolved per account, per user, and per
+dashboard instead.
+
+<Warning>
+
+This feature is **off by default**, and turning it on **moves numbers**. While it is
+off, nothing changes for anyone. Once it is on, a reader whose effective zone differs
+from the Account Time Zone sees different daily, weekly, and monthly totals — because
+the days are cut in a different place.
+
+</Warning>
+
+## What a time zone changes
+
+The effective zone is applied to every query Cube runs on your behalf:
+
+- **Time dimension bucketing** — which rows fall into which day, week, month, or quarter.
+- **Relative dates** — `today`, `yesterday`, `this week`, `last 7 days`, and the dates
+  the agent resolves when you ask about "today".
+- **Date range filters** — the boundaries you type are interpreted in the effective zone.
+
+It applies to charts, dashboards, drill-downs, subtotals and totals, sparklines, period
+comparison, [Analytics Chat](/docs/explore-analyze/analytics-chat), and embedded
+surfaces alike, so a dashboard's charts and its agent panel always agree.
+
+A time zone is a **display and bucketing** concern only. It never affects what data a
+user can see — access control still comes from roles and the security context.
+
+## Turn it on
+
+Go to **Admin → Settings → Time Zones**. Three controls, in the order the decisions are
+made:
+
+| Control | What it does |
+| --- | --- |
+| **Enable user time zones** | The master switch. Off by default; while off, no surface resolves a zone at all. |
+| **Tenant time zone** | The zone everyone in the account gets unless they override it. Leave it as **Deployment default** to keep using each deployment's Account Time Zone. |
+| **Allow personal time zones** | Whether users may choose their own zone on their Preferences page. On by default once the feature is enabled. |
+
+The last two appear only while the feature is enabled, and they apply to every user in
+the tenant.
+
+{/* TODO: screenshot — Admin → Settings → Time Zones card with the three controls */}
+
+## Personal time zone
+
+When **Allow personal time zones** is on, each user can pick their own zone under
+**Preferences → Time zone** (see [Preferences](/docs/preferences#time-zone)). Only a zone
+the user has explicitly chosen is ever applied — Cube never silently uses the browser's
+zone, though it will offer the detected zone as a suggestion.
+
+Turning **Allow personal time zones** off makes everyone query in the tenant zone again,
+and existing personal choices stop applying.
+
+## Dashboard time zone
+
+A dashboard is one artifact many people read, so its zone is a property of the dashboard
+rather than of whoever opens it. Set it in the dashboard builder under
+**Options → Time zone**, which offers three choices:
+
+| Choice | Behavior |
+| --- | --- |
+| **Deployment default** | Inherit — follow the tenant zone, or the deployment's Account Time Zone when no tenant zone is set. |
+| **Viewer time zone** | Resolve per reader, so each viewer sees their own local day. Use this for an operational board. |
+| A named zone | Pin the dashboard — "this dashboard reports in `America/New_York`", and keeps doing so after an admin changes the tenant zone. |
+
+The zone is stored with the **published** version, so editing a draft does not move the
+numbers on the dashboard people are currently reading. Publish to apply it.
+
+**Viewer time zone** is offered only while **Allow personal time zones** is on — without
+it, a per-reader promise is one Cube would not keep.
+
+### Reading a dashboard in another zone
+
+A published dashboard shows the zone its numbers are bucketed in, next to its title,
+along with where that zone came from — **Set by this dashboard**, **Your own time zone**,
+or **Deployment default**.
+
+Where the dashboard leaves the choice open, that control is also a dropdown: pick another
+zone to look at the same dashboard in it. This is a temporary lens, not an edit — nothing
+is saved, nobody else is affected, and leaving the dashboard drops it.
+
+The zone is shown but **not changeable** when the dashboard is pinned to a named zone, or
+when the account does not allow personal time zones. In both cases the zone is not the
+reader's to reinterpret.
+
+## Exploration time zone
+
+A saved exploration carries a zone the same way, chosen from the **Time zone** control in
+the Explore header. The rows mean what they mean on a dashboard: inherit, resolve per
+viewer, or pin a named zone. It saves as soon as you pick it, so anyone who opens the
+exploration afterwards gets that zone; readers with view-only access see the zone but
+cannot change it.
+
+## How the zone is resolved
+
+Highest priority first.
+
+**A dashboard or a saved exploration:**
+
+1. A reader's temporary lens, or an embed host's `?timezone=` (see
+   [embedded time zones](/embedding/iframe/time-zones)).
+2. The artifact's own pinned zone.
+3. The reader's personal zone — only when the artifact is set to **Viewer time zone**,
+   and only when the account allows personal zones.
+4. What the artifact inherits: the account-wide embed zone for an embed, otherwise the
+   tenant zone.
+5. The deployment's Account Time Zone.
+
+**Ad-hoc surfaces** — a new exploration, a standalone chat — resolve the reader's own
+personal zone first, then the tenant zone. Here the only reader is the person asking, so
+their own zone is the right answer.
+
+**Embedded surfaces** follow their own chain, documented in
+[embedded time zones](/embedding/iframe/time-zones).
+
+At every level, if nothing resolves, Cube sends no zone and the deployment applies its
+Account Time Zone — exactly as it did before this feature existed.
+
+## Valid time zone values
+
+Cube accepts [IANA time zone names][link-tzdb] such as `America/New_York` or
+`Asia/Tokyo`. Bare UTC offsets like `+05:30` are **rejected** rather than accepted,
+because Cube would compute them in UTC while reporting the offset back — silently wrong.
+Legacy aliases are understood (`US/Eastern` resolves to `America/New_York`).
+
+[link-tzdb]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/docs-mintlify/admin/time-zones.mdx
+++ b/docs-mintlify/admin/time-zones.mdx
@@ -3,9 +3,10 @@ title: Time zones
 description: Run queries in the time zone your readers actually work in — account-wide, per user, and per dashboard.
 ---
 
-By default, every query Cube runs buckets time in the deployment's Account Time Zone
-(the [`CUBEJS_DEFAULT_TIMEZONE`](/reference/configuration/environment-variables#cubejs_default_timezone)
-environment variable, `UTC` unless you change it). That means "orders today" answers the
+By default, every query Cube runs buckets time in the deployment's
+[default time zone](/docs/data-modeling/configuration#default-time-zone) — the
+[`CUBEJS_DEFAULT_TIMEZONE`](/reference/configuration/environment-variables#cubejs_default_timezone)
+environment variable, `UTC` unless you change it. That means "orders today" answers the
 same question for everyone, regardless of where they sit — which is wrong by up to a day
 for anyone outside that zone.
 
@@ -16,8 +17,8 @@ dashboard instead.
 
 This feature is **off by default**, and turning it on **moves numbers**. While it is
 off, nothing changes for anyone. Once it is on, a reader whose effective zone differs
-from the Account Time Zone sees different daily, weekly, and monthly totals — because
-the days are cut in a different place.
+from that default sees different daily, weekly, and monthly totals — because the days
+are cut in a different place.
 
 </Warning>
 
@@ -45,11 +46,12 @@ made:
 | Control | What it does |
 | --- | --- |
 | **Enable user time zones** | The master switch. Off by default; while off, no surface resolves a zone at all. |
-| **Tenant time zone** | The zone everyone in the account gets unless they override it. Leave it as **Deployment default** to keep using each deployment's Account Time Zone. |
+| **Tenant time zone** | The account-wide zone: everyone gets it unless they override it. Leave it as **Deployment default** to keep using each deployment's own default. |
 | **Allow personal time zones** | Whether users may choose their own zone on their Preferences page. On by default once the feature is enabled. |
 
 The last two appear only while the feature is enabled, and they apply to every user in
-the tenant.
+the account. The UI labels the middle control **Tenant time zone**; this page calls the
+zone it sets the *account-wide zone*, matching how the docs scope things.
 
 {/* TODO: screenshot — Admin → Settings → Time Zones card with the three controls */}
 
@@ -60,7 +62,7 @@ When **Allow personal time zones** is on, each user can pick their own zone unde
 the user has explicitly chosen is ever applied — Cube never silently uses the browser's
 zone, though it will offer the detected zone as a suggestion.
 
-Turning **Allow personal time zones** off makes everyone query in the tenant zone again,
+Turning **Allow personal time zones** off makes everyone query in the account-wide zone again,
 and existing personal choices stop applying.
 
 ## Dashboard time zone
@@ -71,9 +73,9 @@ rather than of whoever opens it. Set it in the dashboard builder under
 
 | Choice | Behavior |
 | --- | --- |
-| **Deployment default** | Inherit — follow the tenant zone, or the deployment's Account Time Zone when no tenant zone is set. |
+| **Deployment default** | Inherit — follow the account-wide zone, or the deployment's own default when no account-wide zone is set. |
 | **Viewer time zone** | Resolve per reader, so each viewer sees their own local day. Use this for an operational board. |
-| A named zone | Pin the dashboard — "this dashboard reports in `America/New_York`", and keeps doing so after an admin changes the tenant zone. |
+| A named zone | Pin the dashboard — "this dashboard reports in `America/New_York`", and keeps doing so after an admin changes the account-wide zone. |
 
 The zone is stored with the **published** version, so editing a draft does not move the
 numbers on the dashboard people are currently reading. Publish to apply it.
@@ -115,18 +117,18 @@ Highest priority first.
 3. The reader's personal zone — only when the artifact is set to **Viewer time zone**,
    and only when the account allows personal zones.
 4. What the artifact inherits: the account-wide embed zone for an embed, otherwise the
-   tenant zone.
-5. The deployment's Account Time Zone.
+   account-wide zone.
+5. The deployment's default time zone.
 
 **Ad-hoc surfaces** — a new exploration, a standalone chat — resolve the reader's own
-personal zone first, then the tenant zone. Here the only reader is the person asking, so
+personal zone first, then the account-wide zone. Here the only reader is the person asking, so
 their own zone is the right answer.
 
 **Embedded surfaces** follow their own chain, documented in
 [embedded time zones](/embedding/iframe/time-zones).
 
 At every level, if nothing resolves, Cube sends no zone and the deployment applies its
-Account Time Zone — exactly as it did before this feature existed.
+default time zone — exactly as it did before this feature existed.
 
 ## Valid time zone values
 

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -408,6 +408,7 @@
                   "admin/customization/dashboard-themes"
                 ]
               },
+              "admin/time-zones",
               "admin/account-billing/ai-tokens",
               "admin/account-billing/api-keys",
               "admin/account-billing/billing-faq",
@@ -434,6 +435,7 @@
               "embedding/iframe/creator-mode",
               "embedding/iframe/customization",
               "embedding/iframe/localization",
+              "embedding/iframe/time-zones",
               "embedding/iframe/events",
               {
                 "group": "Authentication",

--- a/docs-mintlify/docs/preferences.mdx
+++ b/docs-mintlify/docs/preferences.mdx
@@ -18,25 +18,6 @@ account, apply across all devices, and don't affect other users in the account.
 | New message scrolling | Automatically scroll to new messages in chat | On |
 | Alternating row colors | Highlight alternating rows in data tables | Off |
 
-## Time zone
-
-By default your queries run in the deployment's Account Time Zone. If your admin has
-enabled **user time zones** and left personal time zones allowed, you can pick your own
-under **Time zone** on the **Preferences** page — so time dimensions bucket into your
-local day and `today` means your today.
-
-Only a zone you pick is applied; Cube never silently switches you to your browser's zone.
-If your device is somewhere else, Cube offers the detected zone as a dismissible
-suggestion rather than applying it.
-
-Leaving it as **Deployment default** follows the tenant zone your admin set, or the
-deployment's Account Time Zone when there isn't one. The control is hidden when your admin
-has not enabled the feature, or has turned off personal time zones — in that case
-everyone queries in the tenant zone.
-
-See [Time zones](/admin/time-zones) for what a zone changes and how dashboards carry their
-own.
-
 ## Language
 
 The Cube interface is available in 10 languages across 12 locales (Spanish and
@@ -69,3 +50,23 @@ To set the language of **embedded** Cube surfaces (dashboards, Analytics Chat, a
 Creator Mode) instead, see [embedding localization](/embedding/iframe/localization).
 
 </Info>
+
+## Time zone
+
+By default your queries run in the deployment's
+[default time zone](/docs/data-modeling/configuration#default-time-zone). If your admin has
+enabled **user time zones** and left personal time zones allowed, you can pick your own
+under **Time zone** on the **Preferences** page — so time dimensions bucket into your
+local day and `today` means your today.
+
+Only a zone you pick is applied; Cube never silently switches you to your browser's zone.
+If your device is somewhere else, Cube offers the detected zone as a dismissible
+suggestion rather than applying it.
+
+Leaving it as **Deployment default** follows the account-wide zone your admin set, or the
+deployment's default time zone when there isn't one. The control is hidden when your admin
+has not enabled the feature, or has turned off personal time zones — in that case
+everyone queries in the account-wide zone.
+
+See [Time zones](/admin/time-zones) for what a zone changes and how dashboards carry their
+own.

--- a/docs-mintlify/docs/preferences.mdx
+++ b/docs-mintlify/docs/preferences.mdx
@@ -11,11 +11,31 @@ account, apply across all devices, and don't affect other users in the account.
 | --- | --- | --- |
 | Theme | Choose between System, Light, or Dark visual theme | System |
 | Language | Choose the language for the Cube interface | English (US) |
+| Time zone | Run your queries in this time zone, so dates like "today" match your local day | Deployment default |
 | Sidebar drawer | Show only icons and expand the sidebar on hover | Off |
 | Pointer cursors | Use pointer cursors on interactive elements | On |
 | Code editor | Switch to the new CodeMirror-based code editor for data models | Off |
 | New message scrolling | Automatically scroll to new messages in chat | On |
 | Alternating row colors | Highlight alternating rows in data tables | Off |
+
+## Time zone
+
+By default your queries run in the deployment's Account Time Zone. If your admin has
+enabled **user time zones** and left personal time zones allowed, you can pick your own
+under **Time zone** on the **Preferences** page — so time dimensions bucket into your
+local day and `today` means your today.
+
+Only a zone you pick is applied; Cube never silently switches you to your browser's zone.
+If your device is somewhere else, Cube offers the detected zone as a dismissible
+suggestion rather than applying it.
+
+Leaving it as **Deployment default** follows the tenant zone your admin set, or the
+deployment's Account Time Zone when there isn't one. The control is hidden when your admin
+has not enabled the feature, or has turned off personal time zones — in that case
+everyone queries in the tenant zone.
+
+See [Time zones](/admin/time-zones) for what a zone changes and how dashboards carry their
+own.
 
 ## Language
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -314,6 +314,7 @@ sendAction("cube:action:refresh");
 | [`cube:action:set-color-scheme`](#cube-action-set-color-scheme) | Switch light / dark / auto | `{ scheme }` |
 | [`cube:action:set-theme`](#cube-action-set-theme) | Apply a brand theme (colors, fonts) | `embedTheme` object |
 | [`cube:action:set-locale`](#cube-action-set-locale) | Switch the UI language | `{ locale }` |
+| [`cube:action:set-timezone`](#cube-action-set-timezone) | Switch the query time zone | `{ timezone }` |
 | [`cube:action:set-filter`](#cube-action-set-filter) | Push a filter into a dashboard | `{ filterUrlParameter }` |
 | [`cube:action:navigate`](#cube-action-navigate) | Navigate the embed to a path | `{ path }` |
 | [`cube:action:refresh`](#cube-action-refresh) | Re-run the embed's queries | _none_ |
@@ -357,6 +358,20 @@ for the list of supported languages and the other ways to set the language.
 
 ```js
 sendAction("cube:action:set-locale", { locale: "es" });
+```
+
+#### `cube:action:set-timezone` {#cube-action-set-timezone}
+
+Switch the time zone the embed's queries run in — which day a row falls into, and what
+`today` means. Takes precedence over the `?timezone=` URL parameter and the account
+default. See [Time zones](/embedding/iframe/time-zones) for the other ways to set it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `timezone` | `string` | An [IANA time zone name](/admin/time-zones#valid-time-zone-values), e.g. `Asia/Tokyo`. Bare UTC offsets are ignored. |
+
+```js
+sendAction("cube:action:set-timezone", { timezone: "Asia/Tokyo" });
 ```
 
 #### `cube:action:set-filter` {#cube-action-set-filter}

--- a/docs-mintlify/embedding/iframe/time-zones.mdx
+++ b/docs-mintlify/embedding/iframe/time-zones.mdx
@@ -1,0 +1,87 @@
+---
+title: Time zones
+description: Set the time zone for embedded Cube surfaces — account-wide, per embed via URL, or at runtime.
+---
+
+Embedded Cube surfaces — dashboards, [Analytics Chat](/embedding/iframe/analytics-chat),
+and the full app in [Creator Mode](/embedding/iframe/creator-mode) — bucket time in a
+zone you control. You can set a default for the whole account, override it per embed with
+a URL parameter, or switch it at runtime from the host page.
+
+This matters most when your end users are not in your deployment's zone: without it,
+"today" in an embedded dashboard means today in the Account Time Zone, not in your
+customer's.
+
+<Info>
+  Embedded time zones require **user time zones** to be enabled for the account. See
+  [Time zones](/admin/time-zones) for the account-wide policy, what a zone changes, and
+  the console-side behavior.
+</Info>
+
+## How the zone is resolved
+
+The time zone of an embedded surface is resolved from the following sources, highest
+priority first:
+
+1. **Runtime override** — a [`cube:action:set-timezone`](/embedding/iframe/events#cube-action-set-timezone)
+   message sent from the host page (see [At runtime](#at-runtime)).
+2. **URL parameter** — the `?timezone=` query parameter on the embed URL (see
+   [Per embed via URL](#per-embed-via-url)).
+3. **Dashboard's own zone** — a dashboard pinned to a named zone, or set to resolve per
+   viewer (see [dashboard time zone](/admin/time-zones#dashboard-time-zone)).
+4. **Account default** — the zone configured in **Embed → Settings** (see
+   [Account-wide default](#account-wide-default)).
+5. **Tenant zone**, then the deployment's Account Time Zone.
+
+A host override outranks a dashboard's pinned zone by design: the integrator is speaking
+for the whole frame, and you know your user's zone better than the dashboard's author
+does.
+
+<Note>
+  If the account policy is disabled, none of this applies — Cube sends no zone and the
+  deployment's Account Time Zone is used, exactly as before.
+</Note>
+
+## Account-wide default
+
+Set a default time zone for all embedded surfaces:
+
+1. Go to **Embed → Settings**.
+2. In the **Time Zone** card, pick a zone from the dropdown.
+
+The selected zone applies to every embedded surface across the account, unless a specific
+embed overrides it. Re-selecting the tenant zone clears the embed-specific value, so
+embeds follow the tenant zone again.
+
+The picker is inert while user time zones are off for the account — a zone stored there
+would be one nothing applies.
+
+## Per embed via URL
+
+Override the account default for an individual embed by adding the `?timezone=` query
+parameter to the embed URL:
+
+```text
+https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&timezone=America/New_York
+```
+
+The parameter is read once when the embed loads and pinned for the session, so in-app
+navigation won't drop it.
+
+Values must be [IANA time zone names](/admin/time-zones#valid-time-zone-values). An
+unusable value — including a bare UTC offset like `+05:30` — is ignored, and the embed
+falls back to the account default rather than quietly shifting every number.
+
+## At runtime
+
+Switch the zone after the embed has loaded by sending a
+[`cube:action:set-timezone`](/embedding/iframe/events#cube-action-set-timezone) message
+from the host page. This takes precedence over both the URL parameter and the account
+default — use it when your own user changes their zone:
+
+```js
+sendAction("cube:action:set-timezone", { timezone: "Asia/Tokyo" });
+```
+
+See [Events and actions](/embedding/iframe/events) for the full host ↔ embed messaging
+contract.

--- a/docs-mintlify/embedding/iframe/time-zones.mdx
+++ b/docs-mintlify/embedding/iframe/time-zones.mdx
@@ -9,8 +9,15 @@ zone you control. You can set a default for the whole account, override it per e
 a URL parameter, or switch it at runtime from the host page.
 
 This matters most when your end users are not in your deployment's zone: without it,
-"today" in an embedded dashboard means today in the Account Time Zone, not in your
+"today" in an embedded dashboard means today in the deployment's
+[default time zone](/docs/data-modeling/configuration#default-time-zone), not in your
 customer's.
+
+<Note>
+
+Available on [Premium and above plans](https://cube.dev/pricing).
+
+</Note>
 
 <Info>
   Embedded time zones require **user time zones** to be enabled for the account. See
@@ -28,10 +35,13 @@ priority first:
 2. **URL parameter** — the `?timezone=` query parameter on the embed URL (see
    [Per embed via URL](#per-embed-via-url)).
 3. **Dashboard's own zone** — a dashboard pinned to a named zone, or set to resolve per
-   viewer (see [dashboard time zone](/admin/time-zones#dashboard-time-zone)).
+   viewer (see [dashboard time zone](/admin/time-zones#dashboard-time-zone)). In
+   [signed embedding](/embedding/iframe/auth/signed) the viewer has no Cube account and
+   therefore no personal zone, so a viewer-resolved dashboard falls through to the next
+   step — supply `?timezone=` if you want each end user's own zone.
 4. **Account default** — the zone configured in **Embed → Settings** (see
    [Account-wide default](#account-wide-default)).
-5. **Tenant zone**, then the deployment's Account Time Zone.
+5. **Account-wide zone**, then the deployment's default time zone.
 
 A host override outranks a dashboard's pinned zone by design: the integrator is speaking
 for the whole frame, and you know your user's zone better than the dashboard's author
@@ -39,7 +49,7 @@ does.
 
 <Note>
   If the account policy is disabled, none of this applies — Cube sends no zone and the
-  deployment's Account Time Zone is used, exactly as before.
+  deployment's default time zone is used, exactly as before.
 </Note>
 
 ## Account-wide default
@@ -50,8 +60,8 @@ Set a default time zone for all embedded surfaces:
 2. In the **Time Zone** card, pick a zone from the dropdown.
 
 The selected zone applies to every embedded surface across the account, unless a specific
-embed overrides it. Re-selecting the tenant zone clears the embed-specific value, so
-embeds follow the tenant zone again.
+embed overrides it. Re-selecting the account-wide zone clears the embed-specific value, so
+embeds follow the account-wide zone again.
 
 The picker is inert while user time zones are off for the account — a zone stored there
 would be one nothing applies.

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1106,6 +1106,10 @@ The default [time zone][ref-time-zone] for queries.
 You can set the time zone name in the [TZ Database Name][link-tzdb] format, e.g.,
 `America/Los_Angeles`.
 
+This is the fallback. When [user time zones](/admin/time-zones) are enabled for the
+account, a resolved account, personal, dashboard, or embed zone is sent with the query and
+takes precedence over this value.
+
 ## `CUBEJS_DEFAULT_API_SCOPES`
 
 [API scopes][ref-rest-scopes] used to allow or disallow access to REST (JSON) API

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -65,6 +65,10 @@ time zone conversion to dimensions that are not used as time dimensions in a que
 Additionally, note that time zones have impact on [pre-aggregation
 matching][ref-matching-preaggs-time-dimensions].
 
+In the Cube cloud platform, queries run from the interface, dashboards, and Analytics Chat
+can resolve a time zone per account, per user, or per dashboard — see
+[Time zones](/admin/time-zones).
+
 ## Query types
 
 Most commonly, you will run [regular queries](#regular-query). See the table


### PR DESCRIPTION
## Summary

- Linear: [CUB-3754](https://linear.app/cube-d3/issue/CUB-3754), [CUB-3759](https://linear.app/cube-d3/issue/CUB-3759) — both ask for the same coverage, both currently unwritten.
- Two new pages, because the topic genuinely had no home: settings on the **Admin → Settings** page are documented on their own feature page, and time zones had none. `admin/time-zones` is the authoritative one — what a zone actually changes (bucketing, relative dates, filter boundaries), the three admin controls, the personal zone, a dashboard's three choices and when a reader may borrow another zone, the exploration zone, the full resolution order, and why bare UTC offsets are rejected. `embedding/iframe/time-zones` mirrors the existing localization page, whose shape this feature repeats exactly (account default → `?timezone=` → runtime action).
- Four surgical edits: a **Time zone** row and section on Preferences, `cube:action:set-timezone` in the events reference, a note that `CUBEJS_DEFAULT_TIMEZONE` is now the *fallback* rather than the only answer, and a cross-link from the Core Data APIs time-zone section.

## Notes for the reviewer

- **Written against the shipped code, not the tickets** — which corrected one thing: the embed zone is **account-wide** at Admin → Embed → Settings, not per-embed-tenant as CUB-3754 describes. CUB-3759 has it right.
- **The in-product copy understates the feature.** The admin switch says "Run AI agent queries in a user's time zone", but since CUB-3751 the zone feeds every semantic SQL path — charts, drill-downs, totals, sparklines, period comparison. These pages describe the real behaviour, so the product copy is the thing that's now out of step.
- **No plan-availability callout.** I found no plan or feature-flag gate for the policy in the code, and the convention requires naming a specific tier — so I left it out rather than guessing. Tell me the tier and I'll add the `<Note>`.
- **Screenshots** are a `{/* TODO */}` placeholder, since binaries don't go in the repo.
- **One dependency:** the dashboard/exploration lock rules ("pinned = not changeable", "view-only = read-only") describe behaviour from cubedevinc/cubejs-enterprise#13884, which is green and mergeable but **not merged yet**. If that PR changes shape, the *Reading a dashboard in another zone* and *Exploration time zone* sections need a matching edit.

## Test plan

- [ ] `cd docs-mintlify && yarn dev` — both new pages render, and appear in the sidebar under **Account** and **Iframe embedding**
- [ ] Anchors resolve: `/docs/preferences#time-zone`, `/admin/time-zones#dashboard-time-zone`, `/admin/time-zones#valid-time-zone-values`, `/embedding/iframe/events#cube-action-set-timezone`
- [ ] `docs.json` is valid JSON and the diff is the 2-line nav addition only (no reformat)