### PR TITLE
fix(deps): bump uuid from 8.3.2 to 11.1.1 across the packages that declare it

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -49,7 +49,7 @@
     "nexus": "^1.1.0",
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.0",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -62,7 +62,6 @@
     "@types/node-fetch": "^2.5.8",
     "@types/ramda": "^0.27.32",
     "@types/supertest": "^2.0.10",
-    "@types/uuid": "^8.3.1",
     "jest": "^29",
     "mysql": "^2.18.1",
     "should": "^13.2.3",

--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -47,7 +47,7 @@
     "jest-bench": "^29",
     "pg": "^8.11.3",
     "typescript": "~5.2.2",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "dependencies": {
     "@cubejs-backend/cubesql": "1.7.18",

--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -56,7 +56,7 @@
     "proxy-agent": "^6.5.0",
     "shelljs": "^0.8.5",
     "throttle-debounce": "^3.0.1",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-clickhouse-driver/package.json
+++ b/packages/cubejs-clickhouse-driver/package.json
@@ -33,7 +33,7 @@
     "@cubejs-backend/shared": "1.7.18",
     "moment": "^2.24.0",
     "sqlstring": "^2.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -40,7 +40,7 @@
     "dayjs": "^1.10.4",
     "ramda": "^0.27.2",
     "url-search-params-polyfill": "^7.0.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.1"
   },
   "scripts": {
     "build:client-core": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -36,7 +36,7 @@
     "node-fetch": "^2.6.1",
     "sqlstring": "^2.3.3",
     "tempy": "^1.0.1",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "ws": "^7.4.3"
   },
   "devDependencies": {

--- a/packages/cubejs-databricks-jdbc-driver/package.json
+++ b/packages/cubejs-databricks-jdbc-driver/package.json
@@ -37,7 +37,7 @@
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.2",
     "source-map-support": "^0.5.19",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@cubejs-backend/linter": "1.7.18",

--- a/packages/cubejs-databricks-jdbc-driver/package.json
+++ b/packages/cubejs-databricks-jdbc-driver/package.json
@@ -44,7 +44,6 @@
     "@types/jest": "^29",
     "@types/node": "^22",
     "@types/ramda": "^0.27.34",
-    "@types/uuid": "^8.3.4",
     "jest": "^29",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -62,7 +62,7 @@
     "recursive-readdir": "2.2.3",
     "sql-formatter": "^3.1.0",
     "throttle-debounce": "^3.0.1",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@ant-design/compatible": "^1.0.1",

--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -77,7 +77,6 @@
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.34",
-    "@types/uuid": "^8.3.1",
     "@vitejs/plugin-react": "^6",
     "antd": "4.16.13",
     "eslint-config-airbnb": "^18.1.0",

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -41,7 +41,6 @@
     "@types/jest": "^29",
     "@types/node": "^22",
     "@types/ramda": "^0.27.32",
-    "@types/uuid": "^8.3.0",
     "jest": "^29",
     "ts-jest": "^29",
     "typescript": "~5.2.2"

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -54,7 +54,7 @@
     "node-dijkstra": "^2.5.0",
     "ramda": "^0.27.2",
     "syntax-error": "^1.3.0",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "workerpool": "^9.2.0",
     "yaml": "^2.7.1"
   },

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -74,7 +74,6 @@
     "@types/ramda": "^0.27.34",
     "@types/sqlstring": "^2.3.0",
     "@types/syntax-error": "^1.4.1",
-    "@types/uuid": "^8.3.0",
     "jest": "^29",
     "moment": "^2.30.1",
     "mysql": "^2.18.1",

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -72,7 +72,6 @@
     "@types/node": "^22",
     "@types/node-fetch": "^2.5.7",
     "@types/ramda": "^0.27.34",
-    "@types/uuid": "^8.3.0",
     "jest": "^29",
     "typescript": "~5.2.2"
   },

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -58,7 +58,7 @@
     "semver": "^7.6.3",
     "serve-static": "^1.13.2",
     "sqlstring": "^2.3.1",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "ws": "^7.5.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22720,16 +22720,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22812,7 +22803,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22832,13 +22823,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -24115,6 +24099,11 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
+uuid@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -24708,7 +24697,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.2.0.tgz#f74427cbb61234708332ed8ab9cbf56dcb1c4371"
   integrity sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24721,15 +24710,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8727,11 +8727,6 @@
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
   integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
 
-"@types/uuid@^8.3.0", "@types/uuid@^8.3.1", "@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/wrap-ansi@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
@@ -24094,12 +24089,7 @@ uuid@^10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
-uuid@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
-
-uuid@^11.1.1:
+uuid@^11.1.0, uuid@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==


### PR DESCRIPTION
`uuid@^8.3.2` is affected by [`GHSA-w5hq-g745-h8pq`](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate) — *"Missing buffer bounds check in v3/v5/v6 when buf is provided"* — first patched in **11.1.1**.

Ten packages now land on `^11.1.1`: the nine that declared `^8.3.2` (`api-gateway`, `backend-native`, `backend-shared`, `clickhouse-driver`, `cubestore-driver`, `databricks-jdbc-driver`, `playground`, `schema-compiler`, `server-core`) plus `client-core`, which was on `^11.1.0`.

## Why `^11.1.1` and not the newest 14.x

It is the **lowest** version that clears the advisory, and it lets every declared range collapse onto one resolution instead of introducing a second modern major.

Bumping `client-core` from `^11.1.0` turned out to be **required**, not cosmetic: yarn v1 keeps a pre-existing resolution rather than re-resolving it upward, so leaving it alone left `client-core` and the transitive `@cubejs-backend/jdbc` on **11.1.0** — before the fix, and exactly the version this PR exists to remove. Verified from the lockfile:

```
uuid@^11.1.0, uuid@^11.1.1:  version "11.1.1"
uuid 11.x versions resolved: ['11.1.1']  -> single copy: True
```

## The 8 → 11 jump is API-neutral here

Every call site uses **named imports**, all still exported by v11:

| import | packages |
|---|---|
| `v4` | server-core, api-gateway (×3), schema-compiler, cubestore-driver, clickhouse-driver, playground, client-core, backend-native test |
| `v1` + `v5` | backend-shared `process.ts` |
| `parse` | server-core `CompilerApi.ts` |

Nothing imports the **default export**, which is what v7 removed — the usual breakage on this upgrade. v11 ships dual CJS/ESM with a `require` condition, so the CommonJS consumers resolve `dist/cjs/index.js`; no interop change.

## `@types/uuid` removed

Six packages declared `@types/uuid@^8.3.x` (`api-gateway`, `schema-compiler`, `server-core`, `playground`, `databricks-jdbc-driver`, and `query-orchestrator` — which doesn't even declare `uuid`). uuid v11 bundles its own types and the DefinitelyTyped stub is deprecated for v7+.

This wasn't breaking a build, since TS resolves the bundled `dist/cjs/index.d.ts` ahead of `@types/`. But it left a v8-shaped stub that could take over under a `typeRoots`/`paths` setup, or outlive the runtime dependency. It is now absent from both the lockfile and `node_modules`.

## Verification

Runtime shapes checked against 11.1.1 directly:

```
uuid version: 11.1.1
named exports present: v1=function v4=function v5=function parse=function
v5(v1(), v1()): 5dff62e3-5b30-5472-9b07-b4bf9a1dc373 | valid shape: true
parse(v4()) byte length: 16 (expect 16)
v4 stable across calls (distinct): true
```

Types check without the stub — `v4()`, `v5(v1(), v1())` and `parse()` all compile under `strict` with `types: []` against uuid's own declarations.

`cubejs-backend-shared` typechecks clean and its **392 tests pass**; `processUid` (the one non-`v4` consumer) generates correctly from built output. `api-gateway` shows no uuid-related type errors.

## What this does *not* do

uuid 8/9/10 remain in the lockfile via third parties — `aws-sdk` (8.0.0), `sockjs`, `snowflake-sdk`, `@google-cloud/storage`, `@azure/msal-node`, `@cypress/request` (^8.x), `@google-cloud/bigquery`, `gaxios` (^9.x), `dockerode` (^10.x). Those are outside what this repo declares and would need upstream bumps or a `resolutions` entry — a separate decision. The alert is raised against the declared dependency, which this clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)