### PR TITLE
docs: document embedded-user AI billing and correct SCIM audit log events

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -73,6 +73,21 @@ Contact your account executive for details on purchasing token packages.
 Each user on a free plan receives an individual monthly token allowance. This
 allowance resets at the start of each calendar month.
 
+## Embedded users
+
+AI token spend by [embedded](/embedding/iframe) end users — through Analytics
+Chat, Creator Mode, or an embedded dashboard's AI features — is tracked
+separately from regular seats. Embedded users aren't billed as seats, so their
+usage isn't covered by [per-seat token grants](#per-seat-token-grants):
+
+- **Contract customers**: embedded AI spend draws from [token
+  packages](#token-packages) first, then continues as on-demand overage.
+- **On-demand customers**: embedded AI spend is billed directly as [on-demand
+  consumption](#on-demand-consumption), subject to the account's on-demand
+  spending limit if one is set.
+- **Free plan**: embedded users share the account's [free tier](#free-tier)
+  allowance, since free accounts have no seats to grant tokens against.
+
 ## Tracking usage
 
 Administrators can monitor token consumption through the **AI Tokens Usage**

--- a/docs-mintlify/admin/monitoring/audit-log.mdx
+++ b/docs-mintlify/admin/monitoring/audit-log.mdx
@@ -76,7 +76,7 @@ Audit Log collects the following types of events:
 | Category | Event type |
 | --- | --- |
 | Users | `Created user`<br/>`Deleted user`<br/>`Invited user`<br/>`Updated user profile`<br/>`Requested password reset`<br/>`Changed password` |
-| SCIM provisioning | `Created user via SCIM`<br/>`Updated user via SCIM`<br/>`Deleted user via SCIM`<br/>`Created group via SCIM`<br/>`Updated group via SCIM`<br/>`Deleted group via SCIM` |
+| SCIM provisioning | `Created user via SCIM`<br/>`Updated user via SCIM`<br/>`Deleted user via SCIM`<br/>`Created group via SCIM`<br/>`Updated group via SCIM`<br/>`Deleted group via SCIM`<br/>`Added group members via SCIM`<br/>`Removed group members via SCIM`<br/>`Updated group membership via SCIM` |
 | [Custom roles](/admin/users-and-permissions/custom-roles) | `Created role`<br/>`Deleted role`<br/>`Updated role`<br/>`Assigned role to user`<br/>`Assigned roles to user`<br/>`Removed role from user` |
 | Authentication | `Logged in`<br/>`Logged out`<br/>`Redirected to SAML provider for login`<br/>`Logged in via SAML` |
 | Account and [single sign-on](/admin/sso) | `Updated account settings`<br/>`Updated account authentication configuration`<br/>`Updated account SAML configuration`<br/>`Uploaded identity provider metadata file` |


### PR DESCRIPTION
## Summary

Found while cross-checking recent `cubejs-enterprise` changes against `docs-mintlify` for undocumented customer-facing behavior.

- **AI Tokens** (`admin/account-billing/ai-tokens.mdx`): as of CUB-3784, embedded end users (Analytics Chat, Creator Mode, embedded dashboards) — who aren't billed as seats — have their AI token spend routed to its own set of usage dimensions with no per-seat grant coverage. It now draws from token packages / on-demand overage instead. Added an "Embedded users" section so admins aren't surprised by embedded usage appearing as overage on their bill.
- **Audit Log** (`admin/monitoring/audit-log.mdx`): a SCIM group write used to log one generic `Updated group via SCIM` event regardless of what changed. Membership changes now emit specific titles (`Added group members via SCIM`, `Removed group members via SCIM`, `Updated group membership via SCIM`). Added the three new event names to the event types table.

Both are small, additive edits to existing pages — no new pages, no nav changes.

## Test plan

- [x] Verified both behaviors against the `cubejs-enterprise` commits that introduced them (`2a1f5072` billing dimension routing, `9bf3b548` SCIM audit log titles)
- [x] Confirmed neither was already covered elsewhere in `docs-mintlify`
- [ ] Mintlify preview render (no local dev server run in this session)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AxYWsCS56fWz5N1P3n4Znn

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxYWsCS56fWz5N1P3n4Znn)_