### PR TITLE
Document the Python panel and the repositioned SQL toggle

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -48,7 +48,7 @@ SQL report, that is usually correct behavior.
 
 ### From the toolbar
 
-Workbooks and [Explore](/docs/explore-analyze/explore) work the same way.
+Workbooks and [Explore](/docs/explore-analyze/explore) share the same flow.
 
 Click **Python** in the toolbar to open the Python panel, then **Add script** to
 attach one. Cube seeds a starter script and opens it on the **Script** tab.

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -38,24 +38,23 @@ SQL report, that is usually correct behavior.
 
 </Info>
 
-### In a workbook
+Workbooks and [Explore](/docs/explore-analyze/explore) work the same way.
 
-Open the tab menu and choose **Add Python**. Cube seeds a starter script and
-reveals the code panel. **Remove Python** detaches the script, after which the tab
-behaves like any SQL-backed report again.
+Click **Python** in the toolbar to open the Python panel, then **Add script** to
+attach one. Cube seeds a starter script and opens it on the **Script** tab. The
+**Python** button only opens the panel, so passing through it never puts a script
+on the report by itself.
+
+**Remove**, in the panel header, detaches the script, after which the report
+behaves like any SQL-backed one again.
 
 Attaching Python clears any existing SQL result: a python-backed report renders its
 last Python run, and a freshly attached script has none until you press **Run**.
 
-### In Explore
-
-Use the **Add Python** button in the header, with the same **Remove Python**
-counterpart.
-
-This is only available on a **saved** [exploration](/docs/explore-analyze/explore).
-On an unsaved one the button is disabled with the tooltip *"Save exploration before
-adding Python."* — **Run** executes server-persisted code, so the analysis needs a
-saved report to live on.
+In Explore this is only available on a **saved** exploration. On an unsaved one the
+**Python** button is disabled with the tooltip *"Save the exploration to add
+Python"* — **Run** executes server-persisted code, so the analysis needs a saved
+report to live on.
 
 ## Writing the script
 
@@ -68,7 +67,7 @@ The script runs in a sandbox against a fixed contract:
 A top-level dict or object is rejected — flatten any nested structure into one
 array of uniform rows.
 
-{/* TODO: screenshot — the Add Python tab menu entry */}
+{/* TODO: screenshot — the Python panel's Add script button */}
 
 ## Python environment
 
@@ -100,7 +99,8 @@ adding packages to the environment is coming.
 
 ## Running and refreshing
 
-The code panel is editable in place, with line numbers.
+The panel's **Script** tab is editable in place, with line numbers. **Reset**
+restores the starter template.
 
 - **Edits do not run anything.** They save with the report, and the rendered result
   keeps showing the previous run.
@@ -109,10 +109,13 @@ The code panel is editable in place, with line numbers.
   after the last run. Run to refresh the saved result."*
 - **Run** executes the stored script in the sandbox and persists the refreshed
   result.
+- The **Output** tab shows what the last run printed — the script's stdout and
+  stderr, so `print()` is how you inspect intermediate values.
 - The **input SQL panel is read-only** on a python report: that SQL is the
-  sandbox's input, not what gets charted.
-- **A failed run keeps the previous chart.** The error and the script's
-  stdout/stderr surface in the UI while the last good result stays rendered.
+  sandbox's input, not what gets charted. It still offers the **Semantic SQL** and
+  **Generated SQL** tabs, both derived from that input query.
+- **A failed run keeps the previous chart.** The error surfaces with the result
+  while the last good one stays rendered.
 
 **Run is the only way the saved result changes.** Opening the report, reloading the
 page, or viewing a dashboard never re-runs anything on its own.

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -3,6 +3,14 @@ title: Python analysis
 description: Attach a Python script to a report to run forecasting, regression, cohort, and other analysis that SQL can't express, and save the result as a re-runnable report.
 ---
 
+<Warning>
+
+Python analysis is currently in preview, and the user experience and the script
+contract may still change. Reach out to the [Cube support
+team](/admin/account-billing/support) to activate this feature for your account.
+
+</Warning>
+
 A report can carry an attached **Python script** that transforms the report's SQL
 result. The report's chart then renders the script's **output** instead of the raw
 SQL rows. This turns an analysis that would otherwise scroll away in a chat
@@ -38,12 +46,13 @@ SQL report, that is usually correct behavior.
 
 </Info>
 
+### From the toolbar
+
 Workbooks and [Explore](/docs/explore-analyze/explore) work the same way.
 
 Click **Python** in the toolbar to open the Python panel, then **Add script** to
-attach one. Cube seeds a starter script and opens it on the **Script** tab. The
-**Python** button only opens the panel, so passing through it never puts a script
-on the report by itself.
+attach one. Cube seeds a starter script and opens it on the **Script** tab.
+Opening the panel does not attach anything by itself — only **Add script** does.
 
 **Remove**, in the panel header, detaches the script, after which the report
 behaves like any SQL-backed one again.
@@ -51,10 +60,10 @@ behaves like any SQL-backed one again.
 Attaching Python clears any existing SQL result: a python-backed report renders its
 last Python run, and a freshly attached script has none until you press **Run**.
 
-In Explore this is only available on a **saved** exploration. On an unsaved one the
-**Python** button is disabled with the tooltip *"Save the exploration to add
-Python"* — **Run** executes server-persisted code, so the analysis needs a saved
-report to live on.
+Attaching Python in Explore is only available on a **saved** exploration. On an
+unsaved one the **Python** button is disabled with the tooltip *"Save the
+exploration to add Python"* — **Run** executes server-persisted code, so the
+analysis needs a saved report to live on.
 
 ## Writing the script
 
@@ -110,12 +119,13 @@ restores the starter template.
 - **Run** executes the stored script in the sandbox and persists the refreshed
   result.
 - The **Output** tab shows what the last run printed — the script's stdout and
-  stderr, so `print()` is how you inspect intermediate values.
+  stderr, so `print()` is how you inspect intermediate values. Both are captured up
+  to the cap in [Limits](#limits), so a chatty script gets truncated.
 - The **input SQL panel is read-only** on a python report: that SQL is the
   sandbox's input, not what gets charted. It still offers the **Semantic SQL** and
   **Generated SQL** tabs, both derived from that input query.
-- **A failed run keeps the previous chart.** The error surfaces with the result
-  while the last good one stays rendered.
+- **A failed run keeps the previous chart.** The error surfaces alongside the last
+  successful result, which stays rendered.
 
 **Run is the only way the saved result changes.** Opening the report, reloading the
 page, or viewing a dashboard never re-runs anything on its own.

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -241,7 +241,7 @@ the math.
 
 ## Inspecting queries
 
-Every query in the Semantic Query tab can be inspected as code. Open the SQL panel via the **SQL** button in the top-right toolbar to see the query that the workbook generates, switch between representations, and copy it for use elsewhere.
+Every query in the Semantic Query tab can be inspected as code. Open the SQL panel via the **SQL** button in the toolbar, next to the Results and Chart tabs, to see the query that the workbook generates, switch between representations, and copy it for use elsewhere.
 
 <Frame>
   <img src="https://static.cube.dev/docs/explore-analyze/workbooks/inspect-query-tabs-v2.png" />


### PR DESCRIPTION
Updates the Python analysis docs to match the current UI, and corrects where the SQL button lives.

**Attaching a script.** The docs described two entry points that no longer exist: **Add Python** in the workbook's tab menu, and an **Add Python** button in the Explore header. Both surfaces now work the same way — **Python** in the toolbar opens the panel, and **Add script** inside it attaches one — so the separate "In a workbook" / "In Explore" sections are now one.

**Panel contents.** Documents the **Script** and **Output** tabs and **Reset**. The **Output** tab is worth calling out: it shows the run's stdout and stderr, so `print()` is now how you inspect intermediate values. The page already mentioned stdout/stderr being captured but never said where to see them.

**Input SQL panel.** It offers the **Semantic SQL** and **Generated SQL** tabs; the page implied a plain read-only editor.

**Toolbar position.** `querying-data.mdx` said the **SQL** button was in the "top-right toolbar". It now sits next to the Results and Chart tabs.

Also re-points a screenshot placeholder at the control that replaced the one it named.
