### PR TITLE
docs: document six recently-shipped customer-facing changes

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
@@ -132,6 +132,12 @@ be used in pre-aggregations when using AWS Athena as a source database. To learn
 more about AWS Athena's support for approximate aggregate functions, [click
 here][aws-athena-docs-approx-agg-fns].
 
+### Time zones
+
+A `DATE`-typed time dimension converted to a non-UTC time zone is now handled
+correctly. Existing pre-aggregations with a time dimension rebuild once
+automatically on upgrade, since this change affects the generated SQL.
+
 ## Pre-Aggregation Build Strategies
 
 <Info>

--- a/docs-mintlify/admin/connect-to-data/data-sources/presto.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/presto.mdx
@@ -56,6 +56,12 @@ be used in pre-aggregations when using Presto as a source database. To learn
 more about Presto support for approximate aggregate functions, [click
 here][presto-docs-approx-agg-fns].
 
+### Time zones
+
+A `DATE`-typed time dimension converted to a non-UTC time zone is now handled
+correctly. Existing pre-aggregations with a time dimension rebuild once
+automatically on upgrade, since this change affects the generated SQL.
+
 ## Pre-Aggregation Build Strategies
 
 <Info>

--- a/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
@@ -34,6 +34,13 @@ schema). The [export bucket](#export-bucket) strategy writes to the bucket, not 
   mapped service user.
 - Optionally, the warehouse name, the user role, and the database name.
 
+## Query cancellation
+
+Cancelling a query via the [`{base_path}/v1/running-query/{requestId}`][ref-rest-api-cancel]
+endpoint aborts the statement on the Snowflake warehouse itself, not just
+Cube's wait for it — so a cancelled query stops consuming warehouse compute
+instead of continuing to run in the background.
+
 ## Setup
 
 <Warning>
@@ -393,6 +400,7 @@ connections are made over HTTPS.
 [ref-schema-ref-types-formats-countdistinctapprox]: /reference/data-modeling/measures#type
 [ref-oidc-overview]: /admin/deployment/oidc
 [ref-driver-factory]: /reference/configuration/config#driver_factory
+[ref-rest-api-cancel]: /reference/core-data-apis/rest-api/reference#base_path/v1/running-query/requestid
 [self-preaggs-batching]: #batching
 [snowflake]: https://www.snowflake.com/
 [snowflake-docs-account-id]:

--- a/docs-mintlify/admin/connect-to-data/data-sources/trino.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/trino.mdx
@@ -56,6 +56,12 @@ be used in pre-aggregations when using Trino as a source database. To learn more
 about Trino support for approximate aggregate functions, [click
 here][trino-docs-approx-agg-fns].
 
+### Time zones
+
+A `DATE`-typed time dimension converted to a non-UTC time zone is now handled
+correctly. Existing pre-aggregations with a time dimension rebuild once
+automatically on upgrade, since this change affects the generated SQL.
+
 ## Pre-Aggregation Build Strategies
 
 <Info>

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -13,9 +13,11 @@ It is a setting on an existing chart, not a chart type of its own: a bar, line, 
 
 The **Small multiples** section appears in the Fields tab for bar, line, area, and scatter charts.
 
-Pick a dimension in **Split by** and the chart is replaced by one panel per value of that dimension. Clearing the picker returns the chart to a single plot.
+Pick a dimension in **First dimension** and the chart is replaced by one panel per value of that dimension, laid out across columns. Clearing the picker returns the chart to a single plot.
 
-Only dimensions are offered. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
+Optionally pick a **Second dimension** to split by a second dimension at the same time, laying it out down the rows — the grid becomes one panel per combination of the two dimensions' values (row × column). The second picker never offers the dimension already chosen as the first.
+
+Only dimensions are offered in either picker. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
 
 ## Options
 
@@ -23,7 +25,7 @@ These options appear once a **Split by** dimension is chosen.
 
 | Option | What it does |
 |---|---|
-| **Grid** | Columns × rows, up to 5 × 5. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
+| **Grid** | Columns × rows, up to 5 × 5. Both are preselected from the number of distinct values in the split dimension(s), so a four-value dimension opens as a 2 × 2 grid. With a second dimension chosen, each axis is capped independently (still up to 5 columns and 5 rows), and a combination with no matching data renders an empty, labeled panel rather than being skipped. |
 | **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
@@ -54,7 +56,7 @@ A legend is shared across the grid rather than repeated per panel. Clicking a le
 
 ## Limitations
 
-- **One split dimension.** One dimension fills the grid, panel by panel. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
+- **Up to two split dimensions.** A chart can be split by at most a first (column) and second (row) dimension.
 - **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, boxplot, map, and HTML charts cannot be split.
 - **Panel labels are not configurable.** Each panel is labeled with its dimension value; the font, size, and color are fixed.
 - **The split is enabled on a single-view chart.** A chart that already carries data labels, a reference line, or a second Y axis series cannot be split — turn the split on first. The order is the only constraint: once a chart is split, data labels and reference lines can be added freely and are drawn in every panel.

--- a/docs-mintlify/docs/explore-analyze/explore.mdx
+++ b/docs-mintlify/docs/explore-analyze/explore.mdx
@@ -43,6 +43,8 @@ The functionality in Explore is similar to when working with semantic views in w
 
 Explore state is also saved in the URL, making it easy to share your exploration with other users by simply copying and sharing the link.
 
+If you share an exploration with a user who only has view access to it, they can open it and see the results, but the page shows a **Read only** badge and hides editing controls — they can't modify the query, apply a security context, or save changes.
+
 If you have developer or admin access, you can [apply a security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context) to an exploration to verify what a specific end user—or an AI agent querying on their behalf—would see.
 
 Explore results carry the same [freshness and pre-aggregation indicators](/docs/explore-analyze/workbooks/querying-data#result-freshness-and-provenance) as workbook reports.

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -189,21 +189,20 @@ An MCP client is not locked to a single deployment for the whole session. After
 connecting, it can discover the deployments and agents you can access and target a
 specific one on each request.
 
-Three tools work together:
-
 - **`listDeployments`** — discovery. Returns every deployment you can access via MCP
   (already filtered by the admin's deployment-access settings and your permissions) and
-  each deployment's agents. Use it to find valid `deploymentId` and `agentId` values
-  before calling `chat`. Every deployment offers an **Auto** agent (`agentId: null`) in
-  addition to any configured agents.
-- **`chat`** — accepts two optional selection parameters:
-  - **`deploymentId`** — the deployment to use for this request. When omitted, the chat
-    uses the deployment from the current session (the default resolved at connect time).
-  - **`agentId`** — the agent to use for this request. When omitted or `null`, the
-    deployment's **Auto** agent is used. Pass a specific `agentId` to route to a
-    configured agent.
-- **`loadQueryResults`** — paginates through the results of a previous query on the same
-  deployment context.
+  each deployment's agents. Use it to find valid `deploymentId` and `agentId` values.
+  Every deployment offers an **Auto** agent (`agentId: null`) in addition to any
+  configured agents.
+- **Every other tool** accepts an optional **`deploymentId`** parameter to target a
+  deployment other than the session default (the one resolved at connect time). `chat`
+  additionally accepts an optional **`agentId`** — when omitted or `null`, the target
+  deployment's **Auto** agent is used.
+- **`loadQueryResults`** does not take a `deploymentId` — it always resumes a previous
+  query on the deployment that query already ran on.
+- Resuming an existing chat (passing `chatId` to `chat` or `visualize`) always continues
+  on the deployment that conversation started on; passing a different `deploymentId` for
+  the same `chatId` is rejected rather than silently ignored.
 
 A typical client workflow:
 
@@ -225,7 +224,7 @@ A typical client workflow:
 Requests are always validated against the admin's deployment-access settings. A deployment
 that is outside the allow-list — or that you don't have permission to see — is rejected
 with a **403 Forbidden** (`Deployment <id> is not available via MCP for this account`), so
-neither `listDeployments` nor the `chat` selection can reach an excluded deployment.
+no tool's `deploymentId` selection can reach an excluded deployment.
 
 ## Available actions
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -346,6 +346,28 @@ of the PostgreSQL documentation.
 | `LIKE` | Returns `TRUE` if the string matches the supplied pattern | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>✅ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 | `REGEXP_SUBSTR` | Returns the substring that matches a POSIX regular expression pattern | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 
+### Casts
+
+<Info>
+
+Learn more in the
+[relevant section](https://www.postgresql.org/docs/current/datatype-oid.html)
+of the PostgreSQL documentation.
+
+</Info>
+
+The SQL API supports `::regtype` and `::regtype[]` casts, including standard
+type aliases (`int`, `int8`, `decimal`, `char`, `float`, etc.) and
+`pg_catalog`-qualified type names. This lets Postgres-compatible BI tools that
+introspect column types — for example, comparing `pg_attribute.atttypid`
+against a `regtype[]` literal to classify a table's columns — connect to the
+SQL API without erroring.
+
+```sql
+SELECT atttypid = ANY ('{int8,numeric,bool}'::regtype[])
+FROM pg_catalog.pg_attribute;
+```
+
 ### Data type formatting functions
 
 <Info>


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Routine audit of recent commits in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify`, filtered through the shared customer-facing criteria. Found and closed six documentation gaps for changes that had already shipped but weren't reflected in the docs:

- **SQL API** — document `::regtype` / `::regtype[]` casts (#11503), needed by Postgres-compatible BI tools that introspect column types via `pg_catalog`.
- **Snowflake driver** — note that cancelling a query now actually aborts the statement on the Snowflake warehouse, not just Cube's wait for it (#11428).
- **Trino / Presto / Athena** — note that `DATE`-typed time dimensions now convert correctly under a non-UTC time zone, and that existing pre-aggregations with a time dimension rebuild once automatically on upgrade (#11516).
- **Small multiples** — document the new second split-by dimension (row × column facet grid), replacing the now-incorrect "one split dimension" limitation.
- **MCP server** — every tool (not just `chat`) now accepts an optional `deploymentId` override; documented the two exceptions (`listDeployments`, `loadQueryResults`) and the chat/visualize resume behavior.
- **Explore** — viewers with read-only access to a shared exploration can now open it in a genuine view-only mode instead of being redirected away.

Each item was verified against its actual diff (not just the commit subject) before writing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011cjPTiKHNMiW3zBGFNx2Ly)_