### PR TITLE
fix(clickhouse-driver): override generic string type in sqlTemplates

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -274,6 +274,7 @@ export class ClickHouseQuery extends BaseQuery {
     templates.quotes.escape = '\\`';
     templates.types.boolean = 'BOOL';
     templates.types.timestamp = 'DATETIME';
+    templates.types.string = 'String';
     delete templates.types.time;
     // ClickHouse intervals have a distinct type for each granularity
     delete templates.types.interval;


### PR DESCRIPTION
## Description

Fixes #10415.

ClickHouse type names are case-sensitive: `CAST(x, 'STRING')` fails with `Unknown data type family: STRING. Maybe you meant: ['String','Ring']`.

`ClickHouseQuery.sqlTemplates()` overrides `boolean` and `timestamp` but not `string`, so any generated SQL that casts to the generic string type fails against ClickHouse:

- **LAG/LEAD SQL API pushdown** (since v1.6.14): internal columns are emitted as `CAST(NULL, 'STRING') AS __user`, `CAST(NULL, 'STRING') AS __cubejoinfield` (#10415).
- **`count` measures over composite primary keys** with the Tesseract planner (v1.7): the key concatenation is emitted as `count(concat(CAST(pk1, 'STRING'), CAST(pk2, 'STRING'), ...))`, so any such measure returns HTTP 400. Reproduced on v1.7.19 with a plain REST query on a cube whose dimensions declare two `primary_key: true` columns and a `type: count` measure without `sql`.

This one-line change adds `templates.types.string = 'String';` next to the existing overrides, aligning the ClickHouse dialect with its case-sensitive type names.

## Check List

- [ ] Tests has been run in packages where changes made if available — not run locally (one-line dialect override, submitted via web editor); happy to add a `sqlTemplates` assertion to `clickhouse-query.test.ts` if maintainers want one
- [ ] Linter has been run for changed code — change matches the surrounding style
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required — no doc impact
