### PR TITLE
perf(trino-driver): native REST polling to cut coordinator wait/drain latency

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/trino.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/trino.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trino
-description: Map Cube to Trino with host credentials plus catalog, schema, SSL, and optional bearer-token variables on the shared Presto driver.
+description: Map Cube to Trino with host credentials plus catalog, schema, SSL, optional bearer-token variables, and configurable query polling.
 ---
 
 ## Prerequisites
@@ -34,6 +34,11 @@ CUBEJS_DB_SCHEMA=my_trino_schema
 | [`CUBEJS_DB_PASS`](/reference/configuration/environment-variables#cubejs_db_pass)           | The password used to connect to the database                                        | A valid database password                     |    ✅    |
 | [`CUBEJS_DB_PRESTO_CATALOG`](/reference/configuration/environment-variables#cubejs_db_presto_catalog) | The catalog within Presto to connect to                                             | A valid catalog name within a Presto database |    ✅    |
 | [`CUBEJS_DB_PRESTO_AUTH_TOKEN`](/reference/configuration/environment-variables#cubejs_db_presto_auth_token) | The authentication token to use when connecting to Presto/Trino. It will be sent in the `Authorization` header. | A valid authentication token |    ❌    |
+| [`CUBEJS_DB_TRINO_SOURCE`](/reference/configuration/environment-variables#cubejs_db_trino_source) | Value sent as the `X-Trino-Source` header | A string | ❌ |
+| [`CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL`](/reference/configuration/environment-variables#cubejs_db_trino_poll_initial_interval) | First wait (ms) between status polls while a query is queued with no rows | A positive integer | ❌ |
+| [`CUBEJS_DB_TRINO_POLL_INCREMENT_STEP`](/reference/configuration/environment-variables#cubejs_db_trino_poll_increment_step) | Added to the wait-phase poll interval after enough empty polls | A positive integer | ❌ |
+| [`CUBEJS_DB_TRINO_POLL_MAX_INTERVAL`](/reference/configuration/environment-variables#cubejs_db_trino_poll_max_interval) | Cap on wait-phase poll interval (ms) | A positive integer | ❌ |
+| [`CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT`](/reference/configuration/environment-variables#cubejs_db_trino_poll_tries_before_increment) | Empty wait-phase polls at the current interval before increasing it | A positive integer | ❌ |
 | [`CUBEJS_DB_SCHEMA`](/reference/configuration/environment-variables#cubejs_db_schema)         | The schema within the database to connect to                                        | A valid schema name within a Presto database  |    ✅    |
 | [`CUBEJS_DB_SSL`](/reference/configuration/environment-variables#cubejs_db_ssl)            | If `true`, enables SSL encryption for database connections from Cube                | `true`, `false`                               |    ❌    |
 | [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)       | The maximum number of concurrent database connections to pool. Default is `8`       | A valid number                                |    ❌    |
@@ -130,7 +135,8 @@ protocol][trino-docs-client-protocol] for the list of headers accepted by Trino.
 
 Custom headers can't be configured via environment variables. Instead, use the
 [`driver_factory`](/reference/configuration/config#driver_factory) configuration
-option to pass a `headers` object to the driver:
+option to pass a `headers` object to the driver. Headers are sent on the initial
+statement POST and on every follow-up `nextUri` poll.
 
 <CodeGroup>
 
@@ -198,6 +204,65 @@ module.exports = {
 ```
 
 </CodeGroup>
+
+## Query polling
+
+The Trino driver talks to Trino's HTTP protocol directly. While a query is
+queued or planning (no rows yet), it polls `nextUri` with a short progressive
+backoff: 50ms for the first ten empty polls, then 100ms, up to 500ms. After the
+first rows arrive, it drains remaining pages with no extra delay.
+
+Tune this with environment variables, or pass a `pollBackoff` object (and
+optional `drainInterval`, in milliseconds) from
+[`driver_factory`](/reference/configuration/config#driver_factory):
+
+<CodeGroup>
+
+```python title="Python"
+from cube import config
+
+@config('driver_factory')
+def driver_factory(ctx: dict) -> dict:
+  return {
+    'type': 'trino',
+    'pollBackoff': {
+      'initialInterval': 50,
+      'incrementStep': 50,
+      'maxInterval': 500,
+      'triesBeforeIncrement': 10
+    },
+    'drainInterval': 0
+  }
+```
+
+```javascript title="JavaScript"
+module.exports = {
+  driverFactory: () => ({
+    type: "trino",
+    pollBackoff: {
+      initialInterval: 50,
+      incrementStep: 50,
+      maxInterval: 500,
+      triesBeforeIncrement: 10
+    },
+    drainInterval: 0
+  })
+};
+```
+
+</CodeGroup>
+
+To restore constant-interval polling (the previous `presto-client` default of
+800ms between every poll, including while draining rows), set `checkInterval`:
+
+```javascript
+module.exports = {
+  driverFactory: () => ({
+    type: "trino",
+    checkInterval: 800
+  })
+};
+```
 
 [trino-docs-client-protocol]: https://trino.io/docs/current/develop/client-protocol.html
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1042,6 +1042,53 @@ for TLS Secure Contexts [in the Node.js documentation][nodejs-docs-tls-options].
 | ----------------- | ---------------------- | --------------------- |
 | A valid host name | N/A                    | N/A                   |
 
+## `CUBEJS_DB_TRINO_SOURCE`
+
+Value sent as the `X-Trino-Source` header so Trino query history identifies the
+client. Used by the Trino driver. Defaults to `nodejs-client`, matching the
+previous `presto-client` default.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A string        | `nodejs-client`        | `nodejs-client`       |
+
+## `CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL`
+
+First wait, in milliseconds, before the next `nextUri` poll while a Trino query
+is still queued or planning with no rows.
+
+| Possible Values     | Default in Development | Default in Production |
+| ------------------- | ---------------------- | --------------------- |
+| A positive integer  | `50`                   | `50`                  |
+
+## `CUBEJS_DB_TRINO_POLL_INCREMENT_STEP`
+
+Added to the wait-phase poll interval after
+[`CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT`](#cubejs_db_trino_poll_tries_before_increment)
+empty polls.
+
+| Possible Values     | Default in Development | Default in Production |
+| ------------------- | ---------------------- | --------------------- |
+| A positive integer  | `50`                   | `50`                  |
+
+## `CUBEJS_DB_TRINO_POLL_MAX_INTERVAL`
+
+Cap on the wait-phase poll interval, in milliseconds.
+
+| Possible Values     | Default in Development | Default in Production |
+| ------------------- | ---------------------- | --------------------- |
+| A positive integer  | `500`                  | `500`                 |
+
+## `CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT`
+
+Number of empty wait-phase polls at the current interval before increasing it.
+With the default initial interval of 50ms, the default of 10 keeps about 500ms
+of fine-grained polling.
+
+| Possible Values     | Default in Development | Default in Production |
+| ------------------- | ---------------------- | --------------------- |
+| A positive integer  | `10`                   | `10`                  |
+
 ## `CUBEJS_DB_TYPE`
 
 A database from the list of [supported databases][ref-config-db].

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -72,6 +72,35 @@ export function asPortNumber(input: number, envName: string) {
 }
 
 /**
+ * Parse an env var as a base-10 integer. Rejects empty strings, floats,
+ * scientific notation (`1e2`), and unit suffixes (`50ms`) that `parseInt`
+ * would otherwise silently truncate.
+ */
+export function parseNonNegativeIntEnv(
+  envName: string,
+  defaultValue: string,
+  min: number = 0,
+): number {
+  const raw = get(envName).default(defaultValue).asString();
+  if (!/^\d+$/.test(raw)) {
+    throw new InvalidConfiguration(
+      envName,
+      raw,
+      `Must be an integer >= ${min}.`
+    );
+  }
+  const value = parseInt(raw, 10);
+  if (value < min) {
+    throw new InvalidConfiguration(
+      envName,
+      raw,
+      `Must be an integer >= ${min}.`
+    );
+  }
+  return value;
+}
+
+/**
  * Determines whether multiple data sources were declared or not.
  */
 function isMultipleDataSources(): boolean {
@@ -1802,6 +1831,73 @@ const variables: Record<string, (...args: any) => any> = {
     preAggregations,
   }: DataSourceOpts) => (
     get(keyByDataSource('CUBEJS_DB_PRESTO_AUTH_TOKEN', dataSource, preAggregations)).asString()
+  ),
+
+  /**
+   * Value sent as the `X-Trino-Source` header. Identifies the client in
+   * Trino's query history. Default: `nodejs-client` (same as `presto-client`).
+   */
+  trinoSource: ({
+    dataSource,
+    preAggregations,
+  }: DataSourceOpts) => (
+    get(keyByDataSource('CUBEJS_DB_TRINO_SOURCE', dataSource, preAggregations)).asString()
+  ),
+
+  /**
+   * First wait (ms) before the next `nextUri` poll while the query is still
+   * queued/planning with no rows. Default: 50.
+   */
+  trinoPollInitialInterval: ({
+    dataSource,
+    preAggregations,
+  }: DataSourceOpts) => (
+    parseNonNegativeIntEnv(
+      keyByDataSource('CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL', dataSource, preAggregations),
+      '50',
+    )
+  ),
+
+  /**
+   * Added to the wait-phase poll interval after `trinoPollTriesBeforeIncrement`
+   * empty polls. Default: 50.
+   */
+  trinoPollIncrementStep: ({
+    dataSource,
+    preAggregations,
+  }: DataSourceOpts) => (
+    parseNonNegativeIntEnv(
+      keyByDataSource('CUBEJS_DB_TRINO_POLL_INCREMENT_STEP', dataSource, preAggregations),
+      '50',
+    )
+  ),
+
+  /**
+   * Cap on wait-phase poll interval (ms). Default: 500.
+   */
+  trinoPollMaxInterval: ({
+    dataSource,
+    preAggregations,
+  }: DataSourceOpts) => (
+    parseNonNegativeIntEnv(
+      keyByDataSource('CUBEJS_DB_TRINO_POLL_MAX_INTERVAL', dataSource, preAggregations),
+      '500',
+    )
+  ),
+
+  /**
+   * Empty wait-phase polls at the current interval before increasing it.
+   * Default: 10 (so 50ms × 10 ≈ 500ms of fine-grained polling).
+   */
+  trinoPollTriesBeforeIncrement: ({
+    dataSource,
+    preAggregations,
+  }: DataSourceOpts) => (
+    parseNonNegativeIntEnv(
+      keyByDataSource('CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT', dataSource, preAggregations),
+      '10',
+      1,
+    )
   ),
 
   /** ***************************************************************

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -178,3 +178,85 @@ describe('getEnv(apiSecret / apiSecrets)', () => {
     expect(getEnv('apiSecrets')).toEqual(['only']);
   });
 });
+
+const TRINO_POLL_ENV = {
+  trinoPollInitialInterval: 'CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL',
+  trinoPollIncrementStep: 'CUBEJS_DB_TRINO_POLL_INCREMENT_STEP',
+  trinoPollMaxInterval: 'CUBEJS_DB_TRINO_POLL_MAX_INTERVAL',
+  trinoPollTriesBeforeIncrement: 'CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT',
+} as const;
+
+describe('getEnv(trino poll / source)', () => {
+  const opts = { dataSource: 'default' as const };
+
+  afterEach(() => {
+    delete process.env.CUBEJS_DB_TRINO_SOURCE;
+    Object.values(TRINO_POLL_ENV).forEach((key) => {
+      delete process.env[key];
+    });
+  });
+
+  test('defaults', () => {
+    expect(getEnv('trinoSource', opts)).toBeUndefined();
+    expect(getEnv('trinoPollInitialInterval', opts)).toBe(50);
+    expect(getEnv('trinoPollIncrementStep', opts)).toBe(50);
+    expect(getEnv('trinoPollMaxInterval', opts)).toBe(500);
+    expect(getEnv('trinoPollTriesBeforeIncrement', opts)).toBe(10);
+  });
+
+  test('valid overrides', () => {
+    process.env.CUBEJS_DB_TRINO_SOURCE = 'my-app';
+    process.env.CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL = '25';
+    process.env.CUBEJS_DB_TRINO_POLL_INCREMENT_STEP = '0';
+    process.env.CUBEJS_DB_TRINO_POLL_MAX_INTERVAL = '1000';
+    process.env.CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT = '3';
+
+    expect(getEnv('trinoSource', opts)).toBe('my-app');
+    expect(getEnv('trinoPollInitialInterval', opts)).toBe(25);
+    expect(getEnv('trinoPollIncrementStep', opts)).toBe(0);
+    expect(getEnv('trinoPollMaxInterval', opts)).toBe(1000);
+    expect(getEnv('trinoPollTriesBeforeIncrement', opts)).toBe(3);
+  });
+
+  test('empty source is empty string (driver falls back to nodejs-client)', () => {
+    process.env.CUBEJS_DB_TRINO_SOURCE = '';
+    expect(getEnv('trinoSource', opts)).toBe('');
+  });
+
+  test.each(Object.entries(TRINO_POLL_ENV))(
+    '%s rejects improper values',
+    (getter, envKey) => {
+      const read = () => getEnv(getter as keyof typeof TRINO_POLL_ENV, opts);
+
+      process.env[envKey] = '-1';
+      expect(read).toThrow(/Must be an integer >= /);
+
+      process.env[envKey] = 'abc';
+      expect(read).toThrow(/Must be an integer >= /);
+
+      process.env[envKey] = '';
+      expect(read).toThrow(/Must be an integer >= /);
+
+      process.env[envKey] = '1.5';
+      expect(read).toThrow(/Must be an integer >= /);
+
+      process.env[envKey] = '50ms';
+      expect(read).toThrow(/Must be an integer >= /);
+
+      process.env[envKey] = '1e2';
+      expect(read).toThrow(/Must be an integer >= /);
+    }
+  );
+
+  test('triesBeforeIncrement rejects 0', () => {
+    process.env.CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT = '0';
+    expect(() => getEnv('trinoPollTriesBeforeIncrement', opts)).toThrow(
+      /Must be an integer >= 1/
+    );
+  });
+
+  test('interval 0 is allowed (poll immediately)', () => {
+    process.env.CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL = '0';
+    expect(getEnv('trinoPollInitialInterval', opts)).toBe(0);
+  });
+});

--- a/packages/cubejs-schema-compiler/src/adapter/index.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/index.ts
@@ -17,6 +17,7 @@ export * from './MysqlQuery';
 export * from './PostgresQuery';
 export * from './MssqlQuery';
 export * from './PrestodbQuery';
+export * from './TrinoQuery';
 
 export { PreAggregationReferences } from '../compiler/CubeEvaluator';
 

--- a/packages/cubejs-trino-driver/jest.config.js
+++ b/packages/cubejs-trino-driver/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+};

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -29,11 +29,9 @@
   },
   "dependencies": {
     "@cubejs-backend/base-driver": "1.7.19",
-    "@cubejs-backend/prestodb-driver": "1.7.19",
     "@cubejs-backend/schema-compiler": "1.7.19",
     "@cubejs-backend/shared": "1.7.19",
-    "node-fetch": "^2.6.1",
-    "presto-client": "^1.2.0"
+    "node-fetch": "^2.6.1"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -42,6 +40,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.7.19",
     "@types/jest": "^29",
+    "@types/node-fetch": "^2.5.8",
     "jest": "^29",
     "testcontainers": "^10.28.0",
     "typescript": "~5.2.2"

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -1,49 +1,740 @@
+/**
+ * @copyright Cube Dev, Inc.
+ * @license Apache-2.0
+ * @fileoverview Native Trino REST driver. Talks to `/v1/statement` directly
+ * (no `presto-client`) with progressive backoff while waiting for the first
+ * rows, then configurable drain polling.
+ */
+
 import fetch, { RequestInit } from 'node-fetch';
-import { Agent as HttpsAgent } from 'https';
-import { PrestoDriver, PrestoDriverConfiguration } from '@cubejs-backend/prestodb-driver';
-import { PrestodbQuery } from '@cubejs-backend/schema-compiler';
+import * as http from 'http';
+import * as https from 'https';
+import { Transform, TransformCallback } from 'stream';
+import {
+  BaseDriver,
+  DownloadQueryResultsOptions,
+  DownloadQueryResultsResult,
+  DriverCapabilities,
+  DriverInterface,
+  StreamOptions,
+  StreamTableData,
+  TableStructure,
+  UnloadOptions,
+} from '@cubejs-backend/base-driver';
+import {
+  getEnv,
+  assertDataSource,
+  formatAnsi,
+} from '@cubejs-backend/shared';
+import { TrinoQuery } from '@cubejs-backend/schema-compiler';
 
-export type TrinoDriverConfiguration = Omit<PrestoDriverConfiguration, 'engine'>;
+import {
+  TrinoDriverConfiguration,
+  PollBackoffConfig,
+  TrinoQueryResponse,
+  TrinoColumn,
+} from './types';
 
-export class TrinoDriver extends PrestoDriver {
-  public constructor(options: TrinoDriverConfiguration = {}) {
-    super({ ...options, engine: 'trino' });
+const TRINO_HEADERS = {
+  USER: 'X-Trino-User',
+  SOURCE: 'X-Trino-Source',
+  CATALOG: 'X-Trino-Catalog',
+  SCHEMA: 'X-Trino-Schema',
+  TIME_ZONE: 'X-Trino-Time-Zone',
+  SESSION: 'X-Trino-Session',
+};
+
+const DEFAULT_POLL_BACKOFF: Required<PollBackoffConfig> = {
+  initialInterval: 50,
+  incrementStep: 50,
+  maxInterval: 500,
+  triesBeforeIncrement: 10,
+};
+
+const DEFAULT_MAX_TRANSIENT_RETRIES = 5;
+
+const SUPPORTED_BUCKET_TYPES = ['gcs', 's3'];
+
+const TRANSIENT_HTTP_STATUSES = [502, 503, 504];
+
+export class TrinoDriver extends BaseDriver implements DriverInterface {
+  public static getDefaultConcurrency() {
+    return 2;
   }
 
   public static dialectClass() {
-    return PrestodbQuery;
+    return TrinoQuery;
   }
 
-  // eslint-disable-next-line consistent-return
-  public override async testConnection(): Promise<void> {
+  protected readonly config: TrinoDriverConfiguration;
+
+  protected readonly catalog: string | undefined;
+
+  protected readonly pollBackoff: Required<PollBackoffConfig>;
+
+  protected readonly drainInterval: number;
+
+  protected readonly maxTransientRetries: number;
+
+  protected readonly useSelectTestConnection: boolean;
+
+  private readonly baseUrl: string;
+
+  private readonly httpAgent: http.Agent;
+
+  private readonly httpsAgent: https.Agent;
+
+  public constructor(config: TrinoDriverConfiguration = {}) {
+    super();
+
+    const dataSource = config.dataSource || assertDataSource('default');
+    const preAggregations = config.preAggregations || false;
+
+    const dbUser = getEnv('dbUser', { dataSource, preAggregations });
+    const dbPassword = getEnv('dbPass', { dataSource, preAggregations });
+    const authToken = getEnv('prestoAuthToken', { dataSource, preAggregations });
+
+    if (authToken && dbPassword) {
+      throw new Error('Both user/password and auth token are set. Please remove password or token.');
+    }
+
+    this.useSelectTestConnection = config.useSelectTestConnection ??
+      getEnv('dbUseSelectTestConnection', { dataSource, preAggregations });
+
+    this.config = {
+      host: getEnv('dbHost', { dataSource, preAggregations }),
+      port: getEnv('dbPort', { dataSource, preAggregations }),
+      catalog:
+        getEnv('prestoCatalog', { dataSource, preAggregations }) ||
+        getEnv('dbCatalog', { dataSource, preAggregations }),
+      schema:
+        getEnv('dbName', { dataSource, preAggregations }) ||
+        getEnv('dbSchema', { dataSource, preAggregations }),
+      user: dbUser,
+      // Match presto-client: X-Trino-Source defaults to `nodejs-client`.
+      source: getEnv('trinoSource', { dataSource, preAggregations }) || 'nodejs-client',
+      ...(authToken ? { custom_auth: `Bearer ${authToken}` } : {}),
+      ...(dbPassword ? { basic_auth: { user: dbUser, password: dbPassword } } : {}),
+      ssl: this.getSslOptions(dataSource, preAggregations),
+      bucketType: getEnv('dbExportBucketType', { supported: SUPPORTED_BUCKET_TYPES, dataSource, preAggregations }),
+      exportBucket: getEnv('dbExportBucket', { dataSource, preAggregations }),
+      accessKeyId: getEnv('dbExportBucketAwsKey', { dataSource, preAggregations }),
+      secretAccessKey: getEnv('dbExportBucketAwsSecret', { dataSource, preAggregations }),
+      exportBucketRegion: getEnv('dbExportBucketAwsRegion', { dataSource, preAggregations }),
+      credentials: getEnv('dbExportGCSCredentials', { dataSource, preAggregations }),
+      queryTimeout: getEnv('dbQueryTimeout', { dataSource, preAggregations }),
+      ...config,
+    };
+
+    if (this.config.custom_auth && this.config.basic_auth) {
+      throw new Error('Please do not specify basic_auth and custom_auth at the same time.');
+    }
+
+    if (!this.config.source) {
+      this.config.source = 'nodejs-client';
+    }
+
+    // X-Trino-User must match the authenticated principal unless impersonation
+    // is explicit. driverFactory often passes only basic_auth (as the stock
+    // integration tests do); defaulting the session user to `cube` then fails
+    // with PERMISSION_DENIED on current Trino.
+    if (!this.config.user && this.config.basic_auth?.user) {
+      this.config.user = this.config.basic_auth.user;
+    }
+
+    this.catalog = this.config.catalog;
+
+    const envPollBackoff: Required<PollBackoffConfig> = {
+      initialInterval: getEnv('trinoPollInitialInterval', { dataSource, preAggregations }),
+      incrementStep: getEnv('trinoPollIncrementStep', { dataSource, preAggregations }),
+      maxInterval: getEnv('trinoPollMaxInterval', { dataSource, preAggregations }),
+      triesBeforeIncrement: getEnv('trinoPollTriesBeforeIncrement', { dataSource, preAggregations }),
+    };
+
+    const useLegacyCheckInterval = config.checkInterval != null && config.pollBackoff == null;
+    if (useLegacyCheckInterval) {
+      this.pollBackoff = {
+        initialInterval: config.checkInterval as number,
+        incrementStep: 0,
+        maxInterval: config.checkInterval as number,
+        triesBeforeIncrement: 1,
+      };
+      this.drainInterval = config.drainInterval ?? (config.checkInterval as number);
+    } else {
+      this.pollBackoff = {
+        ...DEFAULT_POLL_BACKOFF,
+        ...envPollBackoff,
+        ...this.config.pollBackoff,
+      };
+      this.drainInterval = this.config.drainInterval ?? 0;
+    }
+
+    this.maxTransientRetries = this.config.maxTransientRetries ?? DEFAULT_MAX_TRANSIENT_RETRIES;
+    this.validatePollingConfig();
+
+    const protocol = this.config.ssl ? 'https' : 'http';
+    this.baseUrl = `${protocol}://${this.config.host}:${this.config.port}`;
+
+    const keepAlive = this.config.keepAlive !== false;
+    const sslOptions = (this.config.ssl && typeof this.config.ssl === 'object') ? this.config.ssl : {};
+    this.httpsAgent = new https.Agent({ ...sslOptions, keepAlive });
+    this.httpAgent = new http.Agent({ keepAlive });
+  }
+
+  private static assertNonNegativeInt(name: string, value: number) {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+      throw new Error(`${name} must be a non-negative integer, got ${value}`);
+    }
+  }
+
+  private validatePollingConfig() {
+    TrinoDriver.assertNonNegativeInt('pollBackoff.initialInterval', this.pollBackoff.initialInterval);
+    TrinoDriver.assertNonNegativeInt('pollBackoff.incrementStep', this.pollBackoff.incrementStep);
+    TrinoDriver.assertNonNegativeInt('pollBackoff.maxInterval', this.pollBackoff.maxInterval);
+    TrinoDriver.assertNonNegativeInt('pollBackoff.triesBeforeIncrement', this.pollBackoff.triesBeforeIncrement);
+    if (this.pollBackoff.triesBeforeIncrement < 1) {
+      throw new Error('pollBackoff.triesBeforeIncrement must be >= 1');
+    }
+    if (this.pollBackoff.initialInterval > this.pollBackoff.maxInterval) {
+      throw new Error(
+        `pollBackoff.initialInterval (${this.pollBackoff.initialInterval}) must be <= maxInterval (${this.pollBackoff.maxInterval})`
+      );
+    }
+    TrinoDriver.assertNonNegativeInt('drainInterval', this.drainInterval);
+    TrinoDriver.assertNonNegativeInt('maxTransientRetries', this.maxTransientRetries);
+  }
+
+  private getAuthHeader(): string | undefined {
+    if (this.config.custom_auth) {
+      return this.config.custom_auth;
+    }
+    if (this.config.basic_auth) {
+      const { user, password } = this.config.basic_auth;
+      return `Basic ${Buffer.from(`${user}:${password}`).toString('base64')}`;
+    }
+    return undefined;
+  }
+
+  private getBaseHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      [TRINO_HEADERS.USER]: this.config.user || 'cube',
+      [TRINO_HEADERS.SOURCE]: this.config.source || 'nodejs-client',
+      ...this.config.headers,
+    };
+
+    if (this.config.catalog) {
+      headers[TRINO_HEADERS.CATALOG] = this.config.catalog;
+    }
+    if (this.config.schema) {
+      headers[TRINO_HEADERS.SCHEMA] = this.config.schema;
+    }
+    if (this.config.timezone) {
+      headers[TRINO_HEADERS.TIME_ZONE] = this.config.timezone;
+    }
+
+    const auth = this.getAuthHeader();
+    if (auth) {
+      headers.Authorization = auth;
+    }
+
+    return headers;
+  }
+
+  private getSessionHeader(): string | undefined {
+    const parts: string[] = [];
+    if (this.config.queryTimeout) {
+      parts.push(`query_max_run_time=${this.config.queryTimeout}s`);
+    }
+    if (typeof this.config.session === 'string' && this.config.session) {
+      parts.push(this.config.session);
+    } else if (this.config.session && typeof this.config.session === 'object') {
+      Object.entries(this.config.session).forEach(([key, value]) => {
+        parts.push(`${key}=${value}`);
+      });
+    }
+    return parts.length ? parts.join(',') : undefined;
+  }
+
+  private getFetchOptions(url?: string): RequestInit {
+    const isHttps = url ? url.startsWith('https:') : Boolean(this.config.ssl);
+    return { agent: isHttps ? this.httpsAgent : this.httpAgent };
+  }
+
+  public async testConnection(): Promise<void> {
     if (this.useSelectTestConnection) {
-      return this.testConnectionViaSelect();
+      await this.testConnectionViaSelect();
+      return;
     }
 
-    const { host, port, ssl, basic_auth: basicAuth, custom_auth: customAuth, headers: extraHeaders } = this.config;
-    const protocol = ssl ? 'https' : 'http';
-    const url = `${protocol}://${host}:${port}/v1/info`;
-    const headers: Record<string, string> = { ...extraHeaders };
-
-    if (customAuth) {
-      headers.Authorization = customAuth;
-    } else if (basicAuth) {
-      const { user, password } = basicAuth;
-      const encoded = Buffer.from(`${user}:${password}`).toString('base64');
-      headers.Authorization = `Basic ${encoded}`;
-    }
-
-    const requestInit: RequestInit = { method: 'GET', headers };
-
-    if (ssl) {
-      requestInit.agent = new HttpsAgent({ ...ssl });
-    }
-
-    const response = await fetch(url, requestInit);
+    const headers = this.getBaseHeaders();
+    const response = await fetch(`${this.baseUrl}/v1/info`, {
+      method: 'GET',
+      headers,
+      ...this.getFetchOptions(),
+    });
 
     if (!response.ok) {
       const text = await response.text();
       throw new Error(`Connection test failed: ${response.status} ${response.statusText} - ${text}`);
     }
+  }
+
+  protected async testConnectionViaSelect() {
+    await this.queryPromised('SELECT 1', false);
+  }
+
+  public query(query: string, values: unknown[]): Promise<any[]> {
+    return <Promise<any[]>> this.queryPromised(this.prepareQueryWithParams(query, values), false);
+  }
+
+  protected prepareQueryWithParams(query: string, values: unknown[]) {
+    return formatAnsi(query, values || []);
+  }
+
+  /**
+   * Two-phase polling:
+   * - Wait phase: no rows yet → backoff before each nextUri poll.
+   * - Drain phase: after the first non-empty data page → `drainInterval`
+   *   (default 0, i.e. poll as fast as Trino produces pages).
+   */
+  public queryPromised(query: string, streaming: boolean): Promise<any[] | StreamTableData> {
+    if (streaming) {
+      return this.executeStreaming(query);
+    }
+    return this.executeBuffered(query);
+  }
+
+  private static hasRowData(response: TrinoQueryResponse): boolean {
+    return Array.isArray(response.data) && response.data.length > 0;
+  }
+
+  private createPollBackoffState(): { intervalMs: number; holdsAtCurrent: number } {
+    return {
+      intervalMs: this.pollBackoff.initialInterval,
+      holdsAtCurrent: 0,
+    };
+  }
+
+  private async maybeBackoffBeforePoll(
+    hasReceivedData: boolean,
+    state: { intervalMs: number; holdsAtCurrent: number }
+  ): Promise<void> {
+    if (hasReceivedData) {
+      if (this.drainInterval > 0) {
+        await this.sleep(this.drainInterval);
+      }
+      return;
+    }
+    await this.sleep(state.intervalMs);
+    state.holdsAtCurrent += 1;
+    if (state.holdsAtCurrent >= this.pollBackoff.triesBeforeIncrement) {
+      state.holdsAtCurrent = 0;
+      state.intervalMs = Math.min(
+        state.intervalMs + this.pollBackoff.incrementStep,
+        this.pollBackoff.maxInterval
+      );
+    }
+  }
+
+  private async executeStatement(query: string): Promise<TrinoQueryResponse> {
+    const headers: Record<string, string> = {
+      ...this.getBaseHeaders(),
+      'Content-Type': 'text/plain',
+    };
+
+    const session = this.getSessionHeader();
+    if (session) {
+      headers[TRINO_HEADERS.SESSION] = session;
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/statement`, {
+      method: 'POST',
+      headers,
+      body: query,
+      ...this.getFetchOptions(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Trino statement POST failed (${response.status}): ${text}`);
+    }
+
+    return response.json() as Promise<TrinoQueryResponse>;
+  }
+
+  private async fetchNextUri(uri: string): Promise<TrinoQueryResponse> {
+    const headers = this.getBaseHeaders();
+
+    for (let attempt = 0; attempt <= this.maxTransientRetries; attempt++) {
+      const response = await fetch(uri, {
+        method: 'GET',
+        headers,
+        ...this.getFetchOptions(uri),
+      });
+
+      if (TRANSIENT_HTTP_STATUSES.includes(response.status)) {
+        if (attempt === this.maxTransientRetries) {
+          throw new Error(
+            `Trino poll failed after ${this.maxTransientRetries} retries (last status: ${response.status})`
+          );
+        }
+        const baseDelay = 50 * (2 ** attempt);
+        await this.sleep(baseDelay + Math.floor(Math.random() * baseDelay));
+      } else if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Trino poll failed (${response.status}): ${text}`);
+      } else {
+        return response.json() as Promise<TrinoQueryResponse>;
+      }
+    }
+
+    throw new Error('Trino poll failed: exhausted retries');
+  }
+
+  private async executeBuffered(query: string): Promise<any[]> {
+    let response = await this.executeStatement(query);
+    this.checkError(response);
+
+    let fullData: any[] = [];
+    let columns: TrinoColumn[] | undefined;
+    let hasReceivedData = TrinoDriver.hasRowData(response);
+    const pollBackoffState = this.createPollBackoffState();
+
+    while (response.nextUri) {
+      if (response.columns && !columns) {
+        columns = response.columns;
+      }
+
+      if (TrinoDriver.hasRowData(response)) {
+        hasReceivedData = true;
+        const normalData = this.normalizeResultOverColumns(response.data!, columns || []);
+        fullData = fullData.concat(normalData);
+      }
+
+      await this.maybeBackoffBeforePoll(hasReceivedData, pollBackoffState);
+      response = await this.fetchNextUri(response.nextUri);
+      this.checkError(response);
+    }
+
+    if (response.columns && !columns) {
+      columns = response.columns;
+    }
+    if (TrinoDriver.hasRowData(response)) {
+      const normalData = this.normalizeResultOverColumns(response.data!, columns || []);
+      fullData = fullData.concat(normalData);
+    }
+
+    return fullData;
+  }
+
+  private async executeStreaming(query: string): Promise<StreamTableData> {
+    const rowStream = new Transform({
+      writableObjectMode: true,
+      readableObjectMode: true,
+      transform(obj: any, _encoding: string, callback: TransformCallback) {
+        callback(null, obj);
+      },
+    });
+
+    let response = await this.executeStatement(query);
+    this.checkError(response);
+
+    let columns: TrinoColumn[] | undefined;
+    let columnsResolved = false;
+    let hasReceivedData = TrinoDriver.hasRowData(response);
+    const pollBackoffState = this.createPollBackoffState();
+
+    const resultPromise = new Promise<StreamTableData>((resolve, reject) => {
+      const drain = async () => {
+        try {
+          while (response.nextUri) {
+            if (response.columns && !columns) {
+              columns = response.columns;
+            }
+
+            if (!columnsResolved && columns) {
+              columnsResolved = true;
+              resolve({ rowStream: rowStream as unknown as NodeJS.ReadableStream, types: columns as TableStructure });
+            }
+
+            if (TrinoDriver.hasRowData(response)) {
+              hasReceivedData = true;
+              const normalData = this.normalizeResultOverColumns(response.data!, columns || []);
+              for (const obj of normalData) {
+                rowStream.write(obj);
+              }
+            }
+
+            await this.maybeBackoffBeforePoll(hasReceivedData, pollBackoffState);
+            response = await this.fetchNextUri(response.nextUri);
+            this.checkError(response);
+          }
+
+          if (response.columns && !columns) {
+            columns = response.columns;
+          }
+          if (!columnsResolved) {
+            columnsResolved = true;
+            resolve({ rowStream: rowStream as unknown as NodeJS.ReadableStream, types: (columns || []) as TableStructure });
+          }
+          if (TrinoDriver.hasRowData(response)) {
+            const normalData = this.normalizeResultOverColumns(response.data!, columns || []);
+            for (const obj of normalData) {
+              rowStream.write(obj);
+            }
+          }
+
+          rowStream.end();
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          rowStream.destroy(err);
+          if (!columnsResolved) {
+            reject(err);
+          }
+        }
+      };
+
+      drain().catch(() => {
+        // Errors are handled inside drain(); this prevents unhandled rejection
+      });
+    });
+
+    return resultPromise;
+  }
+
+  private checkError(response: TrinoQueryResponse): void {
+    if (response.error) {
+      const msg = response.error.message || 'Unknown Trino error';
+      const errorName = response.error.errorName ? ` (${response.error.errorName})` : '';
+      throw new Error(`Trino query error${errorName}: ${msg}`);
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  public normalizeResultOverColumns(data: any[][], columns: TrinoColumn[]): Record<string, any>[] {
+    const columnNames = (columns || []).map((c) => c.name);
+    return (data || []).map((row) => {
+      const obj: Record<string, any> = {};
+      for (let i = 0; i < columnNames.length; i++) {
+        obj[columnNames[i]] = row[i];
+      }
+      return obj;
+    });
+  }
+
+  protected informationSchemaQuery() {
+    const catalogPrefix = this.catalog ? `${this.catalog}.` : '';
+    const schemaFilter = this.config.schema ? ` AND columns.table_schema = '${this.config.schema}'` : '';
+
+    return `
+      SELECT columns.column_name as ${this.quoteIdentifier('column_name')},
+             columns.table_name as ${this.quoteIdentifier('table_name')},
+             columns.table_schema as ${this.quoteIdentifier('table_schema')},
+             columns.data_type as ${this.quoteIdentifier('data_type')}
+      FROM ${catalogPrefix}information_schema.columns
+      WHERE columns.table_schema NOT IN ('pg_catalog', 'information_schema', 'mysql', 'performance_schema', 'sys', 'INFORMATION_SCHEMA')${schemaFilter}
+   `;
+  }
+
+  protected getSchemasQuery() {
+    const catalogPrefix = this.catalog ? `${this.catalog}.` : '';
+
+    return `
+      SELECT table_schema as ${this.quoteIdentifier('schema_name')}
+      FROM ${catalogPrefix}information_schema.tables
+      WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'mysql', 'performance_schema', 'sys', 'INFORMATION_SCHEMA')
+      GROUP BY table_schema
+    `;
+  }
+
+  protected getTablesForSpecificSchemasQuery(schemasPlaceholders: string) {
+    const catalogPrefix = this.catalog ? `${this.catalog}.` : '';
+
+    return `
+      SELECT table_schema as ${this.quoteIdentifier('schema_name')},
+            table_name as ${this.quoteIdentifier('table_name')}
+      FROM ${catalogPrefix}information_schema.tables as columns
+      WHERE table_schema IN (${schemasPlaceholders})
+    `;
+  }
+
+  protected getColumnsForSpecificTablesQuery(conditionString: string) {
+    const catalogPrefix = this.catalog ? `${this.catalog}.` : '';
+
+    return `
+      SELECT columns.column_name as ${this.quoteIdentifier('column_name')},
+             columns.table_name as ${this.quoteIdentifier('table_name')},
+             columns.table_schema as ${this.quoteIdentifier('schema_name')},
+             columns.data_type as ${this.quoteIdentifier('data_type')}
+      FROM ${catalogPrefix}information_schema.columns as columns
+      WHERE ${conditionString}
+    `;
+  }
+
+  public downloadQueryResults(
+    query: string,
+    values: unknown[],
+    options: DownloadQueryResultsOptions
+  ): Promise<DownloadQueryResultsResult> {
+    if (options.streamImport) {
+      return <Promise<DownloadQueryResultsResult>> this.stream(query, values, options);
+    }
+    return super.downloadQueryResults(query, values, options);
+  }
+
+  public stream(query: string, values: unknown[], _options: StreamOptions): Promise<StreamTableData> {
+    const queryWithParams = this.prepareQueryWithParams(query, values);
+    return <Promise<StreamTableData>> this.queryPromised(queryWithParams, true);
+  }
+
+  public capabilities(): DriverCapabilities {
+    return {
+      unloadWithoutTempTable: true,
+    };
+  }
+
+  public async createSchemaIfNotExists(schemaName: string) {
+    await this.query(`CREATE SCHEMA IF NOT EXISTS ${this.config.catalog}.${schemaName}`, []);
+  }
+
+  public async isUnloadSupported() {
+    return this.config.exportBucket !== undefined;
+  }
+
+  public async unload(tableName: string, options: UnloadOptions) {
+    if (!this.config.exportBucket) {
+      throw new Error('Export bucket is not configured.');
+    }
+
+    if (!SUPPORTED_BUCKET_TYPES.includes(this.config.bucketType as string)) {
+      throw new Error(`Unsupported export bucket type: ${this.config.bucketType}`);
+    }
+
+    const types = options.query
+      ? await this.unloadWithSql(tableName, options.query.sql, options.query.params)
+      : await this.unloadWithTable(tableName);
+
+    const csvFile = await this.getCsvFiles(tableName);
+
+    return {
+      exportBucketCsvEscapeSymbol: this.config.exportBucketCsvEscapeSymbol,
+      csvFile,
+      types,
+      csvNoHeader: true,
+    };
+  }
+
+  public async queryColumnTypes(sql: string, params: unknown[]): Promise<{ name: string; type: string }[]> {
+    const response = await this.stream(`${sql} LIMIT 0`, params || [], { highWaterMark: 1 });
+    const result = [];
+    for (const column of response.types || []) {
+      result.push({ name: column.name, type: this.toGenericType(column.type) });
+    }
+    return result;
+  }
+
+  private splitTableFullName(tableFullName: string) {
+    const [schema, tableName] = tableFullName.split('.');
+    return { schema, tableName };
+  }
+
+  private generateTableColumnsForExport(types: { name: string; type: string }[]) {
+    return types.map((c) => `CAST(${c.name} AS varchar) ${c.name}`).join(', ');
+  }
+
+  private async unloadWithSql(tableFullName: string, sql: string, params: any[]) {
+    return this.unloadGeneric({
+      tableFullName,
+      typeSql: sql,
+      typeParams: params,
+      fromSql: sql,
+      fromParams: params,
+    });
+  }
+
+  private async unloadWithTable(tableFullName: string) {
+    return this.unloadGeneric({
+      tableFullName,
+      typeSql: `SELECT * FROM ${tableFullName}`,
+      typeParams: [],
+      fromSql: tableFullName,
+      fromParams: [],
+    });
+  }
+
+  private async unloadGeneric(params: {
+    tableFullName: string;
+    typeSql: string;
+    typeParams: any[];
+    fromSql: string;
+    fromParams: any[];
+  }) {
+    if (!this.config.exportBucket) {
+      throw new Error('Export bucket is not configured.');
+    }
+
+    const { bucketType, exportBucket } = this.config;
+    const types = await this.queryColumnTypes(params.typeSql, params.typeParams);
+
+    const { schema, tableName } = this.splitTableFullName(params.tableFullName);
+    const tableWithCatalogAndSchema = `${this.config.catalog}.${schema}.${tableName}`;
+
+    const protocol = {
+      gcs: 'gs',
+      s3: this.config.exportBucketS3AdvancedFS ? 's3a' : 's3',
+    }[bucketType || 'gcs'];
+
+    const externalLocation = `${protocol}://${exportBucket}/${schema}/${tableName}`;
+    const withParams = `( external_location = '${externalLocation}', format = 'CSV')`;
+    const select = `SELECT ${this.generateTableColumnsForExport(types)} FROM (${params.fromSql})`;
+    const createTableQuery = `CREATE TABLE ${tableWithCatalogAndSchema} WITH ${withParams} AS (${select})`;
+
+    try {
+      await this.query(createTableQuery, params.fromParams);
+    } finally {
+      await this.query(`DROP TABLE IF EXISTS ${tableWithCatalogAndSchema}`, []);
+    }
+
+    return types;
+  }
+
+  private async getCsvFiles(tableFullName: string): Promise<string[]> {
+    if (!this.config.exportBucket) {
+      throw new Error('Export bucket is not configured.');
+    }
+    const { bucketType, exportBucket } = this.config;
+    const { schema, tableName } = this.splitTableFullName(tableFullName);
+
+    switch (bucketType) {
+      case 'gcs':
+        return this.extractFilesFromGCS(
+          { credentials: this.config.credentials },
+          exportBucket,
+          `${schema}/${tableName}`
+        );
+      case 's3':
+        return this.extractUnloadedFilesFromS3(
+          {
+            credentials: this.config.accessKeyId && this.config.secretAccessKey
+              ? { accessKeyId: this.config.accessKeyId, secretAccessKey: this.config.secretAccessKey }
+              : undefined,
+            region: this.config.exportBucketRegion,
+          },
+          exportBucket,
+          `${schema}/${tableName}`
+        );
+      default:
+        throw new Error(`Unsupported export bucket type: ${bucketType}`);
+    }
+  }
+
+  public async release() {
+    this.httpAgent.destroy();
+    this.httpsAgent.destroy();
   }
 }

--- a/packages/cubejs-trino-driver/src/index.ts
+++ b/packages/cubejs-trino-driver/src/index.ts
@@ -2,3 +2,8 @@ import { TrinoDriver } from './TrinoDriver';
 
 export default TrinoDriver;
 export { TrinoDriver };
+export type {
+  TrinoDriverConfiguration,
+  TrinoDriverExportBucket,
+  PollBackoffConfig,
+} from './types';

--- a/packages/cubejs-trino-driver/src/types.ts
+++ b/packages/cubejs-trino-driver/src/types.ts
@@ -1,0 +1,117 @@
+import type { ConnectionOptions as TLSConnectionOptions } from 'tls';
+
+/**
+ * Linear backoff used only before the first non-empty data page.
+ * Each interval is held for `triesBeforeIncrement` empty polls before stepping up.
+ * After the first rows arrive, polling uses `drainInterval` (default 0).
+ */
+export type PollBackoffConfig = {
+  /** First wait before nextUri while still waiting for rows (default: 50) */
+  initialInterval?: number;
+  /** Added to the wait after triesBeforeIncrement empty polls (default: 50) */
+  incrementStep?: number;
+  /** Cap on wait between status polls while waiting (default: 500) */
+  maxInterval?: number;
+  /**
+   * Empty wait-polls at the current interval before increasing (default: 10).
+   * Chosen so initialInterval × triesBeforeIncrement ≈ 500ms of fine polling.
+   */
+  triesBeforeIncrement?: number;
+};
+
+export type TrinoDriverExportBucket = {
+  exportBucket?: string;
+  bucketType?: 'gcs' | 's3';
+  credentials?: any;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  exportBucketRegion?: string;
+  exportBucketS3AdvancedFS?: boolean;
+  exportBucketCsvEscapeSymbol?: string;
+};
+
+export type TrinoDriverConfiguration = TrinoDriverExportBucket & {
+  host?: string;
+  port?: string | number;
+  catalog?: string;
+  schema?: string;
+  user?: string;
+  // eslint-disable-next-line camelcase
+  custom_auth?: string;
+  // eslint-disable-next-line camelcase
+  basic_auth?: { user: string; password: string };
+  ssl?: boolean | TLSConnectionOptions;
+  dataSource?: string;
+  queryTimeout?: number;
+  preAggregations?: boolean;
+  useSelectTestConnection?: boolean;
+  // @see https://trino.io/docs/current/develop/client-protocol.html
+  headers?: Record<string, string>;
+  /**
+   * Source identifier sent as `X-Trino-Source`.
+   * Default: `nodejs-client` (same as the previous `presto-client` default).
+   */
+  source?: string;
+  /**
+   * Session timezone sent as `X-Trino-Time-Zone`.
+   */
+  timezone?: string;
+  /**
+   * Extra Trino session properties. `queryTimeout` is always merged in as
+   * `query_max_run_time` when set.
+   */
+  session?: string | Record<string, string>;
+  /**
+   * Progressive backoff while waiting for the first rows. Constructor values
+   * override environment variables.
+   */
+  pollBackoff?: PollBackoffConfig;
+  /**
+   * Sleep (ms) between nextUri polls after the first rows arrive. Default 0
+   * (drain as fast as Trino produces pages).
+   */
+  drainInterval?: number;
+  /**
+   * Legacy `presto-client` poll interval (ms). If set and `pollBackoff` is
+   * omitted, wait-phase and drain polling both use this constant interval.
+   */
+  checkInterval?: number;
+  /**
+   * HTTP keep-alive for coordinator connections. Default: true.
+   */
+  keepAlive?: boolean;
+  /**
+   * Retries for 502/503/504 on nextUri polls. Default: 5.
+   */
+  maxTransientRetries?: number;
+};
+
+export type TrinoColumn = {
+  name: string;
+  type: string;
+};
+
+export type TrinoQueryResponse = {
+  id?: string;
+  infoUri?: string;
+  nextUri?: string;
+  columns?: TrinoColumn[];
+  data?: any[][];
+  stats?: {
+    state: string;
+    queued?: boolean;
+    scheduled?: boolean;
+    nodes?: number;
+    totalSplits?: number;
+    queuedSplits?: number;
+    runningSplits?: number;
+    completedSplits?: number;
+  };
+  error?: {
+    message: string;
+    errorCode?: number;
+    errorName?: string;
+    errorType?: string;
+    failureInfo?: any;
+  };
+};

--- a/packages/cubejs-trino-driver/test/integration/trino-driver.test.ts
+++ b/packages/cubejs-trino-driver/test/integration/trino-driver.test.ts
@@ -11,8 +11,11 @@ describe('TrinoDriver', () => {
 
   const doWithDriver = async (callback: any) => {
     const driver = new TrinoDriver(config);
-
-    await callback(driver);
+    try {
+      await callback(driver);
+    } finally {
+      await driver.release();
+    }
   };
 
   // eslint-disable-next-line consistent-return,func-names
@@ -68,18 +71,102 @@ describe('TrinoDriver', () => {
     });
   });
 
-  // eslint-disable-next-line func-names
   it('should test connection', async () => {
-    await doWithDriver(async (driver: any) => {
+    await doWithDriver(async (driver: TrinoDriver) => {
       await driver.testConnection();
     });
   });
 
-  // eslint-disable-next-line func-names
   it('should test informationSchemaQuery', async () => {
     await doWithDriver(async (driver: any) => {
       const informationSchemaQuery = driver.informationSchemaQuery();
       expect(informationSchemaQuery).toContain('columns.table_schema = \'sf1\'');
+    });
+  });
+
+  it('should execute a simple SELECT', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const result = await driver.query('SELECT 1 AS num, \'hello\' AS str', []);
+      expect(result).toEqual([{ num: 1, str: 'hello' }]);
+    });
+  });
+
+  it('should handle parameterized queries', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const result = await driver.query('SELECT ? + ? AS sum', [2, 3]);
+      expect(result).toEqual([{ sum: 5 }]);
+    });
+  });
+
+  it('should handle NULL values and empty result sets', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const nulls = await driver.query('SELECT CAST(NULL AS INTEGER) AS empty', []);
+      expect(nulls).toEqual([{ empty: null }]);
+
+      const empty = await driver.query('SELECT 1 WHERE 1 = 0', []);
+      expect(empty).toEqual([]);
+    });
+  });
+
+  it('should handle common Trino types', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const result = await driver.query(
+        'SELECT CAST(42 AS INTEGER) AS i, CAST(9999999999 AS BIGINT) AS b, true AS flag, DATE \'2024-06-15\' AS d',
+        []
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].i).toBe(42);
+      expect(result[0].flag).toBe(true);
+      expect(result[0].d).toBeDefined();
+    });
+  });
+
+  it('should list schemas', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const schemas = await driver.getSchemas();
+      expect(schemas.length).toBeGreaterThan(0);
+      expect(schemas[0]).toHaveProperty('schema_name');
+    });
+  });
+
+  it('should stream query results', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const streamResult = await driver.stream(
+        'SELECT * FROM (VALUES (1, \'a\'), (2, \'b\'), (3, \'c\')) AS t(id, letter)',
+        [],
+        { highWaterMark: 1 }
+      );
+
+      expect(streamResult.rowStream).toBeDefined();
+      expect(streamResult.types!.length).toBeGreaterThan(0);
+
+      const rows: any[] = [];
+      await new Promise<void>((resolve, reject) => {
+        streamResult.rowStream.on('data', (row: any) => rows.push(row));
+        streamResult.rowStream.on('end', resolve);
+        streamResult.rowStream.on('error', reject);
+      });
+
+      expect(rows).toHaveLength(3);
+      expect(rows[0]).toEqual({ id: 1, letter: 'a' });
+    });
+  });
+
+  it('should accumulate multi-batch results in order', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      const result = await driver.query(
+        'SELECT x FROM UNNEST(sequence(1, 2000)) AS t(x)',
+        []
+      );
+      expect(result).toHaveLength(2000);
+      expect(result[0]).toEqual({ x: 1 });
+      expect(result[1999]).toEqual({ x: 2000 });
+    });
+  });
+
+  it('should throw on invalid SQL with a Trino error', async () => {
+    await doWithDriver(async (driver: TrinoDriver) => {
+      await expect(driver.query('INVALID SQL SYNTAX HERE', [])).rejects.toThrow(/Trino query error/);
     });
   });
 });

--- a/packages/cubejs-trino-driver/test/unit/edge-cases.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/edge-cases.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Constructor / env / protocol edge cases for TrinoDriver.
+ */
+
+const mockFetch: jest.Mock = jest.fn();
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockFetch(...args),
+}));
+
+jest.mock('@cubejs-backend/schema-compiler', () => ({
+  PrestodbQuery: class PrestodbQuery {},
+  TrinoQuery: class TrinoQuery {},
+}));
+
+/* eslint-disable import/first */
+import { TrinoDriver } from '../../src/TrinoDriver';
+
+function mockResponse(body: object, status = 200): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const baseConfig = {
+  host: 'localhost',
+  port: 8080,
+  catalog: 'hive',
+  schema: 'default',
+  user: 'test',
+  dataSource: 'default',
+};
+
+function createDriver(overrides: Record<string, any> = {}) {
+  return new TrinoDriver({
+    ...baseConfig,
+    ...overrides,
+  });
+}
+
+const TRINO_ENV_KEYS = [
+  'CUBEJS_DB_TRINO_SOURCE',
+  'CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL',
+  'CUBEJS_DB_TRINO_POLL_INCREMENT_STEP',
+  'CUBEJS_DB_TRINO_POLL_MAX_INTERVAL',
+  'CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT',
+  'CUBEJS_DB_PRESTO_AUTH_TOKEN',
+  'CUBEJS_DB_PASS',
+  'CUBEJS_DB_USER',
+];
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  TRINO_ENV_KEYS.forEach((key) => {
+    delete process.env[key];
+  });
+});
+
+afterEach(() => {
+  TRINO_ENV_KEYS.forEach((key) => {
+    delete process.env[key];
+  });
+});
+
+describe('constructor validation', () => {
+  it('throws when both custom_auth and basic_auth are set', () => {
+    expect(() => createDriver({
+      custom_auth: 'Bearer tok',
+      basic_auth: { user: 'u', password: 'p' },
+    })).toThrow('Please do not specify basic_auth and custom_auth at the same time.');
+  });
+
+  it('throws when env auth token and password are both set', () => {
+    process.env.CUBEJS_DB_PRESTO_AUTH_TOKEN = 'tok';
+    process.env.CUBEJS_DB_PASS = 'secret';
+    process.env.CUBEJS_DB_USER = 'u';
+    expect(() => createDriver()).toThrow(/Both user\/password and auth token/);
+  });
+
+  it('throws on negative pollBackoff.initialInterval', () => {
+    expect(() => createDriver({
+      pollBackoff: { initialInterval: -1 },
+    })).toThrow(/pollBackoff.initialInterval must be a non-negative integer/);
+  });
+
+  it('throws on NaN drainInterval', () => {
+    expect(() => createDriver({ drainInterval: Number.NaN })).toThrow(
+      /drainInterval must be a non-negative integer/
+    );
+  });
+
+  it('throws when initialInterval > maxInterval', () => {
+    expect(() => createDriver({
+      pollBackoff: { initialInterval: 800, maxInterval: 100 },
+    })).toThrow(/initialInterval \(800\) must be <= maxInterval \(100\)/);
+  });
+
+  it('throws when triesBeforeIncrement is 0', () => {
+    expect(() => createDriver({
+      pollBackoff: { triesBeforeIncrement: 0 },
+    })).toThrow(/triesBeforeIncrement must be >= 1/);
+  });
+
+  it('throws on negative checkInterval', () => {
+    expect(() => createDriver({ checkInterval: -5 })).toThrow(
+      /pollBackoff.initialInterval must be a non-negative integer/
+    );
+  });
+
+  it('throws on negative maxTransientRetries', () => {
+    expect(() => createDriver({ maxTransientRetries: -1 })).toThrow(
+      /maxTransientRetries must be a non-negative integer/
+    );
+  });
+
+  it('allows incrementStep 0 (constant wait-phase interval)', () => {
+    const driver = createDriver({
+      pollBackoff: { initialInterval: 10, incrementStep: 0, maxInterval: 10, triesBeforeIncrement: 1 },
+    });
+    expect((driver as any).pollBackoff.incrementStep).toBe(0);
+    driver.release();
+  });
+
+  it('allows drainInterval 0 and maxTransientRetries 0', () => {
+    const driver = createDriver({ drainInterval: 0, maxTransientRetries: 0 });
+    expect((driver as any).drainInterval).toBe(0);
+    expect((driver as any).maxTransientRetries).toBe(0);
+    driver.release();
+  });
+
+  it('uses basic_auth.user as X-Trino-User when user is omitted', async () => {
+    const { user, ...rest } = baseConfig;
+    const driver = new TrinoDriver({
+      ...rest,
+      basic_auth: { user: 'presto', password: '' },
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+    await driver.testConnection();
+    expect(mockFetch.mock.calls[0][1].headers['X-Trino-User']).toBe('presto');
+    await driver.release();
+  });
+
+  it('keeps an explicit user when it differs from basic_auth (impersonation)', async () => {
+    const driver = createDriver({
+      user: 'alice',
+      basic_auth: { user: 'presto', password: '' },
+    });
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+    await driver.testConnection();
+    expect(mockFetch.mock.calls[0][1].headers['X-Trino-User']).toBe('alice');
+    await driver.release();
+  });
+});
+
+describe('env-driven configuration', () => {
+  it('applies poll env vars when pollBackoff is not passed', () => {
+    process.env.CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL = '20';
+    process.env.CUBEJS_DB_TRINO_POLL_INCREMENT_STEP = '10';
+    process.env.CUBEJS_DB_TRINO_POLL_MAX_INTERVAL = '80';
+    process.env.CUBEJS_DB_TRINO_POLL_TRIES_BEFORE_INCREMENT = '2';
+
+    const driver = createDriver();
+    expect((driver as any).pollBackoff).toEqual({
+      initialInterval: 20,
+      incrementStep: 10,
+      maxInterval: 80,
+      triesBeforeIncrement: 2,
+    });
+    driver.release();
+  });
+
+  it('lets constructor pollBackoff override env', () => {
+    process.env.CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL = '20';
+    const driver = createDriver({
+      pollBackoff: { initialInterval: 7, incrementStep: 1, maxInterval: 9, triesBeforeIncrement: 1 },
+    });
+    expect((driver as any).pollBackoff.initialInterval).toBe(7);
+    driver.release();
+  });
+
+  it('throws on improper poll env values at construction', () => {
+    process.env.CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL = 'abc';
+    expect(() => createDriver()).toThrow(/CUBEJS_DB_TRINO_POLL_INITIAL_INTERVAL/);
+  });
+
+  it('falls back to nodejs-client when CUBEJS_DB_TRINO_SOURCE is empty', async () => {
+    process.env.CUBEJS_DB_TRINO_SOURCE = '';
+    const driver = createDriver();
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+    await driver.testConnection();
+    expect(mockFetch.mock.calls[0][1].headers['X-Trino-Source']).toBe('nodejs-client');
+    await driver.release();
+  });
+
+  it('sends CUBEJS_DB_TRINO_SOURCE when set', async () => {
+    process.env.CUBEJS_DB_TRINO_SOURCE = 'etl-worker';
+    const driver = createDriver();
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+    await driver.testConnection();
+    expect(mockFetch.mock.calls[0][1].headers['X-Trino-Source']).toBe('etl-worker');
+    await driver.release();
+  });
+});
+
+describe('protocol edge cases', () => {
+  it('does not retry non-transient poll errors (401)', async () => {
+    const driver = createDriver({
+      pollBackoff: { initialInterval: 1, incrementStep: 1, maxInterval: 1, triesBeforeIncrement: 1 },
+    });
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'unauthorized' }, 401));
+
+    await expect(driver.queryPromised('SELECT 1', false)).rejects.toThrow(/Trino poll failed \(401\)/);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    await driver.release();
+  });
+
+  it('throws on statement POST failure', async () => {
+    const driver = createDriver();
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'bad request' }, 400));
+    await expect(driver.queryPromised('SELECT 1', false)).rejects.toThrow(/Trino statement POST failed \(400\)/);
+    await driver.release();
+  });
+
+  it('accumulates a data page that arrives only after nextUri is gone', async () => {
+    const driver = createDriver({
+      pollBackoff: { initialInterval: 1, incrementStep: 1, maxInterval: 1, triesBeforeIncrement: 1 },
+    });
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'v', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[7]], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = await driver.queryPromised('SELECT v FROM t', false);
+    expect(result).toEqual([{ v: 7 }]);
+    await driver.release();
+  });
+
+  it('maps null cells and ignores extra row values past column count', () => {
+    const driver = createDriver();
+    const result = driver.normalizeResultOverColumns(
+      [[1, null, 'x', 'extra']],
+      [{ name: 'a', type: 'integer' }, { name: 'b', type: 'varchar' }, { name: 'c', type: 'varchar' }],
+    );
+    expect(result).toEqual([{ a: 1, b: null, c: 'x' }]);
+    driver.release();
+  });
+
+  it('prefers pollBackoff over checkInterval when both are set', () => {
+    const driver = createDriver({
+      checkInterval: 800,
+      pollBackoff: { initialInterval: 15, incrementStep: 0, maxInterval: 15, triesBeforeIncrement: 1 },
+    });
+    expect((driver as any).pollBackoff.initialInterval).toBe(15);
+    expect((driver as any).drainInterval).toBe(0);
+    driver.release();
+  });
+
+  it('uses the https agent when nextUri is https', async () => {
+    const driver = createDriver({
+      ssl: { rejectUnauthorized: false },
+      pollBackoff: { initialInterval: 1, incrementStep: 1, maxInterval: 1, triesBeforeIncrement: 1 },
+    });
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        nextUri: 'https://worker.internal:8443/v1/statement/q/1',
+        columns: [{ name: 'x', type: 'integer' }],
+        stats: { state: 'RUNNING' },
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT 1', false);
+    const pollOpts = mockFetch.mock.calls[1][1];
+    expect(mockFetch.mock.calls[1][0]).toMatch(/^https:/);
+    expect(pollOpts.agent).toBe((driver as any).httpsAgent);
+    await driver.release();
+  });
+});

--- a/packages/cubejs-trino-driver/test/unit/headers.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/headers.test.ts
@@ -1,7 +1,6 @@
 import { TrinoDriver } from '../../src';
 
 const mockFetch: jest.Mock = jest.fn();
-const mockExecute: jest.Mock = jest.fn();
 
 jest.mock('node-fetch', () => ({
   __esModule: true,
@@ -9,15 +8,19 @@ jest.mock('node-fetch', () => ({
 }));
 
 jest.mock('@cubejs-backend/schema-compiler', () => ({
-  PrestodbQuery: class { },
+  PrestodbQuery: class {},
+  TrinoQuery: class {},
 }));
 
-jest.mock('presto-client', () => ({
-  Client: jest.fn().mockImplementation(() => ({
-    execute: (...args: any[]) => mockExecute(...args),
-    nodes: jest.fn(),
-  })),
-}));
+function mockResponse(body: object, status = 200): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
 
 describe('TrinoDriver headers', () => {
   beforeEach(() => {
@@ -27,11 +30,6 @@ describe('TrinoDriver headers', () => {
       status: 200,
       statusText: 'OK',
       text: async () => '',
-    });
-    mockExecute.mockReset();
-    // Default: synthesize a successful query result with no rows.
-    mockExecute.mockImplementation((opts: any) => {
-      opts.success?.();
     });
   });
 
@@ -61,6 +59,8 @@ describe('TrinoDriver headers', () => {
       'X-Trino-Client-Tags': 'user=alice@example.com',
       'X-Mozart-User-Token': 'abc.def.ghi',
     });
+
+    await driver.release();
   });
 
   it('forwards configured custom headers when useSelectTestConnection is enabled', async () => {
@@ -74,15 +74,76 @@ describe('TrinoDriver headers', () => {
       },
     });
 
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns: [{ name: 'x', type: 'integer' }], data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
     await driver.testConnection();
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(mockExecute).toHaveBeenCalledTimes(1);
-    const [executeOpts] = mockExecute.mock.calls[0];
-    expect(executeOpts.query).toBe('SELECT 1');
-    expect(executeOpts.headers).toEqual({
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://trino.local:8080/v1/statement');
+    expect(options.method).toBe('POST');
+    expect(options.body).toBe('SELECT 1');
+    expect(options.headers).toMatchObject({
       'X-Trino-Source': 'cube',
       'X-Trino-Routing-Group': 'etl',
     });
+
+    await driver.release();
+  });
+
+  it('forwards custom headers on nextUri polls, including a different host', async () => {
+    const driver = new TrinoDriver({
+      host: 'coordinator.local',
+      port: '8080',
+      catalog: 'test',
+      schema: 'default',
+      headers: {
+        'X-Custom-Header': 'custom-value',
+        'Proxy-Authorization': 'Basic dGVzdA==',
+      },
+      pollBackoff: {
+        initialInterval: 1,
+        incrementStep: 1,
+        maxInterval: 1,
+        triesBeforeIncrement: 1,
+      },
+    });
+
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        nextUri: 'http://worker.internal:8081/v1/statement/q1/1',
+        columns: [{ name: 'one', type: 'integer' }],
+        stats: { state: 'QUEUED' },
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        columns: [{ name: 'one', type: 'integer' }],
+        data: [[1]],
+        stats: { state: 'FINISHED' },
+      }),
+    );
+
+    const rows = await driver.query('SELECT 1', []);
+    expect(rows).toEqual([{ one: 1 }]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [postUrl, postOpts] = mockFetch.mock.calls[0];
+    const [pollUrl, pollOpts] = mockFetch.mock.calls[1];
+
+    expect(postUrl).toBe('http://coordinator.local:8080/v1/statement');
+    expect(postOpts.headers['X-Custom-Header']).toBe('custom-value');
+    expect(postOpts.headers['Proxy-Authorization']).toBe('Basic dGVzdA==');
+
+    expect(pollUrl).toBe('http://worker.internal:8081/v1/statement/q1/1');
+    expect(pollOpts.method).toBe('GET');
+    expect(pollOpts.headers['X-Custom-Header']).toBe('custom-value');
+    expect(pollOpts.headers['Proxy-Authorization']).toBe('Basic dGVzdA==');
+
+    await driver.release();
   });
 });

--- a/packages/cubejs-trino-driver/test/unit/params-escaping.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/params-escaping.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable quotes */
+import { TrinoDriver } from '../../src/TrinoDriver';
+
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@cubejs-backend/schema-compiler', () => ({
+  PrestodbQuery: class {},
+  TrinoQuery: class {},
+}));
+
+class TestTrinoDriver extends TrinoDriver {
+  public override prepareQueryWithParams(query: string, values: unknown[]) {
+    return super.prepareQueryWithParams(query, values);
+  }
+}
+
+describe('TrinoDriver SQL parameter escaping', () => {
+  let driver: TestTrinoDriver;
+
+  beforeAll(() => {
+    driver = new TestTrinoDriver({
+      host: 'localhost',
+      port: '8080',
+      catalog: 'test',
+      schema: 'default',
+      dataSource: 'default',
+    });
+  });
+
+  afterAll(async () => {
+    await driver.release();
+  });
+
+  it('preserves LIKE escape sequences emitted by the schema compiler', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      ['new\\_order\\%'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('new\\_order\\%'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('does not double literal backslashes in LIKE parameters', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      ['folder\\\\name'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('folder\\\\name'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('doubles quotes so a LIKE value cannot break out of the literal', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      [`o'reilly'); DROP TABLE orders; --`],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('o''reilly''); DROP TABLE orders; --'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('keeps the literal closed for a backslash-then-quote payload', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE name = ?',
+      [`foo\\' OR 1=1 --`],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE name = 'foo\\'' OR 1=1 --'`);
+  });
+
+  it('keeps a literal percent sign in an equality parameter verbatim', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE discount_label = ?',
+      ['100% cotton'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE discount_label = '100% cotton'`);
+  });
+
+  it('passes an unescaped percent sign through a LIKE parameter untouched', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      ['50%'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('50%'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('escapes quotes in a value that also contains percent signs', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      [`50%' OR 1=1 --`],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('50%'' OR 1=1 --'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('substitutes multiple placeholders in order', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\' AND status = ? AND amount > ?`,
+      ['pending\\_review', 'new', 100],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('pending\\_review'), '%') ESCAPE '\\' AND status = 'new' AND amount > 100`
+    );
+  });
+});

--- a/packages/cubejs-trino-driver/test/unit/query.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/query.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Unit tests for TrinoDriver query execution: backoff, drain, retries,
+ * streaming, errors, auth, and result normalization.
+ */
+
+/* eslint-disable import/first */
+const mockFetch: jest.Mock = jest.fn();
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockFetch(...args),
+}));
+
+jest.mock('@cubejs-backend/schema-compiler', () => ({
+  PrestodbQuery: class PrestodbQuery {},
+  TrinoQuery: class TrinoQuery {},
+}));
+
+import { TrinoDriver } from '../../src/TrinoDriver';
+
+function mockResponse(body: object, status = 200): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function createDriver(overrides: Record<string, any> = {}) {
+  return new TrinoDriver({
+    host: 'localhost',
+    port: 8080,
+    catalog: 'test_catalog',
+    schema: 'test_schema',
+    user: 'test_user',
+    pollBackoff: {
+      initialInterval: 1,
+      incrementStep: 1,
+      maxInterval: 5,
+      triesBeforeIncrement: 2,
+    },
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('normalizeResultOverColumns', () => {
+  it('should map row arrays to column-keyed objects', () => {
+    const driver = createDriver();
+    const columns = [{ name: 'id', type: 'integer' }, { name: 'name', type: 'varchar' }];
+    const data = [[1, 'alice'], [2, 'bob']];
+    const result = driver.normalizeResultOverColumns(data, columns);
+
+    expect(result).toEqual([
+      { id: 1, name: 'alice' },
+      { id: 2, name: 'bob' },
+    ]);
+  });
+
+  it('should handle empty data', () => {
+    const driver = createDriver();
+    const result = driver.normalizeResultOverColumns([], [{ name: 'id', type: 'integer' }]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('executeBuffered (queryPromised)', () => {
+  it('should return rows from a single-page response', async () => {
+    const driver = createDriver();
+    const columns = [{ name: 'x', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[1], [2]], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = await driver.queryPromised('SELECT x FROM t', false);
+    expect(result).toEqual([{ x: 1 }, { x: 2 }]);
+    await driver.release();
+  });
+
+  it('should follow nextUri and accumulate rows in arrival order', async () => {
+    const driver = createDriver();
+    const columns = [{ name: 'v', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/2', data: [[10]], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[20]], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = await driver.queryPromised('SELECT v FROM t', false);
+    expect(result).toEqual([{ v: 10 }, { v: 20 }]);
+    await driver.release();
+  });
+
+  it('should apply progressive backoff while waiting for first rows', async () => {
+    const driver = createDriver();
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'QUEUED' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/2', stats: { state: 'PLANNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[42]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+
+    expect(sleepSpy).toHaveBeenCalledTimes(2);
+    expect(sleepSpy).toHaveBeenNthCalledWith(1, 1);
+    expect(sleepSpy).toHaveBeenNthCalledWith(2, 1);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should NOT sleep once data is flowing (default drainInterval=0)', async () => {
+    const driver = createDriver();
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [[1]], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[2]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+    expect(sleepSpy).not.toHaveBeenCalled();
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should sleep drainInterval between pages after the first rows', async () => {
+    const driver = createDriver({ drainInterval: 7 });
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [[1]], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[2]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+    expect(sleepSpy).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).toHaveBeenCalledWith(7);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should honor legacy checkInterval for both wait and drain phases', async () => {
+    const driver = createDriver({
+      pollBackoff: undefined,
+      checkInterval: 9,
+    });
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'QUEUED' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/2', columns, data: [[1]], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[2]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+    expect(sleepSpy.mock.calls.map((c) => c[0])).toEqual([9, 9]);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should backoff on empty data array until first rows arrive', async () => {
+    const driver = createDriver();
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[99]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+    expect(sleepSpy).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).toHaveBeenCalledWith(1);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should increase interval only after triesBeforeIncrement holds', async () => {
+    const driver = createDriver({
+      pollBackoff: {
+        initialInterval: 3,
+        incrementStep: 3,
+        maxInterval: 5,
+        triesBeforeIncrement: 2,
+      },
+    });
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'QUEUED' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/2', stats: { state: 'QUEUED' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/3', stats: { state: 'PLANNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/4', stats: { state: 'PLANNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT a FROM t', false);
+
+    expect(sleepSpy.mock.calls.map((c) => c[0])).toEqual([3, 3, 5, 5]);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+
+  it('should use TrinoQuery dialect', () => {
+    expect(TrinoDriver.dialectClass().name).toBe('TrinoQuery');
+  });
+
+  it('should throw on Trino query error', async () => {
+    const driver = createDriver();
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        error: { message: 'SYNTAX_ERROR', errorName: 'SYNTAX_ERROR' },
+        stats: { state: 'FAILED' },
+      }),
+    );
+
+    await expect(driver.queryPromised('BAD SQL', false)).rejects.toThrow('Trino query error (SYNTAX_ERROR)');
+    await driver.release();
+  });
+});
+
+describe('fetchNextUri bounded retries', () => {
+  it('should retry on 503 and succeed', async () => {
+    const driver = createDriver();
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({}, 503));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[1]], columns: [{ name: 'x', type: 'integer' }], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = await driver.queryPromised('SELECT 1', false);
+    expect(result).toEqual([{ x: 1 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    await driver.release();
+  });
+
+  it('should throw after maxTransientRetries consecutive failures', async () => {
+    const driver = createDriver({ maxTransientRetries: 5 });
+    jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', stats: { state: 'RUNNING' } }),
+    );
+    for (let i = 0; i < 6; i++) {
+      mockFetch.mockResolvedValueOnce(mockResponse({}, 502));
+    }
+
+    await expect(driver.queryPromised('SELECT 1', false)).rejects.toThrow(
+      /Trino poll failed after 5 retries/,
+    );
+    await driver.release();
+  });
+});
+
+describe('executeStreaming (queryPromised streaming)', () => {
+  it('should resolve with rowStream and types when columns arrive', async () => {
+    const driver = createDriver();
+    const columns = [{ name: 'id', type: 'integer' }, { name: 'val', type: 'varchar' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [[1, 'a']], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[2, 'b']], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = (await driver.queryPromised('SELECT id, val FROM t', true)) as any;
+    expect(result.types).toEqual(columns);
+    expect(result.rowStream).toBeDefined();
+
+    const rows: any[] = [];
+    await new Promise<void>((resolve) => {
+      result.rowStream.on('data', (row: any) => rows.push(row));
+      result.rowStream.on('end', resolve);
+    });
+
+    expect(rows).toEqual([{ id: 1, val: 'a' }, { id: 2, val: 'b' }]);
+    await driver.release();
+  });
+
+  it('should resolve even when no columns are returned (no-hang guarantee)', async () => {
+    const driver = createDriver();
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ stats: { state: 'FINISHED' } }),
+    );
+
+    const result = (await driver.queryPromised('CREATE TABLE t(x int)', true)) as any;
+    expect(result.rowStream).toBeDefined();
+    expect(result.types).toEqual([]);
+    await driver.release();
+  });
+
+  it('should destroy stream on error after promise is resolved', async () => {
+    const driver = createDriver();
+    const columns = [{ name: 'id', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [[1]], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockRejectedValueOnce(new Error('network failure'));
+
+    const result = (await driver.queryPromised('SELECT id FROM t', true)) as any;
+
+    await new Promise<void>((resolve) => {
+      result.rowStream.on('error', (err: Error) => {
+        expect(err.message).toBe('network failure');
+        resolve();
+      });
+    });
+    await driver.release();
+  });
+
+  it('should reject promise on error before columns arrive', async () => {
+    const driver = createDriver();
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        error: { message: 'Permission denied', errorName: 'PERMISSION_DENIED' },
+        stats: { state: 'FAILED' },
+      }),
+    );
+
+    await expect(driver.queryPromised('SELECT 1', true)).rejects.toThrow('Trino query error (PERMISSION_DENIED)');
+    await driver.release();
+  });
+
+  it('should backoff in streaming mode until first rows, then drain', async () => {
+    const driver = createDriver();
+    const sleepSpy = jest.spyOn(driver as any, 'sleep').mockResolvedValue(undefined);
+    const columns = [{ name: 'a', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ nextUri: 'http://localhost:8080/next/1', columns, data: [], stats: { state: 'RUNNING' } }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
+    const result = (await driver.queryPromised('SELECT a FROM t', true)) as any;
+
+    const rows: any[] = [];
+    await new Promise<void>((resolve) => {
+      result.rowStream.on('data', (row: any) => rows.push(row));
+      result.rowStream.on('end', resolve);
+    });
+
+    expect(rows).toEqual([{ a: 1 }]);
+    expect(sleepSpy).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).toHaveBeenCalledWith(1);
+    sleepSpy.mockRestore();
+    await driver.release();
+  });
+});
+
+describe('testConnection', () => {
+  it('should succeed on 200 response from /v1/info', async () => {
+    const driver = createDriver();
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+
+    await expect(driver.testConnection()).resolves.toBeUndefined();
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:8080/v1/info');
+    await driver.release();
+  });
+
+  it('should throw on non-OK response', async () => {
+    const driver = createDriver();
+    mockFetch.mockResolvedValueOnce(mockResponse({}, 503));
+
+    await expect(driver.testConnection()).rejects.toThrow('Connection test failed');
+    await driver.release();
+  });
+});
+
+describe('configuration', () => {
+  it('should build basic auth header', async () => {
+    const driver = createDriver({ basic_auth: { user: 'u', password: 'p' } });
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+
+    await driver.testConnection();
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe(`Basic ${Buffer.from('u:p').toString('base64')}`);
+    await driver.release();
+  });
+
+  it('should build custom auth header (bearer token)', async () => {
+    const driver = createDriver({ custom_auth: 'Bearer tok123' });
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+
+    await driver.testConnection();
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe('Bearer tok123');
+    await driver.release();
+  });
+
+  it('should set catalog, schema, and default source headers', async () => {
+    const driver = createDriver({ catalog: 'hive', schema: 'default' });
+    mockFetch.mockResolvedValueOnce(mockResponse({ starting: false }));
+
+    await driver.testConnection();
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers['X-Trino-Catalog']).toBe('hive');
+    expect(headers['X-Trino-Schema']).toBe('default');
+    expect(headers['X-Trino-Source']).toBe('nodejs-client');
+    await driver.release();
+  });
+
+  it('should set session header with query timeout', async () => {
+    const driver = createDriver({ queryTimeout: 300 });
+    const columns = [{ name: 'x', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT 1', false);
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers['X-Trino-Session']).toBe('query_max_run_time=300s');
+    await driver.release();
+  });
+
+  it('should merge extra session properties with query timeout', async () => {
+    const driver = createDriver({
+      queryTimeout: 60,
+      session: { 'hive.insert_existing_partitions_behavior': 'overwrite' },
+    });
+    const columns = [{ name: 'x', type: 'integer' }];
+
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ columns, data: [[1]], stats: { state: 'FINISHED' } }),
+    );
+
+    await driver.queryPromised('SELECT 1', false);
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers['X-Trino-Session']).toBe(
+      'query_max_run_time=60s,hive.insert_existing_partitions_behavior=overwrite'
+    );
+    await driver.release();
+  });
+});
+
+describe('capabilities', () => {
+  it('should report unloadWithoutTempTable', () => {
+    const driver = createDriver();
+    expect(driver.capabilities()).toEqual({ unloadWithoutTempTable: true });
+  });
+});

--- a/packages/cubejs-trino-driver/test/unit/ssl.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/ssl.test.ts
@@ -1,3 +1,4 @@
+import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { TrinoDriver } from '../../src';
 
@@ -9,14 +10,8 @@ jest.mock('node-fetch', () => ({
 }));
 
 jest.mock('@cubejs-backend/schema-compiler', () => ({
-  PrestodbQuery: class { },
-}));
-
-jest.mock('presto-client', () => ({
-  Client: jest.fn().mockImplementation(() => ({
-    execute: jest.fn(),
-    nodes: jest.fn(),
-  })),
+  PrestodbQuery: class {},
+  TrinoQuery: class {},
 }));
 
 describe('TrinoDriver SSL', () => {
@@ -47,10 +42,13 @@ describe('TrinoDriver SSL', () => {
     expect(options.agent.options).toMatchObject({
       ca,
       rejectUnauthorized: false,
+      keepAlive: true,
     });
+
+    await driver.release();
   });
 
-  it('does not pass an agent when SSL is disabled', async () => {
+  it('uses a keep-alive http agent when SSL is disabled', async () => {
     const driver = new TrinoDriver({
       host: 'trino.local',
       port: '8080',
@@ -61,6 +59,9 @@ describe('TrinoDriver SSL', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toBe('http://trino.local:8080/v1/info');
-    expect(options.agent).toBeUndefined();
+    expect(options.agent).toBeInstanceOf(HttpAgent);
+    expect(options.agent.options).toMatchObject({ keepAlive: true });
+
+    await driver.release();
   });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`@cubejs-backend/trino-driver` no longer wraps `presto-client` / `PrestoDriver`. It talks to Trino's HTTP protocol directly (`POST /v1/statement`, then `GET nextUri`). The protocol is the same; the poll cadence is not.

`presto-client` slept ~800ms on every poll, including while the query was still queued and after rows were already flowing. That wait dominates interactive latency. PrestoDB is unchanged and still uses `presto-client`.

**Polling**

- While queued or planning (no rows yet): 50ms for the first 10 empty polls, then +50ms, capped at 500ms.
- After the first rows: no extra delay (`drainInterval` default `0`).
- `checkInterval: 800` restores constant-interval polling for both phases.

Tune with `CUBEJS_DB_TRINO_POLL_*` or `driverFactory` (`pollBackoff`, `drainInterval`, `checkInterval`). Invalid poll env values are rejected.

**Compatibility**

- Parameter escaping stays `formatAnsi`.
- Custom headers are sent on the statement POST and on every `nextUri` poll, including worker hosts.
- SSL, `/v1/info` `testConnection`, and `X-Trino-Source` default `nodejs-client` are unchanged.

**Behavior changes**

- `dialectClass()` returns `TrinoQuery` (`AT TIME ZONE` plus DATE promotion), matching QueryBuilder's `trino` mapping. The previous wrapper selected `PrestodbQuery`.
- `CUBEJS_DB_QUERY_TIMEOUT` (default `10m`) is sent as `query_max_run_time` on every statement, not only streams.
- When `user` is not set, `X-Trino-User` uses `basic_auth.user` so the session user matches the authenticated principal.
- Multi-page results append in arrival order.
- HTTP(S) keep-alive is on by default; `release()` destroys the agents.
- `TrinoDriver` no longer extends `PrestoDriver`.

**Test plan**
- [x] `packages/cubejs-trino-driver`: lint and 63 unit tests
- [x] `packages/cubejs-backend-shared`: Trino poll/source env parsing tests
- [x] `yarn integration:trino` against a live Trino container (11/11)
- [x] `packages/cubejs-testing`: `yarn smoke:trino` timezone snapshot
