### PR TITLE
docs: document the searchExplorations MCP tool

### DIFF
--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -208,7 +208,7 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 
 ## Available actions
 
-The MCP server exposes 23 tools, grouped below.
+The MCP server exposes 24 tools, grouped below.
 
 Every tool runs as the authenticated user. Queries respect the same
 [permissions][ref-roles] as the rest of Cube, including row-level security — MCP is a new
@@ -240,9 +240,15 @@ work together.
 | --- | --- | --- |
 | `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
 | `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. | Read-only |
+| `searchExplorations` | Searches saved queries — explorations and workbook tabs alike — by name and description. Returns each one's `sqlQuery`, ready to pass to `runQuery`. | Read-only |
 
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
 guessing them.
+
+Call `searchExplorations` first when someone may already have saved a query for the
+question: re-running a vetted exploration returns the numbers your team already trusts,
+instead of deriving new SQL. Matching is on names and descriptions, not on the query body,
+and results are limited to the explorations you have access to.
 
 ### Dashboard authoring
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -238,17 +238,17 @@ work together.
 
 | Tool | Description | Access |
 | --- | --- | --- |
+| `searchExplorations` | Searches saved queries — [explorations][ref-explorations] and workbook tabs alike — by name and description. Returns each one's `sqlQuery`, ready to pass to `runQuery`. | Read-only |
 | `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
 | `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. | Read-only |
-| `searchExplorations` | Searches saved queries — explorations and workbook tabs alike — by name and description. Returns each one's `sqlQuery`, ready to pass to `runQuery`. | Read-only |
 
-Call `searchDataModel` before `runQuery` to find exact view and member names rather than
-guessing them.
+Call `searchExplorations` first when a saved query may already answer the question —
+re-running one reuses a query your team has already vetted. Matching is on names and
+descriptions, not on the query body, and results cover only the explorations you can
+access. A saved query with no runnable SQL comes back with `sqlQuery` set to `null`.
 
-Call `searchExplorations` first when someone may already have saved a query for the
-question: re-running a vetted exploration returns the numbers your team already trusts,
-instead of deriving new SQL. Matching is on names and descriptions, not on the query body,
-and results are limited to the explorations you have access to.
+Otherwise call `searchDataModel` before `runQuery` to find exact view and member names
+rather than guessing them.
 
 ### Dashboard authoring
 
@@ -433,6 +433,7 @@ and friends) are set.
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-pre-aggregations]: /docs/pre-aggregations/using-pre-aggregations
 [ref-sql-api]: /reference/core-data-apis/sql-api
+[ref-explorations]: /docs/explore-analyze/explore#saving-explorations
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-dashboards]: /docs/explore-analyze/dashboards
 [ref-dev-mode]: /docs/data-modeling/dev-mode

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -238,7 +238,7 @@ work together.
 
 | Tool | Description | Access |
 | --- | --- | --- |
-| `searchExplorations` | Searches saved queries — [explorations][ref-explorations] and workbook tabs alike — by name and description. Returns each one's `sqlQuery`, ready to pass to `runQuery`. | Read-only |
+| `searchExplorations` | Searches saved queries — [explorations][ref-explorations] and workbook tabs alike — by name and description. Returns each one's `sqlQuery`, where available, ready to pass to `runQuery`. | Read-only |
 | `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
 | `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. | Read-only |
 


### PR DESCRIPTION
## Summary

- Documents the `searchExplorations` MCP tool, which searches saved queries — explorations and workbook tabs alike — by name and description and returns each one's `sqlQuery`, ready to pass to `runQuery`.
- Adds it to the "Query and discovery" table and updates the tool count.

## Test plan

- [x] Table renders with the new row; surrounding guidance reads correctly
- [ ] CI must pass
