### PR TITLE
docs: fill in several undocumented Cube Cloud features

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -68,6 +68,14 @@ packages are added to a shared pool accessible by all users in the account.
 
 Contact your account executive for details on purchasing token packages.
 
+## Embedded users
+
+AI token usage by [embedded][ref-embedding] end users is not drawn from the account's
+per-seat token grants — it is billed separately through token packages, then as
+on-demand consumption. By default there is no on-demand spending limit for embedded
+usage; set one to cap it, the same way you would for on-demand consumption above. Free
+plan accounts are unaffected, since they have no seats.
+
 ## Free tier
 
 Each user on a free plan receives an individual monthly token allowance. This
@@ -120,3 +128,4 @@ different reasoning path.
 
 [ref-ai-overview]: /admin/ai
 [ref-byom]: /admin/ai/bring-your-own-model
+[ref-embedding]: /embedding

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
@@ -18,3 +18,16 @@ Cube includes a library of built-in chart types covering the most common visuali
 - [HTML](/docs/explore-analyze/charts/chart-types/html)
 
 For configuration options that apply across chart types — axes, color, series settings, tooltips — see [Configure charts](/docs/explore-analyze/charts/configuration).
+
+## Searching for a chart type
+
+The chart type picker's search box also resolves chart concepts Cube doesn't ship as a
+dedicated type — searching "gauge," "waterfall," "sankey," "treemap," "radar," "sunburst,"
+or "choropleth" surfaces the closest built-in alternative and what it can and can't do,
+for example pointing "gauge" to a KPI's progress ring. The search also indexes existing
+settings — donut shape, map projection, small multiples, color-scale rules — so they're
+findable by name even if you don't know which chart type or tab they live under.
+
+Chart types that don't fit your current query are greyed out in the picker, with a
+tooltip naming what's missing (for example, "Needs 1 measure" or "Needs 2 time
+dimensions").

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -28,3 +28,12 @@ Drag the **Inner radius** slider in the Style tab or enter a pixel value. Settin
 ## Color and slice ordering
 
 Slices are colored using the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking) in palette order, matched to the sort order of your query results. To change which slice appears first, adjust the sort in the results table.
+
+## Grouping small slices
+
+Use **Slice grouping** in the Fields tab to collapse low-value categories into a single named slice instead of cluttering the chart with slivers. Choose one of two modes:
+
+- **Minimal share** — group any category below a percentage threshold you set.
+- **Top N values** — keep only the top N categories by value and group the rest.
+
+The grouped slice's name is editable (defaults to "Other"). Its value is the sum of the measure across every category it absorbed, so it isn't directly comparable to the other slices, which each show one category's exact value.

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -17,6 +17,12 @@ Pick a dimension in **Split by** and the chart is replaced by one panel per valu
 
 Only dimensions are offered. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
 
+### Splitting by a second dimension
+
+Once **Split by** is set, a **Second dimension** picker appears. Pick a dimension there to
+lay panels out on a 2-D grid — the first dimension's values run down the rows and the
+second dimension's values run across the columns, instead of a single row of panels.
+
 ## Options
 
 These options appear once a **Split by** dimension is chosen.
@@ -54,7 +60,6 @@ A legend is shared across the grid rather than repeated per panel. Clicking a le
 
 ## Limitations
 
-- **One split dimension.** One dimension fills the grid, panel by panel. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
 - **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, boxplot, map, and HTML charts cannot be split.
 - **Panel labels are not configurable.** Each panel is labeled with its dimension value; the font, size, and color are fixed.
 - **The split is enabled on a single-view chart.** A chart that already carries data labels, a reference line, or a second Y axis series cannot be split — turn the split on first. The order is the only constraint: once a chart is split, data labels and reference lines can be added freely and are drawn in every panel.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -27,7 +27,15 @@ Each chart shows the name of the underlying workbook tab as its title. To rename
 
 Use **Hide Title** in the widget's settings menu to suppress the title on the dashboard — useful when the chart's content already makes the subject obvious, or when an adjacent [text widget][ref-text] provides its own heading. Choose **Show Title** in the same menu to bring it back.
 
+## Downloading a chart
+
+Open a chart widget's `⋮` menu on a published dashboard and choose **Download as CSV**,
+**Download as PNG**, or **Download as PDF** to export just that chart, without downloading
+the whole dashboard. Requires the **Download data** permission. See [Download as PNG or
+PDF][ref-dashboard-download] for the whole-dashboard equivalent.
+
 [ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-dashboard-download]: /docs/explore-analyze/dashboards#download-as-png-or-pdf
 [ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
 [ref-incompatible-controls]: /docs/explore-analyze/dashboards/widgets/controls#incompatible-controls
 [ref-text]: /docs/explore-analyze/dashboards/widgets/text

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -142,6 +142,12 @@ For [time granularity switchers][ref-time-grain], the dimension picker is restri
 
 Mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire controls across charts that use different semantic views without you needing to revisit each chart manually.
 
+#### Mapping suggestions across views
+
+When a chart's semantic view differs from the dimensions the dashboard's controls already target, the chart shows a banner — "Chart not connected to all filters" — naming how many controls could be connected to it. Click **Review** to open **Controls mapping** with name-matched dimensions on the chart's view already suggested for each control, or **Dismiss** to hide the banner for that chart.
+
+Suggestions are staged, not applied automatically — each proposed mapping is marked "Mapping suggestion. Save to apply." until you save. Saving shows a confirmation ("N controls connected") with an **Undo** action.
+
 [ref-time-grain]: #time-granularity-switcher
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -187,7 +187,8 @@ For any MCP-compatible client:
 
 An MCP client is not locked to a single deployment for the whole session. After
 connecting, it can discover the deployments and agents you can access and target a
-specific one on each request.
+specific one on each request — every tool accepts an optional `deploymentId`, validated
+on each call against the deployments you can actually access.
 
 Three tools work together:
 
@@ -204,6 +205,10 @@ Three tools work together:
     configured agent.
 - **`loadQueryResults`** — paginates through the results of a previous query on the same
   deployment context.
+
+Every other tool below — query, discovery, dashboard authoring, data model editing, and
+pre-aggregations — also accepts an optional `deploymentId` to target a deployment other
+than the session default.
 
 A typical client workflow:
 

--- a/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
+++ b/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
@@ -35,6 +35,10 @@ From the IDE, users can pull semantic views from Snowflake and turn them into cu
 
 This allows you to leverage existing Snowflake semantic views in Cube without manual conversion, ensuring consistency between your Snowflake and Cube definitions.
 
+To pull only specific views instead of the whole schema, enter their names
+(comma-separated, `*` wildcards supported) in the **Views** field of the pull dialog.
+Leave it empty to pull every semantic view in the schema, as before.
+
 ## Push Integration
 
 Alternatively, you can push Cube views into Snowflake as native semantic views. The push integration creates DDL from Cube's definitions and executes it in Snowflake, creating Snowflake Semantic Views that match your Cube schema.

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -360,6 +360,20 @@ of the PostgreSQL documentation.
 | --- | --- | --- | --- |
 | `TO_CHAR` | Converts a timestamp to string according to the given format | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 
+### Type casts
+
+<Info>
+
+Learn more in the
+[relevant section](https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS)
+of the PostgreSQL documentation.
+
+</Info>
+
+| Cast | Description |
+| --- | --- |
+| `::regtype`, `::regtype[]` | Resolves an OID column (e.g., `pg_attribute.atttypid`) to a Postgres type name. Used by BI tools that inspect table columns over the Postgres wire protocol. |
+
 ### Date/time functions
 
 <Info>


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Found via a routine sweep of recent commits in `cube-js/cube` and `cubedevinc/cubejs-enterprise` cross-checked against docs-mintlify for undocumented customer-facing changes.

- SQL API: `::regtype` / `::regtype[]` cast support (#11503 shipped without docs)
- Dashboard controls: cross-view mapping suggestion banner (`controls.mdx`)
- Pie/donut chart: grouping small slices into an "Other" bucket (`pie.mdx`)
- Chart type picker: searching for unsupported chart concepts, and the unmet-requirement tooltip on disabled entries (`chart-types/index.mdx`)
- Small multiples: splitting by a second dimension — this was previously documented as unsupported; removed the now-false limitation (`small-multiples.mdx`)
- Chart widgets: per-widget CSV/PNG/PDF download (`widgets/charts.mdx`)
- MCP server: `deploymentId` is accepted by every tool, not just `chat` (`mcp-server.mdx`)
- Snowflake Semantic Views: scoping a pull to named views via the new **Views** field (`snowflake-semantic-views.mdx`)
- AI Tokens: embedded users' token spend is billed outside seat coverage (`ai-tokens.mdx`)

Excluded from this pass (flag-gated / not yet on by default, or already documented elsewhere): the Dashboard Apps component library, the Board dashboard-editor engine, AI token allowance on the Billing page, and the centralized MCP endpoint rollout. A larger rework — the "AI Summary" widget being renamed to "Analysis" with new refresh UI — is tracked separately as a Linear ticket since it needs a near-full rewrite of its docs page rather than a section add.