### PR TITLE
docs(dashboards): document drag-to-place for dashboard widgets (CUB-3179)

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -15,7 +15,20 @@ The dashboard builder supports the following widget types:
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
 - [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks (in preview)
 
-In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
+## Adding widgets
+
+Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
+
+Each toolbar item can be added in two ways:
+
+- **Click** it to drop the widget into the first open spot on the canvas.
+- **Drag** it from the toolbar onto the canvas to place it exactly where you want. As you drag, a full-size placeholder previews the widget's footprint and the surrounding widgets reflow to open a slot; release to drop it there. Dragging is especially handy on dense dashboards, where clicking would otherwise place the new widget far down the page.
+
+<Warning>
+
+Dragging a toolbar item to place it exactly (drag-to-place) is currently in preview, and the behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate it for your account. Clicking to add a widget is available to everyone.
+
+</Warning>
 
 ## Arranging widgets
 


### PR DESCRIPTION
## What

Documents the new **drag-to-place** behavior for adding widgets to a dashboard, alongside the existing click-to-add. Adds a short *Adding widgets* section to the dashboard **Widgets** overview page describing the two placement modes:

- **Click** a toolbar item → widget drops into the first open spot (existing behavior).
- **Drag** a toolbar item onto the canvas → a full-size placeholder previews the footprint, surrounding widgets reflow, and the widget lands where you release. Useful on dense dashboards where auto-placement would drop it far down the page.

## Why

Ships alongside the product change in [cubedevinc/cubejs-enterprise#13820](https://github.com/cubedevinc/cubejs-enterprise/pull/13820) (CUB-3179). One page touched: `docs/explore-analyze/dashboards/widgets/index.mdx`.

> **Note on rollout:** drag-to-place is currently available on the new UI Kit Board dashboard engine (behind the `useBoardDashboards` flag) and is not yet GA for all tenants. Hold merge until the feature is generally available so the docs match what users see, or merge now if the engine is being rolled out broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)