### PR TITLE
docs(dashboards): document Spacer & Divider layout widgets

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -125,6 +125,9 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
             - Filter widget
             - Time grain switcher
           - AI summary
+          - Layout
+            - Spacer
+            - Divider
     - **Dashboard**
       - Scheduled refresh
     - **Semantic Model**

--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -122,8 +122,8 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
           - Charts
           - Text
           - Controls 
-            - Filter widget
-            - Time grain switcher
+            - Filter
+            - Time granularity
           - AI summary
           - Layout
             - Spacer

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -114,7 +114,8 @@
                       "docs/explore-analyze/dashboards/widgets/charts",
                       "docs/explore-analyze/dashboards/widgets/text",
                       "docs/explore-analyze/dashboards/widgets/controls",
-                      "docs/explore-analyze/dashboards/widgets/ai-summary"
+                      "docs/explore-analyze/dashboards/widgets/ai-summary",
+                      "docs/explore-analyze/dashboards/widgets/layout"
                     ]
                   },
                   "docs/explore-analyze/dashboards/styling",

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
@@ -7,7 +7,7 @@ AI summary widgets generate a natural-language summary of the data shown on the 
 
 ## Adding an AI summary
 
-In the [dashboard builder][ref-workbooks], click **Add AI Summary** in the toolbar. The widget opens with a prompt editor — write your prompt and click **Generate Summary** to produce the first response.
+In the [dashboard builder][ref-workbooks], add an AI summary from the **Add Widgets** menu in the toolbar. The widget opens with a prompt editor — write your prompt and click **Generate Summary** to produce the first response.
 
 ## Use cases
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Widgets
-description: Building blocks for dashboards — charts, text, controls, and AI summaries that you arrange on the canvas to tell your data story.
+description: Building blocks for dashboards — charts, text, controls, AI summaries, and layout elements that you arrange on the canvas to tell your data story.
 ---
 
-Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, or an AI-generated summary. Combine them to assemble polished, interactive views of your data.
+Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, an AI-generated summary, or a layout element such as a spacer or divider. Combine them to assemble polished, interactive views of your data.
 
 ## Widget types
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data or switch the time granularity
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
+- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks (in preview)
 
 In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -13,7 +13,8 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data or switch the time granularity
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
+- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
 
-In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, click **Add Text** or **Add AI Summary**, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
+In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -17,13 +17,13 @@ A divider is a horizontal separator line that breaks up the layout flow — a li
 
 ## Adding a layout widget
 
-In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer** or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer) resize it. To remove a layout widget, hover it in edit mode and click the remove control.
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer** or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer) resize it.
 
 ## Styling
 
 Both widgets follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
 
 - The **divider** draws its line using the widget **border** width, style, and color.
-- A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see, but stays invisible on the published dashboard.
+- A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,0 +1,29 @@
+---
+title: Spacer & Divider
+description: Non-data layout elements — a spacer for whitespace and a divider line — that help you structure a dashboard.
+---
+
+Spacer and divider are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace and visual structure to a dashboard.
+
+## Spacer
+
+A spacer is an empty, resizable box. Use it to add deliberate whitespace between widgets — for example, to separate a header row from the charts below it, or to push a widget into a particular column.
+
+A spacer is only visible while you are editing in the [dashboard builder][ref-workbooks]. On the published dashboard (including [embedded views](/embedding/iframe/dashboards)) it renders as empty space, so it never draws a card or border for viewers.
+
+## Divider
+
+A divider is a horizontal separator line that breaks up the layout flow — a lightweight way to signal the boundary between sections of a dashboard. Unlike other widgets, a divider is a fixed height and **cannot be resized** vertically.
+
+## Adding a layout widget
+
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer** or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer) resize it. To remove a layout widget, hover it in edit mode and click the remove control.
+
+## Styling
+
+Both widgets follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
+
+- The **divider** draws its line using the widget **border** width, style, and color.
+- A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see, but stays invisible on the published dashboard.
+
+[ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -3,6 +3,12 @@ title: Spacer & Divider
 description: Non-data layout elements — a spacer for whitespace and a divider line — that help you structure a dashboard.
 ---
 
+<Warning>
+
+Spacer and divider widgets are currently in preview, and their behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate them for your account.
+
+</Warning>
+
 Spacer and divider are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace and visual structure to a dashboard.
 
 ## Spacer

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/text.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/text.mdx
@@ -7,7 +7,7 @@ Text widgets render Markdown content directly on the dashboard. Use them to add 
 
 ## Adding a text widget
 
-In the [dashboard builder][ref-workbooks], click **Add Text** in the toolbar. A new text widget is added to the canvas with an empty editor.
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Text**. A new text widget is added to the canvas with an empty editor.
 
 ## Use cases
 


### PR DESCRIPTION
## What & why

Documents the two non-data **inline layout** widgets added to the dashboard builder in [CUB-3039](https://linear.app/cube-d3/issue/CUB-3039/add-spacer-and-divider-inline-layout-elements-to-the-dashboard-builder) (implemented in cubejs-enterprise#13725):

- **Spacer** — an empty, resizable box for whitespace between widgets; invisible on published/embedded dashboards.
- **Divider** — a fixed, non-resizable separator line for section breaks.

Both follow the dashboard's widget styling settings (border width/style/color), matching the ticket's requirement that they "obey the dashboard styling settings for widgets".

## Changes

- New page `docs/explore-analyze/dashboards/widgets/layout.mdx` ("Spacer & Divider").
- Linked from the Widgets index and added to the Dashboards → Widgets nav in `docs.json`.

Kept intentionally brief, matching the style of the existing widget pages (text, controls, ai-summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)