### PR TITLE
docs: multi-select and group move/delete of dashboard widgets

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -20,6 +20,12 @@ In the dashboard builder, add widgets using the toolbar at the top of the canvas
 
 Drag any widget to move it, and use the handle in its bottom-right corner to resize it — the surrounding widgets shift to make room.
 
+<Warning>
+
+Selecting multiple widgets and moving or deleting them as a group is currently in preview, and the behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate it for your account.
+
+</Warning>
+
 To work with several widgets at once, select them first:
 
 - **Click** a widget to select it.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -16,4 +16,19 @@ The dashboard builder supports the following widget types:
 
 In the dashboard builder, add widgets using the toolbar at the top of the canvas: pick reports from the **Charts** picker to add charts, click **Add Text** or **Add AI Summary**, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
 
+## Arranging widgets
+
+Drag any widget to move it, and use the handle in its bottom-right corner to resize it — the surrounding widgets shift to make room.
+
+To work with several widgets at once, select them first:
+
+- **Click** a widget to select it.
+- **Shift-click** to add widgets to, or remove them from, the selection.
+- **Drag a marquee** — press on any empty part of the canvas and drag a rectangle over the widgets you want; every widget it touches is selected. The marquee can start anywhere on the empty canvas, including the far edges and corners.
+
+With a selection in place:
+
+- **Move the group** — drag any selected widget and the whole selection moves together, keeping its relative arrangement.
+- **Delete the group** — press **Delete** or **Backspace** to remove every selected widget at once.
+
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -24,7 +24,7 @@ To work with several widgets at once, select them first:
 
 - **Click** a widget to select it.
 - **Shift-click** to add widgets to, or remove them from, the selection.
-- **Drag a marquee** — press on any empty part of the canvas and drag a rectangle over the widgets you want; every widget it touches is selected. The marquee can start anywhere on the empty canvas, including the far edges and corners.
+- **Drag a marquee** — press on any empty part of the canvas and drag a rectangle over the widgets you want; every widget it touches is selected.
 
 With a selection in place:
 


### PR DESCRIPTION
Adds a brief **Arranging widgets** section to the dashboards → widgets docs, covering how to move/resize a widget and how to work with several at once:

- select via click, shift-click, or a marquee drag (which can start anywhere on the empty canvas, including the far corners);
- move the whole selection together;
- delete the selection at once with Delete/Backspace.

Companion to the console-ui work in cubedevinc/cubejs-enterprise#14023 (CUB-3818), which lets the marquee start from the empty canvas edges.

> [!NOTE]
> Multi-select + group move/delete is a feature of the new Board-based dashboard builder, currently behind the `useBoardDashboards` preview flag. Hold this until that builder is the default for the docs' audience — or I can add a short "preview" caveat — your call before merging.