### PR TITLE
docs(dashboards): document per-chart PNG/PDF/CSV export (CUB-2707)

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -66,31 +66,35 @@ options sidebar warns you to update those links.)
 
 </Note>
 
-## Download as PNG or PDF
+## Download as PNG, PDF, or CSV {#download-as-png-or-pdf}
 
 Open a published dashboard, click the **More actions** (`⋯`) button in the
 header, and choose **Download as PNG** or **Download as PDF**. The file is
 named after the dashboard's title.
 
-To export a **single chart** instead of the whole dashboard, hover the chart,
-open its **⋮** menu, and choose **Download as PNG** or **Download as PDF** —
-the same menu also offers **Download as CSV** for the chart's underlying data.
-The image captures just that chart, named after the chart's title.
+To export a **single chart** instead of the whole dashboard, hover the chart
+widget, open its **⋮** menu, and choose **Download as PNG** or **Download as
+PDF** — the same menu also offers **Download as CSV** for the chart's
+underlying data. The image captures just that chart, named after the chart's
+title.
 
-The download is a server-rendered snapshot — Cube re-opens the dashboard (or,
-for a single chart, that chart on its own), waits for every widget to finish
-rendering, and captures the result. This can take up to a couple of minutes
+PNG and PDF downloads are server-rendered snapshots — Cube re-opens the
+dashboard (or, for a single chart, that chart on its own), waits for rendering
+to finish, and captures the result. This can take up to a couple of minutes
 for large dashboards. The filter and time-grain selections you currently have
-applied in your browser are carried into the export.
+applied in your browser are carried into the export. (CSV is generated from the
+data already loaded in the chart and downloads immediately.)
 
 Downloading the whole dashboard requires **Manage** permission on the workbook
-that owns it; exporting a single chart requires permission to download the
-deployment's data. The same screenshot mechanism powers PNG/PDF attachments on
-[notifications][ref-notifications] sent after a [scheduled
-refresh][ref-scheduled-refreshes].
+that owns it; exporting a single chart requires the **Download data**
+permission, which is also subject to the account-wide [data download
+controls][ref-data-download-controls]. The same screenshot mechanism powers
+PNG/PDF attachments on [notifications][ref-notifications] sent after a
+[scheduled refresh][ref-scheduled-refreshes].
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-widgets]: /docs/explore-analyze/dashboards/widgets
 [ref-dimension-links]: /docs/data-modeling/dimensions#links
 [ref-notifications]: /docs/explore-analyze/notifications
 [ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes
+[ref-data-download-controls]: /admin/users-and-permissions/roles-and-permissions#restricting-data-downloads

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -72,14 +72,20 @@ Open a published dashboard, click the **More actions** (`⋯`) button in the
 header, and choose **Download as PNG** or **Download as PDF**. The file is
 named after the dashboard's title.
 
-The download is a server-rendered snapshot — Cube re-opens the dashboard,
-waits for every widget to finish rendering, and captures the result. This
-can take up to a couple of minutes for large dashboards. Filter or time
-grain selections you change in your browser before clicking **Download**
-are not applied; the snapshot uses the dashboard's saved state.
+To export a **single chart** instead of the whole dashboard, hover the chart,
+open its **⋮** menu, and choose **Download as PNG** or **Download as PDF** —
+the same menu also offers **Download as CSV** for the chart's underlying data.
+The image captures just that chart, named after the chart's title.
 
-Available to users with **Manage** permission on the workbook that owns
-the dashboard. The same screenshot mechanism powers PNG/PDF attachments on
+The download is a server-rendered snapshot — Cube re-opens the dashboard (or,
+for a single chart, that chart on its own), waits for every widget to finish
+rendering, and captures the result. This can take up to a couple of minutes
+for large dashboards. The filter and time-grain selections you currently have
+applied in your browser are carried into the export.
+
+Downloading the whole dashboard requires **Manage** permission on the workbook
+that owns it; exporting a single chart requires permission to download the
+deployment's data. The same screenshot mechanism powers PNG/PDF attachments on
 [notifications][ref-notifications] sent after a [scheduled
 refresh][ref-scheduled-refreshes].
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -87,10 +87,10 @@ data already loaded in the chart and downloads immediately.)
 
 Downloading the whole dashboard requires **Manage** permission on the workbook
 that owns it; exporting a single chart requires the **Download data**
-permission, which is also subject to the account-wide [data download
-controls][ref-data-download-controls]. The same screenshot mechanism powers
-PNG/PDF attachments on [notifications][ref-notifications] sent after a
-[scheduled refresh][ref-scheduled-refreshes].
+permission. Both are hidden entirely when an admin turns off the account-wide
+[data download controls][ref-data-download-controls]. The same screenshot
+mechanism powers PNG/PDF attachments on [notifications][ref-notifications] sent
+after a [scheduled refresh][ref-scheduled-refreshes].
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-widgets]: /docs/explore-analyze/dashboards/widgets


### PR DESCRIPTION
## What

Updates the **Dashboards → Download as PNG or PDF** page to reflect two things that shipped but weren't documented:

1. **Per-chart export.** You can export an individual chart (not just the whole dashboard) as PNG or PDF — and CSV for its underlying data — from the chart's ⋮ menu. The page previously only documented the whole-dashboard export via the header ⋯ menu.
2. **Fixes a stale caveat.** The page claimed *"Filter or time grain selections you change in your browser before clicking Download are not applied."* That's no longer true — both the whole-dashboard export and the new per-chart export carry the viewer's current filter/time-grain selections into the snapshot.

Also clarifies the permission difference: whole-dashboard export needs **Manage** on the workbook; per-chart export needs data-download permission.

Corresponds to product feature [CUB-2707](https://linear.app/cube-d3/issue/CUB-2707/download-individual-dashboard-charts-as-pdf-and-png) (cubejs-enterprise #13757).