### PR TITLE
docs: fill four gaps found in a customer-facing feature sweep

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/index.mdx
@@ -15,6 +15,8 @@ Chart type icons at the top of the chart panel let you quickly switch between co
 
 Cube automatically picks a chart type when you run a new query. Any manual configuration you apply is preserved when you change query fields.
 
+If a later change to the query — like removing a dimension or measure — leaves the applied chart type unable to render the result, Cube shows a warning naming the chart type and what it still needs. From there you can undo the change that broke it or pick a different chart type that fits the current query.
+
 ### Resetting chart settings
 
 To discard your configuration and let Cube re-select a chart type based on the current query, open the tab options menu and choose **Reset chart**.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -108,6 +108,8 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
+The reverse case — adding a chart from a different semantic view than the dashboard's existing controls (a **cross-view** chart) — isn't wired up automatically, since a same-named dimension on another view isn't necessarily the same dimension. Instead, Cube prompts you to review it: a banner names how many controls could apply, and **Review…** opens [Controls mapping](#controls-mapping) with a suggested dimension already picked for each match. Save to connect them, or **Dismiss** the banner to leave the chart unconnected. A confirmation after saving lets you **Undo** the connection.
+
 ### Incompatible controls
 
 If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Controls of the other type still apply — for example, if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa.
@@ -130,12 +132,13 @@ Open **Controls mapping** from a chart's settings menu to inspect or override th
 - **Toggle the control on or off** for the chart, even when a mapping exists
 - **Pick a different dimension** from the chart's semantic view to remap the control to
 
-Three states show up in the mapping sidebar:
+Four states show up in the mapping sidebar:
 
 | Status | What it means |
 |---|---|
 | **Mapped automatically** | The control's dimension exists on the chart's semantic view, so it's wired up without configuration. |
 | **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
+| **Suggested mapping** | Cube found a matching dimension on a cross-view chart but hasn't applied it yet — save to apply it, or pick a different dimension. |
 | **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view. The chart is unaffected by the control until you map it manually. |
 
 For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -219,7 +219,9 @@ granularity — a month grain offers **Previous period**, **Same period
 previous quarter**, and **Same period previous year** — so the comparison
 period always aligns exactly with the current buckets. A measure can have
 several comparisons active at once, such as month over month and year over
-year side by side.
+year side by side. If the query has more than one time dimension, the same
+comparison can also be applied under each of them independently — each
+combination gets its own derived columns.
 
 Each comparison adds derived columns next to the measure. Choose which ones
 to show under **Comparison columns** in the same menu:

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -404,6 +404,20 @@ deployment is shown in the dbt settings card, ready to drop into a CI step.
   />
 </Frame>
 
+The trigger call accepts an optional `ref` — a branch or tag in your dbt repository —
+to sync from for that call only, without changing the branch saved on the
+integration. Use it in a pull request pipeline to test the ref under review before it
+merges.
+
+The response includes a `syncJobId`, which a pipeline can use to wait on the sync
+instead of firing the trigger and moving on blind:
+
+| Call | What it does |
+| --- | --- |
+| `GET .../dbt-sync/{syncJobId}` | Returns the sync's current `status`. Poll it until `status` reaches `COMPLETED` or `FAILED`. |
+| `GET .../dbt-sync/{syncJobId}/result` | Once `status` is `COMPLETED`, returns the generated cube files and cube count. |
+| `DELETE .../dbt-sync/{syncJobId}` | Cancels a sync that's still running — for example, when a newer push supersedes it. |
+
 ### Trigger on every push
 
 Register a webhook on your dbt repository so Cube syncs automatically whenever the


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Routine sweep of recent `cubejs-enterprise` merges cross-checked against docs-mintlify turned up four shipped, customer-facing behaviors with no documentation. All four are small, surgical additions to existing pages:

- **`docs/integrations/dbt.mdx`** — dbt Sync's public trigger endpoint now accepts an optional `ref` to sync a specific branch/tag for one call (e.g. testing a PR branch before merge), and the previously browser-only status/result/cancel operations are now exposed on the same public, deployment-scoped API so a CI pipeline can start a sync, poll it, and fail the build on error (`cubejs-enterprise#13972`, CUB-3777).
- **`docs/explore-analyze/charts/index.mdx`** — Cube now warns when a later query edit leaves the applied chart type unable to render the result, naming the chart type and offering to undo the edit or pick a different type (`cubejs-enterprise#13942`, CUB-3808).
- **`docs/explore-analyze/dashboards/widgets/controls.mdx`** — adding a chart from a different semantic view than the dashboard's existing controls now surfaces a suggestion prompt (Review… / Dismiss, with Undo after connecting) instead of leaving the chart silently unconnected; added the corresponding "Suggested mapping" state to the mapping-states table (`cubejs-enterprise#13630`).
- **`docs/explore-analyze/workbooks/querying-data.mdx`** — clarified that the same period-comparison offset can now be applied under more than one time-dimension anchor in the same query, each producing its own derived columns (`cubejs-enterprise#13859`, CUB-3459).

No new pages were needed — each fits naturally into an existing section.

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DHtykLftyn3aDkcxgUfZih)_