### PR TITLE
feat(cube-cli): add `cube spec`, and regenerate the Platform API reference

### DIFF
--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -285,6 +285,77 @@ paths:
       summary: Start a dbt sync for a deployment
       tags:
         - dbt Sync
+  /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}:
+    delete:
+      operationId: cancelDbtSync
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: syncJobId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DbtSyncCancelResponse'
+          description: ''
+      summary: Cancel a running dbt sync
+      tags:
+        - dbt Sync
+    get:
+      operationId: getDbtSyncStatus
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: syncJobId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DbtSyncStatusResponse'
+          description: ''
+      summary: Get the status of a dbt sync
+      tags:
+        - dbt Sync
+  /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/result:
+    get:
+      operationId: getDbtSyncResult
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: syncJobId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DbtSyncResultResponse'
+          description: ''
+      summary: Get the result of a completed dbt sync
+      tags:
+        - dbt Sync
   /api/v1/deployments/{deploymentId}/env-vars:
     get:
       operationId: getEnvVariables
@@ -337,7 +408,9 @@ paths:
         content: >-
           Upserts deployment environment variables by name; variables not included keep their
           existing values. Passing the `[ENCRYPTED]` placeholder (the masked read value) is rejected
-          — omit variables you do not intend to change.
+          — omit variables you do not intend to change. New variable names must be POSIX identifiers
+          (`^[A-Za-z_][A-Za-z0-9_]*$`); names already stored on the deployment may be resent
+          unchanged so a legacy name can still be updated or removed.
   /api/v1/deployments/{deploymentId}/environments:
     get:
       operationId: getDeploymentEnvironments
@@ -1575,6 +1648,55 @@ paths:
       summary: Refresh report
       tags:
         - Reports
+  /api/v1/deployments/{deploymentId}/settings:
+    get:
+      operationId: getDeploymentSettings
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentSettings'
+          description: ''
+      summary: >-
+        Read every setting of a deployment - the full contents of the console Settings pages
+        (general, configuration flags, deploy, launchpad, Cube Store private storage). Secrets are
+        excluded; read environment variables through `/env-vars` instead.
+      tags:
+        - Deployments
+    put:
+      operationId: updateDeploymentSettings
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDeploymentInput'
+        description: UpdateDeploymentInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentSettings'
+          description: ''
+      summary: >-
+        Update any subset of a deployment's settings and read the full settings back. Omitted fields
+        are left alone, and `templateVariables` is merged key-by-key rather than replaced.
+      tags:
+        - Deployments
   /api/v1/deployments/{deploymentId}/shared-workspace:
     get:
       operationId: sharedWorkspaceObjects
@@ -1918,37 +2040,6 @@ paths:
                 $ref: '#/components/schemas/WorkbookDashboard'
           description: ''
       summary: Update workbook dashboard
-      tags:
-        - Workbooks
-  /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/dashboard/ai-widget-thread:
-    post:
-      operationId: updatePublishedDashboardAiWidgetThread
-      parameters:
-        - in: path
-          name: deploymentId
-          required: true
-          schema:
-            type: number
-        - in: path
-          name: workbookId
-          required: true
-          schema:
-            type: number
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdatePublishedAiWidgetThreadInput'
-        description: UpdatePublishedAiWidgetThreadInput
-        required: false
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Dashboard'
-          description: ''
-      summary: Update published dashboard AI widget thread
       tags:
         - Workbooks
   /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/duplicate:
@@ -3747,6 +3838,39 @@ paths:
       summary: Create a branch (optionally entering dev mode on it)
       tags:
         - Data Model
+  /build/api/v1/deployments/{deploymentId}/branches/staging-environment:
+    put:
+      operationId: setBranchStagingEnvironment
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetBranchStagingEnvironmentRequest'
+        description: SetBranchStagingEnvironmentRequest
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetBranchStagingEnvironmentResponse'
+          description: ''
+      summary: Enable or disable a branch's staging environment
+      tags:
+        - Data Model
+      x-mint:
+        content: >-
+          Enabling a branch keeps its staging environment always active and accessible at
+          `<deploymentUrl>/dev-mode/{branchName}/cubejs-api/v1`; disabled (the default) it is only
+          active while the branch is viewed in Cube Cloud. Enabled branches are the ones listed by
+          `GET /api/v1/deployments/{deploymentId}/environments?type=staging`. Only shared branches
+          qualify — personal dev branches and the deploy branch are rejected.
   /build/api/v1/deployments/{deploymentId}/commit:
     post:
       operationId: commitChanges
@@ -4243,6 +4367,10 @@ components:
           oneOf:
             - $ref: '#/components/schemas/SheetsUiSettings'
             - type: 'null'
+        timezoneSettings:
+          oneOf:
+            - $ref: '#/components/schemas/TimezoneSettings'
+            - type: 'null'
       required:
         - applyThemeGlobally
       type: object
@@ -4308,6 +4436,10 @@ components:
       properties:
         id:
           type: integer
+        isStagingEnvironmentEnabled:
+          oneOf:
+            - type: boolean
+            - type: 'null'
         lastHash:
           oneOf:
             - type: string
@@ -5015,6 +5147,60 @@ components:
             - type: string
             - type: 'null'
       type: object
+    CspsConfig:
+      properties:
+        awsRoleArn:
+          oneOf:
+            - type: string
+            - type: 'null'
+        azureClientId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        azureContainer:
+          oneOf:
+            - type: string
+            - type: 'null'
+        azureStorageAccount:
+          oneOf:
+            - type: string
+            - type: 'null'
+        azureTenantId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        enabled:
+          type: boolean
+        gcpServiceAccountEmail:
+          oneOf:
+            - type: string
+            - type: 'null'
+        gcpWorkloadIdentityProvider:
+          oneOf:
+            - type: string
+            - type: 'null'
+        gcsBucket:
+          oneOf:
+            - type: string
+            - type: 'null'
+        s3Bucket:
+          oneOf:
+            - type: string
+            - type: 'null'
+        s3Region:
+          oneOf:
+            - type: string
+            - type: 'null'
+        s3Sse:
+          oneOf:
+            - type: string
+            - type: 'null'
+        storageProvider:
+          type: string
+      required:
+        - enabled
+        - storageProvider
+      type: object
     CspsConfigInput:
       properties:
         awsRoleArn:
@@ -5707,8 +5893,10 @@ components:
         - TEXT
         - FILTER
         - AI
-        - TABS_CONTAINER
         - TIME_GRAIN
+        - SPACER
+        - DIVIDER
+        - CONTAINER
       type: string
     DashboardWidgetInput:
       properties:
@@ -5718,6 +5906,7 @@ components:
               additionalProperties: true
             - type: 'null'
         id:
+          maxLength: 128
           type: string
         position:
           $ref: '#/components/schemas/DashboardWidgetPositionInput'
@@ -5743,8 +5932,10 @@ components:
         - TEXT
         - FILTER
         - AI
-        - TABS_CONTAINER
         - TIME_GRAIN
+        - SPACER
+        - DIVIDER
+        - CONTAINER
       type: string
     DashboardWidgetPosition:
       properties:
@@ -5812,6 +6003,53 @@ components:
       required:
         - success
       type: object
+    DbtSyncCancelResponse:
+      properties:
+        message:
+          type: string
+      required:
+        - message
+      type: object
+    DbtSyncGeneratedFile:
+      properties:
+        path:
+          description: Path of the generated file within the data model project.
+          type: string
+      required:
+        - path
+      type: object
+    DbtSyncManifestStats:
+      properties:
+        macros:
+          type: integer
+        models:
+          type: integer
+        sources:
+          type: integer
+      required:
+        - models
+        - sources
+        - macros
+      type: object
+    DbtSyncProgress:
+      properties:
+        message:
+          oneOf:
+            - type: string
+              description: Human-readable description of what the sync is doing right now.
+            - type: 'null'
+        percentComplete:
+          description: >-
+            Rough completion percentage derived from the stage. Progress reporting only — do not
+            gate on it; gate on the status reaching COMPLETED or FAILED.
+          type: integer
+        stage:
+          description: The stage the sync is currently in, from the same set of values as the sync status.
+          type: string
+      required:
+        - stage
+        - percentComplete
+      type: object
     DbtSyncResponse:
       properties:
         branchName:
@@ -5824,6 +6062,61 @@ components:
         - syncJobId
         - workflowId
         - branchName
+      type: object
+    DbtSyncResultResponse:
+      properties:
+        completedAt:
+          description: When the sync finished, as an ISO 8601 timestamp.
+          type: string
+        cubeCount:
+          description: How many cubes the sync generated from the dbt manifest.
+          type: integer
+        durationMs:
+          description: End-to-end sync duration in milliseconds.
+          type: integer
+        generatedFiles:
+          description: The cube files this sync generated and committed to the branch it created.
+          items:
+            $ref: '#/components/schemas/DbtSyncGeneratedFile'
+          type: array
+        manifestStats:
+          $ref: '#/components/schemas/DbtSyncManifestStats'
+        syncJobId:
+          type: string
+      required:
+        - syncJobId
+        - generatedFiles
+        - manifestStats
+        - cubeCount
+        - completedAt
+        - durationMs
+      type: object
+    DbtSyncStatusResponse:
+      properties:
+        error:
+          oneOf:
+            - type: string
+              description: Why the sync stopped. Present only when the status is FAILED.
+            - type: 'null'
+        progress:
+          $ref: '#/components/schemas/DbtSyncProgress'
+        status:
+          description: >-
+            One of INITIALIZING, CREATING_SANDBOX, UPLOADING_PROJECT, INSTALLING_DEPENDENCIES,
+            RUNNING_DBT_DEPS, COMPILING_DBT, PROCESSING_MANIFEST, WRITING_CUBE_FILES, FINALIZING,
+            COMPLETED, FAILED. COMPLETED and FAILED are the only terminal values: poll until one of
+            them, then read the result. Treat any unrecognized value as still running.
+          type: string
+        syncJobId:
+          type: string
+        updatedAt:
+          description: When this status was last updated, as an ISO 8601 timestamp.
+          type: string
+      required:
+        - syncJobId
+        - status
+        - progress
+        - updatedAt
       type: object
     Deployment:
       properties:
@@ -6031,6 +6324,160 @@ components:
       required:
         - items
       type: object
+    DeploymentSettings:
+      properties:
+        autoDomain:
+          oneOf:
+            - type: string
+            - type: 'null'
+        cloudProvider:
+          $ref: '#/components/schemas/DeploymentSettingsCloudProvider'
+        creationMethod:
+          oneOf:
+            - $ref: '#/components/schemas/DeploymentSettingsCreationMethod'
+            - type: 'null'
+        creationStep:
+          oneOf:
+            - $ref: '#/components/schemas/CreationStep'
+            - type: 'null'
+        cspsConfig:
+          oneOf:
+            - $ref: '#/components/schemas/CspsConfig'
+            - type: 'null'
+        cubeImageCloud:
+          oneOf:
+            - type: string
+            - type: 'null'
+        cubeImageVersion:
+          oneOf:
+            - type: string
+            - type: 'null'
+        customDomain:
+          oneOf:
+            - type: string
+            - type: 'null'
+        defaultLaunchpadViewGroup:
+          oneOf:
+            - type: string
+            - type: 'null'
+        deployBranchMergeAllowed:
+          type: boolean
+        deployBranchName:
+          type: string
+        deployBranchReadOnly:
+          type: boolean
+        deployMode:
+          oneOf:
+            - $ref: '#/components/schemas/DeploymentSettingsDeployMode'
+            - type: 'null'
+        deployProjectRoot:
+          type: string
+        deploymentUrl:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: integer
+        isCold:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        isCubeSqlEnabled:
+          type: boolean
+        isManaged:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        isSupportPreAggregations:
+          type: boolean
+        launchpadTabs:
+          oneOf:
+            - items:
+                type: string
+              type: array
+            - type: 'null'
+        name:
+          type: string
+        region:
+          oneOf:
+            - type: string
+            - type: 'null'
+        releaseChannel:
+          $ref: '#/components/schemas/DeploymentSettingsReleaseChannel'
+        releaseChannelVersion:
+          oneOf:
+            - type: string
+            - type: 'null'
+        releaseChannelVersionHold:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        repoType:
+          oneOf:
+            - $ref: '#/components/schemas/DeploymentSettingsRepoType'
+            - type: 'null'
+        shaderConfig:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfig'
+            - type: 'null'
+        targetPlatform:
+          oneOf:
+            - type: string
+            - type: 'null'
+        template:
+          $ref: '#/components/schemas/DeploymentSettingsTemplate'
+        templateVariables:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+      required:
+        - id
+        - name
+        - template
+        - cloudProvider
+        - releaseChannel
+        - deployBranchName
+        - deployBranchReadOnly
+        - deployBranchMergeAllowed
+        - deployProjectRoot
+        - isCubeSqlEnabled
+        - isSupportPreAggregations
+      type: object
+    DeploymentSettingsCloudProvider:
+      enum:
+        - cubecloud
+        - aws
+        - gcp
+      type: string
+    DeploymentSettingsCreationMethod:
+      enum:
+        - upload
+        - cubecloud
+        - github
+        - ssh
+      type: string
+    DeploymentSettingsDeployMode:
+      enum:
+        - git
+        - cli
+      type: string
+    DeploymentSettingsReleaseChannel:
+      enum:
+        - latest
+        - release
+      type: string
+    DeploymentSettingsRepoType:
+      enum:
+        - git
+        - deployRepo
+      type: string
+    DeploymentSettingsTemplate:
+      enum:
+        - single
+        - simpleCluster
+        - multiCluster
+      type: string
     DeploymentTokenResponse:
       properties:
         cubeApiToken:
@@ -6237,6 +6684,10 @@ components:
         showDashboardChat:
           oneOf:
             - type: boolean
+            - type: 'null'
+        timezone:
+          oneOf:
+            - type: string
             - type: 'null'
       type: object
     EmbedTenant:
@@ -7661,6 +8112,10 @@ components:
             - type: 'null'
         id:
           type: integer
+        isSourceReport:
+          oneOf:
+            - type: boolean
+            - type: 'null'
         kind:
           oneOf:
             - $ref: '#/components/schemas/ReportSnapshotDtoKind'
@@ -7839,6 +8294,28 @@ components:
         - name
         - actions
       type: object
+    SetBranchStagingEnvironmentRequest:
+      properties:
+        branchId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        branchName:
+          oneOf:
+            - type: string
+            - type: 'null'
+        enabled:
+          type: boolean
+      required:
+        - enabled
+      type: object
+    SetBranchStagingEnvironmentResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/BranchResponse'
+      required:
+        - data
+      type: object
     SetEnvVariablesInput:
       properties:
         env_variables:
@@ -7848,6 +8325,64 @@ components:
       required:
         - env_variables
       type: object
+    ShaderConfig:
+      properties:
+        chatModel:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfigChatModel'
+            - type: 'null'
+        ragModel:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfigRagModel'
+            - type: 'null'
+      type: object
+    ShaderConfigChatModel:
+      enum:
+        - gemini_1_5_pro
+        - gemini_2_0_flash_lite_preview
+        - gemini_2_0_flash_001
+        - gemini_2_0_flash_thinking_exp
+        - gemini_2_0_pro
+        - gemini_2_5_pro
+        - claude_3_5_sonnet
+        - claude_3_5_sonnetv2
+        - claude_3_7_sonnet
+      type: string
+    ShaderConfigInput:
+      properties:
+        chatModel:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfigInputChatModel'
+            - type: 'null'
+        ragModel:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfigInputRagModel'
+            - type: 'null'
+      type: object
+    ShaderConfigInputChatModel:
+      enum:
+        - gemini_1_5_pro
+        - gemini_2_0_flash_lite_preview
+        - gemini_2_0_flash_001
+        - gemini_2_0_flash_thinking_exp
+        - gemini_2_0_pro
+        - gemini_2_5_pro
+        - claude_3_5_sonnet
+        - claude_3_5_sonnetv2
+        - claude_3_7_sonnet
+      type: string
+    ShaderConfigInputRagModel:
+      enum:
+        - gemini_1_5_flash
+        - gemini_2_0_flash_lite_preview
+        - gemini_2_0_flash_001
+      type: string
+    ShaderConfigRagModel:
+      enum:
+        - gemini_1_5_flash
+        - gemini_2_0_flash_lite_preview
+        - gemini_2_0_flash_001
+      type: string
     SheetsUiSettings:
       properties:
         showAppliedFilters:
@@ -7870,6 +8405,15 @@ components:
         branchName:
           oneOf:
             - type: string
+            - type: 'null'
+        ref:
+          oneOf:
+            - type: string
+              description: >-
+                Git ref in the dbt repository to sync from — a branch or a tag, NOT a commit SHA.
+                Overrides the branch saved on the deployment’s dbt git integration for this sync
+                only, so CI can sync the ref under review (e.g. a pull request’s head branch)
+                instead of the tracked branch. The generated Cube branch is named after it.
             - type: 'null'
       type: object
     StartDevModeRequest:
@@ -7972,6 +8516,21 @@ components:
         - url
         - format
       type: object
+    TimezoneSettings:
+      properties:
+        allowUserOverride:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        enabled:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        timezone:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
     UpdateDashboardEmbeddingInput:
       properties:
         allowEmbed:
@@ -7999,6 +8558,10 @@ components:
       type: object
     UpdateDeploymentInput:
       properties:
+        cloudProvider:
+          oneOf:
+            - $ref: '#/components/schemas/UpdateDeploymentInputCloudProvider'
+            - type: 'null'
         creationMethod:
           oneOf:
             - $ref: '#/components/schemas/UpdateDeploymentInputCreationMethod'
@@ -8007,7 +8570,15 @@ components:
           oneOf:
             - $ref: '#/components/schemas/CspsConfigInput'
             - type: 'null'
+        cubeImageCloud:
+          oneOf:
+            - type: string
+            - type: 'null'
         customDomain:
+          oneOf:
+            - type: string
+            - type: 'null'
+        defaultLaunchpadViewGroup:
           oneOf:
             - type: string
             - type: 'null'
@@ -8031,11 +8602,52 @@ components:
           oneOf:
             - type: string
             - type: 'null'
+        launchpadTabs:
+          oneOf:
+            - items:
+                type: string
+              type: array
+            - type: 'null'
         name:
           oneOf:
             - type: string
             - type: 'null'
+        region:
+          oneOf:
+            - type: string
+            - type: 'null'
+        releaseChannel:
+          oneOf:
+            - $ref: '#/components/schemas/UpdateDeploymentInputReleaseChannel'
+            - type: 'null'
+        releaseChannelVersion:
+          oneOf:
+            - type: string
+            - type: 'null'
+        releaseChannelVersionHold:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        shaderConfig:
+          oneOf:
+            - $ref: '#/components/schemas/ShaderConfigInput'
+            - type: 'null'
+        template:
+          oneOf:
+            - $ref: '#/components/schemas/UpdateDeploymentInputTemplate'
+            - type: 'null'
+        templateVariables:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
       type: object
+    UpdateDeploymentInputCloudProvider:
+      enum:
+        - cubecloud
+        - aws
+        - gcp
+      type: string
     UpdateDeploymentInputCreationMethod:
       enum:
         - upload
@@ -8047,6 +8659,17 @@ components:
       enum:
         - git
         - cli
+      type: string
+    UpdateDeploymentInputReleaseChannel:
+      enum:
+        - latest
+        - release
+      type: string
+    UpdateDeploymentInputTemplate:
+      enum:
+        - single
+        - simpleCluster
+        - multiCluster
       type: string
     UpdateEmbedAccessInput:
       properties:
@@ -8235,20 +8858,6 @@ components:
               type: string
               maxLength: 128
             - type: 'null'
-      type: object
-    UpdatePublishedAiWidgetThreadInput:
-      properties:
-        checksum:
-          oneOf:
-            - type: string
-            - type: 'null'
-        threadId:
-          type: string
-        widgetId:
-          type: string
-      required:
-        - widgetId
-        - threadId
       type: object
     UpdateReportInput:
       properties:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -1664,12 +1664,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/DeploymentSettings'
           description: ''
-      summary: >-
-        Read every setting of a deployment - the full contents of the console Settings pages
-        (general, configuration flags, deploy, launchpad, Cube Store private storage). Secrets are
-        excluded; read environment variables through `/env-vars` instead.
+      summary: Get deployment settings
       tags:
         - Deployments
+      x-mint:
+        content: >-
+          Every setting of a deployment in one payload — the full contents of the console Settings
+          pages (general, configuration flags, deploy, launchpad, Cube Store private storage), plus
+          the read-only values displayed alongside them. Secrets are excluded; read environment
+          variables through `/env-vars` instead.
     put:
       operationId: updateDeploymentSettings
       parameters:
@@ -1692,11 +1695,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/DeploymentSettings'
           description: ''
-      summary: >-
-        Update any subset of a deployment's settings and read the full settings back. Omitted fields
-        are left alone, and `templateVariables` is merged key-by-key rather than replaced.
+      summary: Update deployment settings
       tags:
         - Deployments
+      x-mint:
+        content: >-
+          Update any subset of a deployment’s settings and read the full settings back. Fields you
+          omit are left alone, and `templateVariables` is merged key-by-key rather than replaced, so
+          setting one configuration flag never clears the others.
   /api/v1/deployments/{deploymentId}/shared-workspace:
     get:
       operationId: sharedWorkspaceObjects
@@ -6416,10 +6422,6 @@ components:
           oneOf:
             - $ref: '#/components/schemas/DeploymentSettingsRepoType'
             - type: 'null'
-        shaderConfig:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfig'
-            - type: 'null'
         targetPlatform:
           oneOf:
             - type: string
@@ -8325,64 +8327,6 @@ components:
       required:
         - env_variables
       type: object
-    ShaderConfig:
-      properties:
-        chatModel:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfigChatModel'
-            - type: 'null'
-        ragModel:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfigRagModel'
-            - type: 'null'
-      type: object
-    ShaderConfigChatModel:
-      enum:
-        - gemini_1_5_pro
-        - gemini_2_0_flash_lite_preview
-        - gemini_2_0_flash_001
-        - gemini_2_0_flash_thinking_exp
-        - gemini_2_0_pro
-        - gemini_2_5_pro
-        - claude_3_5_sonnet
-        - claude_3_5_sonnetv2
-        - claude_3_7_sonnet
-      type: string
-    ShaderConfigInput:
-      properties:
-        chatModel:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfigInputChatModel'
-            - type: 'null'
-        ragModel:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfigInputRagModel'
-            - type: 'null'
-      type: object
-    ShaderConfigInputChatModel:
-      enum:
-        - gemini_1_5_pro
-        - gemini_2_0_flash_lite_preview
-        - gemini_2_0_flash_001
-        - gemini_2_0_flash_thinking_exp
-        - gemini_2_0_pro
-        - gemini_2_5_pro
-        - claude_3_5_sonnet
-        - claude_3_5_sonnetv2
-        - claude_3_7_sonnet
-      type: string
-    ShaderConfigInputRagModel:
-      enum:
-        - gemini_1_5_flash
-        - gemini_2_0_flash_lite_preview
-        - gemini_2_0_flash_001
-      type: string
-    ShaderConfigRagModel:
-      enum:
-        - gemini_1_5_flash
-        - gemini_2_0_flash_lite_preview
-        - gemini_2_0_flash_001
-      type: string
     SheetsUiSettings:
       properties:
         showAppliedFilters:
@@ -8627,10 +8571,6 @@ components:
         releaseChannelVersionHold:
           oneOf:
             - type: boolean
-            - type: 'null'
-        shaderConfig:
-          oneOf:
-            - $ref: '#/components/schemas/ShaderConfigInput'
             - type: 'null'
         template:
           oneOf:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -44,6 +44,7 @@ tags:
   - name: Embed
   - name: Embed Tenants
   - name: Dashboard Embed Access
+  - name: OpenAPI Spec
 paths:
   /api/v1/app-config:
     get:
@@ -1801,6 +1802,32 @@ paths:
       summary: Deployment token
       tags:
         - Deployments
+  /api/v1/deployments/{deploymentId}/versions:
+    get:
+      operationId: listDeploymentVersions
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentVersionsResponse'
+          description: ''
+      summary: List available Cube versions
+      tags:
+        - Deployments
+      x-mint:
+        content: >-
+          Every Cube version this deployment can be switched to — the same set the console’s version
+          picker offers: the head of each release channel, plus the older versions the tenant has
+          run before (its release history). Pass a listed `releaseChannelVersion` to `PUT
+          /:deploymentId/settings`; anything else is rejected. The container image is resolved
+          server-side and is not part of the write surface.
   /api/v1/deployments/{deploymentId}/workbooks:
     get:
       operationId: getWorkbooks
@@ -3426,6 +3453,25 @@ paths:
       summary: List regions
       tags:
         - Regions
+  /api/v1/spec:
+    get:
+      operationId: getSpec
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+          description: The OpenAPI 3.1 document
+      summary: Get the OpenAPI specification
+      tags:
+        - OpenAPI Spec
+      x-mint:
+        content: >-
+          The full OpenAPI 3.1 document for this API, as served by the build handling the request —
+          every path, parameter, request body and schema. Intended for runtime discovery by clients
+          and agents; `cube spec` wraps it with filtering.
   /api/v1/tenant/settings:
     get:
       operationId: getTenantSettings
@@ -6487,6 +6533,39 @@ components:
       required:
         - cubeApiToken
       type: object
+    DeploymentVersion:
+      properties:
+        isCurrent:
+          type: boolean
+        isLatestInChannel:
+          type: boolean
+        releaseChannel:
+          $ref: '#/components/schemas/DeploymentVersionReleaseChannel'
+        releaseChannelVersion:
+          type: string
+        version:
+          type: string
+      required:
+        - releaseChannelVersion
+        - version
+        - releaseChannel
+        - isLatestInChannel
+        - isCurrent
+      type: object
+    DeploymentVersionReleaseChannel:
+      enum:
+        - latest
+        - release
+      type: string
+    DeploymentVersionsResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/DeploymentVersion'
+          type: array
+      required:
+        - data
+      type: object
     DeploymentsListResponse:
       properties:
         count:
@@ -8513,10 +8592,6 @@ components:
         cspsConfig:
           oneOf:
             - $ref: '#/components/schemas/CspsConfigInput'
-            - type: 'null'
-        cubeImageCloud:
-          oneOf:
-            - type: string
             - type: 'null'
         customDomain:
           oneOf:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -185,11 +185,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Deployment'
+                $ref: '#/components/schemas/DeploymentSettings'
           description: ''
-      summary: Update deployment
+      summary: Update a deployment
       tags:
         - Deployments
+      x-mint:
+        content: >-
+          Update any subset of a deployment’s settings — everything the console’s Settings pages own
+          — and read the full settings back. Fields you omit are left alone, and `templateVariables`
+          is merged key-by-key rather than replaced, so setting one configuration flag never clears
+          the others. `releaseChannelVersion` must be one of the versions `GET
+          /:deploymentId/versions` lists for the target channel (in any of the forms it reports) —
+          anything else is a 400, and the container image is resolved from the version rather than
+          sent. Choosing a version that is not the channel’s latest also sets
+          `releaseChannelVersionHold` unless you send it explicitly, so auto-upgrade does not undo
+          the pin.
   /api/v1/deployments/{deploymentId}/build-status:
     get:
       operationId: buildStatus
@@ -1673,37 +1684,8 @@ paths:
           Every setting of a deployment in one payload — the full contents of the console Settings
           pages (general, configuration flags, deploy, launchpad, Cube Store private storage), plus
           the read-only values displayed alongside them. Secrets are excluded; read environment
-          variables through `/env-vars` instead.
-    put:
-      operationId: updateDeploymentSettings
-      parameters:
-        - in: path
-          name: deploymentId
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateDeploymentInput'
-        description: UpdateDeploymentInput
-        required: false
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeploymentSettings'
-          description: ''
-      summary: Update deployment settings
-      tags:
-        - Deployments
-      x-mint:
-        content: >-
-          Update any subset of a deployment’s settings and read the full settings back. Fields you
-          omit are left alone, and `templateVariables` is merged key-by-key rather than replaced, so
-          setting one configuration flag never clears the others.
+          variables through `/env-vars` instead. Writes go to `PUT /:deploymentId`, which accepts
+          the same fields and returns this payload.
   /api/v1/deployments/{deploymentId}/shared-workspace:
     get:
       operationId: sharedWorkspaceObjects
@@ -1826,8 +1808,8 @@ paths:
           Every Cube version this deployment can be switched to — the same set the console’s version
           picker offers: the head of each release channel, plus the older versions the tenant has
           run before (its release history). Pass a listed `releaseChannelVersion` to `PUT
-          /:deploymentId/settings`; anything else is rejected. The container image is resolved
-          server-side and is not part of the write surface.
+          /:deploymentId`; anything else is rejected. The container image is resolved server-side
+          and is not part of the write surface.
   /api/v1/deployments/{deploymentId}/workbooks:
     get:
       operationId: getWorkbooks

--- a/docs-mintlify/api-reference/introduction.mdx
+++ b/docs-mintlify/api-reference/introduction.mdx
@@ -95,6 +95,7 @@ Resources by entity:
 | [Embed](/api-reference/embed/get-an-embeddable-dashboard) | `/api/v1/embed` | v1 |
 | [Embed Tenants](/api-reference/embed-tenants/list-embed-tenants) | `/api/v1/embed-tenants` | v1 |
 | [Dashboard Embed Access](/api-reference/dashboard-embed-access/list-a-dashboards-embed-access) | `/api/v1/deployments/{deploymentId}/workbooks/{workbookId}/embed-access` | v1 |
+| [OpenAPI Spec](/api-reference/openapi-spec/get-the-openapi-specification) | `/api/v1/spec` | v1 |
 {/* AUTOGEN:platform-endpoints END */}
 | [Users (SCIM)](/api-reference/scim-users/list-users) | `/scim/v2/Users` | SCIM 2.0 |
 | [Groups (SCIM)](/api-reference/scim-groups/list-groups) | `/scim/v2/Groups` | SCIM 2.0 |

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -762,6 +762,8 @@
                   "POST /api/v1/deployments/{deploymentId}/creation-step/reset",
                   "GET /api/v1/deployments/{deploymentId}/logs",
                   "GET /api/v1/deployments/{deploymentId}/pods",
+                  "GET /api/v1/deployments/{deploymentId}/settings",
+                  "PUT /api/v1/deployments/{deploymentId}/settings",
                   "POST /api/v1/deployments/{deploymentId}/token"
                 ]
               },
@@ -803,6 +805,7 @@
                 "pages": [
                   "GET /build/api/v1/deployments/{deploymentId}/branches",
                   "POST /build/api/v1/deployments/{deploymentId}/branches",
+                  "PUT /build/api/v1/deployments/{deploymentId}/branches/staging-environment",
                   "POST /build/api/v1/deployments/{deploymentId}/commit",
                   "GET /build/api/v1/deployments/{deploymentId}/data-model/files",
                   "PUT /build/api/v1/deployments/{deploymentId}/data-model/files",
@@ -846,7 +849,10 @@
                 "group": "dbt Sync",
                 "openapi": "/api-reference/api.yaml",
                 "pages": [
-                  "POST /api/v1/deployments/{deploymentId}/dbt-sync"
+                  "POST /api/v1/deployments/{deploymentId}/dbt-sync",
+                  "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}",
+                  "DELETE /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}",
+                  "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/result"
                 ]
               },
               {
@@ -885,7 +891,6 @@
                   "PUT /api/v1/deployments/{deploymentId}/workbooks/{workbookId}",
                   "DELETE /api/v1/deployments/{deploymentId}/workbooks/{workbookId}",
                   "PUT /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/dashboard",
-                  "POST /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/dashboard/ai-widget-thread",
                   "POST /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/duplicate",
                   "POST /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/publish"
                 ]

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -764,7 +764,8 @@
                   "GET /api/v1/deployments/{deploymentId}/pods",
                   "GET /api/v1/deployments/{deploymentId}/settings",
                   "PUT /api/v1/deployments/{deploymentId}/settings",
-                  "POST /api/v1/deployments/{deploymentId}/token"
+                  "POST /api/v1/deployments/{deploymentId}/token",
+                  "GET /api/v1/deployments/{deploymentId}/versions"
                 ]
               },
               {
@@ -1028,6 +1029,13 @@
                 "pages": [
                   "GET /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/embed-access",
                   "PUT /api/v1/deployments/{deploymentId}/workbooks/{workbookId}/embed-access"
+                ]
+              },
+              {
+                "group": "OpenAPI Spec",
+                "openapi": "/api-reference/api.yaml",
+                "pages": [
+                  "GET /api/v1/spec"
                 ]
               },
               {

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -763,7 +763,6 @@
                   "GET /api/v1/deployments/{deploymentId}/logs",
                   "GET /api/v1/deployments/{deploymentId}/pods",
                   "GET /api/v1/deployments/{deploymentId}/settings",
-                  "PUT /api/v1/deployments/{deploymentId}/settings",
                   "POST /api/v1/deployments/{deploymentId}/token",
                   "GET /api/v1/deployments/{deploymentId}/versions"
                 ]

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -1243,6 +1243,10 @@
     {
       "source": "/docs/integrations/power-bi/ntlm",
       "destination": "/reference/core-data-apis/dax-api/ntlm"
+    },
+    {
+      "source": "/api-reference/workbooks/update-published-dashboard-ai-widget-thread",
+      "destination": "/api-reference/workbooks/update-workbook-dashboard"
     }
   ]
 }

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -228,7 +228,7 @@ smaller but still valid document containing just the matching operations plus
 every schema they reference, transitively:
 
 ```bash
-cube spec "deployments/{deploymentId}" --json
+cube spec updateDeployment --json
 ```
 
 That last form is the one to reach for when you want an endpoint's full

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -159,12 +159,60 @@ Run `cube <command> --help` for the full options of any command.
 | `tenant`, `notifications`, `integrations`, `oidc`, `api-keys` | Account administration |
 | `embed` | Embed sessions, tokens, embed tenants; `enable-dashboard`/`disable-dashboard` toggle signed embedding for a dashboard |
 | `agents`, `app`, `meta`, `scim` | Agents, app config, model metadata, SCIM v2 |
+| `spec` | Show the API's OpenAPI specification — see [Discovering the API](#discovering-the-api) |
 | `api` | Raw authenticated API request (escape hatch): `cube api GET /api/v1/... -q key=value -d '{...}'` |
 | `update` | Update the CLI to the latest release |
 | `completion` | Generate shell completions |
 
 List commands print tables by default; pass `--json` anywhere for raw JSON
 output, suitable for piping to `jq`.
+
+## Discovering the API
+
+`cube spec` prints the OpenAPI specification of the API you are logged into, so
+neither you nor an AI agent has to guess an endpoint's parameters. It reads
+`/api/v1/spec` from the deployment itself, which means the contract you get is
+the one that build actually serves.
+
+With no arguments it lists every operation:
+
+```bash
+cube spec
+```
+
+```
+METHOD  PATH                                            SUMMARY
+GET     /api/v1/deployments                             Get deployments
+PUT     /api/v1/deployments/{deploymentId}/settings     Update deployment settings
+...
+```
+
+Pass a pattern to narrow it down. The match is case-insensitive and covers the
+method, path, summary, and operation id:
+
+```bash
+cube spec settings
+```
+
+Add `--json` to get OpenAPI instead of a table. Unfiltered, that is the entire
+document — pipe it into a code generator or a validator. Filtered, it is a
+smaller but still valid document containing just the matching operations plus
+every schema they reference, transitively:
+
+```bash
+cube spec "deployments/{deploymentId}/settings" --json
+```
+
+That last form is the one to reach for when you want an endpoint's full
+parameter list: the request body's schema is included rather than left as a
+`$ref` pointing into a document you would then have to fetch in full.
+
+<Tip>
+
+Point an agent at `cube spec <topic> --json` and it can construct a correct
+request without any hardcoded knowledge of the API.
+
+</Tip>
 
 ## Data model Git workflow
 

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -146,7 +146,7 @@ Run `cube <command> --help` for the full options of any command.
 | Command | Description |
 | --- | --- |
 | `login`, `logout`, `whoami`, `context` | Authentication and saved contexts |
-| `deployments` | List, get, create, update, delete deployments; `token`, `build-status`, `advance-step`, `reset-step` |
+| `deployments` | List, get, create, update, delete deployments; `settings`, `versions`, `token`, `build-status`, `advance-step`, `reset-step` |
 | `deploy` | Upload a local project directory and build it |
 | `logs` | Tail deployment pod logs (`--pod`, `-c/--container`, `--source production\|dev`) |
 | `regions` | List available deployment regions |
@@ -166,6 +166,34 @@ Run `cube <command> --help` for the full options of any command.
 
 List commands print tables by default; pass `--json` anywhere for raw JSON
 output, suitable for piping to `jq`.
+
+## Changing the Cube version
+
+`cube deployments versions` lists the Cube versions a deployment can switch to
+— the head of each [update channel][ref-update-channels], plus the older
+versions your account has run before:
+
+```bash
+cube deployments versions DEPLOYMENT_ID
+```
+
+```
+VERSION  CHANNEL  LATEST  CURRENT  PASS AS
+1.7.20   latest   true    true     cubejs/cube:v1.7.20
+1.6.69   latest   false   false    cubejs/cube:v1.6.69
+```
+
+Apply one with `update`. Any of `1.7.20`, `v1.7.20` or `cubejs/cube:v1.7.20` is
+accepted; a version that is not on the list is rejected. The container image is
+resolved from the version, so there is nothing else to set:
+
+```bash
+cube deployments update DEPLOYMENT_ID --release-channel-version 1.7.20
+cube deployments update DEPLOYMENT_ID --release-channel release  # move to a channel's latest
+```
+
+`cube deployments settings DEPLOYMENT_ID` reads back every setting, including
+the version and channel currently in effect.
 
 ## Discovering the API
 
@@ -272,3 +300,4 @@ or explicitly with `CUBE_NO_TELEMETRY=1` (or the legacy `CUBEJS_TELEMETRY=false`
 [ref-api-keys]: /admin/account-billing/api-keys
 [ref-rest-api]: /reference/core-data-apis/rest-api/index
 [ref-staging-env]: /admin/deployment/environments#staging-environments
+[ref-update-channels]: /admin/deployment#update-channels

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -211,7 +211,7 @@ cube spec
 ```
 METHOD  PATH                                            SUMMARY
 GET     /api/v1/deployments                             Get deployments
-PUT     /api/v1/deployments/{deploymentId}/settings     Update deployment settings
+PUT     /api/v1/deployments/{deploymentId}              Update a deployment
 ...
 ```
 
@@ -228,7 +228,7 @@ smaller but still valid document containing just the matching operations plus
 every schema they reference, transitively:
 
 ```bash
-cube spec "deployments/{deploymentId}/settings" --json
+cube spec "deployments/{deploymentId}" --json
 ```
 
 That last form is the one to reach for when you want an endpoint's full

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -273,6 +273,37 @@ Example response:
 The same operation is available in the [CLI][ref-cli] as
 `cube data-model enable-branch` / `cube data-model disable-branch`.
 
+### `/api/v1/spec`
+
+Send a `GET` request to retrieve the OpenAPI 3.1 document for this API. The
+response describes every endpoint, parameter, request body, and schema — the
+same document that backs the [API reference](/api-reference/introduction),
+served by the build handling the request, so a deployment on an older release
+advertises the surface it actually has.
+
+This is intended for runtime discovery: code generators, API clients, and AI
+agents can read the contract instead of having it hardcoded. The
+[CLI][ref-cli]'s `cube spec` command wraps this endpoint with filtering.
+
+Example request:
+
+```bash
+curl \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  "https://YOUR_CUBE_CLOUD_HOST/api/v1/spec"
+```
+
+The response is the OpenAPI document as JSON:
+
+```json
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Console Server Public API", "version": "1.0.0" },
+  "paths": { "/api/v1/deployments": { "get": { "...": "..." } } },
+  "components": { "schemas": { "...": "..." } }
+}
+```
+
 ### `/api/v1/audit-logs/export`
 
 Send a `GET` request to export [audit log][ref-audit-log] events as a CSV

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -326,37 +326,6 @@ The same operation is available in the [CLI][ref-cli] as
 `cube deployments versions`, with `cube deployments update ID
 --release-channel-version 1.7.20` to apply one.
 
-### `/api/v1/spec`
-
-Send a `GET` request to retrieve the OpenAPI 3.1 document for this API. The
-response describes every endpoint, parameter, request body, and schema — the
-same document that backs the [API reference](/api-reference/introduction),
-served by the build handling the request, so a deployment on an older release
-advertises the surface it actually has.
-
-This is intended for runtime discovery: code generators, API clients, and AI
-agents can read the contract instead of having it hardcoded. The
-[CLI][ref-cli]'s `cube spec` command wraps this endpoint with filtering.
-
-Example request:
-
-```bash
-curl \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  "https://YOUR_CUBE_CLOUD_HOST/api/v1/spec"
-```
-
-The response is the OpenAPI document as JSON:
-
-```json
-{
-  "openapi": "3.1.0",
-  "info": { "title": "Console Server Public API", "version": "1.0.0" },
-  "paths": { "/api/v1/deployments": { "get": { "...": "..." } } },
-  "components": { "schemas": { "...": "..." } }
-}
-```
-
 ### `/api/v1/audit-logs/export`
 
 Send a `GET` request to export [audit log][ref-audit-log] events as a CSV

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -273,6 +273,59 @@ Example response:
 The same operation is available in the [CLI][ref-cli] as
 `cube data-model enable-branch` / `cube data-model disable-branch`.
 
+### `/api/v1/deployments/{deployment_id}/versions`
+
+Send a `GET` request to list the Cube versions a deployment can be switched
+to — the same set the Cube Cloud UI's version picker offers: the head of each
+[update channel][ref-update-channels], plus the older versions your account has
+run before.
+
+Example request:
+
+```bash
+curl \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  "https://YOUR_CUBE_CLOUD_HOST/api/v1/deployments/123/versions"
+```
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "releaseChannelVersion": "cubejs/cube:v1.7.20",
+      "version": "1.7.20",
+      "releaseChannel": "latest",
+      "isLatestInChannel": true,
+      "isCurrent": true
+    },
+    {
+      "releaseChannelVersion": "cubejs/cube:v1.6.69",
+      "version": "1.6.69",
+      "releaseChannel": "latest",
+      "isLatestInChannel": false,
+      "isCurrent": false
+    }
+  ]
+}
+```
+
+To change the version, send a listed value as `releaseChannelVersion` to
+`PUT /api/v1/deployments/{deployment_id}/settings`. Any of `1.7.20`, `v1.7.20`
+or `cubejs/cube:v1.7.20` is accepted; a version that is not on the list is
+rejected with a `400`. The container image is resolved from the version
+server-side and cannot be set directly.
+
+<Note>
+Leaving `releaseChannelVersion` out and sending only `releaseChannel` moves the
+deployment to that channel's latest version.
+</Note>
+
+The same operation is available in the [CLI][ref-cli] as
+`cube deployments versions`, with `cube deployments update ID
+--release-channel-version 1.7.20` to apply one.
+
 ### `/api/v1/spec`
 
 Send a `GET` request to retrieve the OpenAPI 3.1 document for this API. The
@@ -359,3 +412,4 @@ curl \
 [ref-api-keys]: /admin/account-billing/api-keys
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-audit-log]: /admin/monitoring/audit-log
+[ref-update-channels]: /admin/deployment#update-channels

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -312,8 +312,8 @@ Example response:
 ```
 
 To change the version, send a listed value as `releaseChannelVersion` to
-`PUT /api/v1/deployments/{deployment_id}/settings`. Any of `1.7.20`, `v1.7.20`
-or `cubejs/cube:v1.7.20` is accepted; a version that is not on the list is
+`PUT /api/v1/deployments/{deployment_id}`. Any of `1.7.20`, `v1.7.20` or
+`cubejs/cube:v1.7.20` is accepted; a version that is not on the list is
 rejected with a `400`. The container image is resolved from the version
 server-side and cannot be set directly.
 

--- a/docs-mintlify/scripts/extract-api.mjs
+++ b/docs-mintlify/scripts/extract-api.mjs
@@ -175,6 +175,8 @@ const TAG_MAP = {
   'Deployments Build Public': 'Deployment Creation',
   'Uploads Public': 'Data Model Uploads',
   'Git Hub Deployment Public': 'GitHub Connection',
+  // Auto-cleaning title-cases the controller name into "Open Api Spec".
+  'Open Api Spec Public': 'OpenAPI Spec',
 };
 // Preferred nav order. Tags not listed here are appended alphabetically, so the
 // docs stay complete even when the upstream spec adds new areas.
@@ -186,6 +188,7 @@ const TAG_ORDER = [
   'User Attributes', 'User Attribute Values', 'Resource Policies', 'Tenant Settings',
   'OAuth Integrations', 'User OAuth Tokens', 'OIDC Token Configs',
   'App Theme', 'AI Engineer', 'Embed', 'Embed Tenants', 'Dashboard Embed Access',
+  'OpenAPI Spec',
 ];
 
 // Mintlify renders the OpenAPI operation `description` as a plain-text node — it

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -130,32 +130,16 @@ function systemAsyncHandler(handler: (req: Request & { context: ExtendedRequestC
   };
 }
 
-/**
- * Whether a token carries the `isDevToken` claim, which is what actually
- * unlocks the developer affordances behind `signedWithPlaygroundAuthSecret`:
- * meta members hidden by `public: false` / access policies, generated SQL and
- * pre-aggregation debug info on load responses, and request ids in errors.
- *
- * Being signed with the playground secret is necessary but no longer
- * sufficient. That secret is shared by every token a Cube Cloud deployment
- * mints — including ones handed to end users and external tools — so keying the
- * bypass off the signature alone handed developer-level visibility to anyone
- * who could obtain any such token. The claim is added only for the
- * developer-facing console surfaces, and only for users who hold
- * deployment-manage permissions; every other playground-secret-signed token now
- * resolves to an ordinary, non-privileged context.
- *
- * `devMode` is unaffected: every affordance gated on the flag already ORs it
- * with `getEnv('devMode')`, so a local `cube dev` server keeps full visibility.
- * The one place that reads the flag alone is the `isPlayground` field on Load
- * Request logs, which correspondingly now marks only developer traffic.
- */
-function hasDevTokenClaim(securityContext: unknown): boolean {
-  return (
-    typeof securityContext === 'object' &&
-    securityContext !== null &&
-    (<Record<string, any>>securityContext).isDevToken === true
-  );
+const DEV_TOKEN_SCOPE = 'dev-token';
+
+function hasDevTokenScope(securityContext: unknown): boolean {
+  if (typeof securityContext !== 'object' || securityContext === null) {
+    return false;
+  }
+
+  const { scope } = <Record<string, any>>securityContext;
+
+  return Array.isArray(scope) && scope.includes(DEV_TOKEN_SCOPE);
 }
 
 // Prepared CheckAuthFn, default or from config: always async
@@ -2644,7 +2628,7 @@ class ApiGateway {
         try {
           req.securityContext = await checkAuthFn(auth);
           req.signedWithPlaygroundAuthSecret =
-            Boolean(internalOptions?.isPlaygroundCheckAuth) && hasDevTokenClaim(req.securityContext);
+            Boolean(internalOptions?.isPlaygroundCheckAuth) && hasDevTokenScope(req.securityContext);
         } catch (e: any) {
           if (this.enforceSecurityChecks) {
             throw new CubejsHandlerError(403, 'Forbidden', 'Invalid token', e);

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -130,6 +130,34 @@ function systemAsyncHandler(handler: (req: Request & { context: ExtendedRequestC
   };
 }
 
+/**
+ * Whether a token carries the `isDevToken` claim, which is what actually
+ * unlocks the developer affordances behind `signedWithPlaygroundAuthSecret`:
+ * meta members hidden by `public: false` / access policies, generated SQL and
+ * pre-aggregation debug info on load responses, and request ids in errors.
+ *
+ * Being signed with the playground secret is necessary but no longer
+ * sufficient. That secret is shared by every token a Cube Cloud deployment
+ * mints — including ones handed to end users and external tools — so keying the
+ * bypass off the signature alone handed developer-level visibility to anyone
+ * who could obtain any such token. The claim is added only for the
+ * developer-facing console surfaces, and only for users who hold
+ * deployment-manage permissions; every other playground-secret-signed token now
+ * resolves to an ordinary, non-privileged context.
+ *
+ * `devMode` is unaffected: every affordance gated on the flag already ORs it
+ * with `getEnv('devMode')`, so a local `cube dev` server keeps full visibility.
+ * The one place that reads the flag alone is the `isPlayground` field on Load
+ * Request logs, which correspondingly now marks only developer traffic.
+ */
+function hasDevTokenClaim(securityContext: unknown): boolean {
+  return (
+    typeof securityContext === 'object' &&
+    securityContext !== null &&
+    (<Record<string, any>>securityContext).isDevToken === true
+  );
+}
+
 // Prepared CheckAuthFn, default or from config: always async
 type PreparedCheckAuthFn = (ctx: any, authorization?: string) => Promise<{
   securityContext: any;
@@ -2615,7 +2643,8 @@ class ApiGateway {
       if (auth) {
         try {
           req.securityContext = await checkAuthFn(auth);
-          req.signedWithPlaygroundAuthSecret = Boolean(internalOptions?.isPlaygroundCheckAuth);
+          req.signedWithPlaygroundAuthSecret =
+            Boolean(internalOptions?.isPlaygroundCheckAuth) && hasDevTokenClaim(req.securityContext);
         } catch (e: any) {
           if (this.enforceSecurityChecks) {
             throw new CubejsHandlerError(403, 'Forbidden', 'Invalid token', e);

--- a/packages/cubejs-api-gateway/test/auth.test.ts
+++ b/packages/cubejs-api-gateway/test/auth.test.ts
@@ -280,6 +280,63 @@ describe('test authorization', () => {
     expectSecurityContext(handlerMock.mock.calls[0][0].context.authInfo);
   });
 
+  describe('signedWithPlaygroundAuthSecret requires the isDevToken claim', () => {
+    const playgroundAuthSecret = 'playgroundSecret';
+    const loggerMock = jest.fn(() => {
+      //
+    });
+
+    // The playground secret signs every token a Cube Cloud deployment mints,
+    // including ones handed to end users and external BI tools, so the
+    // signature alone must not unlock the developer affordances gated on this
+    // flag (hidden meta members, generated SQL, pre-aggregation debug info).
+    const flagFor = async (payload: Record<string, any>) => {
+      const seen: boolean[] = [];
+      const handlerMock = jest.fn((req, res) => {
+        seen.push(req.context.signedWithPlaygroundAuthSecret);
+        res.status(200).end();
+      });
+
+      const { app } = createApiGateway(handlerMock, loggerMock, { playgroundAuthSecret });
+
+      await request(app)
+        .get('/test-auth-fake')
+        .set('Authorization', `Authorization: ${generateAuthToken(payload, {}, playgroundAuthSecret)}`)
+        .expect(200);
+
+      return seen[0];
+    };
+
+    test('is false for a playground-signed token without the claim', async () => {
+      expect(await flagFor({ uid: 5 })).toBe(false);
+    });
+
+    test('is true for a playground-signed token carrying isDevToken', async () => {
+      expect(await flagFor({ uid: 5, isDevToken: true })).toBe(true);
+    });
+
+    test('is false when isDevToken is present but not exactly true', async () => {
+      expect(await flagFor({ uid: 5, isDevToken: 'true' })).toBe(false);
+      expect(await flagFor({ uid: 5, isDevToken: false })).toBe(false);
+    });
+
+    test('is false for a token signed with the main api secret, claim or not', async () => {
+      const handlerMock = jest.fn((req, res) => {
+        expect(req.context.signedWithPlaygroundAuthSecret).toBe(false);
+        res.status(200).end();
+      });
+
+      const { app } = createApiGateway(handlerMock, loggerMock, { playgroundAuthSecret });
+
+      await request(app)
+        .get('/test-auth-fake')
+        .set('Authorization', `Authorization: ${generateAuthToken({ uid: 5, isDevToken: true }, {})}`)
+        .expect(200);
+
+      expect(handlerMock.mock.calls.length).toEqual(1);
+    });
+  });
+
   test('default authorization with JWT token and securityContext in u', async () => {
     const loggerMock = jest.fn(() => {
       //

--- a/packages/cubejs-api-gateway/test/auth.test.ts
+++ b/packages/cubejs-api-gateway/test/auth.test.ts
@@ -280,7 +280,7 @@ describe('test authorization', () => {
     expectSecurityContext(handlerMock.mock.calls[0][0].context.authInfo);
   });
 
-  describe('signedWithPlaygroundAuthSecret requires the isDevToken claim', () => {
+  describe('signedWithPlaygroundAuthSecret requires the dev-token scope', () => {
     const playgroundAuthSecret = 'playgroundSecret';
     const loggerMock = jest.fn(() => {
       //
@@ -307,20 +307,26 @@ describe('test authorization', () => {
       return seen[0];
     };
 
-    test('is false for a playground-signed token without the claim', async () => {
+    test('is false for a playground-signed token with no scope at all', async () => {
       expect(await flagFor({ uid: 5 })).toBe(false);
     });
 
-    test('is true for a playground-signed token carrying isDevToken', async () => {
-      expect(await flagFor({ uid: 5, isDevToken: true })).toBe(true);
+    test('is false for a playground-signed token scoped to something else', async () => {
+      expect(await flagFor({ uid: 5, scope: ['sql-runner', 'agents-config'] })).toBe(false);
     });
 
-    test('is false when isDevToken is present but not exactly true', async () => {
-      expect(await flagFor({ uid: 5, isDevToken: 'true' })).toBe(false);
-      expect(await flagFor({ uid: 5, isDevToken: false })).toBe(false);
+    test('is true for a playground-signed token carrying the dev-token scope', async () => {
+      expect(await flagFor({ uid: 5, scope: ['dev-token'] })).toBe(true);
+      // Alongside the service scopes it is minted with in practice.
+      expect(await flagFor({ uid: 5, scope: ['sql-runner', 'dev-token'] })).toBe(true);
     });
 
-    test('is false for a token signed with the main api secret, claim or not', async () => {
+    test('is false when scope is not an array of scope names', async () => {
+      expect(await flagFor({ uid: 5, scope: 'dev-token' })).toBe(false);
+      expect(await flagFor({ uid: 5, scope: { 'dev-token': true } })).toBe(false);
+    });
+
+    test('is false for a token signed with the main api secret, scope or not', async () => {
       const handlerMock = jest.fn((req, res) => {
         expect(req.context.signedWithPlaygroundAuthSecret).toBe(false);
         res.status(200).end();
@@ -330,7 +336,7 @@ describe('test authorization', () => {
 
       await request(app)
         .get('/test-auth-fake')
-        .set('Authorization', `Authorization: ${generateAuthToken({ uid: 5, isDevToken: true }, {})}`)
+        .set('Authorization', `Authorization: ${generateAuthToken({ uid: 5, scope: ['dev-token'] }, {})}`)
         .expect(200);
 
       expect(handlerMock.mock.calls.length).toEqual(1);

--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -152,7 +152,7 @@ Every endpoint of the Console Server public API is covered:
 | `app` | config, theme |
 | `meta` | POST /api/v1/meta/ |
 | `scim` | Users/Groups CRUD + patch, resource-types, schemas, service-provider-config |
-| `spec` | the API's own OpenAPI document, read from `/api/v1/spec` — so the contract comes from the build being talked to, not a pinned copy. Bare `cube spec` lists every operation; `cube spec <pattern>` filters on method/path/summary/operationId. `--json` prints OpenAPI: the whole document unfiltered, or — filtered — a valid document holding just the matching operations plus the transitive closure of the schemas they reference, which is what makes `cube spec <topic> --json` enough for an agent to build a correct request |
+| `spec` | the API's own OpenAPI document from `/api/v1/spec`: bare lists every operation, `<pattern>` filters on method/path/summary/operationId, `--json` prints OpenAPI (filtered = matching operations + the transitive schema closure) |
 | `api` | raw escape hatch: `cube api GET /api/v1/... -q key=value -d '{...}'` |
 
 Conventions:

--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -128,7 +128,7 @@ Every endpoint of the Console Server public API is covered:
 
 | Group | Endpoints |
 |---|---|
-| `deployments` | list, get, create (`--bootstrap` scaffolds + builds a serving deployment), update, settings, versions, delete, token, advance-step, reset-step. `settings` reads every setting in one payload; `versions` lists the Cube versions the deployment can switch to, and `update --release-channel-version <v>` (accepting `1.7.20`, `v1.7.20` or `cubejs/cube:v1.7.20`) is validated against it — the container image is resolved server-side and is not settable |
+| `deployments` | list, get, create (`--bootstrap` scaffolds + builds a serving deployment), update (`--release-channel`, `--release-channel-version`), settings, versions, delete, token, advance-step, reset-step |
 | `regions` | list available deployment regions |
 | `logs` | tail deployment pod logs (`--pod`, `-c/--container`; defaults to the Cube API container) |
 | `github` (`gh`) | status, installations, repos, branches, connect (import a repo into a deployment + first build) |

--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -152,6 +152,7 @@ Every endpoint of the Console Server public API is covered:
 | `app` | config, theme |
 | `meta` | POST /api/v1/meta/ |
 | `scim` | Users/Groups CRUD + patch, resource-types, schemas, service-provider-config |
+| `spec` | the API's own OpenAPI document, read from `/api/v1/spec` — so the contract comes from the build being talked to, not a pinned copy. Bare `cube spec` lists every operation; `cube spec <pattern>` filters on method/path/summary/operationId. `--json` prints OpenAPI: the whole document unfiltered, or — filtered — a valid document holding just the matching operations plus the transitive closure of the schemas they reference, which is what makes `cube spec <topic> --json` enough for an agent to build a correct request |
 | `api` | raw escape hatch: `cube api GET /api/v1/... -q key=value -d '{...}'` |
 
 Conventions:

--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -128,7 +128,7 @@ Every endpoint of the Console Server public API is covered:
 
 | Group | Endpoints |
 |---|---|
-| `deployments` | list, get, create (`--bootstrap` scaffolds + builds a serving deployment), update, delete, token, advance-step, reset-step |
+| `deployments` | list, get, create (`--bootstrap` scaffolds + builds a serving deployment), update, settings, versions, delete, token, advance-step, reset-step. `settings` reads every setting in one payload; `versions` lists the Cube versions the deployment can switch to, and `update --release-channel-version <v>` (accepting `1.7.20`, `v1.7.20` or `cubejs/cube:v1.7.20`) is validated against it — the container image is resolved server-side and is not settable |
 | `regions` | list available deployment regions |
 | `logs` | tail deployment pod logs (`--pod`, `-c/--container`; defaults to the Cube API container) |
 | `github` (`gh`) | status, installations, repos, branches, connect (import a repo into a deployment + first build) |

--- a/rust/cube-cli/src/commands/deployments.rs
+++ b/rust/cube-cli/src/commands/deployments.rs
@@ -205,18 +205,12 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             util::set(&mut body, "name", &name);
             util::set(&mut body, "releaseChannel", &release_channel);
             util::set(&mut body, "releaseChannelVersion", &release_channel_version);
-            // Both routes share the same request handling, but they differ in
-            // what they hand back: `PUT /:id` responds with the four-field
-            // deployment summary, which carries no version at all. A version
-            // change would print a body in which the thing that changed is
-            // invisible — so route those through /settings, whose response is
-            // the full settings payload and answers "did it switch?".
-            let path = if release_channel.is_some() || release_channel_version.is_some() {
-                format!("/api/v1/deployments/{deployment}/settings")
-            } else {
-                format!("/api/v1/deployments/{deployment}")
-            };
-            let res = api.put(&path, Some(&util::body(body))).await?;
+            let res = api
+                .put(
+                    &format!("/api/v1/deployments/{deployment}"),
+                    Some(&util::body(body)),
+                )
+                .await?;
             output::print_json(&res);
         }
         Cmd::Settings { deployment } => {

--- a/rust/cube-cli/src/commands/deployments.rs
+++ b/rust/cube-cli/src/commands/deployments.rs
@@ -205,12 +205,18 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             util::set(&mut body, "name", &name);
             util::set(&mut body, "releaseChannel", &release_channel);
             util::set(&mut body, "releaseChannelVersion", &release_channel_version);
-            let res = api
-                .put(
-                    &format!("/api/v1/deployments/{deployment}"),
-                    Some(&util::body(body)),
-                )
-                .await?;
+            // Both routes share the same request handling, but they differ in
+            // what they hand back: `PUT /:id` responds with the four-field
+            // deployment summary, which carries no version at all. A version
+            // change would print a body in which the thing that changed is
+            // invisible — so route those through /settings, whose response is
+            // the full settings payload and answers "did it switch?".
+            let path = if release_channel.is_some() || release_channel_version.is_some() {
+                format!("/api/v1/deployments/{deployment}/settings")
+            } else {
+                format!("/api/v1/deployments/{deployment}")
+            };
+            let res = api.put(&path, Some(&util::body(body))).await?;
             output::print_json(&res);
         }
         Cmd::Settings { deployment } => {

--- a/rust/cube-cli/src/commands/deployments.rs
+++ b/rust/cube-cli/src/commands/deployments.rs
@@ -69,9 +69,25 @@ enum Cmd {
         /// Name
         #[arg(long)]
         name: Option<String>,
+        /// Release channel: latest, release
+        #[arg(long)]
+        release_channel: Option<String>,
+        /// Cube version to run — see `cube deployments versions <id>`
+        #[arg(long)]
+        release_channel_version: Option<String>,
         /// Request body as JSON (inline, @file, or - for stdin)
         #[arg(long, short = 'd')]
         data: Option<String>,
+    },
+    /// Show every setting of a deployment
+    Settings {
+        /// Deployment id
+        deployment: i64,
+    },
+    /// List the Cube versions a deployment can switch to
+    Versions {
+        /// Deployment id
+        deployment: i64,
     },
     /// Delete a deployment
     #[command(alias = "rm")]
@@ -181,10 +197,14 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
         Cmd::Update {
             deployment,
             name,
+            release_channel,
+            release_channel_version,
             data,
         } => {
             let mut body = util::parse_data(data.as_deref())?;
             util::set(&mut body, "name", &name);
+            util::set(&mut body, "releaseChannel", &release_channel);
+            util::set(&mut body, "releaseChannelVersion", &release_channel_version);
             let res = api
                 .put(
                     &format!("/api/v1/deployments/{deployment}"),
@@ -192,6 +212,34 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
                 )
                 .await?;
             output::print_json(&res);
+        }
+        Cmd::Settings { deployment } => {
+            let res = api
+                .get(
+                    &format!("/api/v1/deployments/{deployment}/settings"),
+                    &Vec::new(),
+                )
+                .await?;
+            output::print_json(&res);
+        }
+        Cmd::Versions { deployment } => {
+            let res = api
+                .get(
+                    &format!("/api/v1/deployments/{deployment}/versions"),
+                    &Vec::new(),
+                )
+                .await?;
+            output::print_list(
+                ctx.json,
+                &res,
+                &[
+                    ("VERSION", "version"),
+                    ("CHANNEL", "releaseChannel"),
+                    ("LATEST", "isLatestInChannel"),
+                    ("CURRENT", "isCurrent"),
+                    ("PASS AS", "releaseChannelVersion"),
+                ],
+            );
         }
         Cmd::Delete { deployment } => {
             let res = api

--- a/rust/cube-cli/src/commands/mod.rs
+++ b/rust/cube-cli/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod policies;
 pub mod regions;
 pub mod reports;
 pub mod scim;
+pub mod spec;
 pub mod tenant;
 pub mod update;
 pub mod users;

--- a/rust/cube-cli/src/commands/spec.rs
+++ b/rust/cube-cli/src/commands/spec.rs
@@ -1,0 +1,322 @@
+use std::collections::BTreeSet;
+
+use anyhow::{bail, Result};
+use serde_json::{json, Map, Value};
+
+use crate::{output, Ctx};
+
+/// The HTTP verbs an OpenAPI path item can hold. Anything else under a path
+/// (`parameters`, `summary`, `$ref`, extensions) is not an operation.
+const METHODS: [&str; 8] = [
+    "get", "put", "post", "patch", "delete", "options", "head", "trace",
+];
+
+const SCHEMA_REF_PREFIX: &str = "#/components/schemas/";
+
+/// Fetch the API's own OpenAPI document, so every endpoint, parameter and
+/// schema can be discovered at runtime rather than guessed.
+///
+/// Without `--json` this prints an index of operations, which is what a human
+/// scanning for an endpoint wants. With `--json` it prints OpenAPI: the whole
+/// document when unfiltered, or — when a pattern is given — a valid but much
+/// smaller document containing only the matching operations plus the transitive
+/// closure of the schemas they reference. That closure is the point of the
+/// filter: an agent asking "what does this endpoint take?" needs the request
+/// body's schema resolved, not a dangling `$ref` that forces it to pull the
+/// whole spec anyway.
+#[derive(clap::Args)]
+pub struct Args {
+    /// Show only operations whose method, path, summary or operationId contains
+    /// this text (case-insensitive)
+    pattern: Option<String>,
+}
+
+/// One operation, flattened out of the nested `paths` → method structure.
+struct Operation<'a> {
+    path: &'a str,
+    method: &'a str,
+    op: &'a Value,
+}
+
+impl Operation<'_> {
+    fn summary(&self) -> &str {
+        self.op
+            .get("summary")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+    }
+
+    fn operation_id(&self) -> &str {
+        self.op
+            .get("operationId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+    }
+
+    fn matches(&self, needle: &str) -> bool {
+        let haystack = format!(
+            "{} {} {} {}",
+            self.method,
+            self.path,
+            self.summary(),
+            self.operation_id()
+        )
+        .to_lowercase();
+        haystack.contains(needle)
+    }
+}
+
+fn operations(spec: &Value) -> Vec<Operation<'_>> {
+    let Some(paths) = spec.get("paths").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (path, item) in paths {
+        let Some(item) = item.as_object() else {
+            continue;
+        };
+        // Iterate METHODS rather than the object's keys so operations always
+        // come out in verb order, not whatever order the server serialized.
+        for method in METHODS {
+            if let Some(op) = item.get(method) {
+                out.push(Operation { path, method, op });
+            }
+        }
+    }
+    out
+}
+
+/// Every `#/components/schemas/...` name referenced anywhere inside `value`.
+fn collect_refs(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "$ref" {
+                    if let Some(name) = child
+                        .as_str()
+                        .and_then(|r| r.strip_prefix(SCHEMA_REF_PREFIX))
+                    {
+                        out.insert(name.to_string());
+                    }
+                }
+                collect_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Expand a set of schema names to include everything they reference, however
+/// deeply. Schemas are mutually recursive in places, so this runs to a fixpoint
+/// over a visited set rather than recursing through the graph.
+fn schema_closure(spec: &Value, seeds: BTreeSet<String>) -> BTreeSet<String> {
+    let all = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(Value::as_object);
+    let Some(all) = all else {
+        return BTreeSet::new();
+    };
+
+    let mut resolved: BTreeSet<String> = BTreeSet::new();
+    let mut pending: Vec<String> = seeds.into_iter().collect();
+    while let Some(name) = pending.pop() {
+        if !resolved.insert(name.clone()) {
+            continue;
+        }
+        if let Some(schema) = all.get(&name) {
+            let mut refs = BTreeSet::new();
+            collect_refs(schema, &mut refs);
+            pending.extend(refs.into_iter().filter(|r| !resolved.contains(r)));
+        }
+    }
+    resolved
+}
+
+/// Build a valid OpenAPI document holding only `matched`, carrying over the
+/// document-level fields a client needs to make sense of it (version, servers,
+/// security) plus just the schemas those operations reach.
+fn filtered_document(spec: &Value, matched: &[&Operation<'_>]) -> Value {
+    let mut paths = Map::new();
+    let mut seeds = BTreeSet::new();
+    for op in matched {
+        collect_refs(op.op, &mut seeds);
+        paths
+            .entry(op.path.to_string())
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .expect("path item is an object")
+            .insert(op.method.to_string(), op.op.clone());
+    }
+
+    let names = schema_closure(spec, seeds);
+    let mut schemas = Map::new();
+    if let Some(all) = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(Value::as_object)
+    {
+        for name in &names {
+            if let Some(schema) = all.get(name) {
+                schemas.insert(name.clone(), schema.clone());
+            }
+        }
+    }
+
+    let mut components = Map::new();
+    components.insert("schemas".into(), Value::Object(schemas));
+    // Security schemes are tiny and tell the reader how to authenticate the
+    // operations it just asked about, so they ride along.
+    if let Some(security_schemes) = spec
+        .get("components")
+        .and_then(|c| c.get("securitySchemes"))
+    {
+        components.insert("securitySchemes".into(), security_schemes.clone());
+    }
+
+    let mut doc = Map::new();
+    for key in ["openapi", "info", "servers", "security"] {
+        if let Some(value) = spec.get(key) {
+            doc.insert(key.to_string(), value.clone());
+        }
+    }
+    doc.insert("paths".into(), Value::Object(paths));
+    doc.insert("components".into(), Value::Object(components));
+    Value::Object(doc)
+}
+
+pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
+    let spec = ctx.api()?.get("/api/v1/spec", &Vec::new()).await?;
+
+    // Unfiltered JSON is the raw document — no reshaping, so it can be piped
+    // straight into a generator or a validator.
+    let Some(pattern) = args.pattern.as_deref() else {
+        if ctx.json {
+            output::print_json(&spec);
+        } else {
+            print_index(&operations(&spec).iter().collect::<Vec<_>>());
+        }
+        return Ok(());
+    };
+
+    let needle = pattern.to_lowercase();
+    let all = operations(&spec);
+    let matched: Vec<&Operation<'_>> = all.iter().filter(|op| op.matches(&needle)).collect();
+
+    if matched.is_empty() {
+        bail!("no operation matches `{pattern}` — run `cube spec` to list them all");
+    }
+
+    if ctx.json {
+        output::print_json(&filtered_document(&spec, &matched));
+    } else {
+        print_index(&matched);
+    }
+    Ok(())
+}
+
+fn print_index(operations: &[&Operation<'_>]) {
+    let rows = operations
+        .iter()
+        .map(|op| {
+            vec![
+                op.method.to_uppercase(),
+                op.path.to_string(),
+                op.summary().to_string(),
+            ]
+        })
+        .collect();
+    output::table(&["METHOD", "PATH", "SUMMARY"], rows);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> Value {
+        json!({
+            "openapi": "3.1.0",
+            "info": { "title": "t", "version": "1" },
+            "paths": {
+                "/api/v1/deployments/{id}/settings": {
+                    "get": { "operationId": "getSettings", "summary": "Get deployment settings" },
+                    "put": {
+                        "operationId": "updateSettings",
+                        "summary": "Update deployment settings",
+                        "requestBody": { "content": { "application/json": {
+                            "schema": { "$ref": "#/components/schemas/UpdateDeploymentInput" } } } }
+                    },
+                    "parameters": [{ "name": "id", "in": "path" }]
+                },
+                "/api/v1/regions": { "get": { "operationId": "listRegions", "summary": "List regions" } }
+            },
+            "components": {
+                "securitySchemes": { "bearerAuth": { "type": "http" } },
+                "schemas": {
+                    "UpdateDeploymentInput": { "properties": {
+                        "cspsConfig": { "$ref": "#/components/schemas/CspsConfig" } } },
+                    "CspsConfig": { "properties": {
+                        "self": { "$ref": "#/components/schemas/CspsConfig" } } },
+                    "Unrelated": { "type": "object" }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn lists_operations_in_verb_order_ignoring_non_operation_keys() {
+        let spec = spec();
+        let ops = operations(&spec);
+        assert_eq!(ops.len(), 3);
+        // `parameters` on the path item is not an operation.
+        assert!(ops.iter().all(|o| METHODS.contains(&o.method)));
+        let settings: Vec<&str> = ops
+            .iter()
+            .filter(|o| o.path.ends_with("/settings"))
+            .map(|o| o.method)
+            .collect();
+        assert_eq!(settings, vec!["get", "put"]);
+    }
+
+    #[test]
+    fn matches_on_path_summary_and_operation_id() {
+        let spec = spec();
+        let ops = operations(&spec);
+        assert_eq!(ops.iter().filter(|o| o.matches("settings")).count(), 2);
+        assert_eq!(ops.iter().filter(|o| o.matches("listregions")).count(), 1);
+        // Case-insensitive, and the method is part of the haystack.
+        assert_eq!(ops.iter().filter(|o| o.matches("put")).count(), 1);
+        assert_eq!(ops.iter().filter(|o| o.matches("nope")).count(), 0);
+    }
+
+    #[test]
+    fn filtered_document_carries_the_reachable_schemas_only() {
+        let spec = spec();
+        let ops = operations(&spec);
+        let matched: Vec<&Operation<'_>> = ops.iter().filter(|o| o.matches("settings")).collect();
+        let doc = filtered_document(&spec, &matched);
+
+        let paths = doc["paths"].as_object().unwrap();
+        assert_eq!(paths.len(), 1);
+        let item = paths["/api/v1/deployments/{id}/settings"]
+            .as_object()
+            .unwrap();
+        assert!(item.contains_key("get") && item.contains_key("put"));
+
+        let schemas = doc["components"]["schemas"].as_object().unwrap();
+        // Reached through the request body, and through CspsConfig's self-ref
+        // (which must terminate rather than spin).
+        assert!(schemas.contains_key("UpdateDeploymentInput"));
+        assert!(schemas.contains_key("CspsConfig"));
+        assert!(!schemas.contains_key("Unrelated"));
+        // Still a usable document: version, info and auth survive.
+        assert_eq!(doc["openapi"], "3.1.0");
+        assert!(doc["info"].is_object());
+        assert!(doc["components"]["securitySchemes"]["bearerAuth"].is_object());
+    }
+}

--- a/rust/cube-cli/src/commands/spec.rs
+++ b/rust/cube-cli/src/commands/spec.rs
@@ -12,6 +12,7 @@ const METHODS: [&str; 8] = [
 ];
 
 const SCHEMA_REF_PREFIX: &str = "#/components/schemas/";
+const COMPONENT_REF_PREFIX: &str = "#/components/";
 
 /// Fetch the API's own OpenAPI document, so every endpoint, parameter and
 /// schema can be discovered at runtime rather than guessed.
@@ -146,12 +147,25 @@ fn filtered_document(spec: &Value, matched: &[&Operation<'_>]) -> Value {
     let mut seeds = BTreeSet::new();
     for op in matched {
         collect_refs(op.op, &mut seeds);
-        paths
+        let item = paths
             .entry(op.path.to_string())
             .or_insert_with(|| json!({}))
             .as_object_mut()
-            .expect("path item is an object")
-            .insert(op.method.to_string(), op.op.clone());
+            .expect("path item is an object");
+        item.insert(op.method.to_string(), op.op.clone());
+
+        // A path item may declare `parameters` that apply to every operation
+        // under it. Dropping them would silently shrink the parameter list —
+        // the one thing this command exists to report — so they come along and
+        // their refs are seeded too.
+        if let Some(shared) = spec
+            .get("paths")
+            .and_then(|p| p.get(op.path))
+            .and_then(|i| i.get("parameters"))
+        {
+            collect_refs(shared, &mut seeds);
+            item.insert("parameters".into(), shared.clone());
+        }
     }
 
     let names = schema_closure(spec, seeds);
@@ -190,6 +204,66 @@ fn filtered_document(spec: &Value, matched: &[&Operation<'_>]) -> Value {
     Value::Object(doc)
 }
 
+/// Every `#/components/<bucket>/<name>` ref in `value`, as (bucket, name).
+fn collect_component_refs(value: &Value, out: &mut BTreeSet<(String, String)>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "$ref" {
+                    if let Some(rest) = child
+                        .as_str()
+                        .and_then(|r| r.strip_prefix(COMPONENT_REF_PREFIX))
+                    {
+                        if let Some((bucket, name)) = rest.split_once('/') {
+                            out.insert((bucket.to_string(), name.to_string()));
+                        }
+                    }
+                }
+                collect_component_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_component_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Refuse to emit a document whose `$ref`s don't resolve inside it.
+///
+/// The closure only follows `#/components/schemas/`, which is everything the
+/// current spec uses. If an operation ever references another bucket
+/// (`parameters`, `responses`, `requestBodies`, …), the filtered document would
+/// still carry the `$ref` but not its target: a validator rejects it and an
+/// agent resolves it to nothing. Since this output is meant to be consumed
+/// unattended, fail loudly rather than hand back something quietly wrong.
+fn check_no_dangling_refs(doc: &Value) -> Result<()> {
+    let mut refs = BTreeSet::new();
+    collect_component_refs(doc, &mut refs);
+
+    let dangling: Vec<String> = refs
+        .into_iter()
+        .filter(|(bucket, name)| {
+            doc.get("components")
+                .and_then(|c| c.get(bucket))
+                .and_then(|b| b.get(name))
+                .is_none()
+        })
+        .map(|(bucket, name)| format!("#/components/{bucket}/{name}"))
+        .collect();
+
+    if !dangling.is_empty() {
+        bail!(
+            "internal error building the filtered spec: unresolved {} — \
+             re-run without a pattern to get the whole document",
+            dangling.join(", ")
+        );
+    }
+    Ok(())
+}
+
 pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
     let spec = ctx.api()?.get("/api/v1/spec", &Vec::new()).await?;
 
@@ -213,7 +287,9 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
     }
 
     if ctx.json {
-        output::print_json(&filtered_document(&spec, &matched));
+        let doc = filtered_document(&spec, &matched);
+        check_no_dangling_refs(&doc)?;
+        output::print_json(&doc);
     } else {
         print_index(&matched);
     }
@@ -318,5 +394,47 @@ mod tests {
         assert_eq!(doc["openapi"], "3.1.0");
         assert!(doc["info"].is_object());
         assert!(doc["components"]["securitySchemes"]["bearerAuth"].is_object());
+        // Nothing points outside the document it just built.
+        check_no_dangling_refs(&doc).unwrap();
+    }
+
+    #[test]
+    fn filtered_document_keeps_path_level_parameters() {
+        let spec = spec();
+        let ops = operations(&spec);
+        let matched: Vec<&Operation<'_>> = ops.iter().filter(|o| o.matches("settings")).collect();
+        let doc = filtered_document(&spec, &matched);
+
+        // `id` is declared once on the path item, not per operation. Losing it
+        // would understate the endpoint's parameters — the exact thing this
+        // command is supposed to report.
+        let params = doc["paths"]["/api/v1/deployments/{id}/settings"]["parameters"]
+            .as_array()
+            .expect("path-level parameters survive filtering");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0]["name"], "id");
+    }
+
+    #[test]
+    fn dangling_component_refs_are_rejected() {
+        // A ref into a bucket the closure doesn't follow: the document keeps the
+        // `$ref` but not its target, so it must be refused rather than emitted.
+        let doc = json!({
+            "openapi": "3.1.0",
+            "paths": { "/x": { "get": {
+                "parameters": [{ "$ref": "#/components/parameters/Missing" }] } } },
+            "components": { "schemas": {} }
+        });
+        let err = check_no_dangling_refs(&doc).unwrap_err().to_string();
+        assert!(err.contains("#/components/parameters/Missing"), "{err}");
+
+        // A resolvable ref in a non-schema bucket is fine.
+        let ok = json!({
+            "openapi": "3.1.0",
+            "paths": { "/x": { "get": {
+                "parameters": [{ "$ref": "#/components/parameters/Present" }] } } },
+            "components": { "parameters": { "Present": { "name": "p", "in": "query" } } }
+        });
+        check_no_dangling_refs(&ok).unwrap();
     }
 }

--- a/rust/cube-cli/src/main.rs
+++ b/rust/cube-cli/src/main.rs
@@ -190,6 +190,8 @@ enum Command {
     /// SCIM v2 user and group provisioning
     Scim(commands::scim::Args),
 
+    /// Show this API's OpenAPI specification (endpoints, parameters, schemas)
+    Spec(commands::spec::Args),
     /// Make an authenticated raw API request (escape hatch)
     Api(commands::api::Args),
     /// Update the CLI to the latest release
@@ -239,6 +241,7 @@ impl Command {
             App(_) => "app",
             Meta(_) => "meta",
             Scim(_) => "scim",
+            Spec(_) => "spec",
             Api(_) => "api",
             Update(_) => "update",
             Completion(_) => "completion",
@@ -335,6 +338,7 @@ async fn run(global: GlobalArgs, command: Command) -> Result<()> {
         App(args) => commands::app::command(args, &ctx).await,
         Meta(args) => commands::meta::command(args, &ctx).await,
         Scim(args) => commands::scim::command(args, &ctx).await,
+        Spec(args) => commands::spec::command(args, &ctx).await,
         Api(args) => commands::api::command(args, &ctx).await,
         Update(args) => commands::update::command(args, &ctx).await,
         Completion(args) => commands::completion::command(args),


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available — `cargo test` (13 tests, 3 new), `cargo fmt --check`, `cargo clippy --all-targets` clean
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Two things, both downstream of cubedevinc/cubejs-enterprise#14128.

## `cube spec` — runtime API discovery

The API now serves its own OpenAPI document at `GET /api/v1/spec`. `cube spec` is the front end for it, so neither a person nor an agent has to guess an endpoint's parameters, and the contract comes from the build being talked to rather than a pinned copy.

```bash
cube spec                                            # index every operation
cube spec settings                                   # filter on method/path/summary/operationId
cube spec "deployments/{deploymentId}/settings" --json
```

Bare and filtered runs print a `METHOD`/`PATH`/`SUMMARY` table. `--json` prints OpenAPI instead: unfiltered it's the whole document (pipe it into a generator or a validator); filtered it's a **still-valid** document holding only the matching operations plus the transitive closure of the schemas they reference.

That closure is the point of the filter, not a size optimization. An agent asking "what does this endpoint take?" needs the request body's schema resolved — a bare `$ref` would force it to fetch the whole document anyway. Against the current API that turns a 238KB answer into a 9KB one that still carries all 19 properties of `UpdateDeploymentInput`, its nested `CspsConfig`, and every enum they reach:

```
$ cube spec "deployments/{deploymentId}/settings" --json | jq '.components.schemas | keys | length'
16
```

Implementation notes worth a reviewer's attention: the closure runs to a fixpoint over a visited set because the schemas are mutually recursive in places (a naive walk doesn't terminate — there's a test for it); operations are emitted in verb order rather than the server's key order; non-operation keys on a path item (`parameters`, `summary`, extensions) are skipped; and a pattern matching nothing exits non-zero rather than printing an empty table, since it's nearly always a typo.

## Regenerated API reference

`api-reference/api.yaml` and the `docs.json` nav groups are generated from the upstream public spec by `scripts/extract-api.mjs` — this is a re-run, nothing hand-edited. It picks up:

- the new `GET /api/v1/spec`
- `GET`/`PUT /api/v1/deployments/{deploymentId}/settings` (the full deployment Settings surface over REST)
- spec changes that landed upstream without a docs sync: the staging-environment branch route, three dbt-sync status/result routes, and the removal of the workbook `ai-widget-thread` route

Plus a hand-added `redirects` entry for the removed `ai-widget-thread` page, which was published and would otherwise start 404ing. The extractor rewrites only the `openapi`-backed nav groups, so that redirect survives future regenerations.

New prose: a "Discovering the API" section in `reference/cli.mdx` and an `/api/v1/spec` entry in `reference/control-plane-api.mdx`.

## Review feedback from the first pass

All three actionable findings were fixed at the source rather than papered over here:

- **Sentence-long `summary` on the `/settings` operations** → shortened upstream, prose moved to `description` (Mintlify derives both the page title and the slug from `summary`, so it was producing a ~150-char URL).
- **`shaderConfig` published with a dated model enum** → removed from the public spec entirely. It's the AI chat/RAG model override, no Settings page edits it, and the enum is exactly the docs-churn liability the review described.
- **Removed `ai-widget-thread` page** → redirect added, slugs computed with Mintlify's own `slugify` rather than by hand.

Three findings I'm deliberately not acting on, all other teams' endpoint text where fixing it means editing unrelated operations inside a docs-sync PR: the "Cube Cloud" legacy naming in the staging-environment description, the undocumented `branchId`/`branchName` pairing on `SetBranchStagingEnvironmentRequest`, and the `DashboardWidgetDtoType` enum change (which landed upstream in someone else's PR — this sync only makes it visible).

`extract-api.mjs --check` against the updated spec reports the reference up to date.
