### PR TITLE
docs: document regtype casts, AI summary caching, and Order & limit control

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
@@ -22,13 +22,9 @@ Write the prompt as if you were briefing an analyst — describe the audience, t
 
 ## Caching
 
-Once generated, the summary is **cached** with the widget. Viewers loading the dashboard see the cached response immediately — they don't pay for regeneration on every page load.
+Generated summaries are **cached per dashboard state** — the queries behind each chart, the active control values, and the chart configuration. Viewers loading the dashboard, or changing a control, see the cached response for that state immediately instead of paying for regeneration; switching to a state with no cached summary generates one automatically. Because each state caches separately, one viewer's filter selection never overwrites the summary another viewer sees.
 
-## Staleness detection
-
-The widget keeps a checksum of the dashboard state at the time of generation: the queries behind each chart, the active control values, and the chart configuration. When any of those change, the widget marks the cached summary as **stale** and shows a refresh prompt so viewers know the narrative may no longer match the data.
-
-Click the refresh icon (or open the widget menu and choose **Refresh**) to regenerate using the saved prompt against the latest state.
+Click the refresh icon (or open the widget menu and choose **Refresh**) to regenerate using the saved prompt against the current state. The widget shows how long ago its summary was generated, alongside the same freshness indicator used by chart widgets.
 
 ## Choosing the agent
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -124,7 +124,7 @@ also enabled, the pinned totals row shows a grand total for each pivot group.
 
 Every query in a workbook returns at most a fixed number of rows. By
 default, queries are limited to **5,000 rows**, and you can adjust the
-limit up to **50,000 rows** from the query controls.
+limit up to **50,000 rows** from the **Order & limit** control (alongside [sorting](#sorting-control)).
 
 The default and maximum values available in the workbook are governed by
 the deployment's [Model Configuration][ref-configuration]:
@@ -157,7 +157,7 @@ If a column has sorting applied, a chevron icon on the header indicates the curr
 
 ### Sorting control
 
-The sorting control, available via the **Sort** button, lists all query members and their current state:
+The sorting control is available via the **Order & limit** button, alongside the [row limit](#limiting). It lists all query members and their current state:
 unsorted, sorted ascending, or sorted descending. Use it to apply or
 change the sort order for any member. Drag and drop members within the sorting control to change their priority in the sort order.
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -360,6 +360,33 @@ of the PostgreSQL documentation.
 | --- | --- | --- | --- |
 | `TO_CHAR` | Converts a timestamp to string according to the given format | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 
+### Type casts
+
+<Info>
+
+Learn more about the `regtype` pseudo-type in the
+[relevant section](https://www.postgresql.org/docs/current/datatype-oid.html)
+of the PostgreSQL documentation.
+
+</Info>
+
+| Cast | Description | [Pushdown][ref-qpd] | <nobr>[Post-processing][ref-qpp]</nobr> |
+| --- | --- | --- | --- |
+| `::regtype` | Casts a type name or OID to the `regtype` pseudo-type, e.g., `atttypid::regtype` | ✅ Yes | ❌ No |
+| `::regtype[]` | Casts an array literal of type names to `regtype[]`, e.g., `'{int8,numeric,bool}'::regtype[]` | ✅ Yes | ❌ No |
+
+<Note>
+
+`regtype` and `regtype[]` casts accept `pg_type.typname` values, canonical type
+names, common SQL aliases (`int`, `decimal`, `char`, `float`), an optional
+`pg_catalog.` qualifier, and a trailing type modifier. They exist mainly for
+compatibility with BI tools that introspect the schema over the SQL API's
+PostgreSQL wire protocol — for example, a query of the form `atttypid = ANY
+('{int8,numeric,bool}'::regtype[])` against `pg_catalog.pg_attribute` — rather
+than for use in hand-written queries.
+
+</Note>
+
 ### Date/time functions
 
 <Info>


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change, N/A)
- [ ] Linter has been run for changed code (docs-only change, N/A)
- [ ] Tests for the changes have been added if not covered yet (docs-only change, N/A)

**Description of Changes Made**

Routine documentation audit cross-checking recent code changes in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify` for undocumented customer-facing behavior. Three small gaps found and fixed:

- **SQL API reference** (`reference/core-data-apis/sql-api/reference.mdx`): document the `::regtype` / `::regtype[]` casts added in #11503. These exist for BI-tool compatibility — tools that introspect the schema over the SQL API's Postgres wire protocol (e.g. queries of the form `atttypid = ANY ('{int8,numeric,bool}'::regtype[])` against `pg_catalog.pg_attribute`) — and had no docs coverage.
- **AI summary widget** (`docs/explore-analyze/dashboards/widgets/ai-summary.mdx`): the Caching/Staleness detection sections described the old thread-id + checksum persistence model, which was replaced by a per-dashboard-state server-side cache (cubejs-enterprise CUB-3898/CUB-3928). Updated to describe the current behavior: summaries cache per dashboard state, switching states auto-loads or regenerates as needed, and a freshness indicator (matching chart widgets) replaces the old stale-checksum banner.
- **Workbooks querying-data** (`docs/explore-analyze/workbooks/querying-data.mdx`): the separate **Sort** button and row-limit control were merged into one **Order & limit** control (cubejs-enterprise #14064). Updated the Sorting/Limiting sections to name the current control.

No `docs.json` changes needed — all three are edits to already-registered pages.


---
_Generated by [Claude Code](https://claude.ai/code/session_013YiS2UHatWSuMdY2MHdgaP)_