### PR TITLE
fix: Validate query timezone against IANA zones

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1415,6 +1415,14 @@ for][ref-config-sched-refresh-timer].
 | --------------------------------------------------------- | ---------------------- | --------------------- |
 | [A valid timezone from the tz database][wiki-tz-database] | N/A                    | N/A                   |
 
+<Warning>
+
+An invalid value fails at server startup. Only TZ Database names are accepted — fixed
+UTC offsets such as `+05:00` are rejected. Empty entries are ignored, so a trailing or
+repeated comma, e.g. `UTC,`, is not an error.
+
+</Warning>
+
 It can be also set using the [`scheduled_refresh_time_zones` configuration
 option](/reference/configuration/config#scheduled_refresh_time_zones).
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1104,7 +1104,15 @@ The default [time zone][ref-time-zone] for queries.
 | A valid time zone name | `UTC`                  | `UTC`                 |
 
 You can set the time zone name in the [TZ Database Name][link-tzdb] format, e.g.,
-`America/Los_Angeles`.
+`America/Los_Angeles`. Names are matched case-insensitively and normalized to their
+canonical form, so `america/los_angeles` resolves to `America/Los_Angeles`.
+
+<Warning>
+
+An invalid value fails at server startup. Only TZ Database names are accepted — fixed
+UTC offsets such as `+05:00` are rejected.
+
+</Warning>
 
 This is the fallback. When [user time zones](/admin/time-zones) are enabled for the
 account, a resolved account, personal, dashboard, or embed zone is sent with the query and
@@ -1410,6 +1418,13 @@ for][ref-config-sched-refresh-timer].
 
 It can be also set using the [`scheduled_refresh_time_zones` configuration
 option](/reference/configuration/config#scheduled_refresh_time_zones).
+
+<Warning>
+
+An invalid entry fails at server startup. Names are matched case-insensitively and
+normalized to their canonical form.
+
+</Warning>
 
 ## `CUBEJS_SCHEMA_PATH`
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1418,8 +1418,7 @@ for][ref-config-sched-refresh-timer].
 <Warning>
 
 An invalid value fails at server startup. Only TZ Database names are accepted — fixed
-UTC offsets such as `+05:00` are rejected. Empty entries are ignored, so a trailing or
-repeated comma, e.g. `UTC,`, is not an error.
+UTC offsets such as `+05:00` are rejected.
 
 </Warning>
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1104,8 +1104,7 @@ The default [time zone][ref-time-zone] for queries.
 | A valid time zone name | `UTC`                  | `UTC`                 |
 
 You can set the time zone name in the [TZ Database Name][link-tzdb] format, e.g.,
-`America/Los_Angeles`. Names are matched case-insensitively and normalized to their
-canonical form, so `america/los_angeles` resolves to `America/Los_Angeles`.
+`America/Los_Angeles`.
 
 <Warning>
 
@@ -1418,13 +1417,6 @@ for][ref-config-sched-refresh-timer].
 
 It can be also set using the [`scheduled_refresh_time_zones` configuration
 option](/reference/configuration/config#scheduled_refresh_time_zones).
-
-<Warning>
-
-An invalid entry fails at server startup. Names are matched case-insensitively and
-normalized to their canonical form.
-
-</Warning>
 
 ## `CUBEJS_SCHEMA_PATH`
 

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -997,7 +997,6 @@ class ApiGateway {
         case 'post':
           result = await this.preAggregationsJobsPOST(
             context,
-            // Use the selector normalized by the schema (canonical IANA timezones).
             <PreAggsSelector>value.selector
           );
           if (result.length === 0) {

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -92,6 +92,7 @@ import {
   normalizeQueryCancelPreAggregations,
   normalizeQueryPreAggregationPreview,
   normalizeQueryPreAggregations,
+  normalizeTimezone,
   parseInputMemberExpression,
   preAggsJobsRequestSchema,
   remapToQueryAdapterFormat,
@@ -480,7 +481,9 @@ class ApiGateway {
         try {
           await this.assertApiScope('data', req.context?.securityContext);
 
-          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, req.body.timezone, req.body.throwContinueWait, req.context?.requestId);
+          const timezone = normalizeTimezone(req.body.timezone);
+
+          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, timezone, req.body.throwContinueWait, req.context?.requestId);
         } catch (e: any) {
           // Quickfix for https://github.com/cube-js/cube/issues/10450,
           // Right now, it's too complicated to fix the issue correctly, because
@@ -985,7 +988,7 @@ class ApiGateway {
         throw new UserError('No job description provided');
       }
 
-      const { error } = preAggsJobsRequestSchema.validate(query);
+      const { error, value } = preAggsJobsRequestSchema.validate(query);
       if (error) {
         throw new UserError(`Invalid Job query format: ${error.message || error.toString()}`);
       }
@@ -994,7 +997,8 @@ class ApiGateway {
         case 'post':
           result = await this.preAggregationsJobsPOST(
             context,
-            <PreAggsSelector>query.selector
+            // Use the selector normalized by the schema (canonical IANA timezones).
+            <PreAggsSelector>value.selector
           );
           if (result.length === 0) {
             throw new UserError(

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -87,6 +87,7 @@ import { SubscriptionServer, WebSocketSendMessageFn } from './ws/subscription-se
 import { LocalSubscriptionStore } from './ws/local-subscription-store';
 import {
   getPivotQuery,
+  cubeSqlRequestSchema,
   getQueryGranularity,
   normalizeQuery,
   normalizeQueryCancelPreAggregations,
@@ -95,7 +96,6 @@ import {
   parseInputMemberExpression,
   preAggsJobsRequestSchema,
   remapToQueryAdapterFormat,
-  timezoneSchema,
 } from './query';
 import { cachedHandler } from './cached-handler';
 import { createJWKsFetcher } from './jwk';
@@ -481,12 +481,12 @@ class ApiGateway {
         try {
           await this.assertApiScope('data', req.context?.securityContext);
 
-          const { error, value: timezone } = timezoneSchema.validate(req.body.timezone, { errors: { label: false } });
+          const { error, value: body } = cubeSqlRequestSchema.validate(req.body);
           if (error) {
-            throw new UserError(`Invalid timezone: ${error.message || error.toString()}`);
+            throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
           }
 
-          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, timezone, req.body.throwContinueWait, req.context?.requestId);
+          await this.sqlServer.execSql(body.query, res, req.context?.securityContext, body.cache, body.timezone, body.throwContinueWait, req.context?.requestId);
         } catch (e: any) {
           // Quickfix for https://github.com/cube-js/cube/issues/10450,
           // Right now, it's too complicated to fix the issue correctly, because

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -92,10 +92,10 @@ import {
   normalizeQueryCancelPreAggregations,
   normalizeQueryPreAggregationPreview,
   normalizeQueryPreAggregations,
-  normalizeTimezone,
   parseInputMemberExpression,
   preAggsJobsRequestSchema,
   remapToQueryAdapterFormat,
+  timezoneSchema,
 } from './query';
 import { cachedHandler } from './cached-handler';
 import { createJWKsFetcher } from './jwk';
@@ -481,7 +481,10 @@ class ApiGateway {
         try {
           await this.assertApiScope('data', req.context?.securityContext);
 
-          const timezone = normalizeTimezone(req.body.timezone);
+          const { error, value: timezone } = timezoneSchema.validate(req.body.timezone, { errors: { label: false } });
+          if (error) {
+            throw new UserError(`Invalid timezone: ${error.message || error.toString()}`);
+          }
 
           await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, timezone, req.body.throwContinueWait, req.context?.requestId);
         } catch (e: any) {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -69,7 +69,7 @@ const canonicalTimezone = (value) => {
 const timezoneSchema = Joi.string().custom((value, helpers) => {
   const name = canonicalTimezone(value);
   if (!name) {
-    return helpers.message(`{{#label}} must be a valid IANA time zone, got "${value}"`);
+    return helpers.message({ custom: '{{#label}} must be a valid IANA time zone, got "{{#tz}}"' }, { tz: value });
   }
 
   // Normalize to the canonical IANA name.

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -1,5 +1,5 @@
 import R from 'ramda';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Joi from 'joi';
 import { getEnv } from '@cubejs-backend/shared';
 
@@ -56,6 +56,13 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 });
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  if (!moment.tz.zone(value)) {
+    return helpers.error('any.invalid');
+  }
+  return value;
+}, 'timezone');
+
 // It might be member name, td+granularity or member expression
 const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 const dimensionWithTime = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/);
@@ -183,7 +190,7 @@ const querySchema = Joi.object().keys({
     Joi.array().items(Joi.array().min(2).ordered(idOrMemberExpressionName, Joi.valid('asc', 'desc')))
   ),
   segments: Joi.array().items(Joi.alternatives(id, memberExpression, parsedMemberExpression)),
-  timezone: Joi.string(),
+  timezone: timezoneSchema,
   limit: Joi.number().integer().strict().min(0),
   offset: Joi.number().integer().strict().min(0),
   total: Joi.boolean(),
@@ -220,7 +227,7 @@ export const preAggsJobsRequestSchema = Joi.object({
           securityContext: Joi.required(),
         })
       ).min(1).required(),
-      timezones: Joi.array().items(Joi.string()).min(1).required(),
+      timezones: Joi.array().items(timezoneSchema).min(1).required(),
       dataSources: Joi.array().items(Joi.string()),
       cubes: Joi.array().items(Joi.string()),
       preAggregations: Joi.array().items(Joi.string()),
@@ -497,8 +504,8 @@ const remapToQueryAdapterFormat = (query) => (query ? {
 const queryPreAggregationsSchema = Joi.object().keys({
   expand: Joi.array().items(Joi.string()),
   metadata: Joi.object(),
-  timezone: Joi.string(),
-  timezones: Joi.array().items(Joi.string()),
+  timezone: timezoneSchema,
+  timezones: Joi.array().items(timezoneSchema),
   preAggregations: Joi.array().items(Joi.object().keys({
     id: Joi.string().required(),
     cacheOnly: Joi.boolean(),
@@ -524,7 +531,7 @@ const normalizeQueryPreAggregations = (query, defaultValues) => {
 
 const queryPreAggregationPreviewSchema = Joi.object().keys({
   preAggregationId: Joi.string().required(),
-  timezone: Joi.string().required(),
+  timezone: timezoneSchema.required(),
   versionEntry: Joi.object().required().keys({
     content_version: Joi.string(),
     last_updated_at: Joi.number(),

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -56,15 +56,42 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 });
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
-const timezoneSchema = Joi.string().custom((value, helpers) => {
+const canonicalTimezone = (value) => {
   const zone = moment.tz.zone(value);
-  if (!zone) {
-    return helpers.error('any.invalid');
+  if (zone) {
+    // Normalize to the canonical IANA name.
+    return zone.name;
   }
 
-  // Normalize to the canonical IANA name (case-insensitively).
-  return zone.name;
+  return null;
+};
+
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  const name = canonicalTimezone(value);
+  if (!name) {
+    return helpers.message(`{{#label}} must be a valid IANA time zone, got "${value}"`);
+  }
+
+  // Normalize to the canonical IANA name.
+  return name;
 }, 'timezone');
+
+/**
+ * @param {string|undefined} value
+ * @returns {string|undefined}
+ */
+export const normalizeTimezone = (value) => {
+  if (!value) {
+    return value;
+  }
+
+  const name = canonicalTimezone(value);
+  if (!name) {
+    throw new UserError(`timezone must be a valid IANA time zone, got "${value}"`);
+  }
+
+  return name;
+};
 
 // It might be member name, td+granularity or member expression
 const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
@@ -426,7 +453,7 @@ function normalizeQueryCacheMode(query, cacheMode) {
 const normalizeQuery = (query, persistent, cacheMode) => {
   query = normalizeQueryCacheMode(query, cacheMode);
   query.timezone = query.timezone || getEnv('defaultTimezone');
-  const { error } = querySchema.validate(query);
+  const { error, value } = querySchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
@@ -444,10 +471,9 @@ const normalizeQuery = (query, persistent, cacheMode) => {
     dimension: d.split('.').slice(0, 2).join('.'),
     granularity: d.split('.')[2]
   }));
-  // query.timezone is already validated as a known zone above; normalize it to the
-  // canonical IANA name (moment matches zones case-insensitively).
-  const rawTimezone = query.timezone || 'UTC';
-  const timezone = moment.tz.zone(rawTimezone)?.name || rawTimezone;
+  // Use the timezone normalized by the schema (canonical IANA name); the raw request
+  // may carry a different casing.
+  const timezone = value.timezone || 'UTC';
 
   const def = getEnv('dbQueryDefaultLimit') <= getEnv('dbQueryLimit')
     ? getEnv('dbQueryDefaultLimit')
@@ -522,14 +548,15 @@ const queryPreAggregationsSchema = Joi.object().keys({
 });
 
 const normalizeQueryPreAggregations = (query, defaultValues) => {
-  const { error } = queryPreAggregationsSchema.validate(query);
+  const { error, value } = queryPreAggregationsSchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
+  // Use timezones normalized by the schema (canonical IANA names).
   return {
     metadata: query.metadata,
-    timezones: query.timezones || (query.timezone && [query.timezone]) || defaultValues?.timezones || ['UTC'],
+    timezones: value.timezones || (value.timezone && [value.timezone]) || defaultValues?.timezones || ['UTC'],
     preAggregations: query.preAggregations,
     expand: query.expand
   };
@@ -549,12 +576,13 @@ const queryPreAggregationPreviewSchema = Joi.object().keys({
 });
 
 const normalizeQueryPreAggregationPreview = (query) => {
-  const { error } = queryPreAggregationPreviewSchema.validate(query);
+  const { error, value } = queryPreAggregationPreviewSchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
-  return query;
+  // Use the timezone normalized by the schema (canonical IANA name).
+  return { ...query, timezone: value.timezone };
 };
 
 const queryCancelPreAggregationPreviewSchema = Joi.object().keys({

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -75,6 +75,10 @@ export const normalizeTimezone = (value) => {
     return value;
   }
 
+  if (typeof value !== 'string') {
+    throw new UserError(`timezone must be a string, got ${typeof value}`);
+  }
+
   const name = canonicalTimezone(value);
   if (!name) {
     throw new UserError(`timezone must be a valid IANA time zone, got "${value}"`);

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -1,7 +1,7 @@
 import R from 'ramda';
 import moment from 'moment-timezone';
 import Joi from 'joi';
-import { getEnv } from '@cubejs-backend/shared';
+import { canonicalTimezone, getEnv } from '@cubejs-backend/shared';
 
 import { UserError } from './user-error';
 import { dateParser } from './date-parser';
@@ -56,15 +56,6 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 });
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
-const canonicalTimezone = (value) => {
-  const zone = moment.tz.zone(value);
-  if (zone) {
-    // Normalize to the canonical IANA name.
-    return zone.name;
-  }
-
-  return null;
-};
 
 const timezoneSchema = Joi.string().custom((value, helpers) => {
   const name = canonicalTimezone(value);
@@ -72,7 +63,6 @@ const timezoneSchema = Joi.string().custom((value, helpers) => {
     return helpers.message({ custom: '{{#label}} must be a valid IANA time zone, got "{{#tz}}"' }, { tz: value });
   }
 
-  // Normalize to the canonical IANA name.
   return name;
 }, 'timezone');
 
@@ -471,8 +461,6 @@ const normalizeQuery = (query, persistent, cacheMode) => {
     dimension: d.split('.').slice(0, 2).join('.'),
     granularity: d.split('.')[2]
   }));
-  // Use the timezone normalized by the schema (canonical IANA name); the raw request
-  // may carry a different casing.
   const timezone = value.timezone || 'UTC';
 
   const def = getEnv('dbQueryDefaultLimit') <= getEnv('dbQueryLimit')
@@ -553,7 +541,6 @@ const normalizeQueryPreAggregations = (query, defaultValues) => {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
-  // Use timezones normalized by the schema (canonical IANA names).
   return {
     metadata: query.metadata,
     timezones: value.timezones || (value.timezone && [value.timezone]) || defaultValues?.timezones || ['UTC'],
@@ -581,7 +568,6 @@ const normalizeQueryPreAggregationPreview = (query) => {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
-  // Use the timezone normalized by the schema (canonical IANA name).
   return { ...query, timezone: value.timezone };
 };
 

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -57,7 +57,9 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 
-export const timezoneSchema = Joi.string().custom((value, helpers) => {
+const cacheModeSchema = Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache');
+
+const timezoneSchema = Joi.string().custom((value, helpers) => {
   const name = canonicalTimezone(value);
   if (!name) {
     return helpers.message({ custom: '{{#label}} must be a valid IANA time zone, got "{{#tz}}"' }, { tz: value });
@@ -197,8 +199,8 @@ const querySchema = Joi.object().keys({
   limit: Joi.number().integer().strict().min(0),
   offset: Joi.number().integer().strict().min(0),
   total: Joi.boolean(),
-  cacheMode: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
-  cache: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
+  cacheMode: cacheModeSchema,
+  cache: cacheModeSchema,
   ungrouped: Joi.boolean(),
   responseFormat: Joi.valid('default', 'compact', 'columnar'),
   subqueryJoins: Joi.array().items(subqueryJoin),
@@ -207,6 +209,13 @@ const querySchema = Joi.object().keys({
     member: Joi.string().required(),
     filter: Joi.object(),
   })),
+});
+
+export const cubeSqlRequestSchema = Joi.object().keys({
+  query: Joi.string().required(),
+  timezone: timezoneSchema,
+  cache: cacheModeSchema,
+  throwContinueWait: Joi.boolean(),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -57,10 +57,13 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 const timezoneSchema = Joi.string().custom((value, helpers) => {
-  if (!moment.tz.zone(value)) {
+  const zone = moment.tz.zone(value);
+  if (!zone) {
     return helpers.error('any.invalid');
   }
-  return value;
+
+  // Normalize to the canonical IANA name (case-insensitively).
+  return zone.name;
 }, 'timezone');
 
 // It might be member name, td+granularity or member expression
@@ -441,7 +444,10 @@ const normalizeQuery = (query, persistent, cacheMode) => {
     dimension: d.split('.').slice(0, 2).join('.'),
     granularity: d.split('.')[2]
   }));
-  const timezone = query.timezone || 'UTC';
+  // query.timezone is already validated as a known zone above; normalize it to the
+  // canonical IANA name (moment matches zones case-insensitively).
+  const rawTimezone = query.timezone || 'UTC';
+  const timezone = moment.tz.zone(rawTimezone)?.name || rawTimezone;
 
   const def = getEnv('dbQueryDefaultLimit') <= getEnv('dbQueryLimit')
     ? getEnv('dbQueryDefaultLimit')

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -57,7 +57,7 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 
-const timezoneSchema = Joi.string().custom((value, helpers) => {
+export const timezoneSchema = Joi.string().custom((value, helpers) => {
   const name = canonicalTimezone(value);
   if (!name) {
     return helpers.message({ custom: '{{#label}} must be a valid IANA time zone, got "{{#tz}}"' }, { tz: value });
@@ -65,27 +65,6 @@ const timezoneSchema = Joi.string().custom((value, helpers) => {
 
   return name;
 }, 'timezone');
-
-/**
- * @param {string|undefined} value
- * @returns {string|undefined}
- */
-export const normalizeTimezone = (value) => {
-  if (!value) {
-    return value;
-  }
-
-  if (typeof value !== 'string') {
-    throw new UserError(`timezone must be a string, got ${typeof value}`);
-  }
-
-  const name = canonicalTimezone(value);
-  if (!name) {
-    throw new UserError(`timezone must be a valid IANA time zone, got "${value}"`);
-  }
-
-  return name;
-};
 
 // It might be member name, td+granularity or member expression
 const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
+  cubeSqlRequestSchema,
   normalizeQuery,
   normalizeQueryPreAggregations,
   normalizeQueryPreAggregationPreview,
-  timezoneSchema,
 } from '../src/query';
 
 const baseQuery = {
@@ -107,33 +107,57 @@ describe('normalizeQueryPreAggregationPreview timezone handling', () => {
   });
 });
 
-// Used on its own (not as part of an object schema) to validate the /v1/cubesql
-// session timezone.
-describe('timezoneSchema as a standalone validator', () => {
-  test.each([
-    ['america/new_york', 'America/New_York'],
-    ['UTC', 'UTC'],
-    ['uTc', 'UTC'],
-  ])('normalizes %j -> %j', (tz, expected) => {
-    const { error, value } = timezoneSchema.validate(tz);
+describe('cubeSqlRequestSchema', () => {
+  const baseBody = { query: 'SELECT 1' };
+
+  test('accepts a body with only the query', () => {
+    const { error, value } = cubeSqlRequestSchema.validate(baseBody);
     expect(error).toBeUndefined();
-    expect(value).toBe(expected);
+    expect(value).toEqual(baseBody);
   });
 
-  test('accepts an absent value', () => {
-    const { error, value } = timezoneSchema.validate(undefined);
+  test('accepts every supported field', () => {
+    const { error, value } = cubeSqlRequestSchema.validate({
+      ...baseBody,
+      timezone: 'America/Los_Angeles',
+      cache: 'stale-while-revalidate',
+      throwContinueWait: true,
+    });
     expect(error).toBeUndefined();
-    expect(value).toBeUndefined();
+    expect(value.cache).toBe('stale-while-revalidate');
+    expect(value.throwContinueWait).toBe(true);
+  });
+
+  test('requires the query', () => {
+    expect(cubeSqlRequestSchema.validate({}).error?.message).toMatch(/"query" is required/);
+  });
+
+  test('rejects an unknown field', () => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, nope: 1 }).error).toBeDefined();
+  });
+
+  test('rejects an unknown cache mode', () => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, cache: 'sometimes' }).error).toBeDefined();
+  });
+
+  test.each([
+    ['america/new_york', 'America/New_York'],
+    ['uTc', 'UTC'],
+  ])('normalizes timezone %j -> %j', (tz, expected) => {
+    const { error, value } = cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz });
+    expect(error).toBeUndefined();
+    expect(value.timezone).toBe(expected);
   });
 
   test.each([
     'Not/AZone',
     'foo/bar',
   ])('rejects invalid timezone %j', (tz) => {
-    expect(timezoneSchema.validate(tz).error?.message).toMatch(/valid IANA time zone/);
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz }).error?.message)
+      .toMatch(/valid IANA time zone/);
   });
 
-  test.each([null, '', 123, true])('rejects %j', (tz) => {
-    expect(timezoneSchema.validate(tz).error).toBeDefined();
+  test.each([null, '', 123, true])('rejects timezone %j', (tz) => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz }).error).toBeDefined();
   });
 });

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -51,6 +51,28 @@ describe('timezone validation', () => {
   ])('rejects invalid timezone %j', (tz) => {
     expect(() => normalizeQuery({ ...baseQuery, timezone: tz }, false)).toThrow(/Invalid query format/);
   });
+
+  describe('default timezone fallback', () => {
+    afterEach(() => {
+      delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+    });
+
+    test('falls back to UTC when CUBEJS_DEFAULT_TIMEZONE is unset', () => {
+      delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+
+      const { timezone, ...queryWithoutTimezone } = baseQuery;
+      const result = normalizeQuery(queryWithoutTimezone, false);
+      expect(result.timezone).toBe('UTC');
+    });
+
+    test('uses the canonicalized CUBEJS_DEFAULT_TIMEZONE when set', () => {
+      process.env.CUBEJS_DEFAULT_TIMEZONE = 'america/new_york';
+
+      const { timezone, ...queryWithoutTimezone } = baseQuery;
+      const result = normalizeQuery(queryWithoutTimezone, false);
+      expect(result.timezone).toBe('America/New_York');
+    });
+  });
 });
 
 describe('normalizeQueryPreAggregations timezone handling', () => {

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -3,7 +3,7 @@ import {
   normalizeQuery,
   normalizeQueryPreAggregations,
   normalizeQueryPreAggregationPreview,
-  normalizeTimezone,
+  timezoneSchema,
 } from '../src/query';
 
 const baseQuery = {
@@ -107,23 +107,33 @@ describe('normalizeQueryPreAggregationPreview timezone handling', () => {
   });
 });
 
-describe('normalizeTimezone helper', () => {
+// Used on its own (not as part of an object schema) to validate the /v1/cubesql
+// session timezone.
+describe('timezoneSchema as a standalone validator', () => {
   test.each([
     ['america/new_york', 'America/New_York'],
     ['UTC', 'UTC'],
     ['uTc', 'UTC'],
   ])('normalizes %j -> %j', (tz, expected) => {
-    expect(normalizeTimezone(tz)).toBe(expected);
+    const { error, value } = timezoneSchema.validate(tz);
+    expect(error).toBeUndefined();
+    expect(value).toBe(expected);
   });
 
-  test.each([undefined, null, ''])('passes through empty value %j', (tz) => {
-    expect(normalizeTimezone(tz as any)).toBe(tz);
+  test('accepts an absent value', () => {
+    const { error, value } = timezoneSchema.validate(undefined);
+    expect(error).toBeUndefined();
+    expect(value).toBeUndefined();
   });
 
   test.each([
     'Not/AZone',
     'foo/bar',
-  ])('throws on invalid timezone %j', (tz) => {
-    expect(() => normalizeTimezone(tz)).toThrow(/valid IANA time zone/);
+  ])('rejects invalid timezone %j', (tz) => {
+    expect(timezoneSchema.validate(tz).error?.message).toMatch(/valid IANA time zone/);
+  });
+
+  test.each([null, '', 123, true])('rejects %j', (tz) => {
+    expect(timezoneSchema.validate(tz).error).toBeDefined();
   });
 });

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -30,6 +30,16 @@ describe('timezone validation', () => {
   );
 
   test.each([
+    ['america/new_york', 'America/New_York'],
+    ['AMERICA/NEW_YORK', 'America/New_York'],
+    ['utc', 'UTC'],
+    ['uTc', 'UTC'],
+  ])('accepts timezone case-insensitively and normalizes it: %s -> %s', (tz, expected) => {
+    const result = normalizeQuery({ ...baseQuery, timezone: tz }, false);
+    expect(result.timezone).toBe(expected);
+  });
+
+  test.each([
     'Not/AZone',
     '+05:00',
   ])('rejects invalid/injection timezone %j', (tz) => {

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -1,5 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { normalizeQuery } from '../src/query';
+import {
+  normalizeQuery,
+  normalizeQueryPreAggregations,
+  normalizeQueryPreAggregationPreview,
+  normalizeTimezone,
+} from '../src/query';
 
 const baseQuery = {
   measures: ['Foo.count'],
@@ -42,7 +47,61 @@ describe('timezone validation', () => {
   test.each([
     'Not/AZone',
     '+05:00',
-  ])('rejects invalid/injection timezone %j', (tz) => {
+    'foo/bar',
+  ])('rejects invalid timezone %j', (tz) => {
     expect(() => normalizeQuery({ ...baseQuery, timezone: tz }, false)).toThrow(/Invalid query format/);
+  });
+});
+
+describe('normalizeQueryPreAggregations timezone handling', () => {
+  test('normalizes timezone to canonical IANA name', () => {
+    const result = normalizeQueryPreAggregations({ timezone: 'america/new_york' }, undefined);
+    expect(result.timezones).toEqual(['America/New_York']);
+  });
+
+  test('normalizes timezones array to canonical IANA names', () => {
+    const result = normalizeQueryPreAggregations({ timezones: ['utc', 'europe/berlin'] }, undefined);
+    expect(result.timezones).toEqual(['UTC', 'Europe/Berlin']);
+  });
+
+  test('rejects invalid timezone', () => {
+    expect(() => normalizeQueryPreAggregations({ timezones: ['Not/AZone'] }, undefined)).toThrow(/Invalid query format/);
+  });
+});
+
+describe('normalizeQueryPreAggregationPreview timezone handling', () => {
+  const previewQuery = {
+    preAggregationId: 'cube.preAgg',
+    versionEntry: { content_version: 'a', structure_version: 'b' },
+  };
+
+  test('normalizes timezone to canonical IANA name', () => {
+    const result = normalizeQueryPreAggregationPreview({ ...previewQuery, timezone: 'america/new_york' });
+    expect(result.timezone).toBe('America/New_York');
+  });
+
+  test('rejects invalid timezone', () => {
+    expect(() => normalizeQueryPreAggregationPreview({ ...previewQuery, timezone: 'Not/AZone' })).toThrow(/Invalid query format/);
+  });
+});
+
+describe('normalizeTimezone helper', () => {
+  test.each([
+    ['america/new_york', 'America/New_York'],
+    ['UTC', 'UTC'],
+    ['uTc', 'UTC'],
+  ])('normalizes %j -> %j', (tz, expected) => {
+    expect(normalizeTimezone(tz)).toBe(expected);
+  });
+
+  test.each([undefined, null, ''])('passes through empty value %j', (tz) => {
+    expect(normalizeTimezone(tz as any)).toBe(tz);
+  });
+
+  test.each([
+    'Not/AZone',
+    'foo/bar',
+  ])('throws on invalid timezone %j', (tz) => {
+    expect(() => normalizeTimezone(tz)).toThrow(/valid IANA time zone/);
   });
 });

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -19,3 +19,20 @@ describe('responseFormat validation', () => {
     expect(() => normalizeQuery({ ...baseQuery, responseFormat: 'arrow' }, false)).toThrow(/Invalid query format/);
   });
 });
+
+describe('timezone validation', () => {
+  test.each(['UTC', 'America/New_York', 'Europe/Berlin', 'Asia/Tokyo'])(
+    'accepts valid IANA timezone %s',
+    (tz) => {
+      const result = normalizeQuery({ ...baseQuery, timezone: tz }, false);
+      expect(result.timezone).toBe(tz);
+    }
+  );
+
+  test.each([
+    'Not/AZone',
+    '+05:00',
+  ])('rejects invalid/injection timezone %j', (tz) => {
+    expect(() => normalizeQuery({ ...baseQuery, timezone: tz }, false)).toThrow(/Invalid query format/);
+  });
+});

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -2,6 +2,7 @@
 import { get } from 'env-var';
 import { displayCLIWarning, displayCLIWarningOnce } from './cli';
 import { isNativeSupported } from './platform';
+import { canonicalTimezone } from './timezone';
 
 export class InvalidConfiguration extends Error {
   public constructor(key: string, value: any, description: string) {
@@ -269,13 +270,29 @@ const variables: Record<string, (...args: any) => any> = {
   scheduledRefreshQueriesPerAppId: () => get('CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID').asIntPositive(),
   refreshWorkerConcurrency: () => get('CUBEJS_REFRESH_WORKER_CONCURRENCY')
     .asIntPositive(),
-  // eslint-disable-next-line consistent-return
   scheduledRefreshTimezones: () => {
     const timezones = get('CUBEJS_SCHEDULED_REFRESH_TIMEZONES').asString();
-
-    if (timezones) {
-      return timezones.split(',').map(t => t.trim());
+    // Unset must stay `undefined`, not `null`: CreateOptions.scheduledRefreshTimeZones is an
+    // optional property, and optionsValidate's Joi.alternatives() rejects null — which would
+    // break boot if option validation is ever moved after the env defaults are merged.
+    if (!timezones) {
+      return undefined;
     }
+
+    return timezones.split(',').map(t => {
+      const raw = t.trim();
+
+      const timezone = canonicalTimezone(raw);
+      if (!timezone) {
+        throw new InvalidConfiguration(
+          'CUBEJS_SCHEDULED_REFRESH_TIMEZONES',
+          raw,
+          'Must be a comma-separated list of valid IANA time zone names, e.g. UTC,America/Los_Angeles.'
+        );
+      }
+
+      return timezone;
+    });
   },
   preAggregationsBuilder: () => get('CUBEJS_PRE_AGGREGATIONS_BUILDER').asBool(),
   gracefulShutdown: () => get('CUBEJS_GRACEFUL_SHUTDOWN')
@@ -338,9 +355,20 @@ const variables: Record<string, (...args: any) => any> = {
   nestedFoldersDelimiter: () => get('CUBEJS_NESTED_FOLDERS_DELIMITER')
     .default('')
     .asString(),
-  defaultTimezone: () => get('CUBEJS_DEFAULT_TIMEZONE')
-    .default('UTC')
-    .asString(),
+  defaultTimezone: () => {
+    const value = (get('CUBEJS_DEFAULT_TIMEZONE').asString() || '').trim() || 'UTC';
+
+    const timezone = canonicalTimezone(value);
+    if (!timezone) {
+      throw new InvalidConfiguration(
+        'CUBEJS_DEFAULT_TIMEZONE',
+        value,
+        'Must be a valid IANA time zone name, e.g. UTC or America/Los_Angeles.'
+      );
+    }
+
+    return timezone;
+  },
   preciseDecimalInCubestore: () => get('CUBEJS_DB_PRECISE_DECIMAL_IN_CUBESTORE')
     .default('false')
     .asBoolStrict(),

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -271,17 +271,13 @@ const variables: Record<string, (...args: any) => any> = {
   refreshWorkerConcurrency: () => get('CUBEJS_REFRESH_WORKER_CONCURRENCY')
     .asIntPositive(),
   scheduledRefreshTimezones: () => {
-    const timezones = get('CUBEJS_SCHEDULED_REFRESH_TIMEZONES').asString();
-    // Unset must stay `undefined`, not `null`: CreateOptions.scheduledRefreshTimeZones is an
-    // optional property, and optionsValidate's Joi.alternatives() rejects null — which would
-    // break boot if option validation is ever moved after the env defaults are merged.
-    if (!timezones) {
-      return undefined;
-    }
+    const timezones = get('CUBEJS_SCHEDULED_REFRESH_TIMEZONES')
+      .default('')
+      .asArray()
+      .map(timezone => timezone.trim())
+      .filter(Boolean);
 
-    return timezones.split(',').map(t => {
-      const raw = t.trim();
-
+    return timezones.map(raw => {
       const timezone = canonicalTimezone(raw);
       if (!timezone) {
         throw new InvalidConfiguration(

--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -21,6 +21,7 @@ export * from './http-utils';
 export * from './cli';
 export * from './proxy';
 export * from './time';
+export * from './timezone';
 export * from './process';
 export * from './platform';
 export * from './FileRepository';

--- a/packages/cubejs-backend-shared/src/timezone.ts
+++ b/packages/cubejs-backend-shared/src/timezone.ts
@@ -2,19 +2,21 @@ import moment from 'moment-timezone';
 
 /**
  * Resolves `value` to a canonical tz-database zone name, matched case-insensitively,
- * or `null` when it is unset, empty or not a known zone.
+ * or `null` when it is unset or not a known zone.
  *
- * @throws {TypeError} when `value` is neither a string nor unset.
+ * @throws {TypeError} when `value` is an empty string, or is neither a string nor unset.
  */
 export function canonicalTimezone(value?: string | null): string | null {
-  // `''` is checked explicitly rather than left to moment.tz.zone(), which happens to
-  // return null for it. Note `!value` would swallow non-strings that must throw below.
-  if (value === undefined || value === null || value === '') {
+  if (value === undefined || value === null) {
     return null;
   }
 
   if (typeof value !== 'string') {
     throw new TypeError(`Timezone must be a string, got ${typeof value}`);
+  }
+
+  if (value === '') {
+    throw new TypeError('Timezone must not be empty');
   }
 
   const zone = moment.tz.zone(value);

--- a/packages/cubejs-backend-shared/src/timezone.ts
+++ b/packages/cubejs-backend-shared/src/timezone.ts
@@ -2,13 +2,17 @@ import moment from 'moment-timezone';
 
 /**
  * Resolves `value` to a canonical tz-database zone name, matched case-insensitively,
- * or `null` when it is not a known zone.
+ * or `null` when it is unset or not a known zone.
+ *
+ * @throws {TypeError} when `value` is neither a string nor unset.
  */
-export function canonicalTimezone(value: string | null): string | null {
-  // Real callers are plain JS, so the signature is not enforced: moment.tz.zone() throws a
-  // TypeError on a non-string, which would surface as a 500 instead of a validation error.
-  if (typeof value !== 'string' || value === '') {
+export function canonicalTimezone(value?: string | null): string | null {
+  if (value === undefined || value === null) {
     return null;
+  }
+
+  if (typeof value !== 'string') {
+    throw new TypeError(`Timezone must be a string, got ${typeof value}`);
   }
 
   const zone = moment.tz.zone(value);

--- a/packages/cubejs-backend-shared/src/timezone.ts
+++ b/packages/cubejs-backend-shared/src/timezone.ts
@@ -2,12 +2,14 @@ import moment from 'moment-timezone';
 
 /**
  * Resolves `value` to a canonical tz-database zone name, matched case-insensitively,
- * or `null` when it is unset or not a known zone.
+ * or `null` when it is unset, empty or not a known zone.
  *
  * @throws {TypeError} when `value` is neither a string nor unset.
  */
 export function canonicalTimezone(value?: string | null): string | null {
-  if (value === undefined || value === null) {
+  // `''` is checked explicitly rather than left to moment.tz.zone(), which happens to
+  // return null for it. Note `!value` would swallow non-strings that must throw below.
+  if (value === undefined || value === null || value === '') {
     return null;
   }
 

--- a/packages/cubejs-backend-shared/src/timezone.ts
+++ b/packages/cubejs-backend-shared/src/timezone.ts
@@ -1,0 +1,17 @@
+import moment from 'moment-timezone';
+
+/**
+ * Resolves `value` to a canonical tz-database zone name, matched case-insensitively,
+ * or `null` when it is not a known zone.
+ */
+export function canonicalTimezone(value: string | null): string | null {
+  // Real callers are plain JS, so the signature is not enforced: moment.tz.zone() throws a
+  // TypeError on a non-string, which would surface as a 500 instead of a validation error.
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+
+  const zone = moment.tz.zone(value);
+
+  return zone ? zone.name : null;
+}

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -185,8 +185,7 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
     delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
   });
 
-  // env-var's .default() does not fire for a *present but blank* value, and it does not trim.
-  // Blank/padded values are common in .env and compose YAML, so they must keep booting.
+  // env-var's .default() does not fire for a present but blank value, and it does not trim.
   test('defaultTimezone - unset / blank / padded resolve to UTC', () => {
     delete process.env.CUBEJS_DEFAULT_TIMEZONE;
     expect(getEnv('defaultTimezone')).toBe('UTC');
@@ -237,8 +236,7 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
     expect(getEnv('scheduledRefreshTimezones')).toEqual(['America/New_York']);
   });
 
-  // Trailing/repeated separators are common in .env files and compose YAML, so they must
-  // not be read as an empty zone.
+  // Trailing/repeated separators are common in .env files and compose YAML.
   test('scheduledRefreshTimezones - ignores empty entries', () => {
     process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,';
     expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC']);

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -178,3 +178,69 @@ describe('getEnv(apiSecret / apiSecrets)', () => {
     expect(getEnv('apiSecrets')).toEqual(['only']);
   });
 });
+
+describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
+  afterEach(() => {
+    delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+  });
+
+  // env-var's .default() does not fire for a *present but blank* value, and it does not trim.
+  // Blank/padded values are common in .env and compose YAML, so they must keep booting.
+  test('defaultTimezone - unset / blank / padded resolve to UTC', () => {
+    delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+    expect(getEnv('defaultTimezone')).toBe('UTC');
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = '';
+    expect(getEnv('defaultTimezone')).toBe('UTC');
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = '   ';
+    expect(getEnv('defaultTimezone')).toBe('UTC');
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = ' UTC ';
+    expect(getEnv('defaultTimezone')).toBe('UTC');
+  });
+
+  test('defaultTimezone - normalizes to the canonical IANA name', () => {
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'America/Los_Angeles';
+    expect(getEnv('defaultTimezone')).toBe('America/Los_Angeles');
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'america/los_angeles';
+    expect(getEnv('defaultTimezone')).toBe('America/Los_Angeles');
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'utc';
+    expect(getEnv('defaultTimezone')).toBe('UTC');
+  });
+
+  test('defaultTimezone(exception)', () => {
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'Europ/Berlin';
+    expect(() => getEnv('defaultTimezone')).toThrowError(
+      'Value "Europ/Berlin" is not valid for CUBEJS_DEFAULT_TIMEZONE. Must be a valid IANA time zone name, e.g. UTC or America/Los_Angeles.'
+    );
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = '+05:00';
+    expect(() => getEnv('defaultTimezone')).toThrowError(
+      'Value "+05:00" is not valid for CUBEJS_DEFAULT_TIMEZONE. Must be a valid IANA time zone name, e.g. UTC or America/Los_Angeles.'
+    );
+  });
+
+  test('scheduledRefreshTimezones - unset resolves to undefined', () => {
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+    expect(getEnv('scheduledRefreshTimezones')).toBeUndefined();
+  });
+
+  test('scheduledRefreshTimezones - trims and normalizes each entry', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'utc, europe/berlin';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC', 'Europe/Berlin']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'America/New_York';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['America/New_York']);
+  });
+
+  test('scheduledRefreshTimezones(exception)', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,Nope/Zone';
+    expect(() => getEnv('scheduledRefreshTimezones')).toThrowError(
+      'Value "Nope/Zone" is not valid for CUBEJS_SCHEDULED_REFRESH_TIMEZONES. Must be a comma-separated list of valid IANA time zone names, e.g. UTC,America/Los_Angeles.'
+    );
+  });
+});

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -224,9 +224,9 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
     );
   });
 
-  test('scheduledRefreshTimezones - unset resolves to undefined', () => {
+  test('scheduledRefreshTimezones - unset resolves to an empty list', () => {
     delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
-    expect(getEnv('scheduledRefreshTimezones')).toBeUndefined();
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
   });
 
   test('scheduledRefreshTimezones - trims and normalizes each entry', () => {
@@ -235,6 +235,30 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
 
     process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'America/New_York';
     expect(getEnv('scheduledRefreshTimezones')).toEqual(['America/New_York']);
+  });
+
+  // Trailing/repeated separators are common in .env files and compose YAML, so they must
+  // not be read as an empty zone.
+  test('scheduledRefreshTimezones - ignores empty entries', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,,America/Los_Angeles';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC', 'America/Los_Angeles']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = ' UTC , ';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC']);
+  });
+
+  test('scheduledRefreshTimezones - blank resolves to an empty list', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = '';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = '   ';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = ',';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
   });
 
   test('scheduledRefreshTimezones(exception)', () => {

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -29,7 +29,6 @@ describe('canonicalTimezone', () => {
     'Not/AZone',
     'Europ/Berlin',
     'foo/bar',
-    // Offsets are the SQL injection surface.
     '+05:00',
     '+05',
     '05',
@@ -42,18 +41,23 @@ describe('canonicalTimezone', () => {
     expect(canonicalTimezone(value)).toBeNull();
   });
 
-  // The casts are the point: real callers are plain JS, so the signature is not enforced and
-  // moment.tz.zone() would throw a TypeError instead of returning null.
   test.each([
     undefined,
     null,
+  ])('returns null for unset value %j', (value) => {
+    expect(canonicalTimezone(value)).toBeNull();
+  });
+
+  // The casts are the point: real callers are plain JS, so the signature is not enforced.
+  // A wrong type is a bug at the call site, not an unknown zone.
+  test.each([
     123,
     0,
     {},
     [],
     true,
-  ])('returns null without throwing for non-string %j', (value) => {
-    expect(() => canonicalTimezone(value as any)).not.toThrow();
-    expect(canonicalTimezone(value as any)).toBeNull();
+    false,
+  ])('throws for non-string %j', (value) => {
+    expect(() => canonicalTimezone(value as any)).toThrow(TypeError);
   });
 });

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -32,7 +32,6 @@ describe('canonicalTimezone', () => {
     '+05:00',
     '+05',
     '05',
-    '',
     // No trimming: API payloads must be exact.
     ' UTC',
     'UTC ',
@@ -44,7 +43,8 @@ describe('canonicalTimezone', () => {
   test.each([
     undefined,
     null,
-  ])('returns null for unset value %j', (value) => {
+    '',
+  ])('returns null for unset or empty value %j', (value) => {
     expect(canonicalTimezone(value)).toBeNull();
   });
 

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -1,0 +1,59 @@
+import { canonicalTimezone } from '../src/timezone';
+
+describe('canonicalTimezone', () => {
+  test.each([
+    ['UTC', 'UTC'],
+    ['utc', 'UTC'],
+    ['uTc', 'UTC'],
+    ['America/New_York', 'America/New_York'],
+    ['america/new_york', 'America/New_York'],
+    ['AMERICA/NEW_YORK', 'America/New_York'],
+    ['Etc/GMT+5', 'Etc/GMT+5'],
+    ['GMT', 'GMT'],
+    ['EST', 'EST'],
+  ])('resolves %j to the canonical name %j', (value, expected) => {
+    expect(canonicalTimezone(value)).toBe(expected);
+  });
+
+  // Pinned deliberately: resolving links to their target would change query cache keys and
+  // pre-agg partition names for deployments already using them.
+  test.each([
+    ['US/Pacific', 'US/Pacific'],
+    ['Asia/Calcutta', 'Asia/Calcutta'],
+    ['Europe/Kiev', 'Europe/Kiev'],
+  ])('keeps link name %j as-is', (value, expected) => {
+    expect(canonicalTimezone(value)).toBe(expected);
+  });
+
+  test.each([
+    'Not/AZone',
+    'Europ/Berlin',
+    'foo/bar',
+    // Offsets are the SQL injection surface.
+    '+05:00',
+    '+05',
+    '05',
+    '',
+    // No trimming: API payloads must be exact.
+    ' UTC',
+    'UTC ',
+    '  UTC  ',
+  ])('returns null for invalid value %j', (value) => {
+    expect(canonicalTimezone(value)).toBeNull();
+  });
+
+  // The casts are the point: real callers are plain JS, so the signature is not enforced and
+  // moment.tz.zone() would throw a TypeError instead of returning null.
+  test.each([
+    undefined,
+    null,
+    123,
+    0,
+    {},
+    [],
+    true,
+  ])('returns null without throwing for non-string %j', (value) => {
+    expect(() => canonicalTimezone(value as any)).not.toThrow();
+    expect(canonicalTimezone(value as any)).toBeNull();
+  });
+});

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -52,7 +52,6 @@ describe('canonicalTimezone', () => {
   });
 
   // The casts are the point: real callers are plain JS, so the signature is not enforced.
-  // A wrong type is a bug at the call site, not an unknown zone.
   test.each([
     123,
     0,

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -43,9 +43,12 @@ describe('canonicalTimezone', () => {
   test.each([
     undefined,
     null,
-    '',
-  ])('returns null for unset or empty value %j', (value) => {
+  ])('returns null for unset value %j', (value) => {
     expect(canonicalTimezone(value)).toBeNull();
+  });
+
+  test('throws for an empty string', () => {
+    expect(() => canonicalTimezone('')).toThrow(TypeError);
   });
 
   // The casts are the point: real callers are plain JS, so the signature is not enforced.

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -301,9 +301,8 @@ export class BaseQuery {
 
     // Backstop guard for every dialect convertTz() sink. Deliberately does not canonicalize:
     // rewriting this.timezone would change generated SQL and pre-agg partition keys for
-    // non-gateway callers (queryRewrite, refresh scheduler). Message matches the native planner.
-    // The type is checked here so query options carrying a wrong type stay a user error
-    // instead of the TypeError canonicalTimezone raises for call-site bugs.
+    // non-gateway callers (queryRewrite, refresh scheduler). The type is checked here so a
+    // wrong one stays a user error instead of the TypeError canonicalTimezone raises.
     if (this.timezone && (typeof this.timezone !== 'string' || !canonicalTimezone(this.timezone))) {
       throw new UserError(`Incorrect timezone ${this.timezone}`);
     }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -302,7 +302,9 @@ export class BaseQuery {
     // Backstop guard for every dialect convertTz() sink. Deliberately does not canonicalize:
     // rewriting this.timezone would change generated SQL and pre-agg partition keys for
     // non-gateway callers (queryRewrite, refresh scheduler). Message matches the native planner.
-    if (this.timezone && !canonicalTimezone(this.timezone)) {
+    // The type is checked here so query options carrying a wrong type stay a user error
+    // instead of the TypeError canonicalTimezone raises for call-site bugs.
+    if (this.timezone && (typeof this.timezone !== 'string' || !canonicalTimezone(this.timezone))) {
       throw new UserError(`Incorrect timezone ${this.timezone}`);
     }
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -297,6 +297,11 @@ export class BaseQuery {
     this.from = this.options.from;
     this.multiStageQuery = this.options.multiStageQuery;
     this.timezone = this.options.timezone;
+
+    if (this.timezone && !moment.tz.zone(this.timezone)) {
+      throw new UserError(`Incorrect timezone: ${this.timezone}`);
+    }
+
     this.rowLimit = this.options.rowLimit;
     this.offset = this.options.offset;
     /** @type {import('./PreAggregations').PreAggregations} */

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -299,12 +299,15 @@ export class BaseQuery {
     this.multiStageQuery = this.options.multiStageQuery;
     this.timezone = this.options.timezone;
 
-    // Backstop guard for every dialect convertTz() sink. Deliberately does not canonicalize:
-    // rewriting this.timezone would change generated SQL and pre-agg partition keys for
-    // non-gateway callers (queryRewrite, refresh scheduler). The type is checked here so a
-    // wrong one stays a user error instead of the TypeError canonicalTimezone raises.
-    if (this.timezone && (typeof this.timezone !== 'string' || !canonicalTimezone(this.timezone))) {
-      throw new UserError(`Incorrect timezone ${this.timezone}`);
+    // Backstop for every dialect convertTz() sink: callers that bypass the API gateway
+    // (queryRewrite, refresh scheduler, SQL API sessions) reach the dialects through here.
+    if (this.timezone) {
+      const timezone = canonicalTimezone(this.timezone);
+      if (!timezone) {
+        throw new UserError(`Incorrect timezone ${this.timezone}`);
+      }
+
+      this.timezone = timezone;
     }
 
     this.rowLimit = this.options.rowLimit;
@@ -949,7 +952,7 @@ export class BaseQuery {
       dimensions: this.options.dimensions,
       segments: this.options.segments,
       timeDimensions: this.options.timeDimensions,
-      timezone: this.options.timezone,
+      timezone: this.timezone,
       joinGraph: this.joinGraph,
       cubeEvaluator: this.cubeEvaluator,
       securityContext: this.contextSymbols.securityContext,
@@ -1007,7 +1010,7 @@ export class BaseQuery {
       dimensions: this.options.dimensions,
       segments: this.options.segments,
       timeDimensions: this.options.timeDimensions,
-      timezone: this.options.timezone,
+      timezone: this.timezone,
       joinGraph: this.joinGraph,
       cubeEvaluator: this.cubeEvaluator,
       order,

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -299,7 +299,7 @@ export class BaseQuery {
     this.timezone = this.options.timezone;
 
     if (this.timezone && !moment.tz.zone(this.timezone)) {
-      throw new UserError(`Incorrect timezone: ${this.timezone}`);
+      throw new UserError(`Incorrect timezone ${this.timezone}`);
     }
 
     this.rowLimit = this.options.rowLimit;

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -18,6 +18,7 @@ import {
   FROM_PARTITION_RANGE,
   MAX_SOURCE_ROW_LIMIT,
   QueryAlias,
+  canonicalTimezone,
   getEnv,
   localTimestampToUtc,
   timeSeries as timeSeriesBase,
@@ -298,7 +299,10 @@ export class BaseQuery {
     this.multiStageQuery = this.options.multiStageQuery;
     this.timezone = this.options.timezone;
 
-    if (this.timezone && !moment.tz.zone(this.timezone)) {
+    // Backstop guard for every dialect convertTz() sink. Deliberately does not canonicalize:
+    // rewriting this.timezone would change generated SQL and pre-agg partition keys for
+    // non-gateway callers (queryRewrite, refresh scheduler). Message matches the native planner.
+    if (this.timezone && !canonicalTimezone(this.timezone)) {
       throw new UserError(`Incorrect timezone ${this.timezone}`);
     }
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -148,6 +148,31 @@ describe('SQL Generation', () => {
           filters: [],
         })).toThrow(UserError);
       }
+
+      // Valid IANA zones are accepted regardless of case (normalization to the
+      // canonical name happens at the API gateway input layer).
+      const validTimezones = [
+        'America/New_York',
+        'america/new_york',
+        'AMERICA/NEW_YORK',
+        'utc',
+        'uTc',
+      ];
+
+      for (const timezone of validTimezones) {
+        expect(() => new PostgresQuery(compilers, {
+          measures: ['cards.count'],
+          timeDimensions: [
+            {
+              dimension: 'cards.createdAt',
+              granularity: 'day',
+              dateRange: ['2021-01-01', '2021-01-02']
+            }
+          ],
+          timezone,
+          filters: [],
+        })).not.toThrow();
+      }
     });
 
     it('Simple query - complex measure', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -171,19 +171,27 @@ describe('SQL Generation', () => {
       expect(() => buildTimezoneQuery('Not/AZone')).toThrow('Incorrect timezone Not/AZone');
     });
 
-    it('validates without canonicalizing the timezone', async () => {
+    // The native planner parses the zone case-sensitively, so the name reaching the
+    // dialects has to be the canonical one whichever planner runs.
+    it.each([
+      ['utc', 'UTC'],
+      ['america/new_york', 'America/New_York'],
+    ])('canonicalizes timezone %j to %j', async (timezone, expected) => {
       await compilers.compiler.compile();
-      const query = buildTimezoneQuery('utc');
-      expect(query.timezone).toBe('utc');
+      const query = buildTimezoneQuery(timezone);
+      expect(query.timezone).toBe(expected);
+      expect(query.buildSqlAndParams()[0]).toContain(`AT TIME ZONE '${expected}'`);
     });
 
+    // Unreachable over HTTP: every route validates the timezone as a string before the
+    // query is built, so a wrong type here is a bug in a config hook.
     it.each([
       123,
       {},
       true,
-    ])('rejects non-string timezone %j as a UserError', async (timezone) => {
+    ])('rejects non-string timezone %j', async (timezone) => {
       await compilers.compiler.compile();
-      expect(() => buildTimezoneQuery(timezone as any)).toThrow(UserError);
+      expect(() => buildTimezoneQuery(timezone as any)).toThrow(TypeError);
     });
 
     it('Simple query - complex measure', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -95,6 +95,7 @@ describe('SQL Generation', () => {
           'ORDER BY  2  DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - time dimension', async () => {
       await compilers.compiler.compile();
 
@@ -122,6 +123,33 @@ describe('SQL Generation', () => {
       expect(queryAndParams[0]).toContain('GROUP BY 1, 2');
       expect(queryAndParams[0]).toContain('ORDER BY  2');
     });
+
+    it('validate timezone', async () => {
+      await compilers.compiler.compile();
+
+      const maliciousTimezones = [
+        'Not/AZone',
+        '+05:00',
+        '+05',
+        '05'
+      ];
+
+      for (const timezone of maliciousTimezones) {
+        expect(() => new PostgresQuery(compilers, {
+          measures: ['cards.count'],
+          timeDimensions: [
+            {
+              dimension: 'cards.createdAt',
+              granularity: 'day',
+              dateRange: ['2021-01-01', '2021-01-02']
+            }
+          ],
+          timezone,
+          filters: [],
+        })).toThrow(UserError);
+      }
+    });
+
     it('Simple query - complex measure', async () => {
       await compilers.compiler.compile();
 
@@ -137,6 +165,7 @@ describe('SQL Generation', () => {
           'FROM  card_tbl  AS "cards"';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - complex dimension', async () => {
       await compilers.compiler.compile();
 
@@ -157,6 +186,7 @@ describe('SQL Generation', () => {
           'ORDER BY  2  DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - CUBE dimension', async () => {
       await compilers.compiler.compile();
 
@@ -177,6 +207,7 @@ describe('SQL Generation', () => {
           'ORDER BY  2  DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - CUBE id', async () => {
       await compilers.compiler.compile();
 
@@ -197,6 +228,7 @@ describe('SQL Generation', () => {
           'ORDER BY  2  DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - simple filter', async () => {
       await compilers.compiler.compile();
 
@@ -241,6 +273,7 @@ describe('SQL Generation', () => {
       const expectedParams = ['type_value', 'not_type_value', 'type_value'];
       expect(queryAndParams[1]).toEqual(expectedParams);
     });
+
     it('Simple query - null and many equals filter', async () => {
       await compilers.compiler.compile();
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -183,17 +183,6 @@ describe('SQL Generation', () => {
       expect(query.buildSqlAndParams()[0]).toContain(`AT TIME ZONE '${expected}'`);
     });
 
-    // Unreachable over HTTP: every route validates the timezone as a string before the
-    // query is built, so a wrong type here is a bug in a config hook.
-    it.each([
-      123,
-      {},
-      true,
-    ])('rejects non-string timezone %j', async (timezone) => {
-      await compilers.compiler.compile();
-      expect(() => buildTimezoneQuery(timezone as any)).toThrow(TypeError);
-    });
-
     it('Simple query - complex measure', async () => {
       await compilers.compiler.compile();
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -124,55 +124,47 @@ describe('SQL Generation', () => {
       expect(queryAndParams[0]).toContain('ORDER BY  2');
     });
 
-    it('validate timezone', async () => {
+    const buildTimezoneQuery = (timezone: string) => new PostgresQuery(compilers, {
+      measures: ['cards.count'],
+      timeDimensions: [
+        {
+          dimension: 'cards.createdAt',
+          granularity: 'day',
+          dateRange: ['2021-01-01', '2021-01-02']
+        }
+      ],
+      timezone,
+      filters: [],
+    });
+
+    it.each([
+      'Not/AZone',
+      '+05:00',
+      '+05',
+      '05',
+      'foo/bar',
+    ])('rejects invalid timezone %j', async (timezone) => {
       await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery(timezone)).toThrow(UserError);
+    });
 
-      const maliciousTimezones = [
-        'Not/AZone',
-        '+05:00',
-        '+05',
-        '05'
-      ];
+    // Valid IANA zones are accepted regardless of case (normalization to the
+    // canonical name happens at the API gateway input layer, not in BaseQuery).
+    it.each([
+      'America/New_York',
+      'america/new_york',
+      'AMERICA/NEW_YORK',
+      'utc',
+      'uTc',
+    ])('accepts valid timezone regardless of case: %s', async (timezone) => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery(timezone)).not.toThrow();
+    });
 
-      for (const timezone of maliciousTimezones) {
-        expect(() => new PostgresQuery(compilers, {
-          measures: ['cards.count'],
-          timeDimensions: [
-            {
-              dimension: 'cards.createdAt',
-              granularity: 'day',
-              dateRange: ['2021-01-01', '2021-01-02']
-            }
-          ],
-          timezone,
-          filters: [],
-        })).toThrow(UserError);
-      }
-
-      // Valid IANA zones are accepted regardless of case (normalization to the
-      // canonical name happens at the API gateway input layer).
-      const validTimezones = [
-        'America/New_York',
-        'america/new_york',
-        'AMERICA/NEW_YORK',
-        'utc',
-        'uTc',
-      ];
-
-      for (const timezone of validTimezones) {
-        expect(() => new PostgresQuery(compilers, {
-          measures: ['cards.count'],
-          timeDimensions: [
-            {
-              dimension: 'cards.createdAt',
-              granularity: 'day',
-              dateRange: ['2021-01-01', '2021-01-02']
-            }
-          ],
-          timezone,
-          filters: [],
-        })).not.toThrow();
-      }
+    it('renders a canonical timezone into SQL', async () => {
+      await compilers.compiler.compile();
+      const [sql] = buildTimezoneQuery('America/New_York').buildSqlAndParams();
+      expect(sql).toContain("AT TIME ZONE 'America/New_York'");
     });
 
     it('Simple query - complex measure', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -148,8 +148,6 @@ describe('SQL Generation', () => {
       expect(() => buildTimezoneQuery(timezone)).toThrow(UserError);
     });
 
-    // Valid IANA zones are accepted regardless of case (normalization to the
-    // canonical name happens at the API gateway input layer, not in BaseQuery).
     it.each([
       'America/New_York',
       'america/new_york',
@@ -165,6 +163,27 @@ describe('SQL Generation', () => {
       await compilers.compiler.compile();
       const [sql] = buildTimezoneQuery('America/New_York').buildSqlAndParams();
       expect(sql).toContain("AT TIME ZONE 'America/New_York'");
+    });
+
+    // Counterpart: query_tools.rs `format!("Incorrect timezone {}", timezone)`.
+    it('reports the invalid zone with the same message as the native planner', async () => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery('Not/AZone')).toThrow('Incorrect timezone Not/AZone');
+    });
+
+    it('validates without canonicalizing the timezone', async () => {
+      await compilers.compiler.compile();
+      const query = buildTimezoneQuery('utc');
+      expect(query.timezone).toBe('utc');
+    });
+
+    it.each([
+      123,
+      {},
+      true,
+    ])('rejects non-string timezone %j as a UserError', async (timezone) => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery(timezone as any)).toThrow(UserError);
     });
 
     it('Simple query - complex measure', async () => {

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -51,7 +51,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^11.1.0",
     "moment": "^2.29.1",
-    "moment-timezone": "^0.5.46",
     "node-fetch": "^2.6.0",
     "p-limit": "^3.1.0",
     "promise-timeout": "^1.3.0",

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -51,6 +51,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "^11.1.0",
     "moment": "^2.29.1",
+    "moment-timezone": "^0.5.46",
     "node-fetch": "^2.6.0",
     "p-limit": "^3.1.0",
     "promise-timeout": "^1.3.0",

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -91,6 +91,12 @@ export class OptsHandler {
 
     optionsValidate(opts);
 
+    // Probed for its throw: the only consumer is per-request code (normalizeQuery), so an
+    // operator typo would otherwise surface as a client error on every query instead of
+    // failing the boot. CUBEJS_SCHEDULED_REFRESH_TIMEZONES needs none — initializeCoreOptions
+    // reads it eagerly.
+    getEnv('defaultTimezone');
+
     if (
       !this.isDevMode() &&
       !process.env.CUBEJS_DB_TYPE &&

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -30,7 +30,7 @@ import {
 } from './types';
 import { lookupDriverClass, isDriver } from './DriverResolvers';
 import type { CubejsServerCore } from './server';
-import optionsValidate from './optionsValidate';
+import { validateOptions } from './optionsValidate';
 
 const { version } = require('../../../package.json');
 
@@ -46,8 +46,7 @@ export class OptsHandler {
     private createOptions: CreateOptions,
     private systemOptions?: SystemOptions,
   ) {
-    this.assertOptions(createOptions);
-    const options = cloneDeep(this.createOptions);
+    const options = this.assertOptions(cloneDeep(this.createOptions));
     const driverFactory = this.getDriverFactory(options);
     options.driverFactory = driverFactory;
     options.dbType = this.getDbType(driverFactory);
@@ -77,9 +76,10 @@ export class OptsHandler {
   private initializedOptions: ServerCoreInitializedOptions;
 
   /**
-   * Assert create options.
+   * Assert create options and return the sanitized copy: joi coercions (canonical time zone
+   * names) only land for callers that use the returned value.
    */
-  private assertOptions(opts: CreateOptions) {
+  private assertOptions<T extends CreateOptions>(opts: T): T {
     if ((opts as any).dbType) {
       throw new Error(
         'CreateOptions.dbType was removed in v1.7.0. ' +
@@ -89,7 +89,7 @@ export class OptsHandler {
       );
     }
 
-    optionsValidate(opts);
+    const validated = validateOptions(opts);
 
     // Probed for its throw: the only consumer is per-request code (normalizeQuery), so an
     // operator typo would otherwise surface as a client error on every query instead of
@@ -106,6 +106,8 @@ export class OptsHandler {
         'Either CUBEJS_DB_TYPE or CreateOptions.driverFactory must be specified'
       );
     }
+
+    return validated;
   }
 
   /**

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -34,33 +34,21 @@ import { validateOptions } from './optionsValidate';
 
 const { version } = require('../../../package.json');
 
-/**
- * Driver service class.
- */
 export class OptsHandler {
-  /**
-   * Class constructor.
-   */
   public constructor(
     private core: CubejsServerCore,
     private createOptions: CreateOptions,
     private systemOptions?: SystemOptions,
   ) {
-    const options = this.assertOptions(cloneDeep(this.createOptions));
+    const options = this.validateOptions(cloneDeep(this.createOptions));
     const driverFactory = this.getDriverFactory(options);
     options.driverFactory = driverFactory;
     options.dbType = this.getDbType(driverFactory);
     this.initializedOptions = this.initializeCoreOptions(options);
   }
 
-  /**
-   * Decorated driverFactory flag.
-   */
   private decoratedFactory = false;
 
-  /**
-   * Returns true if the user provided a custom driverFactory.
-   */
   public isCustomDriverFactory(): boolean {
     return !this.decoratedFactory;
   }
@@ -70,16 +58,9 @@ export class OptsHandler {
    */
   private driverFactoryType: undefined | 'BaseDriver' | 'DriverConfig';
 
-  /**
-   * Initialized options.
-   */
   private initializedOptions: ServerCoreInitializedOptions;
 
-  /**
-   * Assert create options and return the sanitized copy: joi coercions (canonical time zone
-   * names) only land for callers that use the returned value.
-   */
-  private assertOptions<T extends CreateOptions>(opts: T): T {
+  private validateOptions<T extends CreateOptions>(opts: T): T {
     if ((opts as any).dbType) {
       throw new Error(
         'CreateOptions.dbType was removed in v1.7.0. ' +
@@ -91,10 +72,7 @@ export class OptsHandler {
 
     const validated = validateOptions(opts);
 
-    // Probed for its throw: the only consumer is per-request code (normalizeQuery), so an
-    // operator typo would otherwise surface as a client error on every query instead of
-    // failing the boot. CUBEJS_SCHEDULED_REFRESH_TIMEZONES needs none — initializeCoreOptions
-    // reads it eagerly.
+    // Probed for its throw: the only consumer is per-request code (normalizeQuery)
     getEnv('defaultTimezone');
 
     if (

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -40,7 +40,7 @@ export class OptsHandler {
     private createOptions: CreateOptions,
     private systemOptions?: SystemOptions,
   ) {
-    const options = this.validateOptions(cloneDeep(this.createOptions));
+    const options = this.sanitizeOptions(cloneDeep(this.createOptions));
     const driverFactory = this.getDriverFactory(options);
     options.driverFactory = driverFactory;
     options.dbType = this.getDbType(driverFactory);
@@ -60,7 +60,7 @@ export class OptsHandler {
 
   private initializedOptions: ServerCoreInitializedOptions;
 
-  private validateOptions<T extends CreateOptions>(opts: T): T {
+  private sanitizeOptions<T extends CreateOptions>(opts: T): T {
     if ((opts as any).dbType) {
       throw new Error(
         'CreateOptions.dbType was removed in v1.7.0. ' +

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -2,7 +2,6 @@ import Joi from 'joi';
 import { canonicalTimezone } from '@cubejs-backend/shared';
 import DriverDependencies from './DriverDependencies';
 
-// Fails fast at startup instead of deep in the refresh scheduler.
 const timezoneSchema = Joi.string().custom((value, helpers) => {
   const name = canonicalTimezone(value);
   if (!name) {

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -7,7 +7,12 @@ import DriverDependencies from './DriverDependencies';
 const timezoneSchema = Joi.string().custom((value, helpers) => {
   if (!moment.tz.zone(value)) {
     return helpers.message({ custom: `{{#label}} must be a valid IANA time zone name, got "${value}"` });
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  if (!moment.tz.zone(value)) {
+    return helpers.message({ custom: '{{#label}} must be a valid IANA time zone name, got "{{#tz}}"' }, { tz: value });
   }
+  return value;
+}, 'timezone');
   return value;
 }, 'timezone');
 

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -1,5 +1,15 @@
 import Joi from 'joi';
+import moment from 'moment-timezone';
 import DriverDependencies from './DriverDependencies';
+
+// Reject anything that is not a known IANA timezone name (matched case-insensitively),
+// so a misconfigured zone fails fast at startup instead of deep in the refresh scheduler.
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  if (!moment.tz.zone(value)) {
+    return helpers.message({ custom: `{{#label}} must be a valid IANA time zone name, got "${value}"` });
+  }
+  return value;
+}, 'timezone');
 
 const schemaQueueOptions = Joi.object().strict(true).keys({
   concurrency: Joi.number().min(1).integer(),
@@ -96,7 +106,7 @@ const schemaOptions = Joi.object().keys({
     Joi.number().min(0).integer()
   ),
   scheduledRefreshTimeZones: Joi.alternatives().try(
-    Joi.array().items(Joi.string()),
+    Joi.array().items(timezoneSchema),
     Joi.func()
   ),
   scheduledRefreshContexts: Joi.func(),

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -160,9 +160,11 @@ const schemaOptions = Joi.object().keys({
   fastReload: Joi.boolean(),
 });
 
-export default (options: any) => {
-  const { error } = schemaOptions.validate(options, { abortEarly: false });
+export function validateOptions<T>(options: T): T {
+  const { error, value } = schemaOptions.validate(options, { abortEarly: false });
   if (error) {
     throw new Error(`Invalid cube-server-core options: ${error.message || error.toString()}`);
   }
-};
+
+  return value;
+}

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -1,19 +1,15 @@
 import Joi from 'joi';
-import moment from 'moment-timezone';
+import { canonicalTimezone } from '@cubejs-backend/shared';
 import DriverDependencies from './DriverDependencies';
 
-// Reject anything that is not a known IANA timezone name (matched case-insensitively),
-// so a misconfigured zone fails fast at startup instead of deep in the refresh scheduler.
+// Fails fast at startup instead of deep in the refresh scheduler.
 const timezoneSchema = Joi.string().custom((value, helpers) => {
-  if (!moment.tz.zone(value)) {
-    return helpers.message({ custom: `{{#label}} must be a valid IANA time zone name, got "${value}"` });
-const timezoneSchema = Joi.string().custom((value, helpers) => {
-  if (!moment.tz.zone(value)) {
+  const name = canonicalTimezone(value);
+  if (!name) {
     return helpers.message({ custom: '{{#label}} must be a valid IANA time zone name, got "{{#tz}}"' }, { tz: value });
   }
-  return value;
-}, 'timezone');
-  return value;
+
+  return name;
 }, 'timezone');
 
 const schemaQueueOptions = Joi.object().strict(true).keys({

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -1203,3 +1203,36 @@ describe('OptsHandler class', () => {
     expect(permissions).toEqual(['graphql', 'meta', 'data', 'jobs']);
   });
 });
+
+describe('OptsHandler timezone env validation', () => {
+  beforeEach(() => {
+    process.env.CUBEJS_DB_TYPE = 'postgres';
+  });
+
+  afterEach(() => {
+    delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+  });
+
+  test('must throw at construction if CUBEJS_DEFAULT_TIMEZONE is not a valid zone', () => {
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'Europ/Berlin';
+
+    expect(() => new CubejsServerCoreExposed(conf))
+      .toThrow(/CUBEJS_DEFAULT_TIMEZONE/);
+  });
+
+  test('must construct when CUBEJS_DEFAULT_TIMEZONE is unset or valid in any case', () => {
+    delete process.env.CUBEJS_DEFAULT_TIMEZONE;
+    expect(() => new CubejsServerCoreExposed(conf)).not.toThrow();
+
+    process.env.CUBEJS_DEFAULT_TIMEZONE = 'america/new_york';
+    expect(() => new CubejsServerCoreExposed(conf)).not.toThrow();
+  });
+
+  test('must throw at construction if CUBEJS_SCHEDULED_REFRESH_TIMEZONES has an invalid entry', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,Nope/Zone';
+
+    expect(() => new CubejsServerCoreExposed(conf))
+      .toThrow(/CUBEJS_SCHEDULED_REFRESH_TIMEZONES/);
+  });
+});

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -1235,4 +1235,20 @@ describe('OptsHandler timezone env validation', () => {
     expect(() => new CubejsServerCoreExposed(conf))
       .toThrow(/CUBEJS_SCHEDULED_REFRESH_TIMEZONES/);
   });
+
+  test('must throw at construction if CreateOptions.scheduledRefreshTimeZones has an invalid entry', () => {
+    expect(() => new CubejsServerCoreExposed({
+      ...conf,
+      scheduledRefreshTimeZones: ['UTC', 'Nope/Zone'],
+    })).toThrow(/valid IANA time zone name/);
+  });
+
+  test('must canonicalize CreateOptions.scheduledRefreshTimeZones', () => {
+    const core = new CubejsServerCoreExposed({
+      ...conf,
+      scheduledRefreshTimeZones: ['utc', 'america/new_york'],
+    });
+
+    expect(core.options.scheduledRefreshTimeZones).toEqual(['UTC', 'America/New_York']);
+  });
 });

--- a/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
+++ b/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
@@ -1,25 +1,47 @@
-import optionsValidate from '../../src/core/optionsValidate';
+import { validateOptions } from '../../src/core/optionsValidate';
 
-describe('optionsValidate scheduledRefreshTimeZones', () => {
+describe('validateOptions scheduledRefreshTimeZones', () => {
   test('accepts valid IANA timezones', () => {
-    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] })).not.toThrow();
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] })).not.toThrow();
   });
 
   test('accepts a function', () => {
-    expect(() => optionsValidate({ scheduledRefreshTimeZones: async () => ['UTC'] })).not.toThrow();
+    expect(() => validateOptions({ scheduledRefreshTimeZones: async () => ['UTC'] })).not.toThrow();
   });
 
   test('accepts timezones case-insensitively', () => {
-    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] })).not.toThrow();
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] })).not.toThrow();
+  });
+
+  test('returns canonical timezone names', () => {
+    expect(validateOptions({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] }))
+      .toEqual({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] });
   });
 
   test('rejects an invalid timezone with a descriptive message', () => {
-    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['Not/AZone'] }))
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['Not/AZone'] }))
       .toThrow(/valid IANA time zone name/);
   });
 
   test('names the offending value in the error message', () => {
-    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['UTC', 'Europ/Berlin'] }))
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['UTC', 'Europ/Berlin'] }))
       .toThrow(/Europ\/Berlin/);
+  });
+});
+
+describe('validateOptions sanitized result', () => {
+  test('preserves function options by reference', () => {
+    const driverFactory = () => ({ type: 'postgres' });
+    const validated = validateOptions({ driverFactory });
+
+    expect(validated.driverFactory).toBe(driverFactory);
+  });
+
+  test('does not mutate the input', () => {
+    const options = { scheduledRefreshTimeZones: ['utc'] };
+    const validated = validateOptions(options);
+
+    expect(options.scheduledRefreshTimeZones).toEqual(['utc']);
+    expect(validated).not.toBe(options);
   });
 });

--- a/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
+++ b/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
@@ -1,0 +1,16 @@
+import optionsValidate from '../../src/core/optionsValidate';
+
+describe('optionsValidate scheduledRefreshTimeZones', () => {
+  test('accepts valid IANA timezones', () => {
+    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] })).not.toThrow();
+  });
+
+  test('accepts a function', () => {
+    expect(() => optionsValidate({ scheduledRefreshTimeZones: async () => ['UTC'] })).not.toThrow();
+  });
+
+  test('rejects an invalid timezone with a descriptive message', () => {
+    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['Not/AZone'] }))
+      .toThrow(/valid IANA time zone name/);
+  });
+});

--- a/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
+++ b/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
@@ -9,8 +9,17 @@ describe('optionsValidate scheduledRefreshTimeZones', () => {
     expect(() => optionsValidate({ scheduledRefreshTimeZones: async () => ['UTC'] })).not.toThrow();
   });
 
+  test('accepts timezones case-insensitively', () => {
+    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] })).not.toThrow();
+  });
+
   test('rejects an invalid timezone with a descriptive message', () => {
     expect(() => optionsValidate({ scheduledRefreshTimeZones: ['Not/AZone'] }))
       .toThrow(/valid IANA time zone name/);
+  });
+
+  test('names the offending value in the error message', () => {
+    expect(() => optionsValidate({ scheduledRefreshTimeZones: ['UTC', 'Europ/Berlin'] }))
+      .toThrow(/Europ\/Berlin/);
   });
 });


### PR DESCRIPTION
The query `timezone` was only validated as a free-form string, so invalid or malformed values were accepted and handled inconsistently between the native (Tesseract) and legacy planners. Validate it against known IANA zone names so bad values are rejected early with a clear error.