### PR TITLE
fix: SqlFormatter - fail closed on SQL parameter count mismatch

### DIFF
--- a/packages/cubejs-backend-shared/src/sql-escape.ts
+++ b/packages/cubejs-backend-shared/src/sql-escape.ts
@@ -134,10 +134,8 @@ class SqlEscaper {
 
   /**
    * Substitutes positional placeholders in `sql` with escaped `values`:
-   *   - `?`  is replaced by an escaped value ({@link escapeValue})
-   *   - `??` is replaced by an escaped identifier ({@link escapeIdentifier})
-   * Longer runs of `?` are left untouched. This mirrors `sqlstring.format`'s
-   * placeholder semantics so it can be a drop-in replacement in drivers.
+   * - `?`  is replaced by an escaped value ({@link escapeValue})
+   * - `??` is replaced by an escaped identifier ({@link escapeIdentifier})
    */
   public format(sql: string, values?: unknown): string {
     if (values === null || values === undefined) {
@@ -145,22 +143,28 @@ class SqlEscaper {
     }
 
     const valueList = Array.isArray(values) ? values : [values];
-    if (valueList.length === 0) {
-      return sql;
-    }
 
     const placeholders = /\?+/g;
+
     let result = '';
     let chunkIndex = 0;
     let valuesIndex = 0;
-    let match: RegExpExecArray | null = placeholders.exec(sql);
+    let placeholderCount = 0;
 
-    while (valuesIndex < valueList.length && match !== null) {
-      const len = match[0].length;
+    let match: RegExpExecArray | null;
+
+    // eslint-disable-next-line no-cond-assign
+    while ((match = placeholders.exec(sql)) !== null) {
       // `?` -> value, `??` -> identifier. Longer runs (`???`+) are not placeholders
       // we understand, so we leave them verbatim and consume no value.
-      if (len <= 2) {
-        const rendered = len === 2
+      if (match[0].length > 2) {
+        continue;
+      }
+
+      placeholderCount += 1;
+
+      if (valuesIndex < valueList.length) {
+        const rendered = match[0].length === 2
           ? this.escapeIdentifier(String(valueList[valuesIndex]))
           : this.escapeValue(valueList[valuesIndex]);
 
@@ -168,13 +172,24 @@ class SqlEscaper {
         chunkIndex = placeholders.lastIndex;
         valuesIndex += 1;
       }
-      match = placeholders.exec(sql);
+    }
+
+    if (placeholderCount !== valueList.length) {
+      throw SqlEscaper.parameterCountMismatch(placeholderCount, valueList.length);
     }
 
     if (chunkIndex === 0) {
       return sql;
     }
+
     return chunkIndex < sql.length ? result + sql.slice(chunkIndex) : result;
+  }
+
+  protected static parameterCountMismatch(placeholderCount: number, valueCount: number): Error {
+    return new Error(
+      `SQL parameter count mismatch: ${placeholderCount} placeholder(s) but ${valueCount} value(s) supplied. ` +
+      'A literal \'?\' in SQL must be escaped or bound as a parameter.'
+    );
   }
 }
 

--- a/packages/cubejs-backend-shared/test/sql-escape.test.ts
+++ b/packages/cubejs-backend-shared/test/sql-escape.test.ts
@@ -420,12 +420,12 @@ describe('sql-escape', () => {
     });
 
     it('normalizes a scalar values argument to one parameter like sqlstring', () => {
-      expect(presto.format('SELECT ?, ?', 'whole string'))
-        .toBe("SELECT 'whole string', ?");
       expect(presto.format('SELECT ?', '')).toBe("SELECT ''");
       expect(presto.format('SELECT ?', 0)).toBe('SELECT 0');
       expect(presto.format('SELECT ?', false)).toBe('SELECT FALSE');
       expect(presto.format('SELECT ??', 'column"name')).toBe('SELECT "column""name"');
+      // A scalar is one value, so two placeholders no longer leave a dangling `?`.
+      expect(() => presto.format('SELECT ?, ?', 'whole string')).toThrow(/parameter count mismatch/);
     });
 
     it('closes the injection that the old PrestoDriver escaper allowed', () => {
@@ -454,15 +454,18 @@ describe('sql-escape', () => {
         .toBe('SELECT ???, \'value\', "column""name"');
     });
 
-    it('leaves unmatched placeholders and ignores surplus values', () => {
-      expect(presto.format('SELECT ?, ?', ['first'])).toBe("SELECT 'first', ?");
-      expect(presto.format('SELECT ?', ['first', "'; DROP TABLE users; --"]))
-        .toBe("SELECT 'first'");
+    it('rejects unmatched placeholders and surplus values (fail closed)', () => {
+      expect(() => presto.format('SELECT ?, ?', ['first'])).toThrow(/parameter count mismatch/);
+      expect(() => presto.format('SELECT ?', ['first', "'; DROP TABLE users; --"]))
+        .toThrow(/parameter count mismatch/);
     });
 
-    it('returns SQL unchanged when supplied values have no usable placeholder', () => {
-      expect(presto.format('SELECT 1', ["'; DROP TABLE users; --"])).toBe('SELECT 1');
-      expect(presto.format('SELECT ???', ["'; DROP TABLE users; --"])).toBe('SELECT ???');
+    it('rejects values supplied for SQL with no usable placeholder (fail closed)', () => {
+      expect(() => presto.format('SELECT 1', ["'; DROP TABLE users; --"]))
+        .toThrow(/parameter count mismatch/);
+      // `???` is not a consumable placeholder, so the value has nowhere to land.
+      expect(() => presto.format('SELECT ???', ["'; DROP TABLE users; --"]))
+        .toThrow(/parameter count mismatch/);
     });
 
     it('formats JSON-shaped objects as escaped assignments', () => {
@@ -524,8 +527,59 @@ describe('sql-escape', () => {
     });
 
     it('helpers normalize scalar values', () => {
-      expect(formatAnsi('SELECT ?, ?', "a'b")).toBe("SELECT 'a''b', ?");
       expect(formatMySql('SELECT ?', false)).toBe('SELECT FALSE');
+      // Scalar is one value: two placeholders now fail closed rather than leaving `?`.
+      expect(() => formatAnsi('SELECT ?, ?', "a'b")).toThrow(/parameter count mismatch/);
+    });
+  });
+
+  describe('fail-closed parameter count guard', () => {
+    it('throws when a literal ? in SQL shifts real placeholders (FILTER_PARAMS vector)', () => {
+      // Model SQL with a literal `?` ahead of real placeholders: the compiler emits
+      // one `?` per value, so the stray literal makes the counts diverge and a naive
+      // scan would land the attacker's value in the wrong slot.
+      expect(() => formatAnsi("WHERE (status = '?') AND status = ? AND number = ?", ['x', '7']))
+        .toThrow(/parameter count mismatch/);
+    });
+
+    it('throws on surplus values', () => {
+      expect(() => formatAnsi('WHERE a = ?', ['x', 'y'])).toThrow(/parameter count mismatch/);
+    });
+
+    it('rejects a literal ? even after every real placeholder (intentional break)', () => {
+      expect(() => formatAnsi("SELECT ?, regexp_like(a, 'x+?')", ['v']))
+        .toThrow(/parameter count mismatch/);
+      expect(() => formatAnsi("WHERE a = ? AND b LIKE 'y?'", ['v']))
+        .toThrow(/parameter count mismatch/);
+    });
+
+    it('throws on too few values', () => {
+      expect(() => formatAnsi('WHERE a = ? AND b = ?', ['x'])).toThrow(/parameter count mismatch/);
+    });
+
+    it('accepts a balanced placeholder/value count', () => {
+      expect(formatAnsi('WHERE a = ? AND b = ?', ['x', 'y']))
+        .toBe("WHERE a = 'x' AND b = 'y'");
+    });
+
+    it('counts ?? identifier placeholders as consumable', () => {
+      expect(formatAnsi('SELECT ??, ?', ['col', 'v'])).toBe('SELECT "col", \'v\'');
+      expect(() => formatAnsi('SELECT ??, ?', ['col'])).toThrow(/parameter count mismatch/);
+    });
+
+    it('leaves the no-substitution paths non-throwing', () => {
+      expect(formatAnsi('SELECT 1')).toBe('SELECT 1');
+      expect(formatAnsi('SELECT 1', [])).toBe('SELECT 1');
+      expect(formatAnsi('SELECT ???', [])).toBe('SELECT ???');
+      expect(formatAnsi('SELECT ?')).toBe('SELECT ?');
+      expect(formatAnsi('SELECT ?', null)).toBe('SELECT ?');
+      expect(formatAnsi('SELECT ?', undefined)).toBe('SELECT ?');
+    });
+
+    it('rejects a placeholder against an empty values array', () => {
+      expect(() => formatAnsi('SELECT ?', [])).toThrow(/parameter count mismatch/);
+      expect(() => formatAnsi("SELECT regexp_like(a, 'x+?') FROM t", []))
+        .toThrow(/parameter count mismatch/);
     });
   });
 


### PR DESCRIPTION
SqlEscaper.format substituted `?`/`??` placeholders by scanning the SQL string and silently tolerated a mismatch between placeholder and value counts — surplus values were dropped and surplus placeholders left as a literal `?`. Because the compiler emits exactly one `?` per parameter, any such mismatch means a stray literal `?` in the SQL text (or a wrong-length values array), which shifts every subsequent value into the wrong slot.

Count the consumable placeholders (`?`/`??` runs) in the single formatting pass and throw when the total does not equal `values.length`, reporting both counts. This turns silent, wrong-position substitution into a hard error.
