### PR TITLE
fix(api-gateway): require a dev-token scope for the playground bypass [lts/v1.6]

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -130,6 +130,18 @@ function systemAsyncHandler(handler: (req: Request & { context: ExtendedRequestC
   };
 }
 
+const DEV_TOKEN_SCOPE = 'dev-token';
+
+function hasDevTokenScope(securityContext: unknown): boolean {
+  if (typeof securityContext !== 'object' || securityContext === null) {
+    return false;
+  }
+
+  const { scope } = <Record<string, any>>securityContext;
+
+  return Array.isArray(scope) && scope.includes(DEV_TOKEN_SCOPE);
+}
+
 // Prepared CheckAuthFn, default or from config: always async
 type PreparedCheckAuthFn = (ctx: any, authorization?: string) => Promise<{
   securityContext: any;
@@ -2595,7 +2607,8 @@ class ApiGateway {
       if (auth) {
         try {
           req.securityContext = await checkAuthFn(auth);
-          req.signedWithPlaygroundAuthSecret = Boolean(internalOptions?.isPlaygroundCheckAuth);
+          req.signedWithPlaygroundAuthSecret =
+            Boolean(internalOptions?.isPlaygroundCheckAuth) && hasDevTokenScope(req.securityContext);
         } catch (e: any) {
           if (this.enforceSecurityChecks) {
             throw new CubejsHandlerError(403, 'Forbidden', 'Invalid token', e);

--- a/packages/cubejs-api-gateway/test/auth.test.ts
+++ b/packages/cubejs-api-gateway/test/auth.test.ts
@@ -280,6 +280,69 @@ describe('test authorization', () => {
     expectSecurityContext(handlerMock.mock.calls[0][0].context.authInfo);
   });
 
+  describe('signedWithPlaygroundAuthSecret requires the dev-token scope', () => {
+    const playgroundAuthSecret = 'playgroundSecret';
+    const loggerMock = jest.fn(() => {
+      //
+    });
+
+    // The playground secret signs every token a Cube Cloud deployment mints,
+    // including ones handed to end users and external BI tools, so the
+    // signature alone must not unlock the developer affordances gated on this
+    // flag (hidden meta members, generated SQL, pre-aggregation debug info).
+    const flagFor = async (payload: Record<string, any>) => {
+      const seen: boolean[] = [];
+      const handlerMock = jest.fn((req, res) => {
+        seen.push(req.context.signedWithPlaygroundAuthSecret);
+        res.status(200).end();
+      });
+
+      const { app } = createApiGateway(handlerMock, loggerMock, { playgroundAuthSecret });
+
+      await request(app)
+        .get('/test-auth-fake')
+        .set('Authorization', `Authorization: ${generateAuthToken(payload, {}, playgroundAuthSecret)}`)
+        .expect(200);
+
+      return seen[0];
+    };
+
+    test('is false for a playground-signed token with no scope at all', async () => {
+      expect(await flagFor({ uid: 5 })).toBe(false);
+    });
+
+    test('is false for a playground-signed token scoped to something else', async () => {
+      expect(await flagFor({ uid: 5, scope: ['sql-runner', 'agents-config'] })).toBe(false);
+    });
+
+    test('is true for a playground-signed token carrying the dev-token scope', async () => {
+      expect(await flagFor({ uid: 5, scope: ['dev-token'] })).toBe(true);
+      // Alongside the service scopes it is minted with in practice.
+      expect(await flagFor({ uid: 5, scope: ['sql-runner', 'dev-token'] })).toBe(true);
+    });
+
+    test('is false when scope is not an array of scope names', async () => {
+      expect(await flagFor({ uid: 5, scope: 'dev-token' })).toBe(false);
+      expect(await flagFor({ uid: 5, scope: { 'dev-token': true } })).toBe(false);
+    });
+
+    test('is false for a token signed with the main api secret, scope or not', async () => {
+      const handlerMock = jest.fn((req, res) => {
+        expect(req.context.signedWithPlaygroundAuthSecret).toBe(false);
+        res.status(200).end();
+      });
+
+      const { app } = createApiGateway(handlerMock, loggerMock, { playgroundAuthSecret });
+
+      await request(app)
+        .get('/test-auth-fake')
+        .set('Authorization', `Authorization: ${generateAuthToken({ uid: 5, scope: ['dev-token'] }, {})}`)
+        .expect(200);
+
+      expect(handlerMock.mock.calls.length).toEqual(1);
+    });
+  });
+
   test('default authorization with JWT token and securityContext in u', async () => {
     const loggerMock = jest.fn(() => {
       //


### PR DESCRIPTION
Backport of the `dev-token` gate to the **v1.6 LTS** line. Runtime half only — the control-plane half that mints the scope lives in cubejs-enterprise and has no counterpart in the LTS image.

Upstream: cube-js/cube#11571 (merged to master).

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required — n/a, no user-facing config or API surface changes

**Description of Changes Made**

`signedWithPlaygroundAuthSecret` unlocks the runtime's developer affordances — meta members hidden by `public: false` / access policies, generated SQL, pre-aggregation and refresh-key debug info, request ids in errors. It was set purely from the token having verified against `playgroundAuthSecret`.

In Cube Cloud that secret signs **every** token a deployment mints, including ones handed to end users and to external BI tools, so the signature alone was never evidence that the bearer is a developer. This requires a `dev-token` entry in the token's `scope` as well:

```ts
req.signedWithPlaygroundAuthSecret =
  Boolean(internalOptions?.isPlaygroundCheckAuth) && hasDevTokenScope(req.securityContext);
```

The grant sits in `scope` alongside the runtime's other per-token grants (`sql-runner`, `agents-config`) rather than in a claim of its own.

**What is unaffected**

- **devMode.** All six consumers of the flag on this branch are identical to master's, and every behavioural one already ORs with `getEnv('devMode')`, so a local `cube dev` server keeps full visibility. The one site reading the flag alone is the `isPlayground` field on Load Request logs, which correspondingly now marks only developer traffic.
- **Authentication.** The scope gates what a playground-signed token may *see*, not whether it verifies. `/cubejs-system/v1/*` still accepts any playground-signed token, so service-to-service callers are unchanged.
- **Self-hosted.** Nothing in this repo mints playground tokens, and birdbox sets `CUBEJS_PLAYGROUND_AUTH_SECRET` equal to `CUBEJS_API_SECRET`, so main auth wins there and the flag was already `false`.

**Rollout ordering.** This is fail-closed, so it must not ship ahead of a control plane that stamps the scope: a runtime deployed first would silently drop hidden-member visibility and generated SQL in the console. The enterprise side is already merged.

**Verification**

Run locally on this branch, against a from-scratch native build:

| Check | Result |
| --- | --- |
| `npx tsc -p .` (v1.6 toolchain, src + tests) | clean |
| `npx eslint src/gateway.ts test/auth.test.ts` | clean |
| `jest dist/test/auth.test.js` | **29/29 passing** |

The five added cases pin the strictness that matters: no scope at all, a scope carrying only other grants, `['dev-token']` alone and alongside `sql-runner`, non-array `scope` shapes (`Array.isArray` guards before `includes`, so a bare string cannot match by substring), and a main-secret-signed token carrying the scope. Every pre-existing case still passes — including `apiSecrets - playground secret path is unaffected` and `apiSecrets - coexists with playgroundAuthSecret`, the two most likely to catch a semantic drift on this branch.

The `gateway.ts` diff is byte-identical to what merged on master, and both anchor points are structurally the same here, so this is a true backport rather than a re-implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rhtueaPpiVVNkvA5rWv8X

---
_Generated by [Claude Code](https://claude.ai/code/session_018rhtueaPpiVVNkvA5rWv8X)_