### PR TITLE
docs(byoc): tell customers to create the RDS service-linked role before handover

### DIFF
--- a/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
+++ b/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
@@ -63,6 +63,10 @@ already exists and no action is needed.
 aws iam create-service-linked-role --aws-service-name rds.amazonaws.com
 ```
 
+If the command itself is denied by an SCP, the same denial will block Cube during
+provisioning — ask your AWS organization administrator to permit
+`iam:CreateServiceLinkedRole` for `rds.amazonaws.com` in this account.
+
 </Warning>
 
 ## Provisioning access

--- a/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
+++ b/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
@@ -41,6 +41,40 @@ the `CubeCloudBYOC` IAM role that would allow Cube to:
 - Manage CloudWatch Logs
 - Create and manage RDS PostgreSQL instances
 
+<Warning>
+
+**If this account has never run Amazon RDS, create the RDS service-linked role
+before handing the account over.**
+
+Amazon RDS requires a service-linked role named `AWSServiceRoleForRDS` to exist in
+the account. AWS normally creates it automatically the first time you create a
+database — but that happens under *your* credentials, at a moment when Cube is
+provisioning under the `CubeCloudBYOC` role. If that role cannot create it, the
+database creation fails with a message that names a parameter rather than a
+permission:
+
+```
+InvalidParameterValue: Unable to create the resource.
+Verify that you have permission to create service linked role.
+```
+
+Run this once, in the target account, before granting Cube access:
+
+```bash
+aws iam create-service-linked-role --aws-service-name rds.amazonaws.com
+```
+
+If it returns `InvalidInput: Service role name AWSServiceRoleForRDS has been taken
+in this account`, the role already exists and there is nothing to do.
+
+The policy below does grant `iam:CreateServiceLinkedRole` for `rds.amazonaws.com`,
+so an account whose role carries the current policy can create it on demand. This
+step matters for accounts provisioned against an **earlier version** of the policy,
+and for organisations whose SCPs restrict IAM writes — in both cases the grant is
+present in the document but not effective in the account.
+
+</Warning>
+
 ## Provisioning access
 
 ### Create a CubeCloudBYOC policy

--- a/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
+++ b/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
@@ -43,35 +43,25 @@ the `CubeCloudBYOC` IAM role that would allow Cube to:
 
 <Warning>
 
-**If this account has never run Amazon RDS, create the RDS service-linked role
-before handing the account over.**
-
-Amazon RDS requires a service-linked role named `AWSServiceRoleForRDS` to exist in
-the account. AWS normally creates it automatically the first time you create a
-database — but that happens under *your* credentials, at a moment when Cube is
-provisioning under the `CubeCloudBYOC` role. If that role cannot create it, the
-database creation fails with a message that names a parameter rather than a
-permission:
+**Restrictive SCPs may block RDS provisioning.** Amazon RDS needs a service-linked
+role named `AWSServiceRoleForRDS` in the account. The policy below grants
+`iam:CreateServiceLinkedRole` for `rds.amazonaws.com`, so Cube creates it during
+provisioning — but if your organization's SCPs deny IAM writes, the grant is
+present in the policy without being effective in the account, and provisioning
+fails with a message that names a parameter rather than a permission:
 
 ```
 InvalidParameterValue: Unable to create the resource.
 Verify that you have permission to create service linked role.
 ```
 
-Run this once, in the target account, before granting Cube access:
+To rule this out, run the following once in the target account before granting
+Cube access. `InvalidInput: ... has been taken in this account` means the role
+already exists and no action is needed.
 
 ```bash
 aws iam create-service-linked-role --aws-service-name rds.amazonaws.com
 ```
-
-If it returns `InvalidInput: Service role name AWSServiceRoleForRDS has been taken
-in this account`, the role already exists and there is nothing to do.
-
-The policy below does grant `iam:CreateServiceLinkedRole` for `rds.amazonaws.com`,
-so an account whose role carries the current policy can create it on demand. This
-step matters for accounts provisioned against an **earlier version** of the policy,
-and for organisations whose SCPs restrict IAM writes — in both cases the grant is
-present in the document but not effective in the account.
 
 </Warning>
 

--- a/docs/content/product/administration/deployment/byoc/aws/deployment.mdx
+++ b/docs/content/product/administration/deployment/byoc/aws/deployment.mdx
@@ -185,8 +185,7 @@ actual account ID.
                     "iam:AWSServiceName": [
                         "eks.amazonaws.com",
                         "eks-nodegroup.amazonaws.com",
-                        "eks-fargate.amazonaws.com",
-                        "rds.amazonaws.com"
+                        "eks-fargate.amazonaws.com"
                     ]
                 }
             }

--- a/docs/content/product/administration/deployment/byoc/aws/deployment.mdx
+++ b/docs/content/product/administration/deployment/byoc/aws/deployment.mdx
@@ -185,7 +185,8 @@ actual account ID.
                     "iam:AWSServiceName": [
                         "eks.amazonaws.com",
                         "eks-nodegroup.amazonaws.com",
-                        "eks-fargate.amazonaws.com"
+                        "eks-fargate.amazonaws.com",
+                        "rds.amazonaws.com"
                     ]
                 }
             }


### PR DESCRIPTION
## Why

A real BYOC provisioning run failed on this today. Creating the AI Engineer RDS instance in a customer account returned:

```
InvalidParameterValue: Unable to create the resource.
Verify that you have permission to create service linked role.
```

Amazon RDS needs `AWSServiceRoleForRDS` to exist in the account. AWS normally creates it automatically on the account's **first** database — but during BYOC provisioning that moment arrives under the `CubeCloudBYOC` role rather than the customer's own credentials. If that role can't create it, the failure surfaces as `InvalidParameterValue`, naming a *parameter* rather than a permission, which sends whoever is debugging it looking in entirely the wrong place. It cost us a full round of diagnosis.

## What

**1. A `<Warning>` in Prerequisites** on the live Mintlify page, with the one-off command, the `InvalidInput: ... has been taken` response that means there's nothing to do, and — importantly — why the grant being *present in the policy* is not the same as it being *effective in the account*:

```bash
aws iam create-service-linked-role --aws-service-name rds.amazonaws.com
```

**2. The root cause.** There are two copies of this policy in the repo and they disagree:

| file | `iam:CreateServiceLinkedRole` condition |
|---|---|
| `docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx` | eks, eks-nodegroup, eks-fargate, **rds.amazonaws.com** |
| `docs/content/product/administration/deployment/byoc/aws/deployment.mdx` | eks, eks-nodegroup, eks-fargate — **no rds** |

Any account provisioned from the legacy page holds a role that cannot create the RDS service-linked role, which is precisely the failure above. This PR adds `rds.amazonaws.com` there so the two agree.

## Note for reviewers

The legacy `docs/` tree appears superseded — `cube.dev/docs/...` 308-redirects to `docs.cube.dev/...` — so I've treated the Mintlify page as the live one and the legacy edit as consistency plus provenance. If that tree is genuinely dead it could be deleted instead; I'd rather not do that in a docs-fix PR.

Worth knowing operationally: existing BYOC customers onboarded from the legacy policy will hit this on their first RDS provisioning. The lightest fix for them is the same one-off command above, rather than a full policy refresh, since it needs no review on their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)