### PR TITLE
fix(cubesql): Push down joins between grouped subqueries

### DIFF
--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -129,7 +129,10 @@ that match the list node itself — never by a transform that walks it.
   converted to another node type). The flat pull-up matches the whole list in one rule and
   takes `top_level_elem_vars`, which is how a fact that must hold across every element —
   all queries reaching the same data source — is enforced: name the variable there and
-  unification does the rest, with no comparison of your own.
+  unification does the rest, with no comparison of your own. A rule that adds an element to a
+  list it matched builds it with `ListApplierListPattern::new(..).with_appended(..)`: the
+  applier maps the elements it matched and puts the new ones after them, which a pattern
+  cannot spell out on its own.
 - Generate the traversal with the existing helpers rather than by hand:
   `WrapperRules::list_pushdown_pullup_rules` / `flat_list_pushdown_pullup_rules`
   (or `replacer_push_down_node` / `replacer_pull_up_node` underneath them). They emit
@@ -144,7 +147,11 @@ that match the list node itself — never by a transform that walks it.
 - A transform should only decide scalar facts (a flag, an alias, whether a template
   exists) about nodes the **pattern** already bound. Relationships between several
   matched nodes — "both sides reach the same data source" — belong in the pattern, by
-  reusing one pattern variable in both places, so unification enforces them.
+  reusing one pattern variable in both places, so unification enforces them. A fact about what is
+  *below* a bound node — whether a join is somewhere under it, whether a select carries
+  joins — belongs in `LogicalPlanAnalysis`, computed once per node as the e-graph is built
+  and merged upward (see `joins_subqueries`), never walked from a transform that runs on
+  every iteration.
 - A push-down replacer must never end up on top of an already pulled-up subtree. Inputs
   that arrive as a finished `cube_scan_wrapper(wrapper_pullup_replacer(..))` — the queries
   of a set operation, the sides of a join — have nothing left to push into, so their list

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -820,6 +820,10 @@ impl CubeScanWrapperNode {
             LogicalPlan::Extension(Extension { node }) => {
                 if let Some(cube_scan) = node.as_any().downcast_ref::<CubeScanNode>() {
                     cube_scan.request.ungrouped == Some(true)
+                } else if let Some(wrapper) = node.as_any().downcast_ref::<CubeScanWrapperNode>() {
+                    // A wrapper can sit inside a plan, in a join of a wrapped select, the same
+                    // way SQL generation finds it there
+                    Self::has_ungrouped_wrapped_node(wrapper.wrapped_plan.as_ref())
                 } else if let Some(wrapped_select) =
                     node.as_any().downcast_ref::<WrappedSelectNode>()
                 {
@@ -1193,6 +1197,21 @@ impl CubeScanWrapperNode {
                         node,
                         transport.as_ref(),
                         &load_request_meta,
+                    )
+                    .await
+                } else if let Some(wrapper_node) = node_any.downcast_ref::<CubeScanWrapperNode>() {
+                    // A wrapper can sit inside a plan, in a join of a wrapped select: rules put
+                    // it there instead of the plan it wraps, so that the plan to render is the
+                    // one extraction picked out of it
+                    Self::generate_sql_for_node_rec(
+                        meta,
+                        transport,
+                        load_request_meta,
+                        state,
+                        Arc::clone(&wrapper_node.wrapped_plan),
+                        can_rename_columns,
+                        values,
+                        parent_data_source,
                     )
                     .await
                 } else if let Some(wrapped_select_node) =
@@ -3940,7 +3959,17 @@ impl WrappedSelectNode {
         let join_subqueries = {
             let mut join_subqueries = vec![];
             for (lp, cond, join_type) in &self.joins {
-                match lp.as_ref() {
+                // A join can hold the wrapper of the joined side rather than the plan inside it,
+                // the same way SQL generation finds it there
+                let mut joined = lp.as_ref();
+                while let LogicalPlan::Extension(Extension { node }) = joined {
+                    let Some(wrapper) = node.as_any().downcast_ref::<CubeScanWrapperNode>() else {
+                        break;
+                    };
+                    joined = wrapper.wrapped_plan.as_ref();
+                }
+
+                match joined {
                     LogicalPlan::Extension(Extension { node }) => {
                         if let Some(join_cube_scan) = node.as_any().downcast_ref::<CubeScanNode>() {
                             if join_cube_scan.request.ungrouped == Some(true) {

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -10,7 +10,8 @@ use crate::{
             LiteralMemberRelation, LiteralMemberValue, LogicalPlanLanguage, MeasureName,
             ScalarFunctionExprFun, SegmentMemberMember, SegmentName, TableScanSourceTableName,
             TimeDimensionDateRange, TimeDimensionGranularity, TimeDimensionName, VirtualFieldCube,
-            VirtualFieldName,
+            VirtualFieldName, WrappedSelectSelectType, WrappedSelectType, WRAPPED_SELECT_FROM,
+            WRAPPED_SELECT_JOINS, WRAPPED_SELECT_SELECT_TYPE,
         },
         CubeContext,
     },
@@ -51,6 +52,33 @@ pub struct LogicalPlanData {
     pub cube_reference: Option<String>,
     pub filter_operators: Option<Vec<(String, String)>>,
     pub is_empty_list: Option<bool>,
+    /// A `WrappedSelectJoins` list with at least one join in it.
+    pub non_empty_joins: bool,
+    /// A `WrappedSelectSelectType` that is not an aggregation.
+    pub non_aggregate_select_type: bool,
+    /// A `WrappedSelect` that carries joins of its own.
+    pub select_with_joins: bool,
+    /// Whether the rows of this plan come from a join of subqueries, looking through the
+    /// selects stacked on top of the join and through replacers when a select below is not
+    /// pulled up yet. A grouping in between is where the search stops: aggregation collapses
+    /// the rows a join below it could have duplicated. Note that this does not make the result
+    /// unique on the join keys - that also needs the join keys to cover the group keys, which
+    /// nothing here checks (TODO: check key coverage, the pre-existing subquery join path needs
+    /// it as well).
+    ///
+    /// This is what decides whether a plan can be joined to a Cube query as a subquery join.
+    /// Such a join is rendered by the schema compiler in two ways - counted into the measures
+    /// over the joined rowset, or computed per distinct primary key - which agree only when
+    /// the joined subquery is unique on the join keys. A plan that is itself a join of
+    /// subqueries has no such guarantee, and nothing here can check it, so it is refused: the
+    /// query then plans without pushing the join into the Cube query, or fails with an
+    /// explicit error, instead of returning numbers that depend on how a measure happens to
+    /// be classified.
+    ///
+    /// All four of these only ever go from false to true, which is what makes them safe to
+    /// compute per node and merge with `or`: an e-class only gains representations, and a
+    /// single one that joins subqueries taints the class for everything reading it.
+    pub joins_subqueries: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1251,6 +1279,71 @@ impl LogicalPlanAnalysis {
         }
     }
 
+    fn make_non_empty_joins(enode: &LogicalPlanLanguage) -> bool {
+        match enode {
+            LogicalPlanLanguage::WrappedSelectJoins(joins) => !joins.is_empty(),
+            _ => false,
+        }
+    }
+
+    fn make_non_aggregate_select_type(enode: &LogicalPlanLanguage) -> bool {
+        match enode {
+            LogicalPlanLanguage::WrappedSelectSelectType(WrappedSelectSelectType(select_type)) => {
+                !matches!(select_type, WrappedSelectType::Aggregate)
+            }
+            _ => false,
+        }
+    }
+
+    fn make_select_with_joins(
+        egraph: &EGraph<LogicalPlanLanguage, Self>,
+        enode: &LogicalPlanLanguage,
+    ) -> bool {
+        let LogicalPlanLanguage::WrappedSelect(params) = enode else {
+            return false;
+        };
+        params
+            .get(WRAPPED_SELECT_JOINS)
+            .is_some_and(|joins| egraph.index(*joins).data.non_empty_joins)
+    }
+
+    fn make_joins_subqueries(
+        egraph: &EGraph<LogicalPlanLanguage, Self>,
+        enode: &LogicalPlanLanguage,
+    ) -> bool {
+        match enode {
+            LogicalPlanLanguage::WrappedSelect(params) => {
+                let (Some(select_type), Some(from)) = (
+                    params.get(WRAPPED_SELECT_SELECT_TYPE),
+                    params.get(WRAPPED_SELECT_FROM),
+                ) else {
+                    return false;
+                };
+                // An aggregation collapses the rows a join could have duplicated - the ones
+                // below it and the ones it makes itself - so the search stops there. Every
+                // node of the e-class has to agree that this is one: a class holding an
+                // Aggregate next to something else would otherwise hide the joins from
+                // everything above.
+                if !egraph.index(*select_type).data.non_aggregate_select_type {
+                    return false;
+                }
+                Self::make_select_with_joins(egraph, enode)
+                    || egraph.index(*from).data.joins_subqueries
+            }
+            // A select that is still wrapped in a replacer, or in a wrapper of its own, hides
+            // the same structure one node deeper. A wrapper is not supposed to be reachable
+            // here - every rule that builds one binds a select or a scan inside it - but this
+            // change is what makes a wrapper something that can sit mid-plan at all, and the
+            // three walks in `wrapper.rs` unwrap it for the same reason.
+            LogicalPlanLanguage::WrapperPullupReplacer(params)
+            | LogicalPlanLanguage::WrapperPushdownReplacer(params)
+            | LogicalPlanLanguage::CubeScanWrapper(params) => params
+                .first()
+                .is_some_and(|input| egraph.index(*input).data.joins_subqueries),
+            _ => false,
+        }
+    }
+
     fn make_is_empty_list(
         egraph: &EGraph<LogicalPlanLanguage, Self>,
         enode: &LogicalPlanLanguage,
@@ -1292,6 +1385,16 @@ impl LogicalPlanAnalysis {
         res
     }
 
+    /// Merges a fact that only ever goes from false to true, so a class holding one
+    /// representation it holds for is true for everything reading the class.
+    #[inline]
+    fn merge_or_field(&mut self, a: &mut bool, b: bool) -> DidMerge {
+        let merged = *a || b;
+        let res = DidMerge(merged != *a, merged != b);
+        *a = merged;
+        res
+    }
+
     fn merge_max_field<T: Ord>(&mut self, a: &mut T, mut b: T) -> DidMerge {
         match Ord::cmp(a, &mut b) {
             Ordering::Less => {
@@ -1324,6 +1427,10 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
             cube_reference: Self::make_cube_reference(egraph, enode),
             is_empty_list: Self::make_is_empty_list(egraph, enode),
             filter_operators: Self::make_filter_operators(egraph, enode),
+            non_empty_joins: Self::make_non_empty_joins(enode),
+            non_aggregate_select_type: Self::make_non_aggregate_select_type(enode),
+            select_with_joins: Self::make_select_with_joins(egraph, enode),
+            joins_subqueries: Self::make_joins_subqueries(egraph, enode),
         }
     }
 
@@ -1341,6 +1448,13 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
         let is_empty_list = self.merge_option_field(&mut a.is_empty_list, b.is_empty_list);
         let filter_operators = self.merge_option_field(&mut a.filter_operators, b.filter_operators);
         let column_name = self.merge_option_field(&mut a.column, b.column);
+        let non_empty_joins = self.merge_or_field(&mut a.non_empty_joins, b.non_empty_joins);
+        let non_aggregate_select_type = self.merge_or_field(
+            &mut a.non_aggregate_select_type,
+            b.non_aggregate_select_type,
+        );
+        let select_with_joins = self.merge_or_field(&mut a.select_with_joins, b.select_with_joins);
+        let joins_subqueries = self.merge_or_field(&mut a.joins_subqueries, b.joins_subqueries);
         original_expr
             | member_name_to_expr
             | trivial_push_down
@@ -1352,6 +1466,10 @@ impl Analysis<LogicalPlanLanguage> for LogicalPlanAnalysis {
             | column_name
             | filter_operators
             | is_empty_list
+            | non_empty_joins
+            | non_aggregate_select_type
+            | select_with_joins
+            | joins_subqueries
             | self.merge_max_field(&mut a.iteration_timestamp, b.iteration_timestamp)
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -567,6 +567,12 @@ crate::plan_to_language! {
 
 // trace_macros!(false);
 
+/// Positions of `WrappedSelect` children, for the rules that reach into the node instead of
+/// matching it with a pattern. Keep in sync with the `WrappedSelect` definition above.
+pub const WRAPPED_SELECT_SELECT_TYPE: usize = 0;
+pub const WRAPPED_SELECT_FROM: usize = 6;
+pub const WRAPPED_SELECT_JOINS: usize = 7;
+
 #[macro_export]
 macro_rules! var_iter {
     ($eclass:expr, $field_variant:ident) => {{
@@ -935,6 +941,7 @@ pub enum ListType {
     WrappedSelectGroupExpr,
     WrappedSelectAggrExpr,
     WrappedSelectWindowExpr,
+    WrappedSelectJoins,
     CubeScanMembers,
     UnionInputs,
     WrappedUnionInputs,
@@ -958,6 +965,7 @@ impl ListType {
             Self::WrappedSelectGroupExpr => wrapped_select_group_expr_empty_tail(),
             Self::WrappedSelectAggrExpr => wrapped_select_aggr_expr_empty_tail(),
             Self::WrappedSelectWindowExpr => wrapped_select_window_expr_empty_tail(),
+            Self::WrappedSelectJoins => wrapped_select_joins_empty_tail(),
             Self::CubeScanMembers => cube_scan_members_empty_tail(),
             Self::UnionInputs => union_inputs_empty_tail(),
             Self::WrappedUnionInputs => wrapped_union_inputs_empty_tail(),
@@ -1053,6 +1061,9 @@ impl ListNodeSearcher {
             }
             ListType::WrappedSelectWindowExpr => {
                 matches!(node, LogicalPlanLanguage::WrappedSelectWindowExpr(_))
+            }
+            ListType::WrappedSelectJoins => {
+                matches!(node, LogicalPlanLanguage::WrappedSelectJoins(_))
             }
             ListType::CubeScanMembers => {
                 matches!(node, LogicalPlanLanguage::CubeScanMembers(_))
@@ -1194,6 +1205,11 @@ struct ListNodeApplierList {
     list_type: ListType,
     new_list_var: Var,
     elem_pattern: PatternAst<LogicalPlanLanguage>,
+    /// Elements put after the ones the searcher matched. They are instantiated from the
+    /// outer substitution alone, so they can only mention variables the list walk does not
+    /// bind. This is what lets a rule append to a list it matched: the pattern language can
+    /// name a list, but not spell out a list with one more element than another one.
+    appended_elem_patterns: Vec<PatternAst<LogicalPlanLanguage>>,
 }
 
 impl ListNodeApplierList {
@@ -1224,6 +1240,7 @@ impl ListNodeApplierList {
             ListType::WrappedSelectGroupExpr => LogicalPlanLanguage::WrappedSelectGroupExpr(list),
             ListType::WrappedSelectAggrExpr => LogicalPlanLanguage::WrappedSelectAggrExpr(list),
             ListType::WrappedSelectWindowExpr => LogicalPlanLanguage::WrappedSelectWindowExpr(list),
+            ListType::WrappedSelectJoins => LogicalPlanLanguage::WrappedSelectJoins(list),
             ListType::CubeScanMembers => LogicalPlanLanguage::CubeScanMembers(list),
             ListType::UnionInputs => LogicalPlanLanguage::UnionInputs(list),
             ListType::WrappedUnionInputs => LogicalPlanLanguage::WrappedUnionInputs(list),
@@ -1235,6 +1252,23 @@ pub struct ListApplierListPattern {
     list_type: ListType,
     new_list_var: String,
     elem_pattern: String,
+    appended_elem_patterns: Vec<String>,
+}
+
+impl ListApplierListPattern {
+    pub fn new(list_type: ListType, new_list_var: &str, elem_pattern: &str) -> Self {
+        Self {
+            list_type,
+            new_list_var: new_list_var.to_string(),
+            elem_pattern: elem_pattern.to_string(),
+            appended_elem_patterns: vec![],
+        }
+    }
+
+    pub fn with_appended(mut self, elem_patterns: impl IntoIterator<Item = String>) -> Self {
+        self.appended_elem_patterns = elem_patterns.into_iter().collect();
+        self
+    }
 }
 
 type ListNodeTransform = Box<dyn Fn(&mut CubeEGraph, &mut Subst) -> bool + Sync + Send>;
@@ -1268,11 +1302,11 @@ impl ListNodeApplier {
     ) -> Self {
         Self::from_lists(
             list_pattern,
-            [ListApplierListPattern {
+            [ListApplierListPattern::new(
                 list_type,
-                new_list_var: new_list_var.to_string(),
-                elem_pattern: elem_pattern.to_string(),
-            }],
+                new_list_var,
+                elem_pattern,
+            )],
         )
     }
 
@@ -1290,6 +1324,11 @@ impl ListNodeApplier {
                     list_type: list.list_type,
                     new_list_var: list.new_list_var.parse().unwrap(),
                     elem_pattern: list.elem_pattern.parse().unwrap(),
+                    appended_elem_patterns: list
+                        .appended_elem_patterns
+                        .iter()
+                        .map(|pattern| pattern.parse().unwrap())
+                        .collect(),
                 })
                 .collect(),
         }
@@ -1311,11 +1350,29 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
             .expect("no data, did you use ListNodeSearcher?");
         let list_matches = data.downcast_ref::<ListMatches>().expect("wrong data type");
 
-        let mut subst = subst.clone();
+        let outer_subst = subst.clone();
         let mut result_ids = vec![];
         list_matches.for_each(|list_substs| {
+            // The transform runs before the lists are built, so an element the applier adds
+            // can be spelled out in terms of what the transform binds. It sees the first
+            // element of the list, the way the applier pattern does - but only what it binds
+            // itself is carried on from here: `Subst` keeps the first value of a variable, so
+            // leaving the element's own bindings in place would shadow the other elements.
+            let mut subst = outer_subst.clone();
+            if let Some(transform) = &self.transform {
+                let mut transform_subst = outer_subst.clone();
+                transform_subst.extend(list_substs[0].iter());
+                if !transform(egraph, &mut transform_subst) {
+                    return;
+                }
+                for var in &self.transform_vars {
+                    if let Some(id) = transform_subst.get(*var) {
+                        subst.insert(*var, *id);
+                    }
+                }
+            }
             for list in &self.lists {
-                let new_list = list_substs
+                let mut new_list: Vec<Id> = list_substs
                     .iter()
                     .map(|list_subst| {
                         let mut subst = subst.clone();
@@ -1323,16 +1380,13 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
                         egraph.add_instantiation(&list.elem_pattern, &subst)
                     })
                     .collect();
+                for appended in &list.appended_elem_patterns {
+                    new_list.push(egraph.add_instantiation(appended, &subst));
+                }
 
                 subst.insert(list.new_list_var, egraph.add(list.make_node(new_list)));
             }
-            let mut subst = subst.clone();
             subst.extend(list_substs[0].iter());
-            if let Some(transform) = &self.transform {
-                if !transform(egraph, &mut subst) {
-                    return;
-                }
-            }
             let new_id = egraph.add_instantiation(&self.list_pattern, &subst);
             if egraph.union(eclass, new_id) {
                 result_ids.push(new_id);
@@ -1347,6 +1401,9 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
         let mut vars = self.list_pattern.vars();
         for list in &self.lists {
             vars.extend(list.elem_pattern.vars());
+            for appended in &list.appended_elem_patterns {
+                vars.extend(appended.vars());
+            }
             vars.retain(|v| *v != list.new_list_var); // this is bound by the applier itself
         }
         vars.retain(|v| !self.transform_vars.contains(v)); // and these by the transform
@@ -1715,13 +1772,16 @@ fn wrapped_select_join(input: impl Display, expr: impl Display, join_type: impl 
     format!("(WrappedSelectJoin {} {} {})", input, expr, join_type)
 }
 
-#[allow(dead_code)]
-fn wrapped_select_joins(left: impl Display, right: impl Display) -> String {
-    format!("(WrappedSelectJoins {} {})", left, right)
+/// A join list of a `WrappedSelect`, holding the joins in the order the query joins them in:
+/// a condition can refer to a subquery joined earlier, so the order is part of the meaning.
+/// The list is flat, so a rule that adds a join matches the whole list and rebuilds it with
+/// the new join at the end.
+fn wrapped_select_joins(joins: Vec<impl Display>) -> String {
+    flat_list_expr("WrappedSelectJoins", joins, true)
 }
 
 fn wrapped_select_joins_empty_tail() -> String {
-    "WrappedSelectJoins".to_string()
+    wrapped_select_joins(Vec::<String>::new())
 }
 
 fn wrapped_union(inputs: impl Display, distinct: impl Display, alias: impl Display) -> String {
@@ -2538,6 +2598,10 @@ where
 /// substitution carries the list's own variables — including the `top_level_elem_vars`
 /// every element agreed on — so it can build what a pattern cannot: a cleared replacer
 /// context, an alias converted to another node type.
+///
+/// It runs *before* the lists are built, so an element the applier appends can be spelled
+/// out in terms of what the transform binds. Only the variables named in `transform_vars`
+/// are carried on from it, and it cannot read a `new_list_var`.
 pub fn transforming_list_rewrite_with_lists_and_vars<T>(
     name: &str,
     list_type: ListType,

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
@@ -114,11 +114,11 @@ pub fn replacer_flat_pull_up_node(
             elem: replacer_node("?elem".to_string()),
         },
         &replacer_node("?new_list".to_string()),
-        [ListApplierListPattern {
-            list_type: substitute_list_type,
-            new_list_var: "?new_list".to_string(),
-            elem_pattern: "?elem".to_string(),
-        }],
+        [ListApplierListPattern::new(
+            substitute_list_type,
+            "?new_list",
+            "?elem",
+        )],
         top_level_elem_vars,
     );
     vec![pull_up_rule]
@@ -165,11 +165,11 @@ pub fn replacer_flat_push_down_node_substitute_rules(
                 elem: "?elem".to_string(),
             },
             "?new_list",
-            [ListApplierListPattern {
-                list_type: substitute_type.clone(),
-                new_list_var: "?new_list".to_string(),
-                elem_pattern: replacer_node("?elem".to_string()),
-            }],
+            [ListApplierListPattern::new(
+                substitute_type.clone(),
+                "?new_list",
+                &replacer_node("?elem".to_string()),
+            )],
         ),
         rewrite(
             &format!("{}-tail", name),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/mod.rs
@@ -578,16 +578,16 @@ impl SplitRules {
                         inner_list_type.to_string(),
                     ),
                     [
-                        ListApplierListPattern {
-                            list_type: inner_list_type.clone(),
-                            new_list_var: "?inner_list".to_string(),
-                            elem_pattern: "?inner".to_string(),
-                        },
-                        ListApplierListPattern {
-                            list_type: substitute_list_type.clone(),
-                            new_list_var: "?outer_list".to_string(),
-                            elem_pattern: "?outer".to_string(),
-                        },
+                        ListApplierListPattern::new(
+                            inner_list_type.clone(),
+                            "?inner_list",
+                            "?inner",
+                        ),
+                        ListApplierListPattern::new(
+                            substitute_list_type.clone(),
+                            "?outer_list",
+                            "?outer",
+                        ),
                     ],
                     top_level_elem_vars,
                 )

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/join.rs
@@ -2,14 +2,15 @@ use crate::{
     compile::rewrite::{
         analysis::Member, binary_expr, cross_join, cube_scan_wrapper, filter, fun_expr,
         is_not_null_expr, join, join_check_pull_up, join_check_push_down, join_check_stage,
-        rewrite, rewriter::CubeRewrite, rules::wrapper::WrapperRules, transforming_rewrite,
-        wrapped_select, wrapped_select_aggr_expr_empty_tail, wrapped_select_filter_expr_empty_tail,
+        rewrite, rewriter::CubeRewrite, rules::wrapper::WrapperRules,
+        transforming_list_rewrite_with_lists_and_vars, transforming_rewrite, wrapped_select,
+        wrapped_select_aggr_expr_empty_tail, wrapped_select_filter_expr_empty_tail,
         wrapped_select_group_expr_empty_tail, wrapped_select_having_expr_empty_tail,
-        wrapped_select_join, wrapped_select_joins, wrapped_select_joins_empty_tail,
-        wrapped_select_order_expr_empty_tail, wrapped_select_projection_expr_empty_tail,
-        wrapped_select_subqueries_empty_tail, wrapped_select_window_expr_empty_tail,
-        wrapper_pullup_replacer, wrapper_pushdown_replacer, wrapper_replacer_context, BinaryExprOp,
-        ColumnExprColumn, CubeEGraph, JoinLeftOn, JoinRightOn, LogicalPlanLanguage,
+        wrapped_select_join, wrapped_select_joins, wrapped_select_order_expr_empty_tail,
+        wrapped_select_projection_expr_empty_tail, wrapped_select_subqueries_empty_tail,
+        wrapped_select_window_expr_empty_tail, wrapper_pullup_replacer, wrapper_pushdown_replacer,
+        wrapper_replacer_context, BinaryExprOp, ColumnExprColumn, CubeEGraph, JoinLeftOn,
+        JoinRightOn, ListApplierListPattern, ListPattern, ListType, LogicalPlanLanguage,
         WrappedSelectJoinJoinType, WrappedSelectPushToCube, WrapperReplacerContextAliasToCube,
         WrapperReplacerContextGroupedSubqueries,
     },
@@ -176,40 +177,9 @@ impl WrapperRules {
                             ),
                         ),
                         // We don't want to use list rules here, because ?right_input is already done
-                        wrapped_select_joins(
-                            wrapped_select_join(
-                                wrapper_pullup_replacer(
-                                    "?right_input",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        "WrapperReplacerContextPushToCube:true",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:true",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                wrapper_pushdown_replacer(
-                                    "?out_join_expr",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        // On one hand, this should be PushToCube:true, so we would only join on dimensions
-                                        // On other: RHS is grouped, so any column is just a column
-                                        // Right now, it is relying on grouped_subqueries + PushToCube:true, to allow both dimensions and grouped columns
-                                        "WrapperReplacerContextPushToCube:true",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:true",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                "?out_join_type",
-                            ),
-                            // pullup(tail) just so it could be easily picked up by pullup rules
+                        wrapped_select_joins(vec![wrapped_select_join(
                             wrapper_pullup_replacer(
-                                wrapped_select_joins_empty_tail(),
+                                "?right_input",
                                 wrapper_replacer_context(
                                     "?left_alias_to_cube",
                                     "WrapperReplacerContextPushToCube:true",
@@ -220,7 +190,23 @@ impl WrapperRules {
                                     "?input_data_source",
                                 ),
                             ),
-                        ),
+                            wrapper_pushdown_replacer(
+                                "?out_join_expr",
+                                wrapper_replacer_context(
+                                    "?left_alias_to_cube",
+                                    // On one hand, this should be PushToCube:true, so we would only join on dimensions
+                                    // On other: RHS is grouped, so any column is just a column
+                                    // Right now, it is relying on grouped_subqueries + PushToCube:true, to allow both dimensions and grouped columns
+                                    "WrapperReplacerContextPushToCube:true",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?left_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:true",
+                                    "?input_data_source",
+                                ),
+                            ),
+                            "?out_join_type",
+                        )]),
                         wrapper_pullup_replacer(
                             wrapped_select_filter_expr_empty_tail(),
                             wrapper_replacer_context(
@@ -260,6 +246,7 @@ impl WrapperRules {
                     "CubeScanWrapperFinalized:false",
                 ),
                 self.transform_ungrouped_join_grouped(
+                    "?right_input",
                     "?left_cube_members",
                     "?left_on",
                     "?right_on",
@@ -400,37 +387,9 @@ impl WrapperRules {
                             ),
                         ),
                         // We don't want to use list rules here, because ?right_input is already done
-                        wrapped_select_joins(
-                            wrapped_select_join(
-                                wrapper_pullup_replacer(
-                                    "?right_input",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        "?left_push_to_cube",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:false",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                wrapper_pushdown_replacer(
-                                    "?out_join_expr",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        "?left_push_to_cube",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:false",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                "?out_join_type",
-                            ),
-                            // pullup(tail) just so it could be easily picked up by pullup rules
+                        wrapped_select_joins(vec![wrapped_select_join(
                             wrapper_pullup_replacer(
-                                wrapped_select_joins_empty_tail(),
+                                "?right_input",
                                 wrapper_replacer_context(
                                     "?left_alias_to_cube",
                                     "?left_push_to_cube",
@@ -441,7 +400,20 @@ impl WrapperRules {
                                     "?input_data_source",
                                 ),
                             ),
-                        ),
+                            wrapper_pushdown_replacer(
+                                "?out_join_expr",
+                                wrapper_replacer_context(
+                                    "?left_alias_to_cube",
+                                    "?left_push_to_cube",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?left_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:false",
+                                    "?input_data_source",
+                                ),
+                            ),
+                            "?out_join_type",
+                        )]),
                         wrapper_pullup_replacer(
                             wrapped_select_filter_expr_empty_tail(),
                             wrapper_replacer_context(
@@ -479,6 +451,7 @@ impl WrapperRules {
                     "CubeScanWrapperFinalized:false",
                 ),
                 self.transform_grouped_join_grouped(
+                    "?left_input",
                     "?left_on",
                     "?left_push_to_cube",
                     "?right_on",
@@ -491,6 +464,204 @@ impl WrapperRules {
                 ),
             ),
         ]);
+
+        // A pivot query builder emits one CTE per property, all joined to the same root CTE.
+        // The rule above turns the first of those joins into a WrappedSelect; every next join
+        // is added to that select's join list here, rather than nesting another select around
+        // it. The nesting is what has to be avoided, not undone: an e-graph only ever adds, so
+        // a rule that flattens a stack of selects afterwards leaves every level of it in place
+        // to be matched by everything else. Measured on a chain of joins, each level roughly
+        // doubles the graph and six joins run out of nodes, whether or not such a rule is
+        // there; keeping the joins in one select stays linear.
+        //
+        // The context of the left select is reused as is, including its `grouped_subqueries`:
+        // that list is only read by the column rules to pull a column qualified by a joined
+        // subquery up as a dimension, and only when pushing members to Cube. This select does
+        // not (`WrapperReplacerContextPushToCube:false` below), so the aliases of the
+        // subqueries joined here have nothing to do in that list.
+
+        // Everything the extended select carries over from the one it replaces. The join it
+        // gains changes nothing about it: it still pushes nothing to Cube and stays grouped.
+        let chain_out_context = wrapper_replacer_context(
+            "?left_alias_to_cube",
+            "WrapperReplacerContextPushToCube:false",
+            "WrapperReplacerContextInProjection:false",
+            "?left_cube_members",
+            "?left_grouped_subqueries",
+            "WrapperReplacerContextUngroupedScan:false",
+            "?input_data_source",
+        );
+        rules.push(transforming_list_rewrite_with_lists_and_vars(
+            "wrapper-push-down-grouped-join-grouped-chain",
+            ListType::WrappedSelectJoins,
+            ListPattern {
+                pattern: join(
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            // The select built by the rule above, before anything was pushed
+                            // into it: everything but `from` and `joins` is still empty
+                            wrapped_select(
+                                "WrappedSelectSelectType:Projection",
+                                wrapped_select_projection_expr_empty_tail(),
+                                wrapped_select_subqueries_empty_tail(),
+                                wrapped_select_group_expr_empty_tail(),
+                                wrapped_select_aggr_expr_empty_tail(),
+                                wrapped_select_window_expr_empty_tail(),
+                                "?left_from",
+                                // A select without joins is the job of
+                                // `wrapper-push-down-grouped-join-grouped`, so the list needs
+                                // at least one element - see `min_elements` below
+                                "?left_joins",
+                                wrapped_select_filter_expr_empty_tail(),
+                                wrapped_select_having_expr_empty_tail(),
+                                "WrappedSelectLimit:None",
+                                "WrappedSelectOffset:None",
+                                wrapped_select_order_expr_empty_tail(),
+                                "WrappedSelectAlias:None",
+                                "WrappedSelectDistinct:false",
+                                // Only a select that joins subqueries as plain SQL is extended
+                                // here. A push-to-Cube select carries its joins to the Cube
+                                // query as subquery joins, which are rendered under a
+                                // uniqueness assumption this rule can not check
+                                "WrappedSelectPushToCube:false",
+                                "WrappedSelectUngroupedScan:false",
+                            ),
+                            wrapper_replacer_context(
+                                "?left_alias_to_cube",
+                                // A select with joins can not push anything else to Cube, so
+                                // the join condition needs no member resolution and is built
+                                // as plain columns below
+                                "WrapperReplacerContextPushToCube:false",
+                                "?left_in_projection",
+                                "?left_cube_members",
+                                "?left_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:false",
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?right_input",
+                            wrapper_replacer_context(
+                                "?right_alias_to_cube",
+                                "?right_push_to_cube",
+                                "?right_in_projection",
+                                "?right_cube_members",
+                                "?right_grouped_subqueries",
+                                "WrapperReplacerContextUngroupedScan:false",
+                                "?input_data_source",
+                            ),
+                        ),
+                        "CubeScanWrapperFinalized:false",
+                    ),
+                    "?left_on",
+                    "?right_on",
+                    "?in_join_type",
+                    "?join_constraint",
+                    "JoinNullEqualsNull:false",
+                ),
+                list_var: "?left_joins".to_string(),
+                elem: "?left_join".to_string(),
+            },
+            &cube_scan_wrapper(
+                wrapped_select(
+                    "WrappedSelectSelectType:Projection",
+                    wrapper_pullup_replacer(
+                        wrapped_select_projection_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapper_pullup_replacer(
+                        wrapped_select_subqueries_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapper_pullup_replacer(
+                        wrapped_select_group_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapper_pullup_replacer(
+                        wrapped_select_aggr_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapper_pullup_replacer(
+                        wrapped_select_window_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapper_pullup_replacer("?left_from", &chain_out_context),
+                    wrapper_pullup_replacer("?merged_joins", &chain_out_context),
+                    wrapper_pullup_replacer(
+                        wrapped_select_filter_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    wrapped_select_having_expr_empty_tail(),
+                    "WrappedSelectLimit:None",
+                    "WrappedSelectOffset:None",
+                    wrapper_pullup_replacer(
+                        wrapped_select_order_expr_empty_tail(),
+                        &chain_out_context,
+                    ),
+                    "WrappedSelectAlias:None",
+                    "WrappedSelectDistinct:false",
+                    "WrappedSelectPushToCube:false",
+                    "WrappedSelectUngroupedScan:false",
+                ),
+                "CubeScanWrapperFinalized:false",
+            ),
+            // The new join goes after the ones already there: a join condition can refer to a
+            // subquery joined earlier, so the order the query joins them in is part of what it
+            // means. This is what the flat list buys - the whole list is matched and rebuilt
+            // one element longer, where a cons list could only be prepended to.
+            [ListApplierListPattern::new(
+                ListType::WrappedSelectJoins,
+                "?merged_joins",
+                "?left_join",
+            )
+            .with_appended([wrapped_select_join(
+                // The wrapper of the joined side goes into the join, not the plan inside it: a
+                // grouped subquery is represented by several equivalent plans at once, all
+                // sharing that wrapper, so every match builds the same join here and which
+                // plan is rendered is left to extraction. Referencing the plan directly builds
+                // one join per representation, and those multiply with every join in a chain.
+                //
+                // Extraction reads that choice through `empty_wrappers`, which counts a wrapper
+                // with no `WrappedSelect` under it, so it takes the select over the Cube query
+                // rather than the Cube query itself and the joined side renders one level
+                // deeper than it has to. That is the price of leaving the choice to extraction;
+                // the plans that win carry no empty wrappers, so the count keeps saying what it
+                // says elsewhere.
+                cube_scan_wrapper(
+                    wrapper_pullup_replacer(
+                        "?right_input",
+                        wrapper_replacer_context(
+                            "?right_alias_to_cube",
+                            "?right_push_to_cube",
+                            "?right_in_projection",
+                            "?right_cube_members",
+                            "?right_grouped_subqueries",
+                            "WrapperReplacerContextUngroupedScan:false",
+                            "?input_data_source",
+                        ),
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+                "?out_join_expr",
+                "?out_join_type",
+            )])],
+            // Nothing has to hold across the elements of the list: they are finished joins
+            &[],
+            // A select without joins is not extended here
+            1,
+            &["?out_join_expr", "?out_join_type"],
+            self.transform_grouped_join_grouped_chain(
+                "?left_on",
+                "?right_on",
+                "?in_join_type",
+                "?input_data_source",
+                "?out_join_expr",
+                "?out_join_type",
+            ),
+        ));
 
         // DataFusion plans complex join conditions as Filter(?join_condition, CrossJoin(...))
         // Handling each and every condition in here is not that easy, so for now
@@ -677,40 +848,9 @@ impl WrapperRules {
                             ),
                         ),
                         // We don't want to use list rules here, because ?right_input is already done
-                        wrapped_select_joins(
-                            wrapped_select_join(
-                                wrapper_pullup_replacer(
-                                    "?right_input",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        "WrapperReplacerContextPushToCube:true",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:true",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                wrapper_pushdown_replacer(
-                                    "?join_expr",
-                                    wrapper_replacer_context(
-                                        "?left_alias_to_cube",
-                                        // On one hand, this should be PushToCube:true, so we would only join on dimensions
-                                        // On other: RHS is grouped, so any column is just a column
-                                        // Right now, it is relying on grouped_subqueries + PushToCube:true, to allow both dimensions and grouped columns
-                                        "WrapperReplacerContextPushToCube:true",
-                                        "WrapperReplacerContextInProjection:false",
-                                        "?left_cube_members",
-                                        "?out_grouped_subqueries",
-                                        "WrapperReplacerContextUngroupedScan:true",
-                                        "?input_data_source",
-                                    ),
-                                ),
-                                "?out_join_type",
-                            ),
-                            // pullup(tail) just so it could be easily picked up by pullup rules
+                        wrapped_select_joins(vec![wrapped_select_join(
                             wrapper_pullup_replacer(
-                                wrapped_select_joins_empty_tail(),
+                                "?right_input",
                                 wrapper_replacer_context(
                                     "?left_alias_to_cube",
                                     "WrapperReplacerContextPushToCube:true",
@@ -721,7 +861,23 @@ impl WrapperRules {
                                     "?input_data_source",
                                 ),
                             ),
-                        ),
+                            wrapper_pushdown_replacer(
+                                "?join_expr",
+                                wrapper_replacer_context(
+                                    "?left_alias_to_cube",
+                                    // On one hand, this should be PushToCube:true, so we would only join on dimensions
+                                    // On other: RHS is grouped, so any column is just a column
+                                    // Right now, it is relying on grouped_subqueries + PushToCube:true, to allow both dimensions and grouped columns
+                                    "WrapperReplacerContextPushToCube:true",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?left_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:true",
+                                    "?input_data_source",
+                                ),
+                            ),
+                            "?out_join_type",
+                        )]),
                         wrapper_pullup_replacer(
                             wrapped_select_filter_expr_empty_tail(),
                             wrapper_replacer_context(
@@ -761,6 +917,7 @@ impl WrapperRules {
                     "CubeScanWrapperFinalized:false",
                 ),
                 self.transform_ungrouped_join_grouped_after_check(
+                    "?right_input",
                     "?right_alias_to_cube",
                     "?out_join_type",
                     "?out_grouped_subqueries",
@@ -883,11 +1040,11 @@ impl WrapperRules {
         }
 
         // TODO only pullup is necessary here
-        Self::list_pushdown_pullup_rules(
+        Self::flat_list_pushdown_pullup_rules(
             rules,
             "wrapper-joins",
-            "WrappedSelectJoins",
-            "WrappedSelectJoins",
+            ListType::WrappedSelectJoins,
+            ListType::WrappedSelectJoins,
         );
     }
 
@@ -1016,6 +1173,7 @@ impl WrapperRules {
 
     fn transform_ungrouped_join_grouped(
         &self,
+        right_input_var: &'static str,
         left_members_var: &'static str,
         left_on_var: &'static str,
         right_on_var: &'static str,
@@ -1025,6 +1183,7 @@ impl WrapperRules {
         out_join_type_var: &'static str,
         out_grouped_subqueries_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let right_input_var = var!(right_input_var);
         let left_members_var = var!(left_members_var);
         let left_on_var = var!(left_on_var);
 
@@ -1043,6 +1202,12 @@ impl WrapperRules {
         // It means we don't care about just a "single cube" in LHS, and there's essentially no cubes by this moment in RHS
 
         move |egraph, subst| {
+            // A join of subqueries is not unique on its join keys, so it can not be handed
+            // to a Cube query as a subquery join - see `LogicalPlanData::joins_subqueries`
+            if egraph[subst[right_input_var]].data.joins_subqueries {
+                return false;
+            }
+
             // We are going to generate join with grouped subquery
             // TODO Do we have to check stuff like `transform_check_subquery_allowed` is checking:
             // * Both inputs depend on a single data source
@@ -1213,15 +1378,23 @@ impl WrapperRules {
 
     fn transform_ungrouped_join_grouped_after_check(
         &self,
+        right_input_var: &'static str,
         right_alias_to_cube_var: &'static str,
         out_join_type_var: &'static str,
         out_grouped_subqueries_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let right_input_var = var!(right_input_var);
         let right_alias_to_cube_var = var!(right_alias_to_cube_var);
         let out_join_type_var = var!(out_join_type_var);
         let out_grouped_subqueries_var = var!(out_grouped_subqueries_var);
 
         move |egraph, subst| {
+            // A join of subqueries is not unique on its join keys, so it can not be handed
+            // to a Cube query as a subquery join - see `LogicalPlanData::joins_subqueries`
+            if egraph[subst[right_input_var]].data.joins_subqueries {
+                return false;
+            }
+
             for right_alias_to_cube in var_iter!(
                 egraph[subst[right_alias_to_cube_var]],
                 WrapperReplacerContextAliasToCube
@@ -1262,6 +1435,7 @@ impl WrapperRules {
 
     fn transform_grouped_join_grouped(
         &self,
+        left_input_var: &'static str,
         left_on_var: &'static str,
         left_push_to_cube_var: &'static str,
         right_on_var: &'static str,
@@ -1272,6 +1446,7 @@ impl WrapperRules {
         out_grouped_subqueries_var: &'static str,
         out_push_to_cube_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let left_input_var = var!(left_input_var);
         let left_on_var = var!(left_on_var);
         let left_push_to_cube_var = var!(left_push_to_cube_var);
 
@@ -1288,6 +1463,13 @@ impl WrapperRules {
         let meta = self.meta_context.clone();
 
         move |egraph, subst| {
+            // Joins on top of a select that already has joins are handled by
+            // `wrapper-push-down-grouped-join-grouped-chain`, which keeps them in a single
+            // select instead of nesting one select per join
+            if egraph[subst[left_input_var]].data.select_with_joins {
+                return false;
+            }
+
             // We are going to generate join with grouped subquery
             // TODO Do we have to check stuff like `transform_check_subquery_allowed` is checking:
             // * Both inputs depend on a single data source
@@ -1374,6 +1556,72 @@ impl WrapperRules {
             }
 
             return false;
+        }
+    }
+
+    /// Everything this rule needs beyond its pattern: the join condition, which is built from
+    /// the join keys of the plan, and the join type, which has to be checked against the data
+    /// source before it can be used. Both are the same work the rule this extends does.
+    fn transform_grouped_join_grouped_chain(
+        &self,
+        left_on_var: &'static str,
+        right_on_var: &'static str,
+        in_join_type_var: &'static str,
+        input_data_source_var: &'static str,
+        out_join_expr_var: &'static str,
+        out_join_type_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let left_on_var = var!(left_on_var);
+        let right_on_var = var!(right_on_var);
+        let in_join_type_var = var!(in_join_type_var);
+        let input_data_source_var = var!(input_data_source_var);
+        let out_join_expr_var = var!(out_join_expr_var);
+        let out_join_type_var = var!(out_join_type_var);
+
+        let meta = self.meta_context.clone();
+
+        move |egraph, subst| {
+            for left_join_on in var_iter!(egraph[subst[left_on_var]], JoinLeftOn) {
+                for right_join_on in var_iter!(egraph[subst[right_on_var]], JoinRightOn) {
+                    for in_join_type in
+                        var_list_iter!(egraph[subst[in_join_type_var]], JoinJoinType).cloned()
+                    {
+                        // The select this join is added to is not pushing anything to Cube:
+                        // it is a join of grouped subqueries, where every join type maps to
+                        // SQL directly
+                        if !Self::is_subquery_join_type_supported(
+                            egraph,
+                            subst,
+                            &meta,
+                            input_data_source_var,
+                            &in_join_type.0,
+                            false,
+                        ) {
+                            continue;
+                        }
+
+                        let Some(out_join_expr) = Self::build_join_expr(
+                            egraph,
+                            left_join_on.clone(),
+                            right_join_on.clone(),
+                        ) else {
+                            return false;
+                        };
+
+                        subst.insert(out_join_expr_var, out_join_expr);
+                        subst.insert(
+                            out_join_type_var,
+                            egraph.add(LogicalPlanLanguage::WrappedSelectJoinJoinType(
+                                WrappedSelectJoinJoinType(in_join_type.0),
+                            )),
+                        );
+
+                        return true;
+                    }
+                }
+            }
+
+            false
         }
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -66,11 +66,11 @@ impl WrapperRules {
                     ),
                     "CubeScanWrapperFinalized:false",
                 ),
-                [ListApplierListPattern {
-                    list_type: ListType::WrappedUnionInputs,
-                    new_list_var: "?new_list".to_string(),
-                    elem_pattern: "?elem".to_string(),
-                }],
+                [ListApplierListPattern::new(
+                    ListType::WrappedUnionInputs,
+                    "?new_list",
+                    "?elem",
+                )],
                 &["?input_data_source"],
                 // One query is not a union, and folding a `Distinct` into a single query
                 // one would leave the deduplication with no operator to render it on

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/wrapper_pull_up.rs
@@ -4,9 +4,8 @@ use crate::{
         rewriter::{CubeEGraph, CubeRewrite},
         rules::{members::MemberRules, wrapper::WrapperRules},
         transforming_rewrite, wrapped_select, wrapped_select_having_expr_empty_tail,
-        wrapped_select_joins_empty_tail, wrapper_pullup_replacer, wrapper_replacer_context,
-        LogicalPlanLanguage, WrappedSelectAlias, WrappedSelectSelectType, WrappedSelectType,
-        WrapperReplacerContextAliasToCube,
+        wrapper_pullup_replacer, wrapper_replacer_context, LogicalPlanLanguage, WrappedSelectAlias,
+        WrappedSelectSelectType, WrappedSelectType, WrapperReplacerContextAliasToCube,
     },
     var, var_iter, var_list_iter,
 };
@@ -276,8 +275,7 @@ impl WrapperRules {
                             ),
                         ),
                         wrapper_pullup_replacer(
-                            // TODO handle non-empty joins
-                            wrapped_select_joins_empty_tail(),
+                            "?joins",
                             wrapper_replacer_context(
                                 "?alias_to_cube",
                                 "?push_to_cube",
@@ -351,7 +349,7 @@ impl WrapperRules {
                                 "?inner_push_to_cube",
                                 "?inner_ungrouped_scan",
                             ),
-                            wrapped_select_joins_empty_tail(),
+                            "?joins",
                             "?filter_expr",
                             wrapped_select_having_expr_empty_tail(),
                             "WrappedSelectLimit:None",
@@ -381,6 +379,7 @@ impl WrapperRules {
                     "?projection_expr",
                     "?group_expr",
                     "?aggr_expr",
+                    "?joins",
                     "?inner_select_type",
                     "?inner_projection_expr",
                     "?inner_group_expr",
@@ -455,6 +454,7 @@ impl WrapperRules {
         projection_expr_var: &'static str,
         _group_expr_var: &'static str,
         _aggr_expr_var: &'static str,
+        joins_var: &'static str,
         inner_select_type_var: &'static str,
         inner_projection_expr_var: &'static str,
         _inner_group_expr_var: &'static str,
@@ -465,6 +465,7 @@ impl WrapperRules {
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let select_type_var = var!(select_type_var);
         let projection_expr_var = var!(projection_expr_var);
+        let joins_var = var!(joins_var);
         let inner_select_type_var = var!(inner_select_type_var);
         let inner_projection_expr_var = var!(inner_projection_expr_var);
         let alias_to_cube_var = var!(alias_to_cube_var);
@@ -479,6 +480,12 @@ impl WrapperRules {
                 alias_to_cube_out_var,
             ) {
                 return false;
+            }
+
+            // A select that joins something on top of another select is never a no-op
+            // wrapper around it, no matter how similar the two projections look
+            if egraph[subst[joins_var]].data.non_empty_joins {
+                return true;
             }
 
             for select_type in

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -4202,3 +4202,464 @@ async fn test_wrapper_multi_arg_aggregate_function_without_template() {
         error
     );
 }
+
+/// Pivot SQL from a query builder: several conditional aggregations over one
+/// fan-out join must push down as a single grouped Cube query, not as an
+/// ungrouped scan aggregated in memory.
+#[tokio::test]
+async fn test_wrapper_conditional_aggregation_over_join() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        SELECT k.customer_gender AS "gender",
+               MAX(CASE WHEN l.content = 'PropA' THEN l.read END) AS "PropA",
+               MAX(CASE WHEN l.content = 'PropB' THEN l.read END) AS "PropB"
+        FROM KibanaSampleDataEcommerce k
+        LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+        WHERE k.customer_gender = 'female'
+        GROUP BY 1
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let request = logical_plan.find_cube_scan_wrapped_sql().request;
+    assert_eq!(
+        request.ungrouped, None,
+        "query is grouped in Cube: {:?}",
+        request
+    );
+    let measures = request.measures.unwrap_or_default();
+    assert_eq!(
+        measures.len(),
+        2,
+        "both conditional aggregations are pushed down as measures: {:?}",
+        measures
+    );
+    assert!(
+        measures
+            .iter()
+            .all(|measure| measure.contains("MAX(CASE WHEN")),
+        "measures keep the conditional aggregation: {:?}",
+        measures
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+}
+
+/// The same pivot spread over CTEs joined together: the whole query, including the
+/// join between the CTEs, must be pushed down into a single Cube query.
+#[tokio::test]
+async fn test_wrapper_conditional_aggregation_multi_cte() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH t_root AS (
+            SELECT k.customer_gender AS "gender",
+                   MAX(CASE WHEN l.content = 'PropA' THEN l.read END) AS "PropA"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            WHERE k.customer_gender = 'female'
+            GROUP BY 1
+        ),
+        t_prop_b AS (
+            SELECT k.customer_gender AS "__j_gender",
+                   MAX(l.content) AS "PropB"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            WHERE l.content = 'PropB' AND k.customer_gender = 'female'
+            GROUP BY 1
+        )
+        SELECT t_root."gender", t_root."PropA", t_prop_b."PropB"
+        FROM t_root
+        LEFT JOIN t_prop_b ON t_prop_b."__j_gender" = t_root."gender"
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("MAX(CASE WHEN"),
+        "conditional aggregation is pushed down:\n{}",
+        sql
+    );
+    // The row-preserving side of the LEFT JOIN must stay in `from`, with the other CTE
+    // joined to it - swapping the sides would drop unmatched rows. Both positions are taken
+    // from the aliases of the two CTEs rather than from the first `LEFT JOIN` in the SQL,
+    // which would also match a join Cube renders inside either of them.
+    let from_position = sql.find(r#") AS "t_root""#).expect(&sql);
+    let join_position = sql
+        .find(r#") AS "t_prop_b" ON ("t_root"."gender" = "t_prop_b"."j_gender")"#)
+        .expect(&sql);
+    assert!(
+        from_position < join_position,
+        "left CTE stays the from of the LEFT JOIN, right CTE is joined as a subquery on the \
+         original condition:\n{}",
+        sql
+    );
+    assert!(
+        sql[from_position..join_position].contains("LEFT JOIN (SELECT"),
+        "the second CTE is attached to the first one with a LEFT JOIN:\n{}",
+        sql
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    let plan = format!("{}", displayable(physical_plan.as_ref()).indent());
+    assert_eq!(
+        plan.matches("CubeScanExecutionPlan").count(),
+        1,
+        "the join between the CTEs is executed by the data source, not in memory:\n{}",
+        plan
+    );
+}
+
+/// A pivot query builder emits one CTE per property, all joined to the root CTE.
+/// Every join in that chain must be pushed down, not just the first one.
+#[tokio::test]
+async fn test_wrapper_conditional_aggregation_multi_cte_chain() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH t_root AS (
+            SELECT k.customer_gender AS "gender",
+                   MAX(CASE WHEN l.content = 'PropA' THEN l.read END) AS "PropA"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        ),
+        t_prop_b AS (
+            SELECT k.customer_gender AS "__j_b", MAX(l.content) AS "PropB"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            WHERE l.content = 'PropB'
+            GROUP BY 1
+        ),
+        t_prop_c AS (
+            SELECT k.customer_gender AS "__j_c", MAX(l.content) AS "PropC"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            WHERE l.content = 'PropC'
+            GROUP BY 1
+        )
+        SELECT t_root."gender", t_root."PropA", t_prop_b."PropB", t_prop_c."PropC"
+        FROM t_root
+        LEFT JOIN t_prop_b ON t_prop_b."__j_b" = t_root."gender"
+        LEFT JOIN t_prop_c ON t_prop_c."__j_c" = t_root."gender"
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    for joined in [
+        r#"AS "t_prop_b" ON ("t_root"."gender" = "t_prop_b"."j_b")"#,
+        r#"AS "t_prop_c" ON ("t_root"."gender" = "t_prop_c"."j_c")"#,
+    ] {
+        assert!(
+            sql.contains(joined),
+            "both CTE joins are pushed down, missing {}:\n{}",
+            joined,
+            sql
+        );
+    }
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    let plan = format!("{}", displayable(physical_plan.as_ref()).indent());
+    assert_eq!(
+        plan.matches("CubeScanExecutionPlan").count(),
+        1,
+        "a chain of CTE joins becomes a single Cube query:\n{}",
+        plan
+    );
+}
+
+/// A join condition can reference a CTE joined earlier in the query, so pushed-down joins
+/// must keep the order they had: a subquery can only be referenced after it is joined.
+#[tokio::test]
+async fn test_wrapper_grouped_join_chain_keeps_join_order() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH t_root AS (
+            SELECT k.customer_gender AS "gender", MAX(l.content) AS "a"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        ),
+        t_b AS (
+            SELECT k.customer_gender AS "jb", MAX(l.content) AS "b"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        ),
+        t_c AS (
+            SELECT k.customer_gender AS "jc", MIN(l.content) AS "c"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        )
+        SELECT t_root."gender", t_b."b", t_c."c"
+        FROM t_root
+        LEFT JOIN t_b ON t_b."jb" = t_root."gender"
+        LEFT JOIN t_c ON t_c."jc" = t_b."b"
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    let joined_b = sql
+        .find(r#") AS "t_b" ON ("t_root"."gender" = "t_b"."jb")"#)
+        .expect(&sql);
+    let joined_c = sql
+        .find(r#") AS "t_c" ON ("t_b"."b" = "t_c"."jc")"#)
+        .expect(&sql);
+    assert!(
+        joined_b < joined_c,
+        "t_b is joined before the condition that references it:\n{}",
+        sql
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    let plan = format!("{}", displayable(physical_plan.as_ref()).indent());
+    assert_eq!(
+        plan.matches("CubeScanExecutionPlan").count(),
+        1,
+        "the whole chain is one Cube query:\n{}",
+        plan
+    );
+}
+
+/// A pushed-down join of grouped subqueries is not unique on its join keys, so it must not be
+/// handed to a Cube query as a subquery join: that rendering counts or deduplicates join fanout
+/// depending on how a measure happens to be classified. Refusing to plan the query is the
+/// intended outcome - an error is preferable to numbers that depend on the data model.
+#[tokio::test]
+async fn test_wrapper_grouped_join_is_not_used_as_cube_subquery_join() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query = r#"
+        WITH m1 AS (
+            SELECT customer_gender AS g, sum(sumPrice) AS s
+            FROM KibanaSampleDataEcommerce GROUP BY 1
+        ),
+        m2 AS (
+            SELECT customer_gender AS g2, avg(avgPrice) AS v
+            FROM KibanaSampleDataEcommerce GROUP BY 1
+        ),
+        joined AS (
+            SELECT m2.v AS k, m1.g AS g FROM m1 LEFT JOIN m2 ON m2.g2 = m1.g
+        )
+        SELECT k.customer_gender, MEASURE(k.avgPrice) AS p
+        FROM KibanaSampleDataEcommerce k
+        LEFT JOIN joined ON joined.k = k.customer_gender
+        GROUP BY 1
+        "#
+    .to_string();
+
+    let meta = crate::compile::test::get_test_tenant_ctx();
+    let session =
+        crate::compile::test::get_test_session(DatabaseProtocol::PostgreSQL, meta.clone()).await;
+    let query_plan = crate::compile::test::convert_sql_to_cube_query(&query, meta, session).await;
+
+    // Today the query is refused outright. Planning it some other way would be fine too, as
+    // long as the join of subqueries does not end up as a subquery join of a Cube query - so
+    // check that, rather than only checking that something failed.
+    match query_plan {
+        Err(error) => {
+            println!("Refused at compile time: {}", error);
+        }
+        Ok(query_plan) => {
+            let physical_plan = query_plan.as_physical_plan().await.unwrap();
+            let plan = format!("{}", displayable(physical_plan.as_ref()).indent());
+            panic!(
+                "expected the query to be refused, it planned instead{}:\n{}",
+                if plan.contains("subqueryJoins") {
+                    " - with the join of subqueries sent to Cube as a subquery join"
+                } else {
+                    ""
+                },
+                plan
+            );
+        }
+    }
+}
+
+/// Cube measures can not be computed over a pushed-down join: the aggregation has to stay
+/// outside the wrapper, where it fails with the explicit MEASURE error, rather than be folded
+/// into a Cube query that would give it aggregation semantics it does not have.
+#[tokio::test]
+async fn test_wrapper_no_measure_over_grouped_join_chain() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH t_root AS (
+            SELECT k.customer_gender AS "g", MAX(l.content) AS "a"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        ),
+        t_b AS (
+            SELECT k.customer_gender AS "jb", MIN(l.content) AS "b"
+            FROM KibanaSampleDataEcommerce k
+            LEFT JOIN Logs l ON k.__cubeJoinField = l.__cubeJoinField
+            GROUP BY 1
+        )
+        SELECT t_root."g", MEASURE(t_b."b") AS m
+        FROM t_root
+        LEFT JOIN t_b ON t_b."jb" = t_root."g"
+        GROUP BY 1
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert!(
+        logical_plan.try_expect_root_cube_scan().is_none(),
+        "MEASURE() over a pushed-down join is not wrapped:\n{}",
+        logical_plan.display_indent()
+    );
+}
+
+/// A LIMIT between two joins belongs to the join below it. The second join must go on top of
+/// the limited select, never into it, or it would join before the rows are picked.
+#[tokio::test]
+async fn test_wrapper_grouped_join_chain_keeps_limit_between_joins() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH m1 AS (
+            SELECT customer_gender AS g, sum(sumPrice) AS s
+            FROM KibanaSampleDataEcommerce GROUP BY 1
+        ),
+        m2 AS (
+            SELECT customer_gender AS g2, avg(avgPrice) AS v
+            FROM KibanaSampleDataEcommerce GROUP BY 1
+        ),
+        m3 AS (
+            SELECT customer_gender AS g3, count(count) AS w
+            FROM KibanaSampleDataEcommerce GROUP BY 1
+        ),
+        limited AS (
+            SELECT m1.g AS g, m2.v AS v FROM m1 LEFT JOIN m2 ON m2.g2 = m1.g LIMIT 5
+        )
+        SELECT limited.g, limited.v, m3.w
+        FROM limited
+        LEFT JOIN m3 ON m3.g3 = limited.g
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    let limit = sql.find("LIMIT 5").expect(&sql);
+    let second_join = sql
+        .find(r#"AS "m3" ON ("limited"."g" = "m3"."g3")"#)
+        .expect(&sql);
+    assert!(
+        limit < second_join,
+        "the second join is applied to the limited rows, not inside the limit:\n{}",
+        sql
+    );
+}
+
+/// Same column names on both sides of a pushed-down join must keep distinct aliases,
+/// or the outer projection would read the same column twice.
+#[tokio::test]
+async fn test_wrapper_grouped_join_wrapped_left_duplicate_names() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        WITH m1 AS (
+            SELECT customer_gender AS g, MAX(taxful_total_price) AS v
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        ),
+        m2 AS (
+            SELECT customer_gender AS g, MAX(minPrice) AS v
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        )
+        SELECT COALESCE(m1.g, m2.g) AS g, m1.v AS v1, m2.v AS v2
+        FROM m1
+        LEFT JOIN m2 ON m1.g = m2.g
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains(r#") AS "m2" ON ("m1"."g" = "m2"."g")"#),
+        "the two CTEs are joined, rather than merged into one query:\n{}",
+        sql
+    );
+    // The select that joins them is itself aliased `m1`, so the level above reads both sides
+    // off it - which only works because the right side's columns were given other names
+    assert!(
+        sql.contains(r#"COALESCE("m1"."g", "m1"."g_1")"#),
+        "join sides keep distinct aliases:\n{}",
+        sql
+    );
+    assert!(
+        sql.contains(r#""m1"."v" "v1", "m1"."v_1" "v2""#),
+        "same-named measures from both sides stay distinct:\n{}",
+        sql
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR pushes joins between grouped subqueries down to the data source in one SQL statement, including chains of them and sides that need a SQL wrapper, instead of joining per-subquery results in memory. Related tests are included.

Behaviour change: a join of subqueries is no longer accepted as a subquery join of a Cube query, because that rendering is only correct when the joined subquery is unique on the join keys. Queries relying on it now error instead of returning numbers that depend on how a measure is classified.