### PR TITLE
perf(postgres-driver): build user defined types map in linear time

### DIFF
--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -315,10 +315,13 @@ export class PostgresDriver<Config extends PostgresDriverConfiguration = Postgre
         []
       );
 
-      this.userDefinedTypes = customTypes.rows.reduce(
-        (prev, current) => ({ [current.oid]: current.typname, ...prev }),
-        {}
-      );
+      const userDefinedTypes: Record<string, string> = {};
+
+      for (const row of customTypes.rows) {
+        userDefinedTypes[row.oid] = row.typname;
+      }
+
+      this.userDefinedTypes = userDefinedTypes;
     }
   }
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

`loadUserDefinedTypes` built its oid -> typname map with a reduce that spread the accumulator on every row, copying the whole map n times — quadratic and fully synchronous, so it blocks the event loop. This went unnoticed while the query only selected `typcategory in ('U', 'E')` (~20 rows on a stock Postgres), but #11149 added `'A'` so that array-typed columns get mapped, and Postgres auto-creates an array type for every relation, so the row count now scales with the number of tables in the database rather than with the number of actual user defined types. This replaces the spread-reduce with an in-place loop.

Measured on postgres:16, `SELECT count(*) FROM pg_type WHERE typcategory in ('U', 'E', 'A')`:

| tables in database | rows | spread reduce | in-place loop |
| ------------------ | ---- | ------------- | ------------- |
| 0                  |  313 |        6.3 ms |       0.12 ms |
| 5000               | 5313 |       2355 ms |       0.45 ms |
| ~20000             |   -  |      35116 ms |       1.10 ms |