### PR TITLE
perf(postgres-driver): skip relation array types when loading user defined types

### DIFF
--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -300,18 +300,31 @@ export class PostgresDriver<Config extends PostgresDriverConfiguration = Postgre
       // to be of type text for the drivers purposes.
       // TODO: if full implmentation the constraints can be looked up via pg_enum
       // https://www.postgresql.org/docs/9.1/catalog-pg-enum.html
+      //
+      // Postgres creates a row type for every relation and an array type over it, so
+      // selecting all of typcategory = 'A' returns one row per relation in the database.
+      // That's why there is a NOT EXIST filter.
       const customTypes = await conn.query(
         `SELECT
-            oid,
+            t.oid,
             CASE
-                WHEN typcategory = 'E' THEN 'varchar'
-                WHEN typcategory = 'A' THEN 'text'
-                ELSE typname
+                WHEN t.typcategory = 'E' THEN 'varchar'
+                WHEN t.typcategory = 'A' THEN 'text'
+                ELSE t.typname
             END AS typname
         FROM
-            pg_type
+            pg_type t
         WHERE
-            typcategory in ('U', 'E', 'A')`,
+            t.typcategory in ('U', 'E')
+            OR (
+                t.typcategory = 'A'
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM pg_type e
+                    JOIN pg_class c ON c.oid = e.typrelid
+                    WHERE e.oid = t.typelem AND e.typtype = 'c' AND c.relkind <> 'c'
+                )
+            )`,
         []
       );
 

--- a/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
+++ b/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
@@ -147,6 +147,53 @@ describe('PostgresDriver', () => {
     }
   });
 
+  test('stream (user defined type)', async () => {
+    await driver.query('CREATE TYPE CUBEJS_TEST_POINT AS (x int, y int);', []);
+    // Postgres reports the base type oid in RowDescription rather than the domain one.
+    await driver.query('CREATE DOMAIN CUBEJS_TEST_INT AS int;', []);
+
+    // A driver of its own, the shared one loaded its types before this type existed.
+    const freshDriver = new PostgresDriver({
+      host: container.getHost(),
+      port: container.getMappedPort(5432),
+      user: 'test',
+      password: 'test',
+      database: 'test',
+    });
+
+    try {
+      const tableData = await freshDriver.stream(
+        `SELECT
+          ARRAY[CAST(ROW(1, 2) as CUBEJS_TEST_POINT)] as points,
+          CAST(5 as CUBEJS_TEST_INT) as aliased`,
+        [],
+        {
+          highWaterMark: 1000,
+        }
+      );
+
+      try {
+        expect(await tableData.types).toEqual([
+          {
+            name: 'points',
+            type: 'text'
+          },
+          {
+            name: 'aliased',
+            type: 'int'
+          },
+        ]);
+        expect(await streamToArray(tableData.rowStream)).toEqual([
+          { points: '{"(1,2)"}', aliased: 5 },
+        ]);
+      } finally {
+        await (<any> tableData).release();
+      }
+    } finally {
+      await freshDriver.release();
+    }
+  });
+
   test('stream (exception)', async () => {
     try {
       await driver.stream('select * from test.random_name_for_table_that_doesnot_exist_sql_must_fail', [], {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

#11149 made `loadUserDefinedTypes` select all of `typcategory = 'A'` so that array-typed columns map to `text`, but Postgres creates a row type and an array over it for every relation, so that returns one row per relation in the database — on a multi tenant deployment with a schema per tenant this reached ~63k rows, and the quadratic map build behind it blocked the event loop for minutes on every cold driver. Arrays over relation row types are now skipped, which brings the same database down to ~116 rows while leaving everything the driver actually maps in place: `_text` 1009 and `_int4` 1007 that #11149 relies on, enums, enum arrays, extension types such as hll, and arrays over a standalone `CREATE TYPE ... AS (...)`. Verified on postgres:16 (150 schemas of 20 tables: 3317 rows before, 108 after) and on CrateDB 5.10, which inherits this through `CrateDriver` and returns the same 24 rows for both queries. A `stream (user defined type)` test covers both a composite array and a domain column, and it fails with `Unable to detect type` if the `relkind <> 'c'` carve-out is removed.