### PR TITLE
fix(cubesql): Push `LIMIT 0` down to CubeScan

### DIFF
--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -161,3 +161,15 @@ describe('cubeSqlRequestSchema', () => {
     expect(cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz }).error).toBeDefined();
   });
 });
+
+describe('limit normalization', () => {
+  test('keeps an explicit limit of 0 instead of applying the default limit', () => {
+    const result = normalizeQuery({ ...baseQuery, limit: 0 }, false);
+    expect(result.limit).toBe(0);
+  });
+
+  test('applies the default limit when no limit is given', () => {
+    const result = normalizeQuery({ ...baseQuery }, false);
+    expect(result.limit).toBeGreaterThan(0);
+  });
+});

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -958,8 +958,10 @@ export class BaseQuery {
       securityContext: this.contextSymbols.securityContext,
       order,
       filters: this.options.filters,
-      limit: this.options.limit ? this.options.limit.toString() : null,
-      rowLimit: this.options.rowLimit ? this.options.rowLimit.toString() : null,
+      limit: this.options.limit != null ? this.options.limit.toString() : null,
+      // `rowLimit: 0` is a valid limit (BI tools use `LIMIT 0` as a schema probe),
+      // so it must not be collapsed into `null` (no limit) here
+      rowLimit: this.options.rowLimit != null ? this.options.rowLimit.toString() : null,
       offset: this.options.offset ? this.options.offset.toString() : null,
       baseTools: this,
       ungrouped: this.options.ungrouped,
@@ -1015,8 +1017,10 @@ export class BaseQuery {
       cubeEvaluator: this.cubeEvaluator,
       order,
       filters: this.options.filters,
-      limit: this.options.limit ? this.options.limit.toString() : null,
-      rowLimit: this.options.rowLimit ? this.options.rowLimit.toString() : null,
+      limit: this.options.limit != null ? this.options.limit.toString() : null,
+      // `rowLimit: 0` is a valid limit (BI tools use `LIMIT 0` as a schema probe),
+      // so it must not be collapsed into `null` (no limit) here
+      rowLimit: this.options.rowLimit != null ? this.options.rowLimit.toString() : null,
       offset: this.options.offset ? this.options.offset.toString() : null,
       baseTools: this,
       ungrouped: this.options.ungrouped,
@@ -3209,6 +3213,33 @@ export class BaseQuery {
   }
 
   topLimit() {
+    return '';
+  }
+
+  /**
+   * Row limit as a number, or `null` when it is not set at all. Unlike a truthy check
+   * this keeps `0` (a valid limit that returns no rows) distinct from "no limit", and
+   * unlike a bare `parseInt` it keeps a non-numeric `rowLimit` out of the rendered SQL.
+   * @protected
+   * @returns {number|null}
+   */
+  parsedRowLimit() {
+    if (this.rowLimit == null) {
+      return null;
+    }
+    const parsed = parseInt(this.rowLimit, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * Leading row-limit clause for statements that do not render `topLimit()` -- the legacy
+   * rollup query in `PreAggregations` is the one such statement. Only dialects that cannot
+   * express a zero row limit as a trailing clause (T-SQL, where FETCH NEXT must be >= 1)
+   * return anything here; every other dialect renders `LIMIT 0` and gets `''`.
+   * @public
+   * @returns {string}
+   */
+  zeroRowLimitTopClause() {
     return '';
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -152,6 +152,11 @@ export class MssqlQuery extends BaseQuery {
 
   // TODO replace with limitOffsetClause override
   public groupByDimensionLimit() {
+    // T-SQL requires FETCH NEXT to be greater than zero, so a zero row limit is
+    // rendered as `TOP 0` by topLimit() instead, and OFFSET is redundant for it
+    if (this.parsedRowLimit() === 0) {
+      return '';
+    }
     if (this.rowLimit) {
       return this.offset ? ` OFFSET ${parseInt(this.offset, 10)} ROWS FETCH NEXT ${parseInt(this.rowLimit, 10)} ROWS ONLY` : '';
     } else {
@@ -160,10 +165,32 @@ export class MssqlQuery extends BaseQuery {
   }
 
   public topLimit() {
+    // Deliberately a strict null check: an explicit `rowLimit: null` means "no limit",
+    // while an absent one keeps the historical TOP 10000 default below, since T-SQL has
+    // no LIMIT clause to fall back on
+    if (this.rowLimit === null) {
+      return '';
+    }
+    const rowLimit = this.parsedRowLimit();
+    // `TOP 0` is the only way to express an empty result in T-SQL, and it takes
+    // precedence over the offset branch below: OFFSET without FETCH would return rows
+    if (rowLimit === 0) {
+      return ' TOP 0';
+    }
     if (this.offset) {
       return '';
     }
-    return this.rowLimit === null ? '' : ` TOP ${this.rowLimit && parseInt(this.rowLimit, 10) || 10000}`;
+    return ` TOP ${rowLimit ?? 10000}`;
+  }
+
+  /**
+   * The legacy rollup query in `PreAggregations` renders no `topLimit()`, so a zero row
+   * limit would otherwise emit no row-limiting clause there at all (groupByDimensionLimit()
+   * cannot express it: FETCH NEXT must be >= 1 in T-SQL) and scan the whole rollup.
+   * @override
+   */
+  public zeroRowLimitTopClause() {
+    return this.parsedRowLimit() === 0 ? ' TOP 0' : '';
   }
 
   /**
@@ -344,7 +371,9 @@ export class MssqlQuery extends BaseQuery {
     templates.statements.select = '{% if ctes %} WITH \n' +
       '{{ ctes | join(\',\n\') }}\n' +
       '{% endif %}' +
-      'SELECT {% if limit is not none and not order_by %}TOP {{ limit }} {% endif %}{% if distinct %}DISTINCT {% endif %}' +
+      // T-SQL clause order is SELECT [ALL | DISTINCT] [TOP (expr)], so DISTINCT has to come
+      // first: `SELECT TOP 0 DISTINCT ...` is a syntax error
+      'SELECT {% if distinct %}DISTINCT {% endif %}{% if limit is not none and (not order_by or limit == 0) %}TOP {{ limit }} {% endif %}' +
       '{{ select_concat | map(attribute=\'aliased\') | join(\', \') }} {% if from %}\n' +
       'FROM (\n' +
       '{{ from | indent(2, true) }}\n' +
@@ -354,8 +383,13 @@ export class MssqlQuery extends BaseQuery {
       '{% if filter %}\nWHERE {{ filter }}{% endif %}' +
       '{% if group_by %}\nGROUP BY {{ group_by }}{% endif %}' +
       '{% if having %}\nHAVING {{ having }}{% endif %}' +
-      '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}\nOFFSET {% if offset is not none %}{{ offset }}{% else %}0{% endif %} ROWS' +
-      '\nFETCH NEXT {% if limit is not none %}{{ limit }}{% else %}2147483647{% endif %} ROWS ONLY{% endif %}' +
+      '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}' +
+      // FETCH NEXT must be greater than zero in T-SQL, so `LIMIT 0` is rendered as
+      // `TOP 0` above and the OFFSET/FETCH tail is dropped entirely. `limit` is always a
+      // number here (both renderers pass Option<usize>); `limit | int` would not work as a
+      // guard, since `none | int` is 0 and that would drop the 2147483647 fallback below
+      '{% if limit != 0 %}\nOFFSET {% if offset is not none %}{{ offset }}{% else %}0{% endif %} ROWS' +
+      '\nFETCH NEXT {% if limit is not none %}{{ limit }}{% else %}2147483647{% endif %} ROWS ONLY{% endif %}{% endif %}' +
       '{% if ctes %}\nOPTION (MAXRECURSION 0){% endif %}';
     // MSSQL has no boolean type — a segment projected as a dimension must be a BIT.
     templates.expressions.wrap_segment_select = 'CAST((CASE WHEN {{ expr }} THEN 1 ELSE 0 END) AS BIT)';

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -36,7 +36,11 @@ export class OracleQuery extends BaseQuery {
    * TODO replace with limitOffsetClause override
    */
   public groupByDimensionLimit() {
-    const limitClause = this.rowLimit === null ? '' : ` FETCH NEXT ${this.rowLimit && parseInt(this.rowLimit, 10) || 10000} ROWS ONLY`;
+    // `rowLimit: 0` is a valid limit that returns no rows, so it must not fall back to the
+    // default below the way a truthy check would. Same null policy as MssqlQuery#topLimit:
+    // an explicit `rowLimit: null` means "no limit", an absent one keeps the 10000 default
+    const rowLimit = this.parsedRowLimit() ?? 10000;
+    const limitClause = this.rowLimit === null ? '' : ` FETCH NEXT ${rowLimit} ROWS ONLY`;
     const offsetClause = this.offset ? ` OFFSET ${parseInt(this.offset, 10)} ROWS` : '';
     return `${offsetClause}${limitClause}`;
   }

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -1624,8 +1624,10 @@ export class PreAggregations {
 
     return this.query.evaluateSymbolSqlWithContext(
       () => {
+        // zeroRowLimitTopClause() is empty for every dialect that can express a zero row
+        // limit as a trailing clause; T-SQL can not, and this statement has no topLimit()
         // eslint-disable-next-line prefer-template
-        const query = `SELECT ${this.query.selectAllDimensionsAndMeasures(measures)} FROM ${from} ${this.query.baseWhere(replacedFilters)}` +
+        const query = `SELECT${this.query.zeroRowLimitTopClause()} ${this.query.selectAllDimensionsAndMeasures(measures)} FROM ${from} ${this.query.baseWhere(replacedFilters)}` +
           this.query.groupByClause();
         return isFullSimpleQuery ?
           this.query.baseHaving(query, this.query.measureFilters) +

--- a/packages/cubejs-schema-compiler/test/unit/mssql-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/mssql-query.test.ts
@@ -196,6 +196,194 @@ describe('MssqlQuery', () => {
       expect(/GROUP BY/.test(queryString)).toEqual(false);
     }));
 
+  it('renders rowLimit: 0 as TOP 0 without an invalid FETCH NEXT 0', async () => {
+    await compiler.compile();
+
+    // With an ORDER BY the template would normally emit OFFSET/FETCH NEXT, but T-SQL
+    // rejects `FETCH NEXT 0 ROWS ONLY`, so a zero limit has to go through TOP
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      dimensions: ['visitors.source'],
+      order: [{ id: 'visitors.source', desc: false }],
+      timezone: 'UTC',
+      rowLimit: 0,
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+
+    expect(sql).toContain('TOP 0');
+    expect(sql).not.toContain('FETCH NEXT');
+  });
+
+  it('renders rowLimit: 0 with an offset as TOP 0 and no OFFSET tail', async () => {
+    await compiler.compile();
+
+    // T-SQL forbids TOP together with OFFSET/FETCH, and a zero limit yields no rows
+    // whatever the offset is, so the whole OFFSET/FETCH tail has to go
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      dimensions: ['visitors.source'],
+      order: [{ id: 'visitors.source', desc: false }],
+      timezone: 'UTC',
+      rowLimit: 0,
+      offset: 10,
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+
+    expect(sql).toContain('TOP 0');
+    expect(sql).not.toContain('FETCH NEXT');
+    expect(sql).not.toContain('OFFSET');
+  });
+
+  it('still renders OFFSET/FETCH NEXT for a non-zero rowLimit with an offset', async () => {
+    await compiler.compile();
+
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      dimensions: ['visitors.source'],
+      order: [{ id: 'visitors.source', desc: false }],
+      timezone: 'UTC',
+      rowLimit: 5,
+      offset: 10,
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+
+    expect(sql).toContain('OFFSET 10 ROWS');
+    expect(sql).toContain('FETCH NEXT 5 ROWS ONLY');
+    expect(sql).not.toContain('TOP');
+  });
+
+  it('renders DISTINCT before TOP in the select template', async () => {
+    await compiler.compile();
+
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      timezone: 'UTC',
+      rowLimit: 0,
+    });
+
+    // T-SQL clause order is SELECT [ALL | DISTINCT] [TOP (expr)], so `SELECT TOP 0 DISTINCT`
+    // is a syntax error. A single select carrying both is reachable through the cubesql
+    // wrapper (`SELECT DISTINCT ... LIMIT 0`), which can't be built from here, so the
+    // template itself is what gets pinned
+    const { select } = query.sqlTemplates().statements;
+
+    expect(select).toContain('DISTINCT');
+    expect(select).toContain('TOP');
+    expect(select.indexOf('DISTINCT')).toBeLessThan(select.indexOf('TOP'));
+  });
+
+  it('keeps rowLimit: 0 out of the legacy limit clauses', async () => {
+    await compiler.compile();
+
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      timezone: 'UTC',
+      rowLimit: 0,
+      offset: 10,
+    });
+
+    expect(query.topLimit()).toEqual(' TOP 0');
+    expect(query.groupByDimensionLimit()).toEqual('');
+    // The legacy rollup query in PreAggregations renders no topLimit(), so the zero limit
+    // has to come from this hook or that statement would scan the whole rollup
+    expect(query.zeroRowLimitTopClause()).toEqual(' TOP 0');
+  });
+
+  it('renders no leading zero-limit clause for a non-zero rowLimit', async () => {
+    await compiler.compile();
+
+    const query = new MssqlQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['visitors.count'],
+      timezone: 'UTC',
+      rowLimit: 5,
+    });
+
+    expect(query.zeroRowLimitTopClause()).toEqual('');
+  });
+
+  it('renders TOP 0 in the legacy-planner pre-aggregation rollup query', async () => {
+    // The rollup statement in PreAggregations renders no topLimit(), and T-SQL cannot put a
+    // zero limit in a trailing clause, so without zeroRowLimitTopClause() a `rowLimit: 0`
+    // query served from a pre-aggregation would scan the whole rollup
+    const preAggCompilers = prepareJsCompiler(`
+      cube('visits', {
+        sql: 'SELECT * FROM visits',
+
+        preAggregations: {
+          bySource: {
+            measures: [CUBE.count],
+            dimensions: [CUBE.source],
+          },
+        },
+
+        measures: {
+          count: { type: 'count' },
+        },
+
+        dimensions: {
+          id: { sql: 'id', type: 'number', primaryKey: true },
+          source: { sql: 'source', type: 'string' },
+        },
+      });
+    `);
+    await preAggCompilers.compiler.compile();
+
+    const queryOptions = {
+      measures: ['visits.count'],
+      dimensions: ['visits.source'],
+      timezone: 'UTC',
+      useNativeSqlPlanner: false,
+      preAggregationsSchema: '',
+    };
+
+    const zeroLimit = new MssqlQuery({
+      joinGraph: preAggCompilers.joinGraph,
+      cubeEvaluator: preAggCompilers.cubeEvaluator,
+      compiler: preAggCompilers.compiler,
+    }, { ...queryOptions, rowLimit: 0 });
+
+    const zeroLimitSql = zeroLimit.buildSqlAndParams()[0];
+
+    expect(zeroLimit.preAggregations.findPreAggregationForQuery()).toBeDefined();
+    expect(zeroLimitSql).toContain('TOP 0');
+
+    const nonZeroLimit = new MssqlQuery({
+      joinGraph: preAggCompilers.joinGraph,
+      cubeEvaluator: preAggCompilers.cubeEvaluator,
+      compiler: preAggCompilers.compiler,
+    }, { ...queryOptions, rowLimit: 5 });
+
+    // Non-zero limits keep their existing rendering on this path
+    expect(nonZeroLimit.buildSqlAndParams()[0]).not.toContain('TOP 0');
+  });
+
+  it('keeps DISTINCT and TOP 0 in a valid order for a multiplied-measure query', async () => {
+    await joinedSchemaCompilers.compiler.compile();
+
+    // Multiplied measures make the full-key-aggregate path emit DISTINCT keys sub-selects
+    // alongside the TOP 0 outer select
+    const query = new MssqlQuery({
+      joinGraph: joinedSchemaCompilers.joinGraph,
+      cubeEvaluator: joinedSchemaCompilers.cubeEvaluator,
+      compiler: joinedSchemaCompilers.compiler,
+    }, {
+      measures: ['B.bval_sum', 'C.count'],
+      dimensions: ['B.bid'],
+      order: [{ id: 'B.bid', desc: false }],
+      timezone: 'UTC',
+      rowLimit: 0,
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+
+    expect(sql).toContain('TOP 0');
+    expect(sql).toContain('DISTINCT');
+    expect(sql).not.toMatch(/TOP\s+0\s+DISTINCT/);
+  });
+
   it('aggregating on top of sub-queries', async () => {
     await joinedSchemaCompilers.compiler.compile();
     const query = new MssqlQuery({

--- a/packages/cubejs-schema-compiler/test/unit/oracle-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/oracle-query.test.ts
@@ -236,6 +236,39 @@ describe('OracleQuery', () => {
     expect(sql).not.toContain('LIMIT');
   });
 
+  it('renders rowLimit: 0 as FETCH NEXT 0 ROWS ONLY', async () => {
+    await compiler.compile();
+
+    const query = new OracleQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'visitors.count'
+      ],
+      timezone: 'UTC',
+      rowLimit: 0
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+
+    expect(sql).toContain('FETCH NEXT 0 ROWS ONLY');
+    // A truthy check on rowLimit used to fall back to the default limit here
+    expect(sql).not.toContain('10000');
+    expect(query.groupByDimensionLimit()).toEqual(' FETCH NEXT 0 ROWS ONLY');
+  });
+
+  it('keeps the documented null policy for rowLimit', async () => {
+    await compiler.compile();
+
+    const newQuery = (rowLimit?: number | null) => new OracleQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      { measures: ['visitors.count'], timezone: 'UTC', ...(rowLimit === undefined ? {} : { rowLimit }) }
+    );
+
+    // An absent rowLimit keeps the historical default, an explicit null means no limit
+    expect(newQuery().groupByDimensionLimit()).toEqual(' FETCH NEXT 10000 ROWS ONLY');
+    expect(newQuery(null).groupByDimensionLimit()).toEqual('');
+    expect(newQuery(0).groupByDimensionLimit()).toEqual(' FETCH NEXT 0 ROWS ONLY');
+  });
+
   it('uses FETCH NEXT syntax with subqueries and rolling windows', async () => {
     await compiler.compile();
 

--- a/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/postgres-query.test.ts
@@ -384,6 +384,24 @@ describe('PostgresQuery', () => {
     expect(sql).toMatch(/WHERE/i);
   });
 
+  it('pushes down rowLimit: 0 as LIMIT 0', async () => {
+    await compiler.compile();
+
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'visitors.count'
+      ],
+      dimensions: [
+        'visitors.name'
+      ],
+      timezone: 'UTC',
+      rowLimit: 0,
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    expect(queryAndParams[0]).toContain('LIMIT 0');
+  });
+
   it('uses AS keyword in subquery aliases (regression test)', async () => {
     await compiler.compile();
 

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13992,6 +13992,64 @@ ORDER BY "source"."str0" ASC
         insta::assert_snapshot!(context.execute_query(query).await.unwrap());
     }
 
+    /// `LIMIT 0` should reach the transport as `limit: 0` (and not as the default row
+    /// limit), and execute into an empty result
+    #[tokio::test]
+    async fn test_cube_scan_exec_limit_zero() {
+        init_testing_logger();
+
+        let context = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+
+        // language=PostgreSQL
+        let query = r#"
+            SELECT dim_str0
+            FROM MultiTypeCube
+            GROUP BY 1
+            LIMIT 0
+        "#;
+
+        let expected_cube_scan = V1LoadRequestQuery {
+            measures: Some(vec![]),
+            segments: Some(vec![]),
+            dimensions: Some(vec!["MultiTypeCube.dim_str0".to_string()]),
+            order: Some(vec![]),
+            limit: Some(0),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            context
+                .convert_sql_to_cube_query(query)
+                .await
+                .unwrap()
+                .as_logical_plan()
+                .find_cube_scan()
+                .request,
+            expected_cube_scan,
+        );
+
+        // Mock is matched by the exact request, so execution would fail here if anything
+        // downstream replaced `limit: 0` with a default limit
+        context
+            .add_cube_load_mock(
+                expected_cube_scan,
+                simple_load_response(vec!["MultiTypeCube.dim_str0"], vec![vec![]]),
+            )
+            .await;
+
+        let result = context.execute_query(query).await.unwrap();
+        assert_eq!(
+            result.trim(),
+            [
+                "+----------+",
+                "| dim_str0 |",
+                "+----------+",
+                "+----------+",
+            ]
+            .join("\n")
+        );
+    }
+
     #[tokio::test]
     async fn test_wrapper_tableau_week_number() {
         if !Rewriter::sql_push_down_enabled() {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -2140,11 +2140,6 @@ impl MemberRules {
                 fetch_value = *fetch;
                 break;
             }
-            // TODO support this case
-            if fetch_value == Some(0) {
-                // Broken and unsupported case for now
-                return false;
-            }
 
             let mut inner_skip_value = None;
             for inner_skip in var_iter!(egraph[subst[inner_skip_var]], CubeScanOffset) {

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_scan.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_scan.rs
@@ -100,6 +100,73 @@ async fn cubescan_limit_limit() {
     }
 }
 
+/// LIMIT 0 should be pushed to CubeScan as limit=0, and not replaced with a default limit
+#[tokio::test]
+async fn cubescan_limit_zero() {
+    init_testing_logger();
+
+    let variants = vec![
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender
+        FROM
+            KibanaSampleDataEcommerce
+        GROUP BY
+            1
+        LIMIT 0
+        "#,
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender
+        FROM (
+            SELECT
+                customer_gender
+            FROM
+                KibanaSampleDataEcommerce
+            GROUP BY
+                1
+            LIMIT 3
+        ) scan
+        LIMIT 0
+        "#,
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender
+        FROM (
+            SELECT
+                customer_gender
+            FROM
+                KibanaSampleDataEcommerce
+            GROUP BY
+                1
+            LIMIT 0
+        ) scan
+        LIMIT 3
+        "#,
+    ];
+
+    for variant in variants {
+        let query_plan =
+            convert_select_to_query_plan(variant.to_string(), DatabaseProtocol::PostgreSQL).await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                limit: Some(0),
+                ..Default::default()
+            }
+        );
+    }
+}
+
 /// OFFSET over OFFSET should be pushed to single CubeScan
 #[tokio::test]
 async fn cubescan_offset_offset() {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR makes a row limit of 0 push all the way down to the database instead of being replaced by the default row limit. Related tests are included.