### PR TITLE
feat(cubestore): Support QUEUE ADD_AND_RETRIEVE command

### DIFF
--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -1,135 +1,298 @@
-### Queue design v1:
+# Queue design
 
-Responses as TS types
+`QueryQueue` never holds the queue state itself, every transition goes through
+`QueueDriverInterface`. These diagrams describe the Cube Store driver, where each
+transition is a `QUEUE *` SQL command; Cube Store serializes all queue writes, so the queue
+stays correct across many Cube API instances. `LocalQueueDriver` implements the same
+interface in memory for a single process (development, unit tests).
+
+Two participants matter when reading the diagrams:
+
+- **QueryQueue** — the request side. It enqueues and then waits for a result.
+- **BackgroundQueryQueue** — the same `QueryQueue` object, but the code paths reached
+  through `processQuery`, which run detached from the request (in cluster mode they can
+  even run on another node).
+
+## Cube Store responses as TS types
 
 ```typescript
 type integer = number;
 type QueueId = number;
 
+// QUEUE ADD
 type AddToQueueResponse = {
     id: QueueId,
-    added: boolean,
-    pending: string,
+    added: boolean,   // false when the path was already in the queue
+    pending: integer, // after the operation, scoped to the prefix
 }
+// QUEUE ADD_AND_RETRIEVE, extends AddToQueueResponse (see "Fast track" below)
+type AddAndRetrieveResponse = AddToQueueResponse & {
+    active: string | null,  // comma separated keys, NULL when empty
+    payload: string | null, // NULL means "the item was not claimed"
+    extra: string | null,
+}
+// QUEUE RETRIEVE [EXTENDED] CONCURRENCY
 type RetrieveResponse = {
     payload: string,
-    extra:   string,
+    extra: string | null,
     pending: integer,
-    active: string,
+    active: string | null,
     id: QueueId
 }
+// QUEUE LIST / PENDING / ACTIVE
+type ListResponse = {
+    id: string, // the path, not the QueueId — kept for backward compatibility
+    queue_id: QueueId,
+    status: 'pending' | 'active',
+    extra: string | null,
+    payload?: string, // only with WITH_PAYLOAD
+}
+// QUEUE TO_CANCEL / STALLED / ORPHANED
+type ToCancelResponse = {
+    id: string,
+    queue_id: QueueId,
+}
+// QUEUE GET / CANCEL
+type QueryDefResponse = {
+    payload: string,
+    extra: string | null,
+}
+// QUEUE ACK
 type AckResponse = {
     success: boolean
 }
+// QUEUE RESULT / RESULT_BLOCKING
 type ResultResponse = {
-    payload: string
-    'type': ResultStatus
-}
-type ResultBlockingResponse = {
-    payload: string
-    'type': ResultStatus
+    payload: string,
+    'type': ResultStatus,
+    id: QueueId,
+    external_id: string | null,
 }
 enum ResultStatus {
     Success = 'success'
 }
 ```
 
-```mermaid
-sequenceDiagram
-    participant BackgroundQueryQueue
-    participant QueueQueue
-    participant QueueDriverInterface
-    participant CubeStore
+`EXTENDED` on `QUEUE RETRIEVE` changes only the failure shape: without it a failed claim
+returns zero rows, with it a single row where `payload` and `id` are `NULL` but `pending`
+and `active` are filled. The driver always sends `EXTENDED`.
 
-    QueueQueue->>QueueDriverInterface: getResult
-    QueueDriverInterface->>+CubeStore: QUEUE RESULT ?path
-    QueueDriverInterface-->>+QueueQueue: ResultResponse|null
-    deactivate CubeStore
-
-    QueueQueue->>QueueDriverInterface: addToQueue
-    QueueDriverInterface->>+CubeStore: QUEUE ADD PRIORITY N ?path ?payload
-    QueueDriverInterface-->>+QueueQueue: AddToQueueResponse
-
-    loop reconcileQueueImpl
-        QueueQueue->>QueueDriverInterface: getQueriesToCancel
-        QueueQueue->>QueueDriverInterface: getQueryAndRemove
-        QueueDriverInterface->>CubeStore: QUEUE TO_CANCEL ?stalled_timeout ?orphaned_timeout ?prefix
-
-        QueueQueue->>QueueDriverInterface: getActiveQueries
-        QueueDriverInterface->>CubeStore: QUEUE ACTIVE ?prefix
-        QueueDriverInterface-->>+QueueQueue: getActiveQueriesResponse
-
-        QueueQueue->>QueueDriverInterface: getToProcessQueries
-        QueueDriverInterface->>CubeStore: QUEUE PENDING ?prefix
-        QueueDriverInterface-->>+QueueQueue: getToProcessQueriesResponse
-
-        QueueQueue-)+BackgroundQueryQueue: processQuery
-        Note over QueueQueue,BackgroundQueryQueue: Async call to processQuery, which doesnt block here
-    end
-
-    alt lookUpInActive: Lookup query in processing
-        QueueQueue->>QueueDriverInterface: getQueryDef
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE GET ?key
-        CubeStore-->>+QueueQueue: QueryDef|null
-        deactivate CubeStore
-
-        QueueQueue->>QueueDriverInterface: getQueryStageState
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE LIST
-        CubeStore-->>+QueueQueue: TODO
-        deactivate CubeStore
-        Note over QueueQueue,QueueDriverInterface: Show waiting for query
-    end
-
-    QueueQueue->>QueueDriverInterface: getResultBlocking
-    activate CubeStore
-    QueueDriverInterface->>CubeStore: QUEUE RESULT_BLOCKING ?timeout ?key
-    CubeStore-->>+QueueQueue: ResultBlockingResponse|null
-    deactivate CubeStore
-```
-
-### Background execution process:
+## Enqueue and wait: `executeInQueue`
 
 ```mermaid
 sequenceDiagram
-    participant QueryOrchestrator
-    participant BackgroundQueryQueue
-    participant QueueDriverInterface
+    autonumber
+    actor Caller
+    participant QueryQueue
+    participant QueueDriverInterface as QueueDriver
     participant CubeStore
+    participant BackgroundQueryQueue as Background
 
-    loop processQuery: Background execution
-        BackgroundQueryQueue->>QueueDriverInterface: retrieveForProcessing
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE RETRIEVE CONCURRENCY ?number ?path
-        CubeStore-->>+BackgroundQueryQueue: RetrieveResponse
-        deactivate CubeStore
+    Caller->>QueryQueue: executeInQueue
 
-        BackgroundQueryQueue->>QueueDriverInterface: optimisticQueryUpdate
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE MERGE_EXTRA ?key {"startTime"}
-        CubeStore-->>+BackgroundQueryQueue: ok
-        deactivate CubeStore
+    QueryQueue->>QueueDriver: getResult
+    QueueDriver->>CubeStore: QUEUE RESULT [EXTERNAL_ID ?id] ?path
+    CubeStore-->>QueueDriver: ResultResponse | null
+    QueueDriver-->>QueryQueue: ResultResponse | null
 
-        BackgroundQueryQueue->>QueueDriverInterface: optimisticQueryUpdate
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE MERGE_EXTRA ?key {"cancelHandler"}
-        CubeStore-->>+BackgroundQueryQueue: ok
-        deactivate CubeStore
+    alt result is already there
+        QueryQueue-->>Caller: result
+        Note over QueryQueue,Caller: Nothing is enqueued
+    else no result yet
+        QueryQueue->>QueueDriver: addToQueue
+        QueueDriver->>CubeStore: QUEUE ADD [EXCLUSIVE] PRIORITY ?n<br/>[ORPHANED ?ttl] [EXTERNAL_ID ?id] ?path ?payload
+        CubeStore-->>QueueDriver: AddToQueueResponse
+        QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime]
+        Note over QueryQueue,CubeStore: added=false means another request enqueued<br/>the same key first, both wait for one execution
 
-        par executing: Query
-            BackgroundQueryQueue->>QueueDriverInterface: updateHeartBeat
-            QueueDriverInterface-->>BackgroundQueryQueue: ok
-            Note over BackgroundQueryQueue,QueueDriverInterface: intervalTimer
+        QueryQueue->>QueryQueue: reconcileQueue
+        Note over QueryQueue: Debounced: concurrent callers share<br/>one in-flight reconcile
 
-            BackgroundQueryQueue->>QueryOrchestrator: execute
-            QueryOrchestrator-->>BackgroundQueryQueue: result
+        opt added=false
+            QueryQueue->>QueueDriver: getQueryDef
+            QueueDriver->>CubeStore: QUEUE GET ?queueId
+            CubeStore-->>QueryQueue: QueryDefResponse | null
+
+            QueryQueue->>QueueDriver: getQueryStageState
+            QueueDriver->>CubeStore: QUEUE LIST [WITH_PAYLOAD] ?prefix
+            CubeStore-->>QueryQueue: ListResponse[]
+            Note over QueryQueue: Reports "Waiting for query" with the<br/>stage of the query we are queued behind
         end
 
-        BackgroundQueryQueue->>QueueDriverInterface: setResultAndRemoveQuery
-        activate CubeStore
-        QueueDriverInterface->>CubeStore: QUEUE ACK ?key ?result
-        CubeStore-->>+BackgroundQueryQueue: AckResponse
-        deactivate CubeStore
+        QueryQueue->>QueueDriver: getResultBlocking
+        QueueDriver->>CubeStore: QUEUE RESULT_BLOCKING ?timeout ?queueId
+        CubeStore-->>QueueDriver: ResultResponse | null
+        Note over QueueDriver,CubeStore: Long poll, resolved by the ACK<br/>of Background (see below)
+
+        alt result arrived within continueWaitTimeout
+            QueryQueue-->>Caller: result
+        else timed out
+            QueryQueue-->>Caller: ContinueWaitError
+            Note over Caller,QueryQueue: The client retries and lands<br/>on getResult / RESULT_BLOCKING again
+        end
     end
 ```
+
+## Reconcile: deciding what to start
+
+`reconcileQueue` is the only place that starts work, and it is what enforces concurrency on
+the client side. Note that concurrency is per queue, not per node.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant QueryQueue
+    participant QueueDriverInterface as QueueDriver
+    participant CubeStore
+    participant BackgroundQueryQueue as Background
+
+    loop reconcileQueueImpl
+        QueryQueue->>QueueDriver: getQueriesToCancel
+        QueueDriver->>CubeStore: QUEUE TO_CANCEL ?heartbeat_timeout ?orphaned_timeout ?prefix
+        CubeStore-->>QueryQueue: ToCancelResponse[]
+
+        loop for every stalled / orphaned query
+            QueryQueue->>QueueDriver: getQueryAndRemove
+            QueueDriver->>CubeStore: QUEUE CANCEL ?queueId
+            CubeStore-->>QueryQueue: QueryDefResponse | null
+            QueryQueue->>Background: cancel
+        end
+
+        QueryQueue->>QueueDriver: getActiveQueries
+        QueueDriver->>CubeStore: QUEUE ACTIVE ?prefix
+        CubeStore-->>QueryQueue: ListResponse[]
+
+        QueryQueue->>QueueDriver: getToProcessQueries
+        QueueDriver->>CubeStore: QUEUE PENDING ?prefix
+        CubeStore-->>QueryQueue: ListResponse[]
+
+        Note over QueryQueue: toProcessLimit = active >= concurrency<br/>? 1 : concurrency - active<br/>Persistent queries: only own processUid
+
+        loop for every query within toProcessLimit
+            QueryQueue-)Background: processQuery
+            Note over QueryQueue,Background: Detached call, reconcile does not<br/>wait for the query to finish
+        end
+    end
+```
+
+## Background execution: `processQuery`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant BackgroundQueryQueue as Background
+    participant QueueDriverInterface as QueueDriver
+    participant CubeStore
+    participant QueryOrchestrator
+
+    Background->>QueueDriver: retrieveForProcessing
+    QueueDriver->>CubeStore: QUEUE RETRIEVE EXTENDED CONCURRENCY ?n ?path
+    CubeStore-->>QueueDriver: RetrieveResponse
+    QueueDriver-->>Background: [added, queueId, activeKeys, queueSize, def, lockAcquired]
+    Note over QueueDriver,CubeStore: The claim is atomic in Cube Store:<br/>only one node moves the item to active
+
+    alt def && added && activeKeys includes our key && lockAcquired
+        Background->>QueueDriver: optimisticQueryUpdate
+        QueueDriver->>CubeStore: QUEUE MERGE_EXTRA ?queueId {"startQueryTime"}
+
+        Background->>QueueDriver: optimisticQueryUpdate
+        QueueDriver->>CubeStore: QUEUE MERGE_EXTRA ?queueId {"cancelHandler"}
+
+        par executing the query
+            loop heartBeatInterval
+                Background->>QueueDriver: updateHeartBeat
+                QueueDriver->>CubeStore: QUEUE HEARTBEAT ?queueId
+                Note over Background,CubeStore: Without a heartbeat the item becomes<br/>stalled and TO_CANCEL picks it up
+            end
+        and
+            Background->>QueryOrchestrator: execute
+            QueryOrchestrator-->>Background: result | error
+        end
+
+        Background->>QueueDriver: setResultAndRemoveQuery
+        QueueDriver->>CubeStore: QUEUE ACK ?queueId ?result
+        CubeStore-->>Background: AckResponse
+        Note over QueueDriver,CubeStore: This is what releases the<br/>RESULT_BLOCKING long poll
+
+        Background->>Background: reconcileQueue
+        Note over Background: The freed concurrency slot is<br/>immediately given to the next query
+    else the claim did not succeed
+        Background->>QueueDriver: freeProcessingLock
+        Note over Background,QueueDriver: Another node is running it, or the<br/>concurrency budget is full. No-op for Cube Store
+    end
+```
+
+## Fast track: `QUEUE ADD_AND_RETRIEVE`
+
+Enqueueing a query and starting it costs two round-trips: `QUEUE ADD` marks the item
+pending, then `QUEUE RETRIEVE` (reached through reconcile → `processQuery`) moves it to
+active and returns the payload. Between those two calls another node can take the
+concurrency slot, so the enqueueing node often pays for the second round-trip and gets
+nothing back.
+
+`QUEUE ADD_AND_RETRIEVE` inserts **and** claims the item in one atomic operation when the
+prefix has a free concurrency slot, so the enqueueing request can go straight to executing:
+
+```
+QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY ?n] [ORPHANED ?ttl] [EXTERNAL_ID ?id]
+    ?path ?payload ?concurrency
+```
+
+`payload IS NULL` in the response means the item was not claimed — the budget was full, the
+item was already active, or it belongs to another process — and the caller falls back to
+the normal path with nothing lost, because the item is enqueued either way.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Caller
+    participant QueryQueue
+    participant QueueDriverInterface as QueueDriver
+    participant CubeStore
+    participant BackgroundQueryQueue as Background
+    participant QueryOrchestrator
+
+    Caller->>QueryQueue: executeInQueue
+    QueryQueue->>QueueDriver: addToQueue
+
+    QueueDriver->>CubeStore: QUEUE ADD_AND_RETRIEVE PRIORITY ?n ?path ?payload ?concurrency
+    Note over CubeStore: One atomic batch:<br/>insert, then claim if active < concurrency
+    CubeStore-->>QueueDriver: AddAndRetrieveResponse
+    QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, def?]
+
+    alt fast track: payload is not NULL, we own the item
+        QueryQueue-)Background: processQuery, already claimed
+        Note over QueryQueue,Background: No reconcile, no QUEUE RETRIEVE.<br/>The payload from the response is the QueryDef
+        Background->>QueryOrchestrator: execute
+    else payload IS NULL, the item stays pending
+        QueryQueue->>QueryQueue: reconcileQueue
+        Note over QueryQueue,Background: Normal path, see the diagrams above:<br/>reconcile → processQuery → QUEUE RETRIEVE
+    end
+
+    QueryQueue->>QueueDriver: getResultBlocking
+    QueueDriver->>CubeStore: QUEUE RESULT_BLOCKING ?timeout ?queueId
+    CubeStore-->>QueryQueue: ResultResponse | null
+```
+
+What the fast track saves per query, when the slot is free:
+
+| Step | Normal | Fast track |
+|---|---|---|
+| `QUEUE ADD` | 1 round-trip | folded into one command |
+| `QUEUE ACTIVE` + `QUEUE PENDING` (reconcile) | 2 round-trips | skipped |
+| `QUEUE RETRIEVE` | 1 round-trip | folded into one command |
+| Window for another node to steal the slot | between ADD and RETRIEVE | none |
+
+Everything after the claim is unchanged: `MERGE_EXTRA`, `HEARTBEAT`, `ACK` and
+`RESULT_BLOCKING` behave exactly as in the normal path, and a fast-tracked item is a
+regular active item — `TO_CANCEL` will reclaim it if the heartbeat stops.
+
+The concurrency budget is the same one `QUEUE RETRIEVE CONCURRENCY` uses: prefix scoped,
+and blind to both exclusivity and priority. Being priority blind is the trade-off of the
+fast track — it claims the item being added even when a higher priority item is pending in
+the same prefix, so it should not be used for queues that rely on priority ordering.
+
+> **Status:** the `QUEUE ADD_AND_RETRIEVE` command exists in Cube Store. The driver still
+> emits `QUEUE ADD`; wiring the fast track into `CubeStoreQueueDriver.addToQueue` needs a
+> capability gate (the same version negotiation as `queueExclusive` / `queueExternalId`)
+> plus the `QueryQueue` change that hands the claimed `QueryDef` straight to `processQuery`.

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -242,7 +242,7 @@ The item is claimed when both hold for its prefix:
 
 - a concurrency slot is free — `active < concurrency`, the same budget
   `QUEUE RETRIEVE CONCURRENCY` uses;
-- the backlog is shallow — `pending < concurrency / 2`, not counting the item itself.
+- the backlog is shallow — `pending * 2 < concurrency`, not counting the item itself.
 
 `payload IS NULL` in the response means the item was not claimed — one of the two
 conditions failed, the item was already active, or it belongs to another process — and the

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -238,16 +238,13 @@ QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY ?n] [ORPHANED ?ttl] [EXTERNAL_ID ?i
     ?path ?payload ?concurrency
 ```
 
-The item is claimed when both hold for its prefix:
+The item is claimed when the prefix has a concurrency slot for it *and* for everything
+already queued — `active + pending < concurrency`, where `concurrency` is the same budget
+`QUEUE RETRIEVE CONCURRENCY` uses and `pending` does not count the item itself.
 
-- a concurrency slot is free — `active < concurrency`, the same budget
-  `QUEUE RETRIEVE CONCURRENCY` uses;
-- the backlog is shallow — `pending * 2 < concurrency`, not counting the item itself.
-
-`payload IS NULL` in the response means the item was not claimed — one of the two
-conditions failed, the item was already active, or it belongs to another process — and the
-caller falls back to the normal path with nothing lost, because the item is enqueued either
-way.
+`payload IS NULL` in the response means the item was not claimed — the condition failed,
+the item was already active, or it belongs to another process — and the caller falls back
+to the normal path with nothing lost, because the item is enqueued either way.
 
 ```mermaid
 sequenceDiagram
@@ -263,7 +260,7 @@ sequenceDiagram
     QueryQueue->>QueueDriver: addToQueue
 
     QueueDriver->>CubeStore: QUEUE ADD_AND_RETRIEVE PRIORITY ?n ?path ?payload ?concurrency
-    Note over CubeStore: One atomic batch:<br/>insert, then claim if active < concurrency
+    Note over CubeStore: One atomic batch:<br/>insert, then claim if the prefix allows it
     CubeStore-->>QueueDriver: AddAndRetrieveResponse
     QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, def?]
 
@@ -300,12 +297,12 @@ returns items highest priority first (oldest first within a priority) and reconc
 — it is safe only because the path it is given came from that sorted list.
 
 The fast track selects itself, so it is priority blind with nothing to compensate. That is
-what the `pending < concurrency / 2` condition bounds: with a shallow backlog there is
-almost nothing to jump over, and with a deep one the fast track steps aside and lets
-reconcile pick by priority. Note that a claimed item goes straight to active and never
-becomes pending, so a burst onto an idle queue still fast-tracks every query — items only
-start accumulating in pending once the concurrency budget is exhausted, which is exactly
-when the condition should stop firing.
+what the `active + pending < concurrency` condition rules out: claiming leaves a free slot
+for every item already pending, so no item is jumped over, and once the budget gets tight
+the fast track steps aside and lets reconcile pick by priority. Note that a claimed item
+goes straight to active and never becomes pending, so a burst onto an idle queue still
+fast-tracks every query — items only start accumulating in pending once the concurrency
+budget is exhausted, which is exactly when the condition should stop firing.
 
 > **Status:** the `QUEUE ADD_AND_RETRIEVE` command exists in Cube Store. The driver still
 > emits `QUEUE ADD`; wiring the fast track into `CubeStoreQueueDriver.addToQueue` needs a

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -230,17 +230,24 @@ active and returns the payload. Between those two calls another node can take th
 concurrency slot, so the enqueueing node often pays for the second round-trip and gets
 nothing back.
 
-`QUEUE ADD_AND_RETRIEVE` inserts **and** claims the item in one atomic operation when the
-prefix has a free concurrency slot, so the enqueueing request can go straight to executing:
+`QUEUE ADD_AND_RETRIEVE` inserts **and** claims the item in one atomic operation, so the
+enqueueing request can go straight to executing:
 
 ```
 QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY ?n] [ORPHANED ?ttl] [EXTERNAL_ID ?id]
     ?path ?payload ?concurrency
 ```
 
-`payload IS NULL` in the response means the item was not claimed — the budget was full, the
-item was already active, or it belongs to another process — and the caller falls back to
-the normal path with nothing lost, because the item is enqueued either way.
+The item is claimed when both hold for its prefix:
+
+- a concurrency slot is free — `active < concurrency`, the same budget
+  `QUEUE RETRIEVE CONCURRENCY` uses;
+- the backlog is shallow — `pending < concurrency / 2`, not counting the item itself.
+
+`payload IS NULL` in the response means the item was not claimed — one of the two
+conditions failed, the item was already active, or it belongs to another process — and the
+caller falls back to the normal path with nothing lost, because the item is enqueued either
+way.
 
 ```mermaid
 sequenceDiagram
@@ -287,10 +294,18 @@ Everything after the claim is unchanged: `MERGE_EXTRA`, `HEARTBEAT`, `ACK` and
 `RESULT_BLOCKING` behave exactly as in the normal path, and a fast-tracked item is a
 regular active item — `TO_CANCEL` will reclaim it if the heartbeat stops.
 
-The concurrency budget is the same one `QUEUE RETRIEVE CONCURRENCY` uses: prefix scoped,
-and blind to both exclusivity and priority. Being priority blind is the trade-off of the
-fast track — it claims the item being added even when a higher priority item is pending in
-the same prefix, so it should not be used for queues that rely on priority ordering.
+Priority ordering is enforced by the *selection* step, not by the claim: `QUEUE PENDING`
+returns items highest priority first (oldest first within a priority) and reconcile takes
+`toProcessLimit` off the top of that list. `QUEUE RETRIEVE <path>` itself is priority blind
+— it is safe only because the path it is given came from that sorted list.
+
+The fast track selects itself, so it is priority blind with nothing to compensate. That is
+what the `pending < concurrency / 2` condition bounds: with a shallow backlog there is
+almost nothing to jump over, and with a deep one the fast track steps aside and lets
+reconcile pick by priority. Note that a claimed item goes straight to active and never
+becomes pending, so a burst onto an idle queue still fast-tracks every query — items only
+start accumulating in pending once the concurrency budget is exhausted, which is exactly
+when the condition should stop firing.
 
 > **Status:** the `QUEUE ADD_AND_RETRIEVE` command exists in Cube Store. The driver still
 > emits `QUEUE ADD`; wiring the fast track into `CubeStoreQueueDriver.addToQueue` needs a

--- a/rust/cube/cubestore-ws-transport/src/actor.rs
+++ b/rust/cube/cubestore-ws-transport/src/actor.rs
@@ -20,21 +20,20 @@ pub(crate) type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Mirrors cubestore's `QUEUE_ITEM_PROCESS_ID_MAX_LEN`: the server rejects a longer
 /// `x-process-id` with a 400 during the handshake. Our own id is a uuid (36 chars),
-/// so truncating is a guard rather than something we expect to hit.
+/// so this is a guard rather than something we expect to hit.
 const PROCESS_ID_MAX_LEN: usize = 64;
 
 /// Bytes, matching how the server measures the header.
-fn truncate_process_id(process_id: &str) -> &str {
-    if process_id.len() <= PROCESS_ID_MAX_LEN {
-        return process_id;
+fn check_process_id(process_id: &str) -> Result<(), TransportError> {
+    if process_id.len() > PROCESS_ID_MAX_LEN {
+        return Err(TransportError::Auth(format!(
+            "x-process-id exceeds maximum allowed length of {} characters, actual: {}",
+            PROCESS_ID_MAX_LEN,
+            process_id.len()
+        )));
     }
 
-    let mut end = PROCESS_ID_MAX_LEN;
-    while !process_id.is_char_boundary(end) {
-        end -= 1;
-    }
-
-    &process_id[..end]
+    Ok(())
 }
 
 pub(crate) enum ActorRequest {
@@ -304,7 +303,8 @@ pub(crate) async fn connect_ws(
         builder = builder.header("Authorization", value);
     }
 
-    let value = HeaderValue::from_str(truncate_process_id(process_id))
+    check_process_id(process_id)?;
+    let value = HeaderValue::from_str(process_id)
         .map_err(|e| TransportError::Auth(format!("x-process-id: {e}")))?;
     builder = builder.header("x-process-id", value);
 
@@ -370,20 +370,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truncate_process_id_to_server_limit() {
-        let uuid = "5b3f2c9e-2f1a-4a2e-9d5a-9f1b6c7d8e90";
-        assert_eq!(truncate_process_id(uuid), uuid);
+    fn check_process_id_against_server_limit() {
+        assert!(check_process_id("5b3f2c9e-2f1a-4a2e-9d5a-9f1b6c7d8e90").is_ok());
+        assert!(check_process_id(&"x".repeat(PROCESS_ID_MAX_LEN)).is_ok());
 
-        let max = "x".repeat(PROCESS_ID_MAX_LEN);
-        assert_eq!(truncate_process_id(&max), max);
+        let err = check_process_id(&"x".repeat(PROCESS_ID_MAX_LEN + 1)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("x-process-id exceeds maximum allowed length"),
+            "unexpected error: {err}"
+        );
 
-        let long = "x".repeat(PROCESS_ID_MAX_LEN + 10);
-        assert_eq!(truncate_process_id(&long), max);
-
-        // Cut on a char boundary, so the result stays within the server's byte limit
-        let multibyte = "é".repeat(PROCESS_ID_MAX_LEN);
-        let truncated = truncate_process_id(&multibyte);
-        assert!(truncated.len() <= PROCESS_ID_MAX_LEN);
-        assert_eq!(truncated, "é".repeat(PROCESS_ID_MAX_LEN / 2));
+        // Bytes, not chars, matching how the server measures it
+        assert!(check_process_id(&"é".repeat(PROCESS_ID_MAX_LEN / 2)).is_ok());
+        assert!(check_process_id(&"é".repeat(PROCESS_ID_MAX_LEN / 2 + 1)).is_err());
     }
 }

--- a/rust/cube/cubestore-ws-transport/src/actor.rs
+++ b/rust/cube/cubestore-ws-transport/src/actor.rs
@@ -18,24 +18,6 @@ use crate::result::QueryResult;
 
 pub(crate) type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
-/// Mirrors cubestore's `QUEUE_ITEM_PROCESS_ID_MAX_LEN`: the server rejects a longer
-/// `x-process-id` with a 400 during the handshake. Our own id is a uuid (36 chars),
-/// so this is a guard rather than something we expect to hit.
-const PROCESS_ID_MAX_LEN: usize = 64;
-
-/// Bytes, matching how the server measures the header.
-fn check_process_id(process_id: &str) -> Result<(), TransportError> {
-    if process_id.len() > PROCESS_ID_MAX_LEN {
-        return Err(TransportError::Auth(format!(
-            "x-process-id exceeds maximum allowed length of {} characters, actual: {}",
-            PROCESS_ID_MAX_LEN,
-            process_id.len()
-        )));
-    }
-
-    Ok(())
-}
-
 pub(crate) enum ActorRequest {
     Query {
         sql: String,
@@ -303,7 +285,6 @@ pub(crate) async fn connect_ws(
         builder = builder.header("Authorization", value);
     }
 
-    check_process_id(process_id)?;
     let value = HeaderValue::from_str(process_id)
         .map_err(|e| TransportError::Auth(format!("x-process-id: {e}")))?;
     builder = builder.header("x-process-id", value);
@@ -362,27 +343,5 @@ fn host_header(url: &url::Url) -> Option<String> {
     match url.port() {
         Some(p) => Some(format!("{host}:{p}")),
         None => Some(host.to_string()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_process_id_against_server_limit() {
-        assert!(check_process_id("5b3f2c9e-2f1a-4a2e-9d5a-9f1b6c7d8e90").is_ok());
-        assert!(check_process_id(&"x".repeat(PROCESS_ID_MAX_LEN)).is_ok());
-
-        let err = check_process_id(&"x".repeat(PROCESS_ID_MAX_LEN + 1)).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("x-process-id exceeds maximum allowed length"),
-            "unexpected error: {err}"
-        );
-
-        // Bytes, not chars, matching how the server measures it
-        assert!(check_process_id(&"é".repeat(PROCESS_ID_MAX_LEN / 2)).is_ok());
-        assert!(check_process_id(&"é".repeat(PROCESS_ID_MAX_LEN / 2 + 1)).is_err());
     }
 }

--- a/rust/cube/cubestore-ws-transport/src/actor.rs
+++ b/rust/cube/cubestore-ws-transport/src/actor.rs
@@ -18,6 +18,25 @@ use crate::result::QueryResult;
 
 pub(crate) type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
+/// Mirrors cubestore's `QUEUE_ITEM_PROCESS_ID_MAX_LEN`: the server rejects a longer
+/// `x-process-id` with a 400 during the handshake. Our own id is a uuid (36 chars),
+/// so truncating is a guard rather than something we expect to hit.
+const PROCESS_ID_MAX_LEN: usize = 64;
+
+/// Bytes, matching how the server measures the header.
+fn truncate_process_id(process_id: &str) -> &str {
+    if process_id.len() <= PROCESS_ID_MAX_LEN {
+        return process_id;
+    }
+
+    let mut end = PROCESS_ID_MAX_LEN;
+    while !process_id.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    &process_id[..end]
+}
+
 pub(crate) enum ActorRequest {
     Query {
         sql: String,
@@ -285,8 +304,7 @@ pub(crate) async fn connect_ws(
         builder = builder.header("Authorization", value);
     }
 
-    let truncated: String = process_id.chars().take(64).collect();
-    let value = HeaderValue::from_str(&truncated)
+    let value = HeaderValue::from_str(truncate_process_id(process_id))
         .map_err(|e| TransportError::Auth(format!("x-process-id: {e}")))?;
     builder = builder.header("x-process-id", value);
 
@@ -344,5 +362,28 @@ fn host_header(url: &url::Url) -> Option<String> {
     match url.port() {
         Some(p) => Some(format!("{host}:{p}")),
         None => Some(host.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_process_id_to_server_limit() {
+        let uuid = "5b3f2c9e-2f1a-4a2e-9d5a-9f1b6c7d8e90";
+        assert_eq!(truncate_process_id(uuid), uuid);
+
+        let max = "x".repeat(PROCESS_ID_MAX_LEN);
+        assert_eq!(truncate_process_id(&max), max);
+
+        let long = "x".repeat(PROCESS_ID_MAX_LEN + 10);
+        assert_eq!(truncate_process_id(&long), max);
+
+        // Cut on a char boundary, so the result stays within the server's byte limit
+        let multibyte = "é".repeat(PROCESS_ID_MAX_LEN);
+        let truncated = truncate_process_id(&multibyte);
+        assert!(truncated.len() <= PROCESS_ID_MAX_LEN);
+        assert_eq!(truncated, "é".repeat(PROCESS_ID_MAX_LEN / 2));
     }
 }

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -12155,16 +12155,17 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
     for id in 1..=2 {
         service
             .exec_query(&format!(
-                r#"QUEUE ADD "STANDALONE#queue:{}" "payload{}""#,
+                r#"QUEUE ADD "STANDALONE#queue:key{}" "payload{}""#,
                 id, id
             ))
             .await?;
     }
 
     {
-        // Every concurrency slot is free, only the backlog declines the claim
+        // Every concurrency slot is free, but claiming would leave the 2 pending items
+        // a single slot to share, so the item takes its place in the backlog instead
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:3" "payload3" 4"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key3" "payload3" 2"#)
             .await?;
         assert_queue_add_and_retrieve_columns(&add_response);
         assert_eq!(
@@ -12174,18 +12175,31 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
     }
 
     {
+        // A slot is left over for every one of the 3 pending items, nothing is jumped over
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:4" "payload4" 7"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key4" "payload4" 4"#)
             .await?;
+        assert_queue_add_and_retrieve_columns(&add_response);
         assert_eq!(
             add_response.get_rows(),
             &vec![queue_add_and_retrieve_row(
                 "4",
                 true,
                 3,
-                Some("4"),
+                Some("key4"),
                 Some("payload4")
             )]
+        );
+    }
+
+    {
+        // The very same budget declines the next claim, the slot it took is now busy
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key5" "payload5" 4"#)
+            .await?;
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row("5", true, 4, Some("key4"), None)]
         );
     }
 
@@ -12193,7 +12207,7 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
         let pending_response = service
             .exec_query(r#"QUEUE PENDING "STANDALONE#queue""#)
             .await?;
-        assert_eq!(pending_response.get_rows().len(), 3);
+        assert_eq!(pending_response.get_rows().len(), 4);
 
         let active_response = service
             .exec_query(r#"QUEUE ACTIVE "STANDALONE#queue""#)
@@ -12201,7 +12215,7 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
         assert_eq!(
             active_response.get_rows(),
             &vec![Row::new(vec![
-                TableValue::String("4".to_string()),
+                TableValue::String("key4".to_string()),
                 TableValue::String("4".to_string()),
                 TableValue::String("active".to_string()),
                 TableValue::Null,

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -467,7 +467,6 @@ lazy_static::lazy_static! {
         "planning_topk_hash_aggregate",
         "topk_hash_aggregate_trim",
         "queue_add_and_retrieve",
-        "queue_add_and_retrieve",
         "queue_add_and_retrieve_backlog",
         "queue_add_external_id_max_len",
     ].into_iter().map(ToOwned::to_owned).collect();
@@ -12807,7 +12806,6 @@ async fn queue_add_external_id_max_len(service: Box<dyn SqlClient>) -> Result<()
         .exec_query(r#"QUEUE PENDING "STANDALONE#queue""#)
         .await?;
     assert_eq!(pending.get_rows().len(), 1);
-    assert_eq!(pending.get_rows().len(), 0);
 
     Ok(())
 }

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -12156,8 +12156,7 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
     }
 
     {
-        // 2 pending items is not less than a half of 4, the backlog is left to
-        // QUEUE PENDING + reconcile even though every concurrency slot is free
+        // Every concurrency slot is free, only the backlog declines the claim
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:3" "payload3" 4"#)
             .await?;
@@ -12169,7 +12168,6 @@ async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(
     }
 
     {
-        // 3 pending items is less than a half of 7
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:4" "payload4" 7"#)
             .await?;

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -12049,7 +12049,7 @@ async fn queue_retrieve_extended(service: Box<dyn SqlClient>) -> Result<(), Cube
 async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
     {
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE PRIORITY 1 "STANDALONE#queue:1" "payload1" 1"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE PRIORITY 1 "STANDALONE#queue:key1" "payload1" 1"#)
             .await?;
         assert_queue_add_and_retrieve_columns(&add_response);
         assert_eq!(
@@ -12058,7 +12058,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
                 "1",
                 true,
                 0,
-                Some("1"),
+                Some("key1"),
                 Some("payload1")
             )]
         );
@@ -12066,26 +12066,27 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
 
     {
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2" 1"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key2" "payload2" 1"#)
             .await?;
         assert_eq!(
             add_response.get_rows(),
-            &vec![queue_add_and_retrieve_row("2", true, 1, Some("1"), None)]
+            &vec![queue_add_and_retrieve_row("2", true, 1, Some("key1"), None)]
         );
     }
 
     {
         // The stored payload is returned, not the payload of this call
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2-dup" 2"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key2" "payload2-dup" 2"#)
             .await?;
+        assert_queue_add_and_retrieve_columns(&add_response);
         assert_eq!(
             add_response.get_rows(),
             &vec![queue_add_and_retrieve_row(
                 "2",
                 false,
                 0,
-                Some("1,2"),
+                Some("key1,key2"),
                 Some("payload2")
             )]
         );
@@ -12093,17 +12094,23 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
 
     {
         let add_response = service
-            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:1" "payload1" 5"#)
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:key1" "payload1" 5"#)
             .await?;
         assert_eq!(
             add_response.get_rows(),
-            &vec![queue_add_and_retrieve_row("1", false, 0, Some("1,2"), None)]
+            &vec![queue_add_and_retrieve_row(
+                "1",
+                false,
+                0,
+                Some("key1,key2"),
+                None
+            )]
         );
     }
 
     {
         let add_response = service
-            .exec_query(r#"QUEUE ADD "STANDALONE#queue:3" "payload3""#)
+            .exec_query(r#"QUEUE ADD "STANDALONE#queue:key3" "payload3""#)
             .await?;
         assert_queue_add_columns(&add_response);
     }
@@ -12115,7 +12122,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
         assert_eq!(
             pending_response.get_rows(),
             &vec![Row::new(vec![
-                TableValue::String("3".to_string()),
+                TableValue::String("key3".to_string()),
                 TableValue::String("3".to_string()),
                 TableValue::String("pending".to_string()),
                 TableValue::Null,
@@ -12131,7 +12138,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
     {
         // A claimed item can be acknowledged without an explicit QUEUE RETRIEVE
         let ack_response = service
-            .exec_query(r#"QUEUE ACK "STANDALONE#queue:1" "result1""#)
+            .exec_query(r#"QUEUE ACK "STANDALONE#queue:key1" "result1""#)
             .await?;
         assert_eq!(
             ack_response.get_rows(),
@@ -12139,7 +12146,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
         );
 
         let result_response = service
-            .exec_query(r#"QUEUE RESULT "STANDALONE#queue:1""#)
+            .exec_query(r#"QUEUE RESULT "STANDALONE#queue:key1""#)
             .await?;
         assert_queue_result_columns(&result_response);
         assert_eq!(

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -467,7 +467,9 @@ lazy_static::lazy_static! {
         "planning_topk_hash_aggregate",
         "topk_hash_aggregate_trim",
         "queue_add_and_retrieve",
+        "queue_add_and_retrieve",
         "queue_add_and_retrieve_backlog",
+        "queue_add_external_id_max_len",
     ].into_iter().map(ToOwned::to_owned).collect();
 }
 
@@ -12800,10 +12802,11 @@ async fn queue_add_external_id_max_len(service: Box<dyn SqlClient>) -> Result<()
         );
     }
 
-    // The rejected item was never written
+    // The rejected items were never written, only the max-length one
     let pending = service
-        .exec_query(r#"QUEUE PENDING "STANDALONE#queue:ext_too_long""#)
+        .exec_query(r#"QUEUE PENDING "STANDALONE#queue""#)
         .await?;
+    assert_eq!(pending.get_rows().len(), 1);
     assert_eq!(pending.get_rows().len(), 0);
 
     Ok(())

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -316,6 +316,7 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         ),
         t("queue_latest_result_v1", queue_latest_result_v1),
         t("queue_retrieve_extended", queue_retrieve_extended),
+        t("queue_add_and_retrieve", queue_add_and_retrieve),
         t("queue_ack_then_result_v1", queue_ack_then_result_v1),
         t("queue_ack_then_result_v2", queue_ack_then_result_v2),
         t(
@@ -456,6 +457,8 @@ lazy_static::lazy_static! {
         "prefilter_chunks_shared_scan",
         "planning_topk_hash_aggregate",
         "topk_hash_aggregate_trim",
+        // QUEUE ADD_AND_RETRIEVE is not supported by the older CubeStore binary
+        "queue_add_and_retrieve",
     ].into_iter().map(ToOwned::to_owned).collect();
 }
 
@@ -11881,6 +11884,40 @@ fn assert_queue_add_columns(response: &Arc<DataFrame>) {
     );
 }
 
+fn queue_add_and_retrieve_row(
+    id: &str,
+    added: bool,
+    pending: i64,
+    active: &str,
+    payload: Option<&str>,
+) -> Row {
+    Row::new(vec![
+        TableValue::String(id.to_string()),
+        TableValue::Boolean(added),
+        TableValue::Int(pending),
+        TableValue::String(active.to_string()),
+        payload.map_or(TableValue::Null, |payload| {
+            TableValue::String(payload.to_string())
+        }),
+        // extra is always empty for a freshly added item
+        TableValue::Null,
+    ])
+}
+
+fn assert_queue_add_and_retrieve_columns(response: &Arc<DataFrame>) {
+    assert_eq!(
+        response.get_columns(),
+        &vec![
+            Column::new("id".to_string(), ColumnType::String, 0),
+            Column::new("added".to_string(), ColumnType::Boolean, 1),
+            Column::new("pending".to_string(), ColumnType::Int, 2),
+            Column::new("active".to_string(), ColumnType::String, 3),
+            Column::new("payload".to_string(), ColumnType::String, 4),
+            Column::new("extra".to_string(), ColumnType::String, 5),
+        ]
+    );
+}
+
 fn assert_queue_add_and_get_id(response: &Arc<DataFrame>) -> Result<String, CubeError> {
     assert_queue_add_columns(response);
 
@@ -11995,6 +12032,116 @@ async fn queue_retrieve_extended(service: Box<dyn SqlClient>) -> Result<(), Cube
             ]),]
         );
     }
+    Ok(())
+}
+
+async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    {
+        // A brand new item is claimed by the insert itself
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE PRIORITY 1 "STANDALONE#queue:1" "payload1" 1"#)
+            .await?;
+        assert_queue_add_and_retrieve_columns(&add_response);
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row(
+                "1",
+                true,
+                0,
+                "1",
+                Some("payload1")
+            )]
+        );
+    }
+
+    {
+        // The concurrency budget is used up, the item is added, but not claimed
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2" 1"#)
+            .await?;
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row("2", true, 1, "1", None)]
+        );
+    }
+
+    {
+        // The same path is not added twice, but it's claimed when there is a room.
+        // The stored payload is returned, not the payload of this call.
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2-dup" 2"#)
+            .await?;
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row(
+                "2",
+                false,
+                0,
+                "1,2",
+                Some("payload2")
+            )]
+        );
+    }
+
+    {
+        // An already active item is not claimed again
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:1" "payload1" 5"#)
+            .await?;
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row("1", false, 0, "1,2", None)]
+        );
+    }
+
+    {
+        // A plain QUEUE ADD keeps its original response shape
+        let add_response = service
+            .exec_query(r#"QUEUE ADD "STANDALONE#queue:3" "payload3""#)
+            .await?;
+        assert_queue_add_columns(&add_response);
+    }
+
+    {
+        let pending_response = service
+            .exec_query(r#"QUEUE PENDING "STANDALONE#queue""#)
+            .await?;
+        assert_eq!(
+            pending_response.get_rows(),
+            &vec![Row::new(vec![
+                TableValue::String("3".to_string()),
+                TableValue::String("3".to_string()),
+                TableValue::String("pending".to_string()),
+                TableValue::Null,
+            ]),]
+        );
+
+        let active_response = service
+            .exec_query(r#"QUEUE ACTIVE "STANDALONE#queue""#)
+            .await?;
+        assert_eq!(active_response.get_rows().len(), 2);
+    }
+
+    {
+        // A claimed item can be acknowledged without an explicit QUEUE RETRIEVE
+        let ack_response = service
+            .exec_query(r#"QUEUE ACK "STANDALONE#queue:1" "result1""#)
+            .await?;
+        assert_eq!(
+            ack_response.get_rows(),
+            &vec![Row::new(vec![TableValue::Boolean(true)])]
+        );
+
+        let result_response = service
+            .exec_query(r#"QUEUE RESULT "STANDALONE#queue:1""#)
+            .await?;
+        assert_queue_result_columns(&result_response);
+        assert_eq!(
+            result_response.get_rows(),
+            &vec![queue_result_row("result1", "1", None)]
+        );
+    }
+
     Ok(())
 }
 

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -457,7 +457,6 @@ lazy_static::lazy_static! {
         "prefilter_chunks_shared_scan",
         "planning_topk_hash_aggregate",
         "topk_hash_aggregate_trim",
-        // QUEUE ADD_AND_RETRIEVE is not supported by the older CubeStore binary
         "queue_add_and_retrieve",
     ].into_iter().map(ToOwned::to_owned).collect();
 }
@@ -12037,7 +12036,6 @@ async fn queue_retrieve_extended(service: Box<dyn SqlClient>) -> Result<(), Cube
 
 async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
     {
-        // A brand new item is claimed by the insert itself
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE PRIORITY 1 "STANDALONE#queue:1" "payload1" 1"#)
             .await?;
@@ -12055,7 +12053,6 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
     }
 
     {
-        // The concurrency budget is used up, the item is added, but not claimed
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2" 1"#)
             .await?;
@@ -12066,8 +12063,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
     }
 
     {
-        // The same path is not added twice, but it's claimed when there is a room.
-        // The stored payload is returned, not the payload of this call.
+        // The stored payload is returned, not the payload of this call
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:2" "payload2-dup" 2"#)
             .await?;
@@ -12084,7 +12080,6 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
     }
 
     {
-        // An already active item is not claimed again
         let add_response = service
             .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:1" "payload1" 5"#)
             .await?;
@@ -12095,7 +12090,6 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
     }
 
     {
-        // A plain QUEUE ADD keeps its original response shape
         let add_response = service
             .exec_query(r#"QUEUE ADD "STANDALONE#queue:3" "payload3""#)
             .await?;

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -317,6 +317,10 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         t("queue_latest_result_v1", queue_latest_result_v1),
         t("queue_retrieve_extended", queue_retrieve_extended),
         t("queue_add_and_retrieve", queue_add_and_retrieve),
+        t(
+            "queue_add_and_retrieve_backlog",
+            queue_add_and_retrieve_backlog,
+        ),
         t("queue_ack_then_result_v1", queue_ack_then_result_v1),
         t("queue_ack_then_result_v2", queue_ack_then_result_v2),
         t(
@@ -458,6 +462,7 @@ lazy_static::lazy_static! {
         "planning_topk_hash_aggregate",
         "topk_hash_aggregate_trim",
         "queue_add_and_retrieve",
+        "queue_add_and_retrieve_backlog",
     ].into_iter().map(ToOwned::to_owned).collect();
 }
 
@@ -11887,17 +11892,18 @@ fn queue_add_and_retrieve_row(
     id: &str,
     added: bool,
     pending: i64,
-    active: &str,
+    active: Option<&str>,
     payload: Option<&str>,
 ) -> Row {
+    let to_value =
+        |v: Option<&str>| v.map_or(TableValue::Null, |v| TableValue::String(v.to_string()));
+
     Row::new(vec![
         TableValue::String(id.to_string()),
         TableValue::Boolean(added),
         TableValue::Int(pending),
-        TableValue::String(active.to_string()),
-        payload.map_or(TableValue::Null, |payload| {
-            TableValue::String(payload.to_string())
-        }),
+        to_value(active),
+        to_value(payload),
         // extra is always empty for a freshly added item
         TableValue::Null,
     ])
@@ -12046,7 +12052,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
                 "1",
                 true,
                 0,
-                "1",
+                Some("1"),
                 Some("payload1")
             )]
         );
@@ -12058,7 +12064,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
             .await?;
         assert_eq!(
             add_response.get_rows(),
-            &vec![queue_add_and_retrieve_row("2", true, 1, "1", None)]
+            &vec![queue_add_and_retrieve_row("2", true, 1, Some("1"), None)]
         );
     }
 
@@ -12073,7 +12079,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
                 "2",
                 false,
                 0,
-                "1,2",
+                Some("1,2"),
                 Some("payload2")
             )]
         );
@@ -12085,7 +12091,7 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
             .await?;
         assert_eq!(
             add_response.get_rows(),
-            &vec![queue_add_and_retrieve_row("1", false, 0, "1,2", None)]
+            &vec![queue_add_and_retrieve_row("1", false, 0, Some("1,2"), None)]
         );
     }
 
@@ -12133,6 +12139,69 @@ async fn queue_add_and_retrieve(service: Box<dyn SqlClient>) -> Result<(), CubeE
         assert_eq!(
             result_response.get_rows(),
             &vec![queue_result_row("result1", "1", None)]
+        );
+    }
+
+    Ok(())
+}
+
+async fn queue_add_and_retrieve_backlog(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    for id in 1..=2 {
+        service
+            .exec_query(&format!(
+                r#"QUEUE ADD "STANDALONE#queue:{}" "payload{}""#,
+                id, id
+            ))
+            .await?;
+    }
+
+    {
+        // 2 pending items is not less than a half of 4, the backlog is left to
+        // QUEUE PENDING + reconcile even though every concurrency slot is free
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:3" "payload3" 4"#)
+            .await?;
+        assert_queue_add_and_retrieve_columns(&add_response);
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row("3", true, 3, None, None)]
+        );
+    }
+
+    {
+        // 3 pending items is less than a half of 7
+        let add_response = service
+            .exec_query(r#"QUEUE ADD_AND_RETRIEVE "STANDALONE#queue:4" "payload4" 7"#)
+            .await?;
+        assert_eq!(
+            add_response.get_rows(),
+            &vec![queue_add_and_retrieve_row(
+                "4",
+                true,
+                3,
+                Some("4"),
+                Some("payload4")
+            )]
+        );
+    }
+
+    {
+        let pending_response = service
+            .exec_query(r#"QUEUE PENDING "STANDALONE#queue""#)
+            .await?;
+        assert_eq!(pending_response.get_rows().len(), 3);
+
+        let active_response = service
+            .exec_query(r#"QUEUE ACTIVE "STANDALONE#queue""#)
+            .await?;
+        assert_eq!(
+            active_response.get_rows(),
+            &vec![Row::new(vec![
+                TableValue::String("4".to_string()),
+                TableValue::String("4".to_string()),
+                TableValue::String("active".to_string()),
+                TableValue::Null,
+            ]),]
         );
     }
 

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -2,6 +2,7 @@ use crate::files::write_tmp_file;
 use crate::rows::{rows, NULL};
 use crate::SqlClient;
 use async_compression::tokio::write::GzipEncoder;
+use cubestore::cachestore::QUEUE_ITEM_EXTERNAL_ID_MAX_LEN;
 use cubestore::metastore::{Column, ColumnType};
 use cubestore::queryplanner::physical_plan_flags::PhysicalPlanFlags;
 use cubestore::queryplanner::pretty_printers::{pp_phys_plan, pp_phys_plan_ext, PPOptions};
@@ -313,6 +314,10 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         t(
             "queue_full_workflow_v2_with_external_id",
             queue_full_workflow_v2_with_external_id,
+        ),
+        t(
+            "queue_add_external_id_max_len",
+            queue_add_external_id_max_len,
         ),
         t("queue_latest_result_v1", queue_latest_result_v1),
         t("queue_retrieve_extended", queue_retrieve_extended),
@@ -12755,6 +12760,51 @@ async fn queue_full_workflow_v2_with_external_id(
         .exec_query(r#"QUEUE RESULT EXTERNAL_ID "unknown-ext" "STANDALONE#queue:ext_v2""#)
         .await?;
     assert_eq!(result.get_rows().len(), 0);
+
+    Ok(())
+}
+
+async fn queue_add_external_id_max_len(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    let max_id = "x".repeat(QUEUE_ITEM_EXTERNAL_ID_MAX_LEN);
+    let too_long_id = "x".repeat(QUEUE_ITEM_EXTERNAL_ID_MAX_LEN + 1);
+
+    let add_response = service
+        .exec_query(&format!(
+            r#"QUEUE ADD EXTERNAL_ID '{}' "STANDALONE#queue:ext_max_len" "payload_max_len""#,
+            max_id
+        ))
+        .await?;
+    assert_queue_add_and_get_id(&add_response)?;
+
+    for query in [
+        format!(
+            r#"QUEUE ADD EXTERNAL_ID '{}' "STANDALONE#queue:ext_too_long" "payload_too_long""#,
+            too_long_id
+        ),
+        format!(
+            r#"QUEUE ADD_AND_RETRIEVE EXTERNAL_ID '{}' "STANDALONE#queue:ext_too_long" "payload_too_long" 1"#,
+            too_long_id
+        ),
+        format!(
+            r#"QUEUE RESULT EXTERNAL_ID '{}' "STANDALONE#queue:ext_too_long""#,
+            too_long_id
+        ),
+    ] {
+        let err = service.exec_query(&query).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("external_id exceeds maximum allowed length"),
+            "unexpected error for {}: {}",
+            query,
+            err
+        );
+    }
+
+    // The rejected item was never written
+    let pending = service
+        .exec_query(r#"QUEUE PENDING "STANDALONE#queue:ext_too_long""#)
+        .await?;
+    assert_eq!(pending.get_rows().len(), 0);
 
     Ok(())
 }

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -5,7 +5,7 @@ use crate::cachestore::cache_item::{
 use crate::cachestore::queue_item::{
     active_keys_to_value, QueueItem, QueueItemIndexKey, QueueItemRocksIndex, QueueItemRocksTable,
     QueueItemStatus, QueueResultAckEvent, QueueResultAckEventResult, QueueRetrieveResponse,
-    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN, QUEUE_ITEM_PROCESS_ID_MAX_LEN,
+    QUEUE_ITEM_PROCESS_ID_MAX_LEN,
 };
 use crate::cachestore::queue_result::{QueueResultRocksIndex, QueueResultRocksTable};
 use crate::cachestore::{compaction, QueueItemPayload, QueueResult};
@@ -1380,14 +1380,6 @@ impl CacheStore for RocksCacheStore {
                 )));
             }
         }
-        if let Some(ref id) = payload.external_id {
-            if id.len() > QUEUE_ITEM_EXTERNAL_ID_MAX_LEN {
-                return Err(CubeError::user(format!(
-                    "external_id exceeds maximum allowed length of {} characters",
-                    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN
-                )));
-            }
-        }
 
         self.write_operation_queue("queue_add", move |db_ref, batch_pipe| {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
@@ -1450,14 +1442,6 @@ impl CacheStore for RocksCacheStore {
                 return Err(CubeError::user(format!(
                     "process_id exceeds maximum allowed length of {} characters",
                     QUEUE_ITEM_PROCESS_ID_MAX_LEN
-                )));
-            }
-        }
-        if let Some(ref id) = payload.external_id {
-            if id.len() > QUEUE_ITEM_EXTERNAL_ID_MAX_LEN {
-                return Err(CubeError::user(format!(
-                    "external_id exceeds maximum allowed length of {} characters",
-                    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN
                 )));
             }
         }
@@ -2783,27 +2767,6 @@ mod tests {
                 "Second insert with None external_id should succeed"
             );
             assert!(res.unwrap().added);
-        }
-
-        // external_id exceeding max length should fail
-        {
-            let long_id = "x".repeat(QUEUE_ITEM_EXTERNAL_ID_MAX_LEN + 1);
-            let res = cachestore
-                .queue_add(QueueAddPayload {
-                    path: "prefix:path5".to_string(),
-                    value: "v5".to_string(),
-                    priority: 0,
-                    orphaned: None,
-                    process_id: None,
-                    exclusive: false,
-                    external_id: Some(long_id),
-                })
-                .await;
-            assert!(res.is_err(), "external_id exceeding max length should fail");
-            assert!(res
-                .unwrap_err()
-                .to_string()
-                .contains("external_id exceeds maximum allowed length"));
         }
 
         // process_id exceeding max length should fail

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -1467,11 +1467,23 @@ impl CacheStore for RocksCacheStore {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
             let (pending, mut active) = Self::queue_prefix_counters(&queue_schema, &payload.path)?;
 
-            let claim = active.len() < (payload.concurrency as usize);
-
             let index_key = QueueItemIndexKey::ByPath(payload.path.clone());
             let id_row_opt = queue_schema
                 .get_single_opt_row_by_index(&index_key, &QueueItemRocksIndex::ByPath)?;
+
+            // An item which is already pending is not a part of its own backlog
+            let backlog = match &id_row_opt {
+                Some(id_row) if id_row.get_row().get_status() == &QueueItemStatus::Pending => {
+                    pending.saturating_sub(1)
+                }
+                _ => pending,
+            };
+
+            // A deep backlog is left to QUEUE PENDING + reconcile, which pick by priority.
+            // Claiming the item being added ignores priority, it's acceptable only while
+            // there is almost nothing to jump over.
+            let claim = active.len() < (payload.concurrency as usize)
+                && backlog * 2 < (payload.concurrency as u64);
 
             if let Some(id_row) = id_row_opt {
                 let id = id_row.get_id();
@@ -2941,6 +2953,57 @@ mod tests {
         assert_queue_item_status(&cachestore, "path4", QueueItemStatus::Pending, false).await?;
 
         RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_queue_add_and_retrieve_backlog() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
+            "test_queue_add_and_retrieve_backlog",
+            Config::test("test_queue_add_and_retrieve_backlog"),
+        );
+
+        for path in ["prefix:path1", "prefix:path2"] {
+            cachestore
+                .queue_add(QueueAddPayload {
+                    path: path.to_string(),
+                    value: "v".to_string(),
+                    priority: 0,
+                    orphaned: None,
+                    process_id: None,
+                    exclusive: false,
+                    external_id: None,
+                })
+                .await?;
+        }
+
+        // 2 pending items is not less than a half of 4, the backlog is left to reconcile
+        // even though all the concurrency slots are free
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 4))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, None);
+        assert_eq!(res.active, Vec::<String>::new());
+        assert_eq!(res.pending, 3);
+
+        assert_queue_item_status(&cachestore, "path3", QueueItemStatus::Pending, false).await?;
+
+        // 3 pending items is less than a half of 7
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path4", "v4", 7))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, Some("v4".to_string()));
+        assert_eq!(res.active, vec!["path4".to_string()]);
+        assert_eq!(res.pending, 3);
+
+        assert_queue_item_status(&cachestore, "path4", QueueItemStatus::Active, true).await?;
+
+        RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve_backlog");
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -774,12 +774,8 @@ impl RocksCacheStore {
                             active,
                         });
                     }
-
-                    // OK, caller matches the exclusive item owner
                 }
-                (None, None) => {
-                    // No process_id on item and no caller — allow retrieval
-                }
+                (None, None) => {}
             }
         }
 

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -3,8 +3,8 @@ use crate::cachestore::cache_item::{
     CACHE_ITEM_SIZE_WITHOUT_VALUE,
 };
 use crate::cachestore::queue_item::{
-    QueueItem, QueueItemIndexKey, QueueItemRocksIndex, QueueItemRocksTable, QueueItemStatus,
-    QueueResultAckEvent, QueueResultAckEventResult, QueueRetrieveResponse,
+    active_keys_to_value, QueueItem, QueueItemIndexKey, QueueItemRocksIndex, QueueItemRocksTable,
+    QueueItemStatus, QueueResultAckEvent, QueueResultAckEventResult, QueueRetrieveResponse,
     QUEUE_ITEM_EXTERNAL_ID_MAX_LEN, QUEUE_ITEM_PROCESS_ID_MAX_LEN,
 };
 use crate::cachestore::queue_result::{QueueResultRocksIndex, QueueResultRocksTable};
@@ -711,6 +711,112 @@ impl RocksCacheStore {
             })
             .collect()
     }
+
+    /// Reads the concurrency budget of the prefix the path belongs to: the number of
+    /// pending items and the keys of the active ones. Shared by `QUEUE RETRIEVE` and
+    /// `QUEUE ADD_AND_RETRIEVE` so that both use the same (prefix scoped, exclusivity
+    /// and priority blind) budget.
+    fn queue_prefix_counters(
+        queue_schema: &QueueItemRocksTable,
+        path: &str,
+    ) -> Result<(u64, Vec<String>), CubeError> {
+        let prefix = QueueItem::extract_prefix(path.to_string()).unwrap_or("".to_string());
+
+        let pending = queue_schema.count_rows_by_index(
+            &QueueItemIndexKey::ByPrefixAndStatus(prefix.clone(), QueueItemStatus::Pending),
+            &QueueItemRocksIndex::ByPrefixAndStatus,
+        )?;
+
+        let active = queue_schema
+            .get_rows_by_index(
+                &QueueItemIndexKey::ByPrefixAndStatus(prefix, QueueItemStatus::Active),
+                &QueueItemRocksIndex::ByPrefixAndStatus,
+            )?
+            .into_iter()
+            .map(|item| item.into_row().key)
+            .collect();
+
+        Ok((pending, active))
+    }
+
+    /// Claims a pending queue item: moves it to the active status inside the caller's
+    /// batch and returns its payload. Shared by `QUEUE RETRIEVE` and
+    /// `QUEUE ADD_AND_RETRIEVE`, so both use identical exclusivity, heartbeat and
+    /// missing payload semantics. The concurrency budget must be checked by the caller.
+    fn try_claim_queue_item(
+        queue_schema: &QueueItemRocksTable,
+        queue_payload_schema: &QueueItemPayloadRocksTable,
+        batch_pipe: &mut BatchPipe,
+        id_row: IdRow<QueueItem>,
+        caller_process_id: &Option<String>,
+        pending: u64,
+        mut active: Vec<String>,
+    ) -> Result<QueueRetrieveResponse, CubeError> {
+        if id_row.get_row().get_status() != &QueueItemStatus::Pending {
+            return Ok(QueueRetrieveResponse::LockFailed { pending, active });
+        }
+
+        if id_row.get_row().get_exclusive() {
+            match (id_row.get_row().get_process_id(), caller_process_id) {
+                (Some(_), None) => {
+                    return Err(CubeError::user(
+                        "Claiming an exclusive queue item requires a process_id in the connection context (x-process-id header)".to_string(),
+                    ))
+                }
+                (None, Some(_)) => {
+                    log::warn!(
+                        "Incorrect queue_item with exclusive flag, empty process_id, id: {:?}",
+                        caller_process_id
+                    );
+
+                    return Ok(QueueRetrieveResponse::NotFound { pending, active });
+                }
+                (Some(item_process_id), Some(caller_id)) => {
+                    if item_process_id != caller_id {
+                        return Ok(QueueRetrieveResponse::ExclusiveAccessFailed {
+                            pending,
+                            active,
+                        });
+                    }
+
+                    // OK, caller matches the exclusive item owner
+                }
+                (None, None) => {
+                    // No process_id on item and no caller — allow retrieval
+                }
+            }
+        }
+
+        let mut new = id_row.get_row().clone();
+        new.status = QueueItemStatus::Active;
+        // It's important to insert heartbeat, because
+        // without that created datetime will be used for orphaned filtering
+        new.update_heartbeat();
+
+        let res = queue_schema.update(id_row.get_id(), new, id_row.get_row(), batch_pipe)?;
+        let payload = if let Some(r) = queue_payload_schema.get_row(res.get_id())? {
+            r.into_row().value
+        } else {
+            error!(
+                "Unable to find payload for queue item, id = {}",
+                res.get_id()
+            );
+
+            queue_schema.delete_row(res, batch_pipe)?;
+
+            return Ok(QueueRetrieveResponse::NotFound { pending, active });
+        };
+
+        active.push(res.get_row().get_key().clone());
+
+        Ok(QueueRetrieveResponse::Success {
+            id: res.get_id(),
+            payload,
+            item: res.into_row(),
+            pending: pending.saturating_sub(1),
+            active,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, DeepSizeOf)]
@@ -756,6 +862,74 @@ pub struct QueueAddPayload {
     pub process_id: Option<String>,
     pub exclusive: bool,
     pub external_id: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct QueueAddAndRetrievePayload {
+    pub path: String,
+    pub value: String,
+    pub priority: i64,
+    pub orphaned: Option<u32>,
+    pub process_id: Option<String>,
+    pub exclusive: bool,
+    pub external_id: Option<String>,
+    /// The item is claimed only when the prefix has less than `concurrency` active
+    /// items. It's the same budget as `QUEUE RETRIEVE CONCURRENCY` uses.
+    pub concurrency: u32,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct QueueAddAndRetrieveResponse {
+    pub id: u64,
+    pub added: bool,
+    pub pending: u64,
+    /// Keys of the active items in the prefix after this operation
+    pub active: Vec<String>,
+    /// `Some` only when the item was claimed (moved to the active status) by this call
+    pub payload: Option<String>,
+    pub extra: Option<String>,
+}
+
+impl QueueAddAndRetrieveResponse {
+    /// Wraps the outcome of a claim attempt on an item which already existed
+    pub fn from_claim(id: u64, claim: QueueRetrieveResponse) -> Self {
+        let (payload, extra, pending, active) = match claim {
+            QueueRetrieveResponse::Success {
+                item,
+                payload,
+                pending,
+                active,
+                ..
+            } => (Some(payload), item.extra, pending, active),
+            QueueRetrieveResponse::LockFailed { pending, active }
+            | QueueRetrieveResponse::NotEnoughConcurrency { pending, active }
+            | QueueRetrieveResponse::NotFound { pending, active }
+            | QueueRetrieveResponse::ExclusiveAccessFailed { pending, active } => {
+                (None, None, pending, active)
+            }
+        };
+
+        Self {
+            id,
+            // An existing item is never added twice, it's unique by path
+            added: false,
+            pending,
+            active,
+            payload,
+            extra,
+        }
+    }
+
+    pub fn into_queue_add_and_retrieve_row(self) -> Row {
+        Row::new(vec![
+            TableValue::String(self.id.to_string()),
+            TableValue::Boolean(self.added),
+            TableValue::Int(self.pending as i64),
+            active_keys_to_value(self.active),
+            self.payload.map_or(TableValue::Null, TableValue::String),
+            self.extra.map_or(TableValue::Null, TableValue::String),
+        ])
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -902,6 +1076,10 @@ pub trait CacheStore: DIService + Send + Sync {
     ) -> Result<Vec<IdRow<QueueResult>>, CubeError>;
     async fn queue_results_multi_delete(&self, ids: Vec<u64>) -> Result<(), CubeError>;
     async fn queue_add(&self, payload: QueueAddPayload) -> Result<QueueAddResponse, CubeError>;
+    async fn queue_add_and_retrieve(
+        &self,
+        payload: QueueAddAndRetrievePayload,
+    ) -> Result<QueueAddAndRetrieveResponse, CubeError>;
     async fn queue_clear(&self) -> Result<(), CubeError>;
     async fn queue_to_cancel(
         &self,
@@ -1268,6 +1446,117 @@ impl CacheStore for RocksCacheStore {
         .await
     }
 
+    async fn queue_add_and_retrieve(
+        &self,
+        payload: QueueAddAndRetrievePayload,
+    ) -> Result<QueueAddAndRetrieveResponse, CubeError> {
+        if let Some(ref id) = payload.process_id {
+            if id.len() > QUEUE_ITEM_PROCESS_ID_MAX_LEN {
+                return Err(CubeError::user(format!(
+                    "process_id exceeds maximum allowed length of {} characters",
+                    QUEUE_ITEM_PROCESS_ID_MAX_LEN
+                )));
+            }
+        }
+        if let Some(ref id) = payload.external_id {
+            if id.len() > QUEUE_ITEM_EXTERNAL_ID_MAX_LEN {
+                return Err(CubeError::user(format!(
+                    "external_id exceeds maximum allowed length of {} characters",
+                    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN
+                )));
+            }
+        }
+
+        self.write_operation_queue("queue_add_and_retrieve", move |db_ref, batch_pipe| {
+            let queue_schema = QueueItemRocksTable::new(db_ref.clone());
+            let (pending, mut active) = Self::queue_prefix_counters(&queue_schema, &payload.path)?;
+
+            // The same budget as QUEUE RETRIEVE CONCURRENCY uses
+            let claim = active.len() < (payload.concurrency as usize);
+
+            let index_key = QueueItemIndexKey::ByPath(payload.path.clone());
+            let id_row_opt = queue_schema
+                .get_single_opt_row_by_index(&index_key, &QueueItemRocksIndex::ByPath)?;
+
+            if let Some(id_row) = id_row_opt {
+                let id = id_row.get_id();
+                let claim_result = if claim {
+                    let queue_payload_schema = QueueItemPayloadRocksTable::new(db_ref.clone());
+
+                    Self::try_claim_queue_item(
+                        &queue_schema,
+                        &queue_payload_schema,
+                        batch_pipe,
+                        id_row,
+                        &payload.process_id,
+                        pending,
+                        active,
+                    )?
+                } else {
+                    QueueRetrieveResponse::NotEnoughConcurrency { pending, active }
+                };
+
+                return Ok(QueueAddAndRetrieveResponse::from_claim(id, claim_result));
+            }
+
+            // A brand new item is inserted with the active status right away, it saves
+            // an update of the just written row (and its secondary indexes) inside the
+            // same batch. The exclusive flag can never block it: the process_id of a new
+            // item is the process_id of the caller, see sql/cachestore.rs.
+            let mut item = QueueItem::new(
+                payload.path,
+                if claim {
+                    QueueItemStatus::Active
+                } else {
+                    QueueItem::status_default()
+                },
+                payload.priority,
+                payload.orphaned.clone(),
+                payload.process_id,
+                payload.exclusive,
+                payload.external_id,
+            );
+            if claim {
+                // It's important to insert heartbeat, because
+                // without that created datetime will be used for orphaned filtering
+                item.update_heartbeat();
+            }
+
+            let queue_item_row = queue_schema.insert(item, batch_pipe)?;
+
+            let queue_payload_schema = QueueItemPayloadRocksTable::new(db_ref.clone());
+            let queue_payload_row = queue_payload_schema.insert_with_pk(
+                queue_item_row.id,
+                QueueItemPayload::new(
+                    payload.value,
+                    queue_item_row.row.get_created().clone(),
+                    queue_item_row.row.get_expire().clone(),
+                ),
+                batch_pipe,
+            )?;
+
+            // The value can be huge, take it back from the inserted row instead of cloning
+            let claimed_payload = if claim {
+                active.push(queue_item_row.row.get_key().clone());
+
+                Some(queue_payload_row.into_row().value)
+            } else {
+                None
+            };
+
+            Ok(QueueAddAndRetrieveResponse {
+                id: queue_item_row.id,
+                added: true,
+                // A claimed item is inserted as active, it was never counted as pending
+                pending: if claim { pending } else { pending + 1 },
+                active,
+                payload: claimed_payload,
+                extra: None,
+            })
+        })
+        .await
+    }
+
     async fn queue_clear(&self) -> Result<(), CubeError> {
         self.write_operation_queue("queue_clear", move |db_ref, batch_pipe| {
             let queue_item_schema = QueueItemRocksTable::new(db_ref.clone());
@@ -1449,22 +1738,7 @@ impl CacheStore for RocksCacheStore {
     ) -> Result<QueueRetrieveResponse, CubeError> {
         self.write_operation_queue("queue_retrieve_by_path", move |db_ref, batch_pipe| {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
-            let prefix = QueueItem::parse_path(path.clone())
-                .0
-                .unwrap_or("".to_string());
-            let mut pending = queue_schema.count_rows_by_index(
-                &QueueItemIndexKey::ByPrefixAndStatus(prefix.clone(), QueueItemStatus::Pending),
-                &QueueItemRocksIndex::ByPrefixAndStatus,
-            )?;
-
-            let mut active: Vec<String> = queue_schema
-                .get_rows_by_index(
-                    &QueueItemIndexKey::ByPrefixAndStatus(prefix, QueueItemStatus::Active),
-                    &QueueItemRocksIndex::ByPrefixAndStatus,
-                )?
-                .into_iter()
-                .map(|item| item.into_row().key)
-                .collect();
+            let (pending, active) = Self::queue_prefix_counters(&queue_schema, &path)?;
             if active.len() >= (allow_concurrency as usize) {
                 return Ok(QueueRetrieveResponse::NotEnoughConcurrency { pending, active });
             }
@@ -1479,66 +1753,17 @@ impl CacheStore for RocksCacheStore {
                 return Ok(QueueRetrieveResponse::NotFound { pending, active });
             };
 
-            if id_row.get_row().get_status() == &QueueItemStatus::Pending {
-                if id_row.get_row().get_exclusive() {
-                    match (id_row.get_row().get_process_id(), &caller_process_id) {
-                        (Some(_), None) => return Err(CubeError::user(
-                            "QUEUE RETRIEVE requires a process_id in the connection context (x-process-id header)".to_string(),
-                        )),
-                        (None, Some(_)) => {
-                            log::warn!("Incorrect queue_item with exclusive flag, empty process_id, id: {:?}", caller_process_id);
+            let queue_payload_schema = QueueItemPayloadRocksTable::new(db_ref.clone());
 
-                            return Ok(QueueRetrieveResponse::NotFound { pending, active })
-                        }
-                        (Some(item_process_id), Some(caller_id)) => if item_process_id == caller_id {
-                            // OK, caller matches the exclusive item owner
-                        } else {
-                            return Ok(QueueRetrieveResponse::ExclusiveAccessFailed {
-                                pending,
-                                active,
-                            })
-                        },
-                        (None, None) => {
-                            // No process_id on item and no caller — allow retrieval
-                        }
-                    }
-                }
-
-                let mut new = id_row.get_row().clone();
-                new.status = QueueItemStatus::Active;
-                // It's important to insert heartbeat, because
-                // without that created datetime will be used for orphaned filtering
-                new.update_heartbeat();
-
-                let queue_payload_schema = QueueItemPayloadRocksTable::new(db_ref.clone());
-
-                let res =
-                    queue_schema.update(id_row.get_id(), new, id_row.get_row(), batch_pipe)?;
-                let payload = if let Some(r) = queue_payload_schema.get_row(res.get_id())? {
-                    r.into_row().value
-                } else {
-                    error!(
-                        "Unable to find payload for queue item, id = {}",
-                        res.get_id()
-                    );
-
-                    queue_schema.delete_row(res, batch_pipe)?;
-
-                    return Ok(QueueRetrieveResponse::NotFound { pending, active });
-                };
-
-                active.push(res.get_row().get_key().clone());
-                pending -= 1;
-                Ok(QueueRetrieveResponse::Success {
-                    id: id_row.get_id(),
-                    payload,
-                    item: res.into_row(),
-                    pending,
-                    active,
-                })
-            } else {
-                Ok(QueueRetrieveResponse::LockFailed { pending, active })
-            }
+            Self::try_claim_queue_item(
+                &queue_schema,
+                &queue_payload_schema,
+                batch_pipe,
+                id_row,
+                &caller_process_id,
+                pending,
+                active,
+            )
         })
         .await
     }
@@ -1799,6 +2024,13 @@ impl CacheStore for ClusterCacheStoreClient {
 
     async fn queue_add(&self, _payload: QueueAddPayload) -> Result<QueueAddResponse, CubeError> {
         panic!("CacheStore cannot be used on the worker node! queue_add was used.")
+    }
+
+    async fn queue_add_and_retrieve(
+        &self,
+        _payload: QueueAddAndRetrievePayload,
+    ) -> Result<QueueAddAndRetrieveResponse, CubeError> {
+        panic!("CacheStore cannot be used on the worker node! queue_add_and_retrieve was used.")
     }
 
     async fn queue_clear(&self) -> Result<(), CubeError> {
@@ -2590,6 +2822,207 @@ mod tests {
         }
 
         RocksCacheStore::cleanup_test_cachestore("test_queue_add_validations");
+
+        Ok(())
+    }
+
+    async fn assert_queue_item_status(
+        cachestore: &Arc<RocksCacheStore>,
+        key: &str,
+        status: QueueItemStatus,
+        with_heartbeat: bool,
+    ) -> Result<(), CubeError> {
+        let item = cachestore
+            .queue_all(None)
+            .await?
+            .into_iter()
+            .find(|row| row.item.get_row().get_key() == key)
+            .expect("queue item must exist");
+
+        assert_eq!(item.item.get_row().get_status(), &status, "key: {}", key);
+        assert_eq!(
+            item.item.get_row().get_heartbeat().is_some(),
+            with_heartbeat,
+            "heartbeat for key: {}",
+            key
+        );
+
+        Ok(())
+    }
+
+    fn queue_add_and_retrieve_payload(
+        path: &str,
+        value: &str,
+        concurrency: u32,
+    ) -> QueueAddAndRetrievePayload {
+        QueueAddAndRetrievePayload {
+            path: path.to_string(),
+            value: value.to_string(),
+            priority: 0,
+            orphaned: None,
+            process_id: None,
+            exclusive: false,
+            external_id: None,
+            concurrency,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_queue_add_and_retrieve() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
+            "test_queue_add_and_retrieve",
+            Config::test("test_queue_add_and_retrieve"),
+        );
+
+        // A brand new item is claimed right away, it's inserted with the active status
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path1", "v1", 1))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, Some("v1".to_string()));
+        assert_eq!(res.extra, None);
+        assert_eq!(res.active, vec!["path1".to_string()]);
+        // A claimed item is inserted as active, it was never pending
+        assert_eq!(res.pending, 0);
+
+        assert_queue_item_status(&cachestore, "path1", QueueItemStatus::Active, true).await?;
+
+        // The concurrency budget is used up by path1, path2 stays pending
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2", 1))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, None);
+        assert_eq!(res.active, vec!["path1".to_string()]);
+        assert_eq!(res.pending, 1);
+
+        assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
+
+        // The same path is not inserted twice, but it can be claimed when there is a room.
+        // The stored value is returned, not the value of this call.
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2-dup", 2))
+            .await?;
+        assert!(!res.added);
+        assert_eq!(res.payload, Some("v2".to_string()));
+        assert_eq!(res.pending, 0);
+
+        let mut active = res.active;
+        active.sort();
+        assert_eq!(active, vec!["path1".to_string(), "path2".to_string()]);
+
+        assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Active, true).await?;
+
+        // An already active item cannot be claimed again
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path1", "v1", 5))
+            .await?;
+        assert!(!res.added);
+        assert_eq!(res.payload, None);
+        assert_eq!(res.pending, 0);
+        assert_eq!(res.active.len(), 2);
+
+        // A zero concurrency never claims
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 0))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, None);
+        assert_eq!(res.pending, 1);
+
+        assert_queue_item_status(&cachestore, "path3", QueueItemStatus::Pending, false).await?;
+
+        // A plain QUEUE ADD never claims, it always inserts a pending item
+        let res = cachestore
+            .queue_add(QueueAddPayload {
+                path: "prefix:path4".to_string(),
+                value: "v4".to_string(),
+                priority: 0,
+                orphaned: None,
+                process_id: None,
+                exclusive: false,
+                external_id: None,
+            })
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.pending, 2);
+
+        assert_queue_item_status(&cachestore, "path4", QueueItemStatus::Pending, false).await?;
+
+        RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_queue_add_and_retrieve_exclusive() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
+            "test_queue_add_and_retrieve_excl",
+            Config::test("test_queue_add_and_retrieve_excl"),
+        );
+
+        // The process_id of a brand new item is the process_id of the caller,
+        // the exclusive flag can never block the claim on insert
+        let res = cachestore
+            .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                process_id: Some("process-a".to_string()),
+                exclusive: true,
+                ..queue_add_and_retrieve_payload("prefix:path1", "v1", 1)
+            })
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, Some("v1".to_string()));
+
+        // No room for path2, it stays pending and exclusive for process-a
+        let res = cachestore
+            .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                process_id: Some("process-a".to_string()),
+                exclusive: true,
+                ..queue_add_and_retrieve_payload("prefix:path2", "v2", 1)
+            })
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, None);
+
+        // Another process cannot claim it
+        let res = cachestore
+            .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                process_id: Some("process-b".to_string()),
+                exclusive: true,
+                ..queue_add_and_retrieve_payload("prefix:path2", "v2", 5)
+            })
+            .await?;
+        assert!(!res.added);
+        assert_eq!(res.payload, None);
+        assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
+
+        // A caller without a process_id gets an error, nothing is written.
+        // It's reachable without the EXCLUSIVE keyword, because the item is exclusive.
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2", 5))
+            .await;
+        assert!(res.is_err(), "expected an error, actual: {:?}", res);
+        assert!(res.unwrap_err().to_string().contains("process_id"));
+        assert_eq!(cachestore.queue_all(None).await?.len(), 2);
+        assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
+
+        // The owner claims it
+        let res = cachestore
+            .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                process_id: Some("process-a".to_string()),
+                exclusive: true,
+                ..queue_add_and_retrieve_payload("prefix:path2", "v2", 5)
+            })
+            .await?;
+        assert!(!res.added);
+        assert_eq!(res.payload, Some("v2".to_string()));
+        assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Active, true).await?;
+
+        RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve_excl");
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -5,7 +5,6 @@ use crate::cachestore::cache_item::{
 use crate::cachestore::queue_item::{
     active_keys_to_value, QueueItem, QueueItemIndexKey, QueueItemRocksIndex, QueueItemRocksTable,
     QueueItemStatus, QueueResultAckEvent, QueueResultAckEventResult, QueueRetrieveResponse,
-    QUEUE_ITEM_PROCESS_ID_MAX_LEN,
 };
 use crate::cachestore::queue_result::{QueueResultRocksIndex, QueueResultRocksTable};
 use crate::cachestore::{compaction, QueueItemPayload, QueueResult};
@@ -1372,15 +1371,6 @@ impl CacheStore for RocksCacheStore {
     }
 
     async fn queue_add(&self, payload: QueueAddPayload) -> Result<QueueAddResponse, CubeError> {
-        if let Some(ref id) = payload.process_id {
-            if id.len() > QUEUE_ITEM_PROCESS_ID_MAX_LEN {
-                return Err(CubeError::user(format!(
-                    "process_id exceeds maximum allowed length of {} characters",
-                    QUEUE_ITEM_PROCESS_ID_MAX_LEN
-                )));
-            }
-        }
-
         self.write_operation_queue("queue_add", move |db_ref, batch_pipe| {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
             let pending = queue_schema.count_rows_by_index(
@@ -1437,15 +1427,6 @@ impl CacheStore for RocksCacheStore {
         &self,
         payload: QueueAddAndRetrievePayload,
     ) -> Result<QueueAddAndRetrieveResponse, CubeError> {
-        if let Some(ref id) = payload.process_id {
-            if id.len() > QUEUE_ITEM_PROCESS_ID_MAX_LEN {
-                return Err(CubeError::user(format!(
-                    "process_id exceeds maximum allowed length of {} characters",
-                    QUEUE_ITEM_PROCESS_ID_MAX_LEN
-                )));
-            }
-        }
-
         self.write_operation_queue("queue_add_and_retrieve", move |db_ref, batch_pipe| {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
             let (pending, mut active) = Self::queue_prefix_counters(&queue_schema, &payload.path)?;
@@ -2767,27 +2748,6 @@ mod tests {
                 "Second insert with None external_id should succeed"
             );
             assert!(res.unwrap().added);
-        }
-
-        // process_id exceeding max length should fail
-        {
-            let long_id = "x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN + 1);
-            let res = cachestore
-                .queue_add(QueueAddPayload {
-                    path: "prefix:path6".to_string(),
-                    value: "v6".to_string(),
-                    priority: 0,
-                    orphaned: None,
-                    process_id: Some(long_id),
-                    exclusive: false,
-                    external_id: None,
-                })
-                .await;
-            assert!(res.is_err(), "process_id exceeding max length should fail");
-            assert!(res
-                .unwrap_err()
-                .to_string()
-                .contains("process_id exceeds maximum allowed length"));
         }
 
         RocksCacheStore::cleanup_test_cachestore("test_queue_add_validations");

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -712,10 +712,8 @@ impl RocksCacheStore {
             .collect()
     }
 
-    /// Reads the concurrency budget of the prefix the path belongs to: the number of
-    /// pending items and the keys of the active ones. Shared by `QUEUE RETRIEVE` and
-    /// `QUEUE ADD_AND_RETRIEVE` so that both use the same (prefix scoped, exclusivity
-    /// and priority blind) budget.
+    /// The budget is prefix scoped, exclusivity and priority blind. Shared by
+    /// `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE` so that they cannot drift apart.
     fn queue_prefix_counters(
         queue_schema: &QueueItemRocksTable,
         path: &str,
@@ -739,10 +737,9 @@ impl RocksCacheStore {
         Ok((pending, active))
     }
 
-    /// Claims a pending queue item: moves it to the active status inside the caller's
-    /// batch and returns its payload. Shared by `QUEUE RETRIEVE` and
-    /// `QUEUE ADD_AND_RETRIEVE`, so both use identical exclusivity, heartbeat and
-    /// missing payload semantics. The concurrency budget must be checked by the caller.
+    /// Moves the item to the active status inside the caller's batch. Shared by
+    /// `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE`, so both use identical exclusivity,
+    /// heartbeat and missing payload semantics. The budget is checked by the caller.
     fn try_claim_queue_item(
         queue_schema: &QueueItemRocksTable,
         queue_payload_schema: &QueueItemPayloadRocksTable,
@@ -891,7 +888,6 @@ pub struct QueueAddAndRetrieveResponse {
 }
 
 impl QueueAddAndRetrieveResponse {
-    /// Wraps the outcome of a claim attempt on an item which already existed
     pub fn from_claim(id: u64, claim: QueueRetrieveResponse) -> Self {
         let (payload, extra, pending, active) = match claim {
             QueueRetrieveResponse::Success {
@@ -1471,7 +1467,6 @@ impl CacheStore for RocksCacheStore {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
             let (pending, mut active) = Self::queue_prefix_counters(&queue_schema, &payload.path)?;
 
-            // The same budget as QUEUE RETRIEVE CONCURRENCY uses
             let claim = active.len() < (payload.concurrency as usize);
 
             let index_key = QueueItemIndexKey::ByPath(payload.path.clone());
@@ -2876,7 +2871,6 @@ mod tests {
             Config::test("test_queue_add_and_retrieve"),
         );
 
-        // A brand new item is claimed right away, it's inserted with the active status
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path1", "v1", 1))
             .await?;
@@ -2889,7 +2883,6 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path1", QueueItemStatus::Active, true).await?;
 
-        // The concurrency budget is used up by path1, path2 stays pending
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2", 1))
             .await?;
@@ -2900,8 +2893,7 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
 
-        // The same path is not inserted twice, but it can be claimed when there is a room.
-        // The stored value is returned, not the value of this call.
+        // The stored value is returned, not the value of this call
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2-dup", 2))
             .await?;
@@ -2915,7 +2907,6 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Active, true).await?;
 
-        // An already active item cannot be claimed again
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path1", "v1", 5))
             .await?;
@@ -2924,7 +2915,6 @@ mod tests {
         assert_eq!(res.pending, 0);
         assert_eq!(res.active.len(), 2);
 
-        // A zero concurrency never claims
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 0))
             .await?;
@@ -2934,7 +2924,6 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path3", QueueItemStatus::Pending, false).await?;
 
-        // A plain QUEUE ADD never claims, it always inserts a pending item
         let res = cachestore
             .queue_add(QueueAddPayload {
                 path: "prefix:path4".to_string(),
@@ -2977,7 +2966,6 @@ mod tests {
         assert!(res.added);
         assert_eq!(res.payload, Some("v1".to_string()));
 
-        // No room for path2, it stays pending and exclusive for process-a
         let res = cachestore
             .queue_add_and_retrieve(QueueAddAndRetrievePayload {
                 process_id: Some("process-a".to_string()),
@@ -2988,7 +2976,6 @@ mod tests {
         assert!(res.added);
         assert_eq!(res.payload, None);
 
-        // Another process cannot claim it
         let res = cachestore
             .queue_add_and_retrieve(QueueAddAndRetrievePayload {
                 process_id: Some("process-b".to_string()),
@@ -3010,7 +2997,6 @@ mod tests {
         assert_eq!(cachestore.queue_all(None).await?.len(), 2);
         assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
 
-        // The owner claims it
         let res = cachestore
             .queue_add_and_retrieve(QueueAddAndRetrievePayload {
                 process_id: Some("process-a".to_string()),

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -1423,6 +1423,12 @@ impl CacheStore for RocksCacheStore {
         &self,
         payload: QueueAddAndRetrievePayload,
     ) -> Result<QueueAddAndRetrieveResponse, CubeError> {
+        if payload.exclusive && payload.process_id.is_none() {
+            return Err(CubeError::user(
+                "An exclusive queue item requires a process_id".to_string(),
+            ));
+        }
+
         self.write_operation_queue("queue_add_and_retrieve", move |db_ref, batch_pipe| {
             let queue_schema = QueueItemRocksTable::new(db_ref.clone());
             let (pending, mut active) = Self::queue_prefix_counters(&queue_schema, &payload.path)?;
@@ -1465,10 +1471,8 @@ impl CacheStore for RocksCacheStore {
                 return Ok(QueueAddAndRetrieveResponse::from_claim(id, claim_result));
             }
 
-            // A brand new item is inserted with the active status right away, it saves
-            // an update of the just written row (and its secondary indexes) inside the
-            // same batch. The exclusive flag can never block it: the process_id of a new
-            // item is the process_id of the caller, see sql/cachestore.rs.
+            // Inserting a claimed item as active saves an update of the just written row
+            // (and its secondary indexes) inside the same batch
             let mut item = QueueItem::new(
                 payload.path,
                 if claim {
@@ -1477,7 +1481,7 @@ impl CacheStore for RocksCacheStore {
                     QueueItem::status_default()
                 },
                 payload.priority,
-                payload.orphaned.clone(),
+                payload.orphaned,
                 payload.process_id,
                 payload.exclusive,
                 payload.external_id,
@@ -2978,8 +2982,7 @@ mod tests {
         assert_eq!(res.payload, None);
         assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Pending, false).await?;
 
-        // A caller without a process_id gets an error, nothing is written.
-        // It's reachable without the EXCLUSIVE keyword, because the item is exclusive.
+        // Reachable without the EXCLUSIVE keyword, because the item itself is exclusive
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path2", "v2", 5))
             .await;
@@ -2998,6 +3001,18 @@ mod tests {
         assert!(!res.added);
         assert_eq!(res.payload, Some("v2".to_string()));
         assert_queue_item_status(&cachestore, "path2", QueueItemStatus::Active, true).await?;
+
+        // An exclusive item without an owner would be inserted straight in the active
+        // status and could never be claimed back
+        let res = cachestore
+            .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                exclusive: true,
+                ..queue_add_and_retrieve_payload("prefix:path3", "v3", 5)
+            })
+            .await;
+        assert!(res.is_err(), "expected an error, actual: {:?}", res);
+        assert!(res.unwrap_err().to_string().contains("process_id"));
+        assert_eq!(cachestore.queue_all(None).await?.len(), 2);
 
         RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve_excl");
 

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -1439,11 +1439,10 @@ impl CacheStore for RocksCacheStore {
                 _ => pending,
             };
 
-            // A deep backlog is left to QUEUE PENDING + reconcile, which pick by priority.
-            // Claiming the item being added ignores priority, it's acceptable only while
-            // there is almost nothing to jump over.
-            let claim = active.len() < (payload.concurrency as usize)
-                && backlog * 2 < (payload.concurrency as u64);
+            // Claiming the item being added ignores priority, it's harmless exactly while a
+            // slot is left over for every pending item too, so nothing can be jumped over.
+            // A deeper backlog is left to QUEUE PENDING + reconcile, which pick by priority.
+            let claim = (active.len() as u64) + backlog < (payload.concurrency as u64);
 
             if let Some(id_row) = id_row_opt {
                 let id = id_row.get_id();
@@ -2898,9 +2897,10 @@ mod tests {
                 .await?;
         }
 
-        // Every concurrency slot is free, only the backlog declines the claim
+        // Every concurrency slot is free, but claiming would leave the 2 pending items
+        // a single slot to share, so the item takes its place in the backlog instead
         let res = cachestore
-            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 4))
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 2))
             .await?;
         assert!(res.added);
         assert_eq!(res.payload, None);
@@ -2909,8 +2909,9 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path3", QueueItemStatus::Pending, false).await?;
 
+        // A slot is left over for every one of the 3 pending items, nothing is jumped over
         let res = cachestore
-            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path4", "v4", 7))
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path4", "v4", 4))
             .await?;
         assert!(res.added);
         assert_eq!(res.payload, Some("v4".to_string()));
@@ -2918,6 +2919,17 @@ mod tests {
         assert_eq!(res.pending, 3);
 
         assert_queue_item_status(&cachestore, "path4", QueueItemStatus::Active, true).await?;
+
+        // The very same budget declines the next claim, the slot it took is now busy
+        let res = cachestore
+            .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path5", "v5", 4))
+            .await?;
+        assert!(res.added);
+        assert_eq!(res.payload, None);
+        assert_eq!(res.active, vec!["path4".to_string()]);
+        assert_eq!(res.pending, 4);
+
+        assert_queue_item_status(&cachestore, "path5", QueueItemStatus::Pending, false).await?;
 
         RocksCacheStore::cleanup_test_cachestore("test_queue_add_and_retrieve_backlog");
 

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -870,8 +870,7 @@ pub struct QueueAddAndRetrievePayload {
     pub process_id: Option<String>,
     pub exclusive: bool,
     pub external_id: Option<String>,
-    /// The item is claimed only when the prefix has less than `concurrency` active
-    /// items. It's the same budget as `QUEUE RETRIEVE CONCURRENCY` uses.
+    /// The same budget as `QUEUE RETRIEVE CONCURRENCY` uses
     pub concurrency: u32,
 }
 
@@ -2980,8 +2979,7 @@ mod tests {
                 .await?;
         }
 
-        // 2 pending items is not less than a half of 4, the backlog is left to reconcile
-        // even though all the concurrency slots are free
+        // Every concurrency slot is free, only the backlog declines the claim
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path3", "v3", 4))
             .await?;
@@ -2992,7 +2990,6 @@ mod tests {
 
         assert_queue_item_status(&cachestore, "path3", QueueItemStatus::Pending, false).await?;
 
-        // 3 pending items is less than a half of 7
         let res = cachestore
             .queue_add_and_retrieve(queue_add_and_retrieve_payload("prefix:path4", "v4", 7))
             .await?;

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -1,7 +1,7 @@
 use crate::cachestore::cache_eviction_manager::EvictionResult;
 use crate::cachestore::cache_rocksstore::{
-    CachestoreInfo, QueueAddPayload, QueueAddResponse, QueueAllItem, QueueGetResponse,
-    QueueListItem,
+    CachestoreInfo, QueueAddAndRetrievePayload, QueueAddAndRetrieveResponse, QueueAddPayload,
+    QueueAddResponse, QueueAllItem, QueueGetResponse, QueueListItem,
 };
 use crate::cachestore::queue_item::QueueRetrieveResponse;
 use crate::cachestore::{
@@ -292,6 +292,13 @@ impl CacheStore for LazyRocksCacheStore {
 
     async fn queue_add(&self, payload: QueueAddPayload) -> Result<QueueAddResponse, CubeError> {
         self.init().await?.queue_add(payload).await
+    }
+
+    async fn queue_add_and_retrieve(
+        &self,
+        payload: QueueAddAndRetrievePayload,
+    ) -> Result<QueueAddAndRetrieveResponse, CubeError> {
+        self.init().await?.queue_add_and_retrieve(payload).await
     }
 
     async fn queue_clear(&self) -> Result<(), CubeError> {

--- a/rust/cubestore/cubestore/src/cachestore/mod.rs
+++ b/rust/cubestore/cubestore/src/cachestore/mod.rs
@@ -22,7 +22,7 @@ pub use cache_rocksstore::{
 pub use lazy::LazyRocksCacheStore;
 pub use queue_item::{
     QueueItem, QueueItemStatus, QueueResultAckEvent, QueueRetrieveResponse,
-    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN,
+    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN, QUEUE_ITEM_PROCESS_ID_MAX_LEN,
 };
 pub use queue_item_payload::QueueItemPayload;
 pub use queue_result::QueueResult;

--- a/rust/cubestore/cubestore/src/cachestore/mod.rs
+++ b/rust/cubestore/cubestore/src/cachestore/mod.rs
@@ -20,7 +20,10 @@ pub use cache_rocksstore::{
     QueueResultResponse, RocksCacheStore,
 };
 pub use lazy::LazyRocksCacheStore;
-pub use queue_item::{QueueItem, QueueItemStatus, QueueResultAckEvent, QueueRetrieveResponse};
+pub use queue_item::{
+    QueueItem, QueueItemStatus, QueueResultAckEvent, QueueRetrieveResponse,
+    QUEUE_ITEM_EXTERNAL_ID_MAX_LEN,
+};
 pub use queue_item_payload::QueueItemPayload;
 pub use queue_result::QueueResult;
 pub use scheduler::CacheStoreSchedulerImpl;

--- a/rust/cubestore/cubestore/src/cachestore/mod.rs
+++ b/rust/cubestore/cubestore/src/cachestore/mod.rs
@@ -14,8 +14,9 @@ pub use cache_eviction_manager::{
 };
 pub use cache_item::CacheItem;
 pub use cache_rocksstore::{
-    CacheStore, CacheStoreRpcClient, CachestoreInfo, ClusterCacheStoreClient, QueueAddPayload,
-    QueueAddResponse, QueueAllItem, QueueCancelResponse, QueueGetResponse, QueueKey, QueueListItem,
+    CacheStore, CacheStoreRpcClient, CachestoreInfo, ClusterCacheStoreClient,
+    QueueAddAndRetrievePayload, QueueAddAndRetrieveResponse, QueueAddPayload, QueueAddResponse,
+    QueueAllItem, QueueCancelResponse, QueueGetResponse, QueueKey, QueueListItem,
     QueueResultResponse, RocksCacheStore,
 };
 pub use lazy::LazyRocksCacheStore;

--- a/rust/cubestore/cubestore/src/cachestore/queue_item.rs
+++ b/rust/cubestore/cubestore/src/cachestore/queue_item.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use crate::cachestore::QueueKey;
 use serde::{Deserialize, Deserializer, Serialize};
 
-// We use ${uuidv4()}-span-${u32}, it's 36 + 6 + 8 = 50, let's limit to 96
-pub const QUEUE_ITEM_PROCESS_ID_MAX_LEN: usize = 96;
+// It's the x-process-id header, a uuid (36 chars), bounded on ingress in src/http
+pub const QUEUE_ITEM_PROCESS_ID_MAX_LEN: usize = 64;
 // We use ${uuidv4()}, it's 36, let's limit to 48
 pub const QUEUE_ITEM_EXTERNAL_ID_MAX_LEN: usize = 48;
 

--- a/rust/cubestore/cubestore/src/cachestore/queue_item.rs
+++ b/rust/cubestore/cubestore/src/cachestore/queue_item.rs
@@ -309,6 +309,15 @@ pub enum QueueRetrieveResponse {
     },
 }
 
+/// Wire format of the `active` column, shared by all commands which report it
+pub fn active_keys_to_value(active: Vec<String>) -> TableValue {
+    if active.is_empty() {
+        TableValue::Null
+    } else {
+        TableValue::String(active.join(","))
+    }
+}
+
 impl QueueRetrieveResponse {
     pub fn into_queue_retrieve_rows(self, extended: bool) -> Vec<Row> {
         match self {
@@ -326,11 +335,7 @@ impl QueueRetrieveResponse {
                     TableValue::Null
                 },
                 TableValue::Int(pending as i64),
-                if active.len() > 0 {
-                    TableValue::String(active.join(","))
-                } else {
-                    TableValue::Null
-                },
+                active_keys_to_value(active),
                 TableValue::String(id.to_string()),
             ])],
             QueueRetrieveResponse::LockFailed { pending, active }
@@ -342,11 +347,7 @@ impl QueueRetrieveResponse {
                         TableValue::Null,
                         TableValue::Null,
                         TableValue::Int(pending as i64),
-                        if active.len() > 0 {
-                            TableValue::String(active.join(","))
-                        } else {
-                            TableValue::Null
-                        },
+                        active_keys_to_value(active),
                         TableValue::Null,
                     ])]
                 } else {

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -1841,7 +1841,6 @@ mod tests {
             request
         }
 
-        // The handshake is where the header is bounded, so an over-long one never gets a socket
         let err = connect_async(connect_request(
             &"x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN + 1),
         ))

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use warp::{Filter, Rejection, Reply};
 
+use crate::cachestore::QUEUE_ITEM_PROCESS_ID_MAX_LEN;
 use crate::metastore::{Column, ColumnType, ImportFormat};
 use crate::mysql::SqlAuthService;
 use crate::sql::{
@@ -63,6 +64,7 @@ crate::di_service!(HttpServer, []);
 #[derive(Debug)]
 pub enum CubeRejection {
     NotAuthorized,
+    BadRequest(String),
     Internal(String),
 }
 
@@ -76,6 +78,21 @@ impl From<CubeError> for warp::reject::Rejection {
 /// so they shouldn't pollute the error log.
 fn is_rate_limit_error(e: &CubeError) -> bool {
     e.message.to_ascii_lowercase().contains("rate limit")
+}
+
+/// `process_id` is connection scoped and reaches the cachestore as `QueueItem.process_id`,
+/// so it's bounded here, on its only ingress.
+fn check_process_id_header(process_id: &Option<String>) -> Result<(), CubeRejection> {
+    if let Some(id) = process_id {
+        if id.len() > QUEUE_ITEM_PROCESS_ID_MAX_LEN {
+            return Err(CubeRejection::BadRequest(format!(
+                "x-process-id header exceeds maximum allowed length of {} characters",
+                QUEUE_ITEM_PROCESS_ID_MAX_LEN
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Deserialize)]
@@ -124,13 +141,8 @@ impl HttpServer {
                 move |auth_header: Option<String>, process_id: Option<String>| {
                     let auth_service = auth_service.clone();
                     async move {
-                        if let Some(ref id) = process_id {
-                            if id.len() > 64 {
-                                return Err(warp::reject::custom(CubeRejection::Internal(
-                                    "x-process-id header exceeds 64 characters".to_string(),
-                                )));
-                            }
-                        }
+                        check_process_id_header(&process_id).map_err(warp::reject::custom)?;
+
                         let res = HttpServer::authorize(auth_service, auth_header).await;
                         match res {
                             Ok(user) => Ok(SqlQueryContext {
@@ -533,6 +545,13 @@ impl HttpServer {
                             Ok(warp::reply::with_status(
                                 warp::reply::json(&obj),
                                 StatusCode::FORBIDDEN,
+                            ))
+                        }
+                        CubeRejection::BadRequest(e) => {
+                            obj.insert("error".to_string(), e.to_string());
+                            Ok(warp::reply::with_status(
+                                warp::reply::json(&obj),
+                                StatusCode::BAD_REQUEST,
                             ))
                         }
                         CubeRejection::Internal(e) => {
@@ -1101,7 +1120,10 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::net::TcpStream;
-    use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::handshake::client::Request;
+    use tokio_tungstenite::tungstenite::http::HeaderValue;
+    use tokio_tungstenite::tungstenite::{Error as WsError, Message};
     use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
     use url::Url;
 
@@ -1758,6 +1780,84 @@ mod tests {
 
         let mut socket2 = connect_and_send(3, Some("foo2".to_string())).await;
         assert_message(&mut socket2, "10").await;
+
+        http_server.stop_processing().await;
+        Ok(())
+    }
+
+    #[test]
+    fn check_process_id_header_bounds() {
+        assert!(check_process_id_header(&None).is_ok());
+        assert!(check_process_id_header(&Some("".to_string())).is_ok());
+        assert!(
+            check_process_id_header(&Some("x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN))).is_ok(),
+            "the limit is inclusive"
+        );
+
+        let res = check_process_id_header(&Some("x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN + 1)));
+        match res {
+            Err(CubeRejection::BadRequest(msg)) => assert!(
+                msg.contains("x-process-id header exceeds maximum allowed length"),
+                "unexpected message: {}",
+                msg
+            ),
+            other => panic!("Expected CubeRejection::BadRequest, actual: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_process_id_header_test() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let mut auth = MockSqlAuthService::new();
+        auth.expect_authenticate().return_const(Ok(None));
+
+        let config = Config::test("ws_process_id_header_test").config_obj();
+
+        let http_server = Arc::new(HttpServer::new(
+            "127.0.0.1:53032".to_string(),
+            Arc::new(auth),
+            Arc::new(SqlServiceMock {
+                message_counter: AtomicU64::new(0),
+            }),
+            Duration::from_millis(100),
+            Duration::from_millis(10000),
+            Duration::from_millis(1000),
+            config.transport_max_message_size(),
+            config.transport_max_frame_size(),
+        ));
+        {
+            let http_server = http_server.clone();
+            cube_ext::spawn(async move { http_server.run_server().await });
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        fn connect_request(process_id: &str) -> Request {
+            let mut request = "ws://127.0.0.1:53032/ws".into_client_request().unwrap();
+            request
+                .headers_mut()
+                .insert("x-process-id", HeaderValue::from_str(process_id).unwrap());
+            request
+        }
+
+        // The handshake is where the header is bounded, so an over-long one never gets a socket
+        let err = connect_async(connect_request(
+            &"x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN + 1),
+        ))
+        .await
+        .err()
+        .expect("expected the handshake to be rejected");
+        match err {
+            WsError::Http(response) => assert_eq!(response.status().as_u16(), 400),
+            other => panic!("Expected an http error, actual: {:?}", other),
+        }
+
+        let (socket, _) =
+            connect_async(connect_request(&"x".repeat(QUEUE_ITEM_PROCESS_ID_MAX_LEN)))
+                .await
+                .expect("a header at the limit should be accepted");
+        drop(socket);
 
         http_server.stop_processing().await;
         Ok(())

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -838,6 +838,16 @@ impl CacheStore for CacheStoreMock {
         panic!("CacheStore mock queue_add, payload: {:?}!", payload)
     }
 
+    async fn queue_add_and_retrieve(
+        &self,
+        payload: crate::cachestore::QueueAddAndRetrievePayload,
+    ) -> Result<crate::cachestore::QueueAddAndRetrieveResponse, CubeError> {
+        panic!(
+            "CacheStore mock queue_add_and_retrieve, payload: {:?}!",
+            payload
+        )
+    }
+
     async fn queue_clear(&self) -> Result<(), CubeError> {
         panic!("CacheStore mock!")
     }

--- a/rust/cubestore/cubestore/src/sql/cachestore.rs
+++ b/rust/cubestore/cubestore/src/sql/cachestore.rs
@@ -1,4 +1,6 @@
-use crate::cachestore::{CacheItem, CacheStore, EvictionResult, QueueAddPayload, QueueItem};
+use crate::cachestore::{
+    CacheItem, CacheStore, EvictionResult, QueueAddAndRetrievePayload, QueueAddPayload, QueueItem,
+};
 use crate::metastore::{Column, ColumnType};
 
 use crate::cluster::rate_limiter::{ProcessRateLimiter, TaskType, TraceIndex};
@@ -372,6 +374,52 @@ impl CacheStoreSqlService {
                             TableValue::Boolean(response.added),
                             TableValue::Int(response.pending as i64),
                         ])],
+                    )),
+                    Some(value_size),
+                    true,
+                )
+            }
+            QueueCommand::AddAndRetrieve {
+                key,
+                exclusive,
+                priority,
+                orphaned,
+                value,
+                external_id,
+                concurrency,
+            } => {
+                if exclusive && context.process_id.is_none() {
+                    return Err(CubeError::user(
+                        "QUEUE ADD_AND_RETRIEVE EXCLUSIVE requires a process_id in the connection context (x-process-id header)".to_string(),
+                    ));
+                }
+
+                let value_size = key.value.deep_size_of() + value.deep_size_of();
+                let response = self
+                    .cachestore
+                    .queue_add_and_retrieve(QueueAddAndRetrievePayload {
+                        path: key.value,
+                        value,
+                        priority,
+                        orphaned,
+                        process_id: context.process_id.clone(),
+                        exclusive,
+                        external_id,
+                        concurrency,
+                    })
+                    .await?;
+
+                (
+                    Arc::new(DataFrame::new(
+                        vec![
+                            Column::new("id".to_string(), ColumnType::String, 0),
+                            Column::new("added".to_string(), ColumnType::Boolean, 1),
+                            Column::new("pending".to_string(), ColumnType::Int, 2),
+                            Column::new("active".to_string(), ColumnType::String, 3),
+                            Column::new("payload".to_string(), ColumnType::String, 4),
+                            Column::new("extra".to_string(), ColumnType::String, 5),
+                        ],
+                        vec![response.into_queue_add_and_retrieve_row()],
                     )),
                     Some(value_size),
                     true,

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -121,6 +121,17 @@ pub enum QueueCommand {
         value: String,
         external_id: Option<String>,
     },
+    /// `QUEUE ADD` which also claims the item (moves it to the active status) in the
+    /// same atomic operation, when the prefix has less than `concurrency` active items.
+    AddAndRetrieve {
+        exclusive: bool,
+        priority: i64,
+        orphaned: Option<u32>,
+        key: Ident,
+        value: String,
+        external_id: Option<String>,
+        concurrency: u32,
+    },
     Get {
         key: QueueKey,
     },
@@ -169,6 +180,7 @@ impl QueueCommand {
     pub fn as_tag_command(&self) -> &'static str {
         match self {
             QueueCommand::Add { .. } => "add",
+            QueueCommand::AddAndRetrieve { .. } => "add_and_retrieve",
             QueueCommand::Get { .. } => "get",
             QueueCommand::ToCancel { .. } => "to_cancel",
             QueueCommand::List { status_filter, .. } => match status_filter {
@@ -673,6 +685,31 @@ impl<'a> CubeStoreParser<'a> {
                     key: self.parse_identifier()?,
                     value: self.parse_literal_string()?,
                     external_id,
+                }
+            }
+            "add_and_retrieve" => {
+                let mut exclusive = false;
+                let mut priority = 0i64;
+                let mut orphaned: Option<u32> = None;
+                let mut external_id: Option<String> = None;
+
+                parse_sql_options!(self, {
+                    "exclusive" => { exclusive = true },
+                    "priority" => { priority = self.parse_integer("priority", true)? },
+                    "orphaned" => { orphaned = Some(self.parse_integer("orphaned", false)?) },
+                    // Placeholder aware, unlike self.parser.parse_literal_string
+                    "external_id" => { external_id = Some(self.parse_literal_string()?) },
+                });
+
+                QueueCommand::AddAndRetrieve {
+                    exclusive,
+                    priority,
+                    orphaned,
+                    key: self.parse_identifier()?,
+                    value: self.parse_literal_string()?,
+                    external_id,
+                    // Concurrency is a required argument, it goes after the value
+                    concurrency: self.parse_integer("concurrency", false)?,
                 }
             }
             "cancel" => QueueCommand::Cancel {
@@ -1234,6 +1271,88 @@ mod tests {
     }
 
     #[test]
+    fn parse_queue_add_and_retrieve() -> Result<(), CubeError> {
+        // Concurrency is the required third positional argument
+        let res = parse_stmt("QUEUE ADD_AND_RETRIEVE 'key' 'value' 4")?;
+        match res {
+            Statement::Queue(QueueCommand::AddAndRetrieve {
+                exclusive,
+                priority,
+                orphaned,
+                key,
+                value,
+                external_id,
+                concurrency,
+            }) => {
+                assert!(!exclusive);
+                assert_eq!(priority, 0);
+                assert_eq!(orphaned, None);
+                assert_eq!(key.value, "key");
+                assert_eq!(value, "value");
+                assert_eq!(external_id, None);
+                assert_eq!(concurrency, 4);
+            }
+            _ => panic!("Expected QueueCommand::AddAndRetrieve"),
+        }
+
+        // Options are supported and order independent
+        let res = parse_stmt(
+            "QUEUE ADD_AND_RETRIEVE ORPHANED 60 EXCLUSIVE PRIORITY -3 EXTERNAL_ID 'ext' 'key' 'value' 1",
+        )?;
+        match res {
+            Statement::Queue(QueueCommand::AddAndRetrieve {
+                exclusive,
+                priority,
+                orphaned,
+                external_id,
+                concurrency,
+                ..
+            }) => {
+                assert!(exclusive);
+                assert_eq!(priority, -3);
+                assert_eq!(orphaned, Some(60));
+                assert_eq!(external_id, Some("ext".to_string()));
+                assert_eq!(concurrency, 1);
+            }
+            _ => panic!("Expected QueueCommand::AddAndRetrieve"),
+        }
+
+        // Concurrency is required
+        let res = parse_stmt("QUEUE ADD_AND_RETRIEVE 'key' 'value'");
+        assert!(res.is_err(), "expected parse error, got: {:?}", res);
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_queue_add_and_retrieve_placeholders() -> Result<(), CubeError> {
+        let mut parser = CubeStoreParser::new(
+            "QUEUE ADD_AND_RETRIEVE ? ? ?",
+            Some(vec![
+                QueryParameter::StringValue("key".to_string()),
+                QueryParameter::StringValue("value".to_string()),
+                QueryParameter::Int64Value(8),
+            ]),
+        )?;
+
+        match parser.parse_statement()? {
+            Statement::Queue(QueueCommand::AddAndRetrieve {
+                key,
+                value,
+                concurrency,
+                ..
+            }) => {
+                assert_eq!(key.value, "key");
+                assert_eq!(value, "value");
+                assert_eq!(concurrency, 8);
+            }
+            other => panic!("Expected QueueCommand::AddAndRetrieve, actual: {:?}", other),
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn parse_queue_add_duplicate_option_error() -> Result<(), CubeError> {
         let res = parse_stmt("QUEUE ADD PRIORITY 1 PRIORITY 2 'key' 'value'");
         assert!(res.is_err());
@@ -1248,6 +1367,13 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Duplicate option: EXCLUSIVE"));
+
+        let res = parse_stmt("QUEUE ADD_AND_RETRIEVE ORPHANED 1 ORPHANED 2 'key' 'value' 1");
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("Duplicate option: ORPHANED"));
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -1,4 +1,4 @@
-use crate::cachestore::{QueueItemStatus, QueueKey};
+use crate::cachestore::{QueueItemStatus, QueueKey, QUEUE_ITEM_EXTERNAL_ID_MAX_LEN};
 use crate::sql::{QueryParameter, QueryParameters};
 use sqlparser::ast::{
     ColumnDef, CreateIndex, CreateTable, HiveDistributionStyle, Ident, ObjectName, Query,
@@ -458,6 +458,18 @@ impl<'a> CubeStoreParser<'a> {
         }
     }
 
+    fn parse_external_id(&mut self) -> Result<String, ParserError> {
+        let external_id = self.parse_literal_string()?;
+        if external_id.len() > QUEUE_ITEM_EXTERNAL_ID_MAX_LEN {
+            return Err(ParserError::ParserError(format!(
+                "external_id exceeds maximum allowed length of {} characters",
+                QUEUE_ITEM_EXTERNAL_ID_MAX_LEN
+            )));
+        }
+
+        Ok(external_id)
+    }
+
     fn parse_identifier(&mut self) -> Result<Ident, ParserError> {
         if let Token::Placeholder(placeholder) = self.parser.peek_token().token {
             self.parser.next_token();
@@ -675,7 +687,7 @@ impl<'a> CubeStoreParser<'a> {
                     "exclusive" => { exclusive = true },
                     "priority" => { priority = self.parse_integer("priority", true)? },
                     "orphaned" => { orphaned = Some(self.parse_integer("orphaned", false)?) },
-                    "external_id" => { external_id = Some(self.parser.parse_literal_string()?) },
+                    "external_id" => { external_id = Some(self.parse_external_id()?) },
                 });
 
                 QueueCommand::Add {
@@ -697,8 +709,7 @@ impl<'a> CubeStoreParser<'a> {
                     "exclusive" => { exclusive = true },
                     "priority" => { priority = self.parse_integer("priority", true)? },
                     "orphaned" => { orphaned = Some(self.parse_integer("orphaned", false)?) },
-                    // Placeholder aware, unlike self.parser.parse_literal_string
-                    "external_id" => { external_id = Some(self.parse_literal_string()?) },
+                    "external_id" => { external_id = Some(self.parse_external_id()?) },
                 });
 
                 QueueCommand::AddAndRetrieve {
@@ -809,7 +820,7 @@ impl<'a> CubeStoreParser<'a> {
             }
             "result" => {
                 let external_id = if self.parse_custom_token("external_id") {
-                    Some(self.parser.parse_literal_string()?)
+                    Some(self.parse_external_id()?)
                 } else {
                     None
                 };
@@ -1343,6 +1354,77 @@ mod tests {
                 assert_eq!(concurrency, 8);
             }
             other => panic!("Expected QueueCommand::AddAndRetrieve, actual: {:?}", other),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_queue_external_id_max_len() -> Result<(), CubeError> {
+        let max_id = "x".repeat(QUEUE_ITEM_EXTERNAL_ID_MAX_LEN);
+        let too_long_id = "x".repeat(QUEUE_ITEM_EXTERNAL_ID_MAX_LEN + 1);
+
+        // The limit is inclusive
+        match parse_stmt(&format!("QUEUE ADD EXTERNAL_ID '{}' 'key' 'value'", max_id))? {
+            Statement::Queue(QueueCommand::Add { external_id, .. }) => {
+                assert_eq!(external_id, Some(max_id.clone()));
+            }
+            other => panic!("Expected QueueCommand::Add, actual: {:?}", other),
+        }
+
+        match parse_stmt(&format!(
+            "QUEUE ADD_AND_RETRIEVE EXTERNAL_ID '{}' 'key' 'value' 1",
+            max_id
+        ))? {
+            Statement::Queue(QueueCommand::AddAndRetrieve { external_id, .. }) => {
+                assert_eq!(external_id, Some(max_id.clone()));
+            }
+            other => panic!("Expected QueueCommand::AddAndRetrieve, actual: {:?}", other),
+        }
+
+        match parse_stmt(&format!("QUEUE RESULT EXTERNAL_ID '{}' 'key'", max_id))? {
+            Statement::Queue(QueueCommand::Result { external_id, .. }) => {
+                assert_eq!(external_id, Some(max_id.clone()));
+            }
+            other => panic!("Expected QueueCommand::Result, actual: {:?}", other),
+        }
+
+        for query in [
+            format!("QUEUE ADD EXTERNAL_ID '{}' 'key' 'value'", too_long_id),
+            format!(
+                "QUEUE ADD_AND_RETRIEVE EXTERNAL_ID '{}' 'key' 'value' 1",
+                too_long_id
+            ),
+            format!("QUEUE RESULT EXTERNAL_ID '{}' 'key'", too_long_id),
+        ] {
+            let res = parse_stmt(&query);
+            assert!(res.is_err(), "expected parse error for: {}", query);
+
+            let msg = res.unwrap_err().to_string();
+            assert!(
+                msg.contains("external_id exceeds maximum allowed length"),
+                "unexpected error for {}: {}",
+                query,
+                msg
+            );
+        }
+
+        // Values coming from parameters are validated too
+        {
+            let mut parser = CubeStoreParser::new(
+                "QUEUE ADD EXTERNAL_ID ? 'key' 'value'",
+                Some(vec![QueryParameter::StringValue(too_long_id)]),
+            )?;
+
+            let res = parser.parse_statement();
+            assert!(res.is_err(), "expected parse error, got: {:?}", res);
+
+            let msg = res.unwrap_err().to_string();
+            assert!(
+                msg.contains("external_id exceeds maximum allowed length"),
+                "unexpected error: {}",
+                msg
+            );
         }
 
         Ok(())

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -122,7 +122,7 @@ pub enum QueueCommand {
         external_id: Option<String>,
     },
     /// `QUEUE ADD` which also claims the item (moves it to the active status) in the
-    /// same atomic operation, when the prefix has less than `concurrency` active items.
+    /// same atomic operation, when the `concurrency` budget of the prefix allows it.
     AddAndRetrieve {
         exclusive: bool,
         priority: i64,

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -708,7 +708,6 @@ impl<'a> CubeStoreParser<'a> {
                     key: self.parse_identifier()?,
                     value: self.parse_literal_string()?,
                     external_id,
-                    // Concurrency is a required argument, it goes after the value
                     concurrency: self.parse_integer("concurrency", false)?,
                 }
             }
@@ -1272,7 +1271,6 @@ mod tests {
 
     #[test]
     fn parse_queue_add_and_retrieve() -> Result<(), CubeError> {
-        // Concurrency is the required third positional argument
         let res = parse_stmt("QUEUE ADD_AND_RETRIEVE 'key' 'value' 4")?;
         match res {
             Statement::Queue(QueueCommand::AddAndRetrieve {
@@ -1295,7 +1293,6 @@ mod tests {
             _ => panic!("Expected QueueCommand::AddAndRetrieve"),
         }
 
-        // Options are supported and order independent
         let res = parse_stmt(
             "QUEUE ADD_AND_RETRIEVE ORPHANED 60 EXCLUSIVE PRIORITY -3 EXTERNAL_ID 'ext' 'key' 'value' 1",
         )?;
@@ -1317,7 +1314,6 @@ mod tests {
             _ => panic!("Expected QueueCommand::AddAndRetrieve"),
         }
 
-        // Concurrency is required
         let res = parse_stmt("QUEUE ADD_AND_RETRIEVE 'key' 'value'");
         assert!(res.is_err(), "expected parse error, got: {:?}", res);
 


### PR DESCRIPTION
Taking a job into work costs two round-trips today: QUEUE ADD inserts the item as pending, then QUEUE RETRIEVE flips it to active and returns the payload. The gap between the two calls is also where another node can take the slot.

QUEUE ADD_AND_RETRIEVE inserts and claims the item in the same atomic RocksDB batch when the prefix has spare concurrency:

    QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY n] [ORPHANED n]
        [EXTERNAL_ID 's'] <key> '<value>' <concurrency>

refs https://github.com/cube-js/cube/issues/8490
