### PR TITLE
docs: fill four small customer-facing doc gaps

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -13,17 +13,20 @@ It is a setting on an existing chart, not a chart type of its own: a bar, line, 
 
 The **Small multiples** section appears in the Fields tab for bar, line, area, and scatter charts.
 
-Pick a dimension in **Split by** and the chart is replaced by one panel per value of that dimension. Clearing the picker returns the chart to a single plot.
+Pick a dimension in **First dimension** and the chart is replaced by one panel per value of that dimension. Clearing the picker returns the chart to a single plot.
 
-Only dimensions are offered. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
+Optionally pick a second dimension in **Second dimension** to lay panels out in a grid with the first dimension across columns and the second down rows, instead of a single wrapped sequence of panels. Clearing the second picker collapses the grid back to the one-dimensional layout.
+
+Only dimensions are offered in either picker. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
 
 ## Options
 
-These options appear once a **Split by** dimension is chosen.
+These options appear once a **First dimension** is chosen.
 
 | Option | What it does |
 |---|---|
-| **Grid** | Columns × rows, up to 5 × 5. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
+| **Columns** | Caps the number of panels drawn across the first dimension's values, up to 5. Preselected from the number of distinct values, so a four-value dimension opens at 4 columns. When a second dimension is set, this caps the column axis independently of the row axis. |
+| **Rows** | Only shown once a **Second dimension** is chosen. Caps the number of panels drawn across the second dimension's values, up to 5, independently of **Columns**. |
 | **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
@@ -38,9 +41,9 @@ Switch to **Independent** when the question is about the *shape* of each series 
 
 ### How many panels are drawn
 
-The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 5, or twenty-five panels.
+Each axis is capped independently: **Columns** bounds the first dimension's values and, when a second dimension is set, **Rows** separately bounds the second dimension's values — so a 3-column × 2-row grid draws at most six panels. Since each axis clamps on its own, the largest grid is 5 × 5, or twenty-five panels, regardless of how many distinct values either dimension has.
 
-When a dimension has more values than the grid has tiles, the chart draws the first ones in the current sort order. The underlying query is unaffected, so no data is lost — a bigger grid simply shows more of it.
+When a dimension has more values than its axis has room for, the chart draws the first ones in the current sort order on that axis. The underlying query is unaffected, so no data is lost — a bigger grid simply shows more of it. A combination of the two dimensions' values that has no matching data renders as an empty panel labeled **No data**.
 
 Sorting interacts with this: with **Sort panels by** set to a measure and a descending order, the grid keeps the top panels by that measure, which is usually more useful than the first ones alphabetically.
 
@@ -54,7 +57,7 @@ A legend is shared across the grid rather than repeated per panel. Clicking a le
 
 ## Limitations
 
-- **One split dimension.** One dimension fills the grid, panel by panel. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
+- **Up to two split dimensions.** A grid can facet by a first dimension (columns) and, optionally, a second (rows) — not more.
 - **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, boxplot, map, and HTML charts cannot be split.
 - **Panel labels are not configurable.** Each panel is labeled with its dimension value; the font, size, and color are fixed.
 - **The split is enabled on a single-view chart.** A chart that already carries data labels, a reference line, or a second Y axis series cannot be split — turn the split on first. The order is the only constraint: once a chart is split, data labels and reference lines can be added freely and are drawn in every panel.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/ai-summary.mdx
@@ -1,13 +1,13 @@
 ---
-title: AI summary
+title: Analysis
 description: Generate natural-language summaries of dashboard data on demand using an AI agent.
 ---
 
-AI summary widgets generate a natural-language summary of the data shown on the dashboard. Write a prompt — for example, _"Summarize the key trends and call out anything unusual"_ — and the configured [AI agent][ref-agents] produces a Markdown narrative based on the current dashboard state, including the data behind every chart and the values of any active [controls][ref-controls].
+Analysis widgets generate a natural-language summary of the data shown on the dashboard. Write a prompt — for example, _"Summarize the key trends and call out anything unusual"_ — and the configured [AI agent][ref-agents] produces a Markdown narrative based on the current dashboard state, including the data behind every chart and the values of any active [controls][ref-controls].
 
-## Adding an AI summary
+## Adding an Analysis widget
 
-In the [dashboard builder][ref-workbooks], add an AI summary from the **Add Widgets** menu in the toolbar. The widget opens with a prompt editor — write your prompt and click **Generate Summary** to produce the first response.
+In the [dashboard builder][ref-workbooks], add an Analysis widget from the **Add Widgets** menu in the toolbar. The widget opens with a prompt editor — write your prompt and click **Run** to produce the first response. A widget that hasn't been run yet shows "Analysis is not run yet" with a **Run** button.
 
 ## Use cases
 
@@ -28,11 +28,11 @@ Once generated, the summary is **cached** with the widget. Viewers loading the d
 
 The widget keeps a checksum of the dashboard state at the time of generation: the queries behind each chart, the active control values, and the chart configuration. When any of those change, the widget marks the cached summary as **stale** and shows a refresh prompt so viewers know the narrative may no longer match the data.
 
-Click the refresh icon (or open the widget menu and choose **Refresh**) to regenerate using the saved prompt against the latest state.
+On a published dashboard, a widget that has run shows a freshness indicator instead of a menu — colored by how old the data is, with a tooltip reading "Refreshed *N* ago". Open it and choose **Refresh** to regenerate using the saved prompt against the latest state. The dashboard's **Refresh all charts** control also refreshes any Analysis widget that has already run at least once.
 
 ## Choosing the agent
 
-By default, AI summaries use the agent configured at the dashboard level. You can override the agent per widget when you need a particular [agent's][ref-agents] tooling, model, or guardrails for a specific summary.
+By default, Analysis widgets use the agent configured at the dashboard level. You can override the agent per widget when you need a particular [agent's][ref-agents] tooling, model, or guardrails for a specific summary.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-agents]: /admin/ai

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -12,7 +12,7 @@ The dashboard builder supports the following widget types:
 - [Charts](/docs/explore-analyze/dashboards/widgets/charts) — Visualize reports from your workbook
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data or switch the time granularity
-- [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
+- [Analysis](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
 - [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks (in preview)
 
 ## Adding widgets

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -187,23 +187,29 @@ For any MCP-compatible client:
 
 An MCP client is not locked to a single deployment for the whole session. After
 connecting, it can discover the deployments and agents you can access and target a
-specific one on each request.
-
-Three tools work together:
+specific one on each request — every tool except `listDeployments` accepts an optional
+**`deploymentId`**, and falls back to the deployment resolved at connect time when it's
+omitted.
 
 - **`listDeployments`** — discovery. Returns every deployment you can access via MCP
   (already filtered by the admin's deployment-access settings and your permissions) and
-  each deployment's agents. Use it to find valid `deploymentId` and `agentId` values
-  before calling `chat`. Every deployment offers an **Auto** agent (`agentId: null`) in
-  addition to any configured agents.
+  each deployment's agents. Use it to find valid `deploymentId` and `agentId` values.
+  Every deployment offers an **Auto** agent (`agentId: null`) in addition to any
+  configured agents.
 - **`chat`** — accepts two optional selection parameters:
   - **`deploymentId`** — the deployment to use for this request. When omitted, the chat
     uses the deployment from the current session (the default resolved at connect time).
   - **`agentId`** — the agent to use for this request. When omitted or `null`, the
     deployment's **Auto** agent is used. Pass a specific `agentId` to route to a
     configured agent.
-- **`loadQueryResults`** — paginates through the results of a previous query on the same
-  deployment context.
+- **Every other tool** — dashboard authoring, data model editing, query and discovery,
+  and pre-aggregation tools all accept the same optional `deploymentId`, resolved and
+  permission-checked the same way as for `chat`.
+
+**Resuming a conversation.** `loadQueryResults` and `visualize`, and `chat` when it's
+passed an existing `chatId`, act on a thread that already belongs to one deployment —
+they derive `deploymentId` from that thread instead of accepting an arbitrary one, and
+reject a `deploymentId` that conflicts with it.
 
 A typical client workflow:
 

--- a/docs-mintlify/docs/organize-content/sharing.mdx
+++ b/docs-mintlify/docs/organize-content/sharing.mdx
@@ -38,6 +38,12 @@ Sharing permissions are organized into three levels:
 
 The creator of a piece of content automatically receives **Full access**.
 
+For an exploration, **Can view** opens it in a read-only view: charts and data are
+visible, but saving, converting to a workbook, running Python, and the security
+context control are hidden, and any SQL is read-only. The time zone control stays
+visible so viewers can see how data is bucketed, but it can't be changed without
+**Can edit** or higher.
+
 <Info>
 
 When sharing is set at the [folder level][ref-folders], content inside

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -360,6 +360,17 @@ of the PostgreSQL documentation.
 | --- | --- | --- | --- |
 | `TO_CHAR` | Converts a timestamp to string according to the given format | ✅ Yes | <nobr>✅ Outer</nobr><br/><nobr>❌ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 
+### Type casts
+
+The SQL API supports casting to `regtype` and `regtype[]`, e.g., `atttypid::regtype`
+or `'{int8,numeric,bool}'::regtype[]`. This is primarily useful for BI tools that
+introspect table columns via `pg_catalog.pg_attribute`/`pg_type` queries, comparing
+`atttypid` against a `regtype[]` literal.
+
+Accepted spellings include the internal type name (`int4`), the canonical `regtype`
+name (`integer`), and common SQL aliases (`int`, `decimal`, `char`, `float`), with or
+without an explicit `pg_catalog.` qualifier.
+
 ### Date/time functions
 
 <Info>


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

## Description of Changes Made

Found while auditing recent cube-js/cube and cubejs-enterprise changes against docs-mintlify for undocumented customer-facing behavior:

- **SQL API**: document `::regtype` / `::regtype[]` cast support (cube-js/cube#11503), which shipped with no doc update.
- **Small multiples**: document splitting by a second dimension — columns + rows, each independently capped at 5 (cubejs-enterprise#13860). The reference page previously stated this was unsupported.
- **Analysis widget**: rename docs from "AI summary" to "Analysis" and document the Run/Refresh actions and freshness indicator that replaced Generate Summary/Re-run and the gear menu (cubejs-enterprise#13915, already announced in the in-app changelog).
- **MCP server**: document that `deploymentId` is now accepted by every tool, not just `chat`/`loadQueryResults`, and how resuming a chat/visualize/loadQueryResults call derives its deployment from the existing thread (cubejs-enterprise#13897).
- **Sharing**: describe what `Can view` access looks like for a shared exploration now that it's genuinely read-only (cubejs-enterprise#13893).

No functional/code changes — docs-mintlify only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPmGA7GCZQsCjWE5whQSCS)_