### PR TITLE
refactor(query-orchestrator): LocalQueueDriver - drop processingId

### DIFF
--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -54,8 +54,6 @@ export interface QueueDriverConnectionInterface {
    * Adds specified by the queryKey query to the queue, returns tuple
    * with the operation result.
    *
-   * @param keyScore Redis specific thing, ignored by every current driver: ordering is
-   *   derived from priority and insertion time instead.
    * @param queryKey
    * @param orphanedTime Ignored by every current driver: the per item orphaned deadline is
    *   derived from options.orphanedTimeout (in seconds) instead.
@@ -64,7 +62,7 @@ export interface QueueDriverConnectionInterface {
    * @param priority
    * @param options
    */
-  addToQueue(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
+  addToQueue(queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -55,14 +55,12 @@ export interface QueueDriverConnectionInterface {
    * with the operation result.
    *
    * @param queryKey
-   * @param orphanedTime Ignored by every current driver: the per item orphaned deadline is
-   *   derived from options.orphanedTimeout (in seconds) instead.
    * @param queryHandler Our queue allows using different handlers. For example, query, cvsQuery, etc.
    * @param query
    * @param priority
-   * @param options
+   * @param options The per item orphaned deadline comes from options.orphanedTimeout, in seconds
    */
-  addToQueue(queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
+  addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -20,7 +20,7 @@ export type RetrieveForProcessingResponse = [
   active: QueryKeyHash[],
   pending: number,
   def: QueryDef | null,
-] | null;
+];
 
 export interface AddToQueueQuery {
   isJob: boolean,

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -24,7 +24,8 @@ export type RetrieveForProcessingResponse = [
 
 export interface AddToQueueQuery {
   isJob: boolean,
-  orphanedTimeout: unknown
+  // Read only by QueryQueue.executeInQueue, which copies it into AddToQueueOptions
+  orphanedTimeout?: unknown
 }
 
 export interface AddToQueueOptions {

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -1,8 +1,6 @@
 export type QueryDef = any;
 // Primary key of Queue item
 export type QueueId = string | number | bigint;
-// This was used as a lock for Redis, deprecated.
-export type ProcessingId = string | number | bigint;
 export type QueryKey = (string | [string, any[]]) & {
   persistent?: true,
 };
@@ -12,25 +10,17 @@ export type QueryKeysTuple = [keyHash: QueryKeyHash, queueId: QueueId | null /**
 export type GetActiveAndToProcessResponse = [active: QueryKeysTuple[], toProcess: QueryKeysTuple[]];
 export type AddToQueueResponse = [added: number, queueId: QueueId | null, queueSize: number, addedToQueueTime: number];
 export type QueryStageStateResponse = [active: string[], toProcess: string[]] | [active: string[], toProcess: string[], defs: Record<string, QueryDef>];
-export type RetrieveForProcessingSuccess = [
-  added: unknown,
+/**
+ * `added` is `1` when the queue item was moved from pending to active by this call, `0` otherwise.
+ */
+export type RetrieveForProcessingResponse = [
+  added: number,
   // QueueId is required for Cube Store, other providers don't support it
   queueId: QueueId | null,
   active: QueryKeyHash[],
   pending: number,
-  def: QueryDef,
-  lockAquired: true
-];
-export type RetrieveForProcessingFail = [
-  added: unknown,
-  // QueueId is required for Cube Store, other providers don't support it
-  queueId: QueueId | null,
-  active: QueryKeyHash[],
-  pending: number,
-  def: null,
-  lockAquired: false
-];
-export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | RetrieveForProcessingFail | null;
+  def: QueryDef | null,
+] | null;
 
 export interface AddToQueueQuery {
   isJob: boolean,
@@ -64,9 +54,11 @@ export interface QueueDriverConnectionInterface {
    * Adds specified by the queryKey query to the queue, returns tuple
    * with the operation result.
    *
-   * @param keyScore Redis specific thing
+   * @param keyScore Redis specific thing, ignored by every current driver: ordering is
+   *   derived from priority and insertion time instead.
    * @param queryKey
-   * @param orphanedTime
+   * @param orphanedTime Ignored by every current driver: the per item orphaned deadline is
+   *   derived from options.orphanedTimeout (in seconds) instead.
    * @param queryHandler Our queue allows using different handlers. For example, query, cvsQuery, etc.
    * @param query
    * @param priority
@@ -83,17 +75,18 @@ export interface QueueDriverConnectionInterface {
   getStalledQueries(): Promise<QueryKeysTuple[]>;
   getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse>;
   updateHeartBeat(hash: QueryKeyHash, queueId: QueueId | null): Promise<void>;
-  getNextProcessingId(): Promise<ProcessingId>;
-  // Trying to acquire a lock for processing a queue item, this method can return null when
-  // multiple nodes tries to process the same query
-  retrieveForProcessing(hash: QueryKeyHash, processingId: ProcessingId): Promise<RetrieveForProcessingResponse>;
-  freeProcessingLock(hash: QueryKeyHash, processingId: ProcessingId, activated: unknown): Promise<void>;
-  optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, processingId: ProcessingId, queueId: QueueId | null): Promise<boolean>;
+  // Atomically moves a pending queue item to active, which is what stops multiple nodes
+  // from processing the same query. Returns `added: 0` when the item is missing, already
+  // active, or the queue is at its concurrency limit - in all of those cases nothing is
+  // mutated, so there is nothing for the caller to roll back.
+  retrieveForProcessing(hash: QueryKeyHash): Promise<RetrieveForProcessingResponse>;
+  optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, queueId: QueueId | null): Promise<boolean>;
   cancelQuery(queryKey: QueryKey, queueId: QueueId | null): Promise<QueryDef | null>;
   getQueryAndRemove(hash: QueryKeyHash, queueId: QueueId | null): Promise<[QueryDef]>;
-  setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: any, processingId: ProcessingId, queueId: QueueId | null): Promise<unknown>;
+  // Returns false when the queue item is gone (cancelled or orphaned while it was executing),
+  // which means the result was dropped.
+  setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: any, queueId: QueueId | null): Promise<unknown>;
   release(): void;
-  //
   getQueriesToCancel(): Promise<QueryKeysTuple[]>
   // @deprecated
   getActiveAndToProcess(): Promise<GetActiveAndToProcessResponse>;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -68,7 +68,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
 
   public async addToQueue(
     queryKey: QueryKey,
-    _orphanedTime: number,
     queryHandler: string,
     query: AddToQueueQuery,
     priority: number,

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -67,7 +67,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async addToQueue(
-    _keyScore: number,
     queryKey: QueryKey,
     _orphanedTime: number,
     queryHandler: string,

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -11,7 +11,6 @@ import {
   AddToQueueResponse,
   QueryKey,
   QueryKeyHash,
-  ProcessingId,
   QueueId,
   GetActiveAndToProcessResponse,
   QueryKeysTuple,
@@ -132,10 +131,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async freeProcessingLock(_hash: QueryKeyHash, _processingId: string, _activated: unknown): Promise<void> {
-    // nothing to do
-  }
-
   public async getActiveQueries(): Promise<QueryKeysTuple[]> {
     const rows = await this.driver.query<CubeStoreListResponse>('QUEUE ACTIVE ?', [
       this.options.redisQueuePrefix
@@ -183,17 +178,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
       active,
       toProcess,
     ];
-  }
-
-  public async getNextProcessingId(): Promise<number | string> {
-    const rows = await this.driver.query('CACHE INCR ?', [
-      `${this.options.redisQueuePrefix}:PROCESSING_COUNTER`
-    ]);
-    if (rows && rows.length) {
-      return rows[0].value;
-    }
-
-    throw new Error('Unable to get next processing id');
   }
 
   public async getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse> {
@@ -297,7 +281,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, _processingId: ProcessingId, queueId: QueueId): Promise<boolean> {
+  public async optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, queueId: QueueId): Promise<boolean> {
     await this.driver.query('QUEUE MERGE_EXTRA ? ?', [
       // queryKeyHash as compatibility fallback
       queueId || this.prefixKey(hash),
@@ -311,7 +295,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     // nothing to release
   }
 
-  public async retrieveForProcessing(hash: QueryKeyHash, _processingId: string): Promise<RetrieveForProcessingResponse> {
+  public async retrieveForProcessing(hash: QueryKeyHash): Promise<RetrieveForProcessingResponse> {
     const rows = await this.driver.query<{ id: string /* cube store convert int64 to string */, active: string | null, pending: string, payload: string, extra: string | null }>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
@@ -329,15 +313,17 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
           active,
           pending,
           def,
-          true
         ];
       } else {
+        // NotEnoughConcurrency, NotFound, LockFailed or ExclusiveAccessFailed. Cube Store
+        // returns all of them as an empty EXTENDED row and mutates nothing.
         return [
-          0, null, active, pending, null, false
+          0, null, active, pending, null
         ];
       }
     }
 
+    // Old Cube Store without EXTENDED support returns no rows at all on failure
     return null;
   }
 
@@ -354,7 +340,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: unknown, _processingId: ProcessingId, queueId: QueueId): Promise<boolean> {
+  public async setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: unknown, queueId: QueueId): Promise<boolean> {
     const rows = await this.driver.query('QUEUE ACK ? ?', [
       // queryKeyHash as compatibility fallback
       queueId || this.prefixKey(hash),

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -322,8 +322,9 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
       }
     }
 
-    // Old Cube Store without EXTENDED support returns no rows at all on failure
-    return null;
+    // EXTENDED always yields exactly one row, so no rows means we are talking to something
+    // that isn't Cube Store
+    throw new Error('Empty response on QUEUE RETRIEVE');
   }
 
   public async getResultBlocking(hash: QueryKeyHash, queueId: QueueId): Promise<QueryDef | null> {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -236,7 +236,6 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   }
 
   public async addToQueue(
-    _keyScore: number,
     queryKey: QueryKey,
     _orphanedTime: number,
     queryHandler: string,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -128,7 +128,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
       return { ...item.payload, ...item.extra };
     }
 
-    return item.payload;
+    return { ...item.payload };
   }
 
   /**

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -237,7 +237,6 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
   public async addToQueue(
     queryKey: QueryKey,
-    _orphanedTime: number,
     queryHandler: string,
     query: AddToQueueQuery,
     priority: number,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -1,10 +1,8 @@
-import R from 'ramda';
 import {
   QueueDriverConnectionInterface,
   QueryKey,
   QueryKeyHash,
   QueueId,
-  ProcessingId,
   QueryDef,
   AddToQueueQuery,
   AddToQueueOptions,
@@ -19,10 +17,14 @@ import {
   LocalQueueDriver
 } from './LocalQueueDriver';
 
-export interface QueueItem {
-  order: number;
-  key: QueryKeyHash;
-  queueId: QueueId;
+/**
+ * A queue item goes `Pending -> Active -> deleted`. There is no terminal state: `Active` is the
+ * only lock there is, it's set atomically by retrieveForProcessing and released by an ack or a
+ * cancel, both of which delete the item outright.
+ */
+export enum LocalQueueItemStatus {
+  Pending = 'pending',
+  Active = 'active',
 }
 
 export interface QueryDefObject {
@@ -36,37 +38,54 @@ export interface QueryDefObject {
   addedToQueueTime: number;
 }
 
+export interface LocalQueueItem {
+  /**
+   * Starts at 1, never 0: callers fall back to a key lookup on a falsy queueId.
+   */
+  id: number;
+  key: QueryKeyHash;
+  status: LocalQueueItemStatus;
+  priority: number;
+  created: number;
+  heartbeat: number | null;
+  /**
+   * Absolute deadline in ms, not a duration. Overrides the driver level orphanedTimeout
+   * option, which is what null falls back to.
+   */
+  orphaned: number | null;
+  payload: QueryDefObject;
+  /**
+   * Written only by optimisticQueryUpdate, kept out of the payload so that a concurrent
+   * update cannot mutate the def other connections are holding.
+   */
+  extra: Record<string, any> | null;
+}
+
 export interface PromiseWithResolve<T = any> extends Promise<T> {
   resolve?: (value: T) => void;
   resolved?: boolean;
 }
 
-export interface ProcessingCounter {
-  counter: number;
-}
-
 export class LocalQueueDriverConnectionState {
-  public resultPromises: Record<QueryKeyHash, PromiseWithResolve> = {};
+  public resultPromises: Record<string, PromiseWithResolve> = {};
 
-  public queryDef: Record<QueryKeyHash, QueryDefObject> = {};
+  /**
+   * A Map because insertion order matches id order, which is the order active items are
+   * reported in. A plain object would reorder them.
+   */
+  public items: Map<QueryKeyHash, LocalQueueItem> = new Map();
 
-  public toProcess: Record<QueryKeyHash, QueueItem> = {};
+  public byId: Map<number, LocalQueueItem> = new Map();
 
-  public recent: Record<QueryKeyHash, QueueItem> = {};
-
-  public active: Record<QueryKeyHash, QueueItem> = {};
-
-  public heartBeat: Record<QueryKeyHash, QueueItem> = {};
-
-  public processingCounter: ProcessingCounter = { counter: 1 };
-
-  public processingLocks: Record<QueryKeyHash, any> = {};
+  public idSequence: number = 0;
 }
 
 export class LocalQueueDriverConnection implements QueueDriverConnectionInterface {
   private redisQueuePrefix: string;
 
   private continueWaitTimeout: number;
+
+  private orphanedTimeout: number;
 
   private heartBeatTimeout: number;
 
@@ -79,28 +98,99 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   public constructor(driver: LocalQueueDriver, state: LocalQueueDriverConnectionState, options: QueueDriverOptions) {
     this.redisQueuePrefix = options.redisQueuePrefix;
     this.continueWaitTimeout = options.continueWaitTimeout;
+    this.orphanedTimeout = options.orphanedTimeout;
     this.heartBeatTimeout = options.heartBeatTimeout;
     this.concurrency = options.concurrency;
     this.driver = driver;
     this.state = state;
   }
 
-  public async getQueriesToCancel(): Promise<QueryKeysTuple[]> {
-    const [stalled, orphaned] = await Promise.all([
-      this.getStalledQueries(),
-      this.getOrphanedQueries(),
-    ]);
+  /**
+   * There is deliberately no key fallback once an id is supplied: a stale id has to miss,
+   * otherwise an in-flight query would never notice that it was cancelled and re-added
+   * under a new id.
+   */
+  protected resolveItem(queryKeyHash: QueryKeyHash, queueId?: QueueId | null): LocalQueueItem | null {
+    if (queueId) {
+      return this.state.byId.get(Number(queueId)) || null;
+    }
 
-    return stalled.concat(orphaned);
+    return this.state.items.get(queryKeyHash) || null;
+  }
+
+  protected removeItem(item: LocalQueueItem): void {
+    this.state.items.delete(item.key);
+    this.state.byId.delete(item.id);
+  }
+
+  protected mergeDef(item: LocalQueueItem): QueryDef {
+    if (item.extra) {
+      return { ...item.payload, ...item.extra };
+    }
+
+    return item.payload;
+  }
+
+  /**
+   * FIFO within a priority band. The id breaks ties between items added in the same millisecond.
+   */
+  protected sortedItems(): LocalQueueItem[] {
+    return Array.from(this.state.items.values()).sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return b.priority - a.priority;
+      }
+
+      if (a.created !== b.created) {
+        return a.created - b.created;
+      }
+
+      return a.id - b.id;
+    });
+  }
+
+  protected pendingItems(): LocalQueueItem[] {
+    return this.sortedItems().filter((item) => item.status === LocalQueueItemStatus.Pending);
+  }
+
+  /**
+   * Deliberately not priority sorted, unlike pendingItems: active items are reported in id order.
+   */
+  protected activeItems(): LocalQueueItem[] {
+    return Array.from(this.state.items.values()).filter((item) => item.status === LocalQueueItemStatus.Active);
+  }
+
+  protected countPending(): number {
+    let count = 0;
+
+    for (const item of this.state.items.values()) {
+      if (item.status === LocalQueueItemStatus.Pending) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
+  protected asTuple(items: LocalQueueItem[]): QueryKeysTuple[] {
+    return items.map((item): QueryKeysTuple => [item.key, item.id]);
+  }
+
+  public async getQueriesToCancel(): Promise<QueryKeysTuple[]> {
+    const now = Date.now();
+
+    return this.asTuple(
+      Array.from(this.state.items.values()).filter((item) => (
+        item.status === LocalQueueItemStatus.Pending
+          ? this.isOrphaned(item, now)
+          : this.isStalled(item, now)
+      ))
+    );
   }
 
   public async getActiveAndToProcess(): Promise<GetActiveAndToProcessResponse> {
-    const activeQueries = this.queueArrayAsTuple(this.state.active);
-    const toProcessQueries = this.queueArrayAsTuple(this.state.toProcess);
-
     return [
-      activeQueries,
-      toProcessQueries
+      this.asTuple(this.activeItems()),
+      this.asTuple(this.pendingItems()),
     ];
   }
 
@@ -118,7 +208,9 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
   public async getResultBlocking(queryKeyHash: QueryKeyHash, _queueId?: QueueId): Promise<any> {
     const resultListKey = this.resultListKey(queryKeyHash);
-    if (!this.state.queryDef[queryKeyHash] && !this.state.resultPromises[resultListKey]) {
+    // With neither an item nor a result there is nothing that could ever resolve, so don't
+    // make the caller wait out the timeout
+    if (!this.state.items.has(queryKeyHash) && !this.state.resultPromises[resultListKey]) {
       return null;
     }
     const timeoutPromise = (timeout: number) => new Promise((resolve) => setTimeout(() => resolve(null), timeout));
@@ -143,87 +235,83 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return null;
   }
 
-  protected queueArray(queueObj: Record<QueryKeyHash, QueueItem>, orderFilterLessThan?: number): string[] {
-    return R.pipe(
-      R.values,
-      R.filter(orderFilterLessThan ? (q: QueueItem) => q.order < orderFilterLessThan : R.identity),
-      R.sortBy((q: QueueItem) => q.order),
-      R.map((q: QueueItem) => q.key)
-    )(queueObj);
-  }
-
-  protected queueArrayAsTuple(queueObj: Record<QueryKeyHash, QueueItem>, orderFilterLessThan?: number): QueryKeysTuple[] {
-    return R.pipe(
-      R.values,
-      R.filter(orderFilterLessThan ? (q: QueueItem) => q.order < orderFilterLessThan : R.identity),
-      R.sortBy((q: QueueItem) => q.order),
-      R.map((q: QueueItem): QueryKeysTuple => [q.key, q.queueId])
-    )(queueObj);
-  }
-
-  public async addToQueue(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse> {
-    const queryQueueObj: QueryDefObject = {
-      queueId: options.queueId,
-      queryHandler,
-      query,
-      queryKey,
-      stageQueryKey: options.stageQueryKey,
-      priority,
-      requestId: options.requestId,
-      addedToQueueTime: new Date().getTime()
-    };
-
+  public async addToQueue(
+    _keyScore: number,
+    queryKey: QueryKey,
+    _orphanedTime: number,
+    queryHandler: string,
+    query: AddToQueueQuery,
+    priority: number,
+    options: AddToQueueOptions
+  ): Promise<AddToQueueResponse> {
     const key = this.redisHash(queryKey);
+    const pending = this.countPending();
 
-    if (!this.state.queryDef[key]) {
-      this.state.queryDef[key] = queryQueueObj;
+    // Returning the existing id rather than a fresh one is what makes the caller wait on the
+    // query that is already queued instead of on an id that will never be acked.
+    const existing = this.state.items.get(key);
+    if (existing) {
+      return [
+        0,
+        existing.id,
+        pending,
+        existing.payload.addedToQueueTime,
+      ];
     }
 
-    let added = 0;
+    const created = Date.now();
+    const id = ++this.state.idSequence;
 
-    if (!this.state.toProcess[key] && !this.state.active[key]) {
-      this.state.toProcess[key] = {
-        order: keyScore,
-        queueId: options.queueId,
-        key
-      };
-
-      added = 1;
-    }
-
-    this.state.recent[key] = {
-      order: orphanedTime,
+    const item: LocalQueueItem = {
+      id,
       key,
-      queueId: options.queueId,
+      status: LocalQueueItemStatus.Pending,
+      priority,
+      created,
+      heartbeat: null,
+      // options.orphanedTimeout is in seconds
+      orphaned: options.orphanedTimeout ? created + options.orphanedTimeout * 1000 : null,
+      payload: {
+        queueId: id,
+        queryHandler,
+        query,
+        queryKey,
+        stageQueryKey: options.stageQueryKey,
+        priority,
+        requestId: options.requestId,
+        addedToQueueTime: created,
+      },
+      extra: null,
     };
+
+    this.state.items.set(key, item);
+    this.state.byId.set(id, item);
 
     return [
-      added,
-      queryQueueObj.queueId,
-      Object.keys(this.state.toProcess).length,
-      queryQueueObj.addedToQueueTime
+      1,
+      id,
+      pending + 1,
+      created,
     ];
   }
 
   public async getToProcessQueries(): Promise<QueryKeysTuple[]> {
-    return this.queueArrayAsTuple(this.state.toProcess);
+    return this.asTuple(this.pendingItems());
   }
 
   public async getActiveQueries(): Promise<QueryKeysTuple[]> {
-    return this.queueArrayAsTuple(this.state.active);
+    return this.asTuple(this.activeItems());
   }
 
-  public async getQueryAndRemove(queryKeyHash: QueryKeyHash, _queueId?: QueueId | null): Promise<[QueryDef]> {
-    const query = this.state.queryDef[queryKeyHash];
+  public async getQueryAndRemove(queryKeyHash: QueryKeyHash, queueId?: QueueId | null): Promise<[QueryDef]> {
+    const item = this.resolveItem(queryKeyHash, queueId);
+    if (!item) {
+      return [null];
+    }
 
-    delete this.state.active[queryKeyHash];
-    delete this.state.heartBeat[queryKeyHash];
-    delete this.state.toProcess[queryKeyHash];
-    delete this.state.recent[queryKeyHash];
-    delete this.state.queryDef[queryKeyHash];
-    delete this.state.processingLocks[queryKeyHash];
+    this.removeItem(item);
 
-    return [query];
+    return [this.mergeDef(item)];
   }
 
   public async cancelQuery(queryKey: QueryKey, queueId?: QueueId | null): Promise<QueryDef | null> {
@@ -231,19 +319,16 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return query;
   }
 
-  public async setResultAndRemoveQuery(queryKeyHash: QueryKeyHash, executionResult: any, processingId: ProcessingId, _queueId?: QueueId | null): Promise<boolean> {
-    if (this.state.processingLocks[queryKeyHash] !== processingId) {
+  public async setResultAndRemoveQuery(queryKeyHash: QueryKeyHash, executionResult: any, queueId?: QueueId | null): Promise<boolean> {
+    const item = this.resolveItem(queryKeyHash, queueId);
+    // The item was cancelled or orphaned while it was executing, so the result is dropped
+    if (!item) {
       return false;
     }
 
-    const promise = this.getResultPromise(this.resultListKey(queryKeyHash));
+    this.removeItem(item);
 
-    delete this.state.active[queryKeyHash];
-    delete this.state.heartBeat[queryKeyHash];
-    delete this.state.toProcess[queryKeyHash];
-    delete this.state.recent[queryKeyHash];
-    delete this.state.queryDef[queryKeyHash];
-    delete this.state.processingLocks[queryKeyHash];
+    const promise = this.getResultPromise(this.resultListKey(item.key));
 
     promise.resolved = true;
     if (promise.resolve) {
@@ -253,84 +338,112 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return true;
   }
 
-  public async getNextProcessingId(): Promise<ProcessingId> {
-    this.state.processingCounter.counter += 1;
-    return this.state.processingCounter.counter;
+  /**
+   * The orphaned timeout only ever applies to pending items, never to ones being executed.
+   */
+  protected isOrphaned(item: LocalQueueItem, now: number): boolean {
+    if (item.orphaned !== null) {
+      return item.orphaned < now;
+    }
+
+    return now - item.created > this.orphanedTimeout * 1000;
+  }
+
+  /**
+   * The heartbeat timeout only ever applies to active items. retrieveForProcessing always sets
+   * a heartbeat, so `created` is only a fallback.
+   */
+  protected isStalled(item: LocalQueueItem, now: number): boolean {
+    return now - (item.heartbeat ?? item.created) > this.heartBeatTimeout * 1000;
   }
 
   public async getOrphanedQueries(): Promise<QueryKeysTuple[]> {
-    return this.queueArrayAsTuple(this.state.recent, new Date().getTime());
+    const now = Date.now();
+
+    return this.asTuple(this.pendingItems().filter((item) => this.isOrphaned(item, now)));
   }
 
   public async getStalledQueries(): Promise<QueryKeysTuple[]> {
-    return this.queueArrayAsTuple(this.state.heartBeat, new Date().getTime() - this.heartBeatTimeout * 1000);
+    const now = Date.now();
+
+    return this.asTuple(this.activeItems().filter((item) => this.isStalled(item, now)));
   }
 
   public async getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse> {
-    return [this.queueArray(this.state.active), this.queueArray(this.state.toProcess), onlyKeys ? {} : R.clone(this.state.queryDef)];
+    const active: string[] = [];
+    const toProcess: string[] = [];
+    const defs: Record<string, QueryDef> = {};
+
+    for (const item of this.sortedItems()) {
+      if (!onlyKeys) {
+        defs[item.key] = this.mergeDef(item);
+      }
+
+      if (item.status === LocalQueueItemStatus.Active) {
+        active.push(item.key);
+      } else {
+        toProcess.push(item.key);
+      }
+    }
+
+    return [active, toProcess, defs];
   }
 
-  public async getQueryDef(queryKeyHash: QueryKeyHash, _queueId?: QueueId | null): Promise<QueryDef | null> {
-    return this.state.queryDef[queryKeyHash] || null;
+  public async getQueryDef(queryKeyHash: QueryKeyHash, queueId?: QueueId | null): Promise<QueryDef | null> {
+    const item = this.resolveItem(queryKeyHash, queueId);
+
+    return item ? this.mergeDef(item) : null;
   }
 
   public async updateHeartBeat(queryKeyHash: QueryKeyHash, queueId?: QueueId | null): Promise<void> {
-    if (this.state.heartBeat[queryKeyHash]) {
-      this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId: queueId || this.state.heartBeat[queryKeyHash].queueId };
+    const item = this.resolveItem(queryKeyHash, queueId);
+    // Succeeds silently for an unknown key
+    if (item) {
+      item.heartbeat = Date.now();
     }
   }
 
-  public async retrieveForProcessing(queryKeyHash: QueryKeyHash, processingId: ProcessingId): Promise<RetrieveForProcessingResponse> {
-    let lockAcquired = false;
+  public async retrieveForProcessing(queryKeyHash: QueryKeyHash): Promise<RetrieveForProcessingResponse> {
+    // Keep this method free of `await`: activation is only atomic while the whole
+    // read-modify-write below stays a single synchronous block.
+    const active = this.activeItems().map((item) => item.key);
+    const pending = this.countPending();
 
-    if (!this.state.processingLocks[queryKeyHash]) {
-      this.state.processingLocks[queryKeyHash] = processingId;
-      lockAcquired = true;
-    } else {
-      return null;
+    // Every rejection below happens before anything is mutated, so a caller that fails
+    // here has nothing to roll back.
+    if (active.length >= this.concurrency) {
+      return [0, null, active, pending, null];
     }
 
-    let added = 0;
-
-    if (Object.keys(this.state.active).length < this.concurrency && !this.state.active[queryKeyHash]) {
-      this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(processingId), queueId: Number(processingId) };
-      delete this.state.toProcess[queryKeyHash];
-
-      added = 1;
+    const item = this.state.items.get(queryKeyHash);
+    if (!item) {
+      return [0, null, active, pending, null];
     }
 
-    this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId: Number(processingId) };
+    if (item.status !== LocalQueueItemStatus.Pending) {
+      return [0, null, active, pending, null];
+    }
 
-    return [
-      added,
-      this.state.queryDef[queryKeyHash]?.queueId || null,
-      this.queueArray(this.state.active) as QueryKeyHash[],
-      Object.keys(this.state.toProcess).length,
-      this.state.queryDef[queryKeyHash],
-      lockAcquired
-    ];
+    item.status = LocalQueueItemStatus.Active;
+    // Without a heartbeat the creation time would be used for stalled filtering
+    item.heartbeat = Date.now();
+    active.push(item.key);
+
+    return [1, item.id, active, pending - 1, this.mergeDef(item)];
   }
 
-  public async freeProcessingLock(queryKeyHash: QueryKeyHash, processingId: ProcessingId, activated: any): Promise<void> {
-    if (this.state.processingLocks[queryKeyHash] === processingId) {
-      delete this.state.processingLocks[queryKeyHash];
-      if (activated) {
-        delete this.state.active[queryKeyHash];
-      }
-    }
-  }
-
-  public async optimisticQueryUpdate(queryKeyHash: QueryKeyHash, toUpdate: any, processingId: ProcessingId, _queueId?: QueueId | null): Promise<boolean> {
-    if (this.state.processingLocks[queryKeyHash] !== processingId) {
-      return false;
+  public async optimisticQueryUpdate(queryKeyHash: QueryKeyHash, toUpdate: any, queueId?: QueueId | null): Promise<boolean> {
+    const item = this.resolveItem(queryKeyHash, queueId);
+    // Succeeds silently for an unknown key
+    if (item) {
+      item.extra = { ...(item.extra ?? {}), ...toUpdate };
     }
 
-    this.state.queryDef[queryKeyHash] = { ...this.state.queryDef[queryKeyHash], ...toUpdate };
     return true;
   }
 
   public release(): void {
-    // Empty implementation as required by interface
+    // nothing to release
   }
 
   public queryRedisKey(queryKey: QueryKey, suffix: string): string {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -746,18 +746,16 @@ export class QueryQueue {
     let activeKeys;
     let queueSize;
     let query;
-    let processingLockAcquired;
 
     try {
-      const processingId = queueId || /** for Redis only */ await queueConnection.getNextProcessingId();
-      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, processingId);
+      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed);
 
       if (retrieveResult) {
         let retrieveQueueId;
 
-        [insertedCount, retrieveQueueId, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
+        [insertedCount, retrieveQueueId, activeKeys, queueSize, query] = retrieveResult;
 
-        // Backward compatibility for old Cube Store, Redis and Memory
+        // Null on anything but a successful activation, and on old Cube Store always
         if (retrieveQueueId) {
           queueId = retrieveQueueId;
         }
@@ -768,7 +766,7 @@ export class QueryQueue {
         query = await queueConnection.getQueryDef(queryKeyHashed, null);
       }
 
-      if (query && insertedCount && activated && processingLockAcquired) {
+      if (query && insertedCount && activated) {
         let executionResult;
         let queryExecutionFinished = false;
         // Set by the query handler's setCancelHandler callback once execution begins.
@@ -778,7 +776,6 @@ export class QueryQueue {
         const timeInQueue = (new Date()).getTime() - query.addedToQueueTime;
         this.logger('Performing query', {
           queueId,
-          processingId,
           queueSize,
           queryKey: query.queryKey,
           queuePrefix: this.redisQueuePrefix,
@@ -790,7 +787,7 @@ export class QueryQueue {
           preAggregation: query.query?.preAggregation,
           addedToQueueTime: query.addedToQueueTime,
         });
-        await queueConnection.optimisticQueryUpdate(queryKeyHashed, { startQueryTime }, processingId, queueId);
+        await queueConnection.optimisticQueryUpdate(queryKeyHashed, { startQueryTime }, queueId);
 
         let queryProcessHeartbeat = Date.now();
         const heartBeatTimer = setInterval(
@@ -874,7 +871,7 @@ export class QueryQueue {
                     async (cancelHandler) => {
                       localCancelHandler = cancelHandler;
                       try {
-                        await queueConnection.optimisticQueryUpdate(queryKeyHashed, { cancelHandler }, processingId, queueId);
+                        await queueConnection.optimisticQueryUpdate(queryKeyHashed, { cancelHandler }, queueId);
                       } catch (e: any) {
                         this.logger('Error while query update', {
                           queueId,
@@ -898,7 +895,6 @@ export class QueryQueue {
 
           this.logger('Performing query completed', {
             queueId,
-            processingId,
             queueSize,
             duration: ((new Date()).getTime() - startQueryTime),
             queryKey: query.queryKey,
@@ -917,7 +913,6 @@ export class QueryQueue {
           };
           this.logger('Error while querying', {
             queueId,
-            processingId,
             queueSize,
             duration: ((new Date()).getTime() - startQueryTime),
             queryKey: query.queryKey,
@@ -936,7 +931,6 @@ export class QueryQueue {
             if (queryWithCancelHandle) {
               this.logger('Cancelling query due to timeout', {
                 queueId,
-                processingId,
                 queryKey: queryWithCancelHandle.queryKey,
                 queuePrefix: this.redisQueuePrefix,
                 requestId: queryWithCancelHandle.requestId,
@@ -955,11 +949,10 @@ export class QueryQueue {
           clearInterval(heartBeatTimer);
         }
 
-        if (!(await queueConnection.setResultAndRemoveQuery(queryKeyHashed, executionResult, processingId, queueId))) {
+        if (!(await queueConnection.setResultAndRemoveQuery(queryKeyHashed, executionResult, queueId))) {
           this.logger('Orphaned execution result', {
             queueId,
-            processingId,
-            warn: 'Result for query was not set due to processing lock wasn\'t acquired',
+            warn: 'Result for query was not set, queue item was already removed (cancelled or orphaned)',
             queryKey: query.queryKey,
             queuePrefix: this.redisQueuePrefix,
             requestId: query.requestId,
@@ -982,20 +975,19 @@ export class QueryQueue {
         //   }
         // }
 
+        // Nothing to clean up here: retrieveForProcessing only reports a failure when it left
+        // the queue untouched, so the item is either missing, still pending or active elsewhere.
         this.logger('Skip processing', {
           queueId,
-          processingId,
           queryKey: query && query.queryKey || queryKeyHashed,
           requestId: query && query.requestId,
           queuePrefix: this.redisQueuePrefix,
-          processingLockAcquired,
           query,
           insertedCount,
           activeKeys,
           activated,
           queryExists: !!query
         });
-        await queueConnection.freeProcessingLock(queryKeyHashed, processingId, activated);
       }
     } catch (e: any) {
       this.logger('Queue storage error', {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -251,15 +251,12 @@ export class QueryQueue {
         if (jobExists) return null;
       }
 
-      const time = new Date().getTime();
-
+      // Undefined unless the query carries its own ttl, in which case it overrides the
+      // queue wide orphanedTimeout
       options.orphanedTimeout = query.orphanedTimeout;
 
-      const orphanedTimeout = 'orphanedTimeout' in query ? query.orphanedTimeout : this.orphanedTimeout;
-      const orphanedTime = time + (orphanedTimeout * 1000);
-
       const [added, queueId, queueSize, addedToQueueTime] = await queueConnection.addToQueue(
-        queryKey, orphanedTime, queryHandler, query, priority, options
+        queryKey, queryHandler, query, priority, options
       );
 
       if (added > 0) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -252,7 +252,6 @@ export class QueryQueue {
       }
 
       const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
 
       options.orphanedTimeout = query.orphanedTimeout;
 
@@ -260,7 +259,7 @@ export class QueryQueue {
       const orphanedTime = time + (orphanedTimeout * 1000);
 
       const [added, queueId, queueSize, addedToQueueTime] = await queueConnection.addToQueue(
-        keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
+        queryKey, orphanedTime, queryHandler, query, priority, options
       );
 
       if (added > 0) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -747,17 +747,13 @@ export class QueryQueue {
     let query;
 
     try {
-      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed);
+      let retrieveQueueId;
 
-      if (retrieveResult) {
-        let retrieveQueueId;
+      [insertedCount, retrieveQueueId, activeKeys, queueSize, query] = await queueConnection.retrieveForProcessing(queryKeyHashed);
 
-        [insertedCount, retrieveQueueId, activeKeys, queueSize, query] = retrieveResult;
-
-        // Null on anything but a successful activation, and on old Cube Store always
-        if (retrieveQueueId) {
-          queueId = retrieveQueueId;
-        }
+      // Null on anything but a successful activation
+      if (retrieveQueueId) {
+        queueId = retrieveQueueId;
       }
 
       const activated = activeKeys && activeKeys.indexOf(queryKeyHashed) !== -1;

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -42,10 +42,8 @@ function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInt
     setResultAndRemoveQuery: wrapAsyncMethod('setResultAndRemoveQuery'),
     getQueryStageState: wrapAsyncMethod('getQueryStageState'),
     getResultBlocking: wrapAsyncMethod('getResultBlocking'),
-    freeProcessingLock: wrapAsyncMethod('freeProcessingLock'),
     optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
     getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
-    getNextProcessingId: wrapAsyncMethod('getNextProcessingId'),
     release: connection.release,
   };
 }

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -286,12 +286,12 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       try {
         const priority = 10;
-        const time = new Date().getTime();
 
         expect(await connection.getOrphanedQueries()).toEqual([]);
 
+        // The orphanedTimeout that matters is the one in the options below, in seconds
         let orphanedTimeout = 2;
-        await connection.addToQueue(['1', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['1', []], 'delay', { isJob: true }, priority, {
           queueId: 1,
           stageQueryKey: '1',
           requestId: '1',
@@ -302,7 +302,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         orphanedTimeout = 60;
 
-        await connection.addToQueue(['2', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['2', []], 'delay', { isJob: true }, priority, {
           queueId: 2,
           stageQueryKey: '2',
           requestId: '2',
@@ -382,7 +382,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const addQuery = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
         queryKey,
         'delay',
-        <any>{ isJob: true },
+        { isJob: true },
         priority,
         { stageQueryKey: queryKey, requestId, orphanedTimeout: 60 }
       );
@@ -491,7 +491,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const addWithOrphanedTimeout = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
         queryKey,
         'delay',
-        <any>{ isJob: true },
+        { isJob: true },
         priority,
         { stageQueryKey: queryKey, requestId, orphanedTimeout: 1 }
       );

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -1,11 +1,11 @@
 import { Readable } from 'stream';
 import crypto from 'crypto';
 
-import type { QueryKey, QueueDriverInterface } from '@cubejs-backend/base-driver';
+import type { QueryKey, QueueDriverInterface, QueueDriverOptions } from '@cubejs-backend/base-driver';
 import { pausePromise } from '@cubejs-backend/shared';
-import { CubestoreQueueDriverConnection } from '@cubejs-backend/cubestore-driver';
+import { CubestoreQueueDriverConnection, CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
 
-import { QueryQueue, QueryQueueOptions } from '../../src';
+import { LocalQueueDriver, QueryQueue, QueryQueueOptions } from '../../src';
 import { ContinueWaitError } from '../../src/orchestrator/ContinueWaitError';
 import { processUidRE } from '../../src/orchestrator/utils';
 
@@ -29,6 +29,14 @@ class QueryQueueExtended extends QueryQueue {
 export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => {
   describe(`QueryQueue${name}`, () => {
     jest.setTimeout(10 * 1000);
+
+    // Same switch as QueryQueue's private factoryQueueDriver, for tests that need
+    // driver options the shared queue instance cannot provide
+    const createQueueDriver = (driverOptions: QueueDriverOptions): QueueDriverInterface => (
+      options.cacheAndQueueDriver === 'cubestore'
+        ? new CubeStoreQueueDriver(() => options.cubeStoreDriverFactory!(), driverOptions)
+        : new LocalQueueDriver(driverOptions)
+    );
 
     const delayFn = (result, delay) => new Promise(resolve => setTimeout(() => resolve(result), delay));
     const logger = jest.fn((message, event) => console.log(`${message} ${JSON.stringify(event)}`));
@@ -247,8 +255,6 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(result).toEqual(['10', '21', '32', '43']);
     });
 
-    const onlyLocalTest = options.cacheAndQueueDriver !== 'cubestore' ? test : xtest;
-
     test('orphaned', async () => {
       // recover if previous test broken something
       for (let i = 1; i <= 4; i++) {
@@ -369,85 +375,233 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(result).toBe('select * from bar');
     });
 
-    onlyLocalTest('queue driver lock obtain race condition', async () => {
-      const connection: any = await queue.queueDriver.createConnection();
-      const connection2: any = await queue.queueDriver.createConnection();
+    // A queue item being active is the only lock there is, so these pin down the semantics both
+    // drivers have to agree on. Note the suite runs with concurrency: 1.
+    describe('queue driver semantics', () => {
       const priority = 10;
-      const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
 
-      await queue.reconcileQueue();
+      const addQuery = (connection: any, queryKey: QueryKey, requestId: string) => {
+        const time = new Date().getTime();
 
-      await connection.addToQueue(
-        keyScore, 'race', time, 'handler', ['select'], priority, { stageQueryKey: 'race' }
-      );
+        return connection.addToQueue(
+          time + (10000 - priority) * 1E14,
+          queryKey,
+          time + 60 * 1000,
+          'delay',
+          <any>{ isJob: true },
+          priority,
+          { stageQueryKey: queryKey, requestId, orphanedTimeout: 60 }
+        );
+      };
 
-      await connection.addToQueue(
-        keyScore + 100, 'race2', time + 100, 'handler2', ['select2'], priority, { stageQueryKey: 'race2' }
-      );
+      const withConnections = async (count: number, fn: (...connections: any[]) => Promise<QueryKey[]>) => {
+        const connections = await Promise.all(
+          Array.from({ length: count }, () => queue.queueDriver.createConnection())
+        );
 
-      const processingId1 = await connection.getNextProcessingId();
-      const processingId4 = await connection.getNextProcessingId();
+        let keys: QueryKey[] = [];
+        try {
+          keys = await fn(...connections);
+        } finally {
+          for (const key of keys) {
+            await connections[0].getQueryAndRemove(connections[0].redisHash(key), null);
+          }
 
-      await connection.freeProcessingLock('race', processingId1, true);
-      await connection.freeProcessingLock('race2', processingId4, true);
+          connections.forEach(connection => queue.queueDriver.release(connection));
+        }
+      };
 
-      await connection2.retrieveForProcessing('race2', await connection.getNextProcessingId());
+      test('addToQueue dedupes by key and returns the existing queue id', async () => {
+        await withConnections(2, async (connection, connection2) => {
+          const key: QueryKey = ['dedupe', []];
 
-      const processingId = await connection.getNextProcessingId();
-      const retrieve6 = await connection.retrieveForProcessing('race', processingId);
-      console.log(retrieve6);
-      expect(!!retrieve6[5]).toBe(true);
+          const [added, queueId] = await addQuery(connection, key, 'dedupe-1');
+          expect(added).toBe(1);
 
-      console.log(await connection.getQueryAndRemove('race'));
-      console.log(await connection.getQueryAndRemove('race2'));
+          const [addedAgain, queueIdAgain] = await addQuery(connection2, key, 'dedupe-2');
+          expect(addedAgain).toBe(0);
+          expect(queueIdAgain).toEqual(queueId);
 
-      await queue.queueDriver.release(connection);
-      await queue.queueDriver.release(connection2);
-    });
+          // The first add wins outright: the second one must not overwrite the payload
+          const def = await connection.getQueryDef(connection.redisHash(key), queueId);
+          expect(def.requestId).toBe('dedupe-1');
 
-    onlyLocalTest('activated but lock is not acquired', async () => {
-      const connection = await queue.queueDriver.createConnection();
-      const connection2 = await queue.queueDriver.createConnection();
-      const priority = 10;
-      const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
+          return [key];
+        });
+      });
 
-      await queue.reconcileQueue();
+      test('retrieveForProcessing does not activate an already active item', async () => {
+        await withConnections(2, async (connection, connection2) => {
+          const key: QueryKey = ['already-active', []];
+          const hash = connection.redisHash(key);
 
-      await connection.addToQueue(
-        keyScore, 'activated1', time, 'handler', <any>['select'], priority, { stageQueryKey: 'race', requestId: '1' }
-      );
+          await addQuery(connection, key, 'already-active');
 
-      await connection.addToQueue(
-        keyScore + 100, 'activated2', time + 100, 'handler2', <any>['select2'], priority, { stageQueryKey: 'race2', requestId: '1' }
-      );
+          const [added, queueId, active, , def] = await connection.retrieveForProcessing(hash);
+          expect(added).toBe(1);
+          expect(def).toBeTruthy();
+          expect(active).toContain(hash);
 
-      const processingId1 = await connection.getNextProcessingId();
-      const processingId2 = await connection.getNextProcessingId();
-      const processingId3 = await connection.getNextProcessingId();
+          const [addedAgain, queueIdAgain, activeAgain, , defAgain] = await connection2.retrieveForProcessing(hash);
+          expect(addedAgain).toBe(0);
+          expect(queueIdAgain).toBe(null);
+          expect(defAgain).toBe(null);
+          expect(activeAgain).toContain(hash);
+          expect(await connection.getActiveQueries()).toEqual([[hash, queueId]]);
 
-      const retrieve1 = await connection.retrieveForProcessing('activated1' as any, processingId1);
-      console.log(retrieve1);
-      const retrieve2 = await connection2.retrieveForProcessing('activated2' as any, processingId2);
-      console.log(retrieve2);
-      console.log(await connection.freeProcessingLock('activated1' as any, processingId1, retrieve1 && retrieve1[2].indexOf('activated1' as any) !== -1));
-      const retrieve3 = await connection.retrieveForProcessing('activated2' as any, processingId3);
-      console.log(retrieve3);
-      console.log(await connection.freeProcessingLock('activated2' as any, processingId3, retrieve3 && retrieve3[2].indexOf('activated2' as any) !== -1));
-      console.log(retrieve2[2].indexOf('activated2' as any) !== -1);
-      console.log(await connection2.freeProcessingLock('activated2' as any, processingId2, retrieve2 && retrieve2[2].indexOf('activated2' as any) !== -1));
+          return [key];
+        });
+      });
 
-      const retrieve4 = await connection.retrieveForProcessing('activated2' as any, await connection.getNextProcessingId());
-      console.log(retrieve4);
-      expect(retrieve4[0]).toBe(1);
-      expect(!!retrieve4[5]).toBe(true);
+      test('retrieveForProcessing leaves the item pending when the queue is saturated', async () => {
+        await withConnections(2, async (connection, connection2) => {
+          const first: QueryKey = ['saturated-1', []];
+          const second: QueryKey = ['saturated-2', []];
+          const secondHash = connection.redisHash(second);
 
-      console.log(await connection.getQueryAndRemove('activated1' as any, null));
-      console.log(await connection.getQueryAndRemove('activated2' as any, null));
+          await addQuery(connection, first, 'saturated-1');
+          const [, secondQueueId] = await addQuery(connection, second, 'saturated-2');
 
-      await queue.queueDriver.release(connection);
-      await queue.queueDriver.release(connection2);
+          const [added] = await connection.retrieveForProcessing(connection.redisHash(first));
+          expect(added).toBe(1);
+
+          const [addedSecond, queueIdSecond, , , defSecond] = await connection2.retrieveForProcessing(secondHash);
+          expect(addedSecond).toBe(0);
+          expect(queueIdSecond).toBe(null);
+          expect(defSecond).toBe(null);
+          // Nothing was mutated, so it is still waiting to be picked up
+          expect(await connection.getToProcessQueries()).toEqual([[secondHash, secondQueueId]]);
+
+          return [first, second];
+        });
+      });
+
+      test('retrieveForProcessing on an unknown key creates nothing', async () => {
+        await withConnections(1, async (connection) => {
+          const hash = connection.redisHash(['never-added', []]);
+
+          const result = await connection.retrieveForProcessing(hash);
+          // Old Cube Store without EXTENDED support answers with null here
+          if (result) {
+            expect(result[0]).toBe(0);
+            expect(result[4]).toBe(null);
+          }
+
+          const [active, toProcess] = await connection.getQueryStageState(true);
+          expect(active).not.toContain(hash);
+          expect(toProcess).not.toContain(hash);
+          expect(await connection.getQueryDef(hash, null)).toBe(null);
+
+          return [];
+        });
+      });
+
+      // `QUEUE ADD ... ORPHANED n` takes seconds and derives the deadline itself, so the
+      // only way to get an orphaned item is to wait it out
+      const addWithOrphanedTimeout = (connection: any, queryKey: QueryKey, requestId: string) => {
+        const time = new Date().getTime();
+
+        return connection.addToQueue(
+          time + (10000 - priority) * 1E14,
+          queryKey,
+          time + 1000,
+          'delay',
+          <any>{ isJob: true },
+          priority,
+          { stageQueryKey: queryKey, requestId, orphanedTimeout: 1 }
+        );
+      };
+
+      test('orphaned queries only cover pending items', async () => {
+        await withConnections(1, async (connection) => {
+          const key: QueryKey = ['orphaned-pending', []];
+          const hash = connection.redisHash(key);
+
+          await addWithOrphanedTimeout(connection, key, 'orphaned-pending');
+          expect(await connection.getOrphanedQueries()).toEqual([]);
+
+          await pausePromise(1000 + 500 /* additional timeout on CI */);
+          expect(await connection.getOrphanedQueries()).toEqual([[hash, expect.any(Number)]]);
+
+          const [added] = await connection.retrieveForProcessing(hash);
+          expect(added).toBe(1);
+
+          // Once it is being executed the heartbeat takes over from the orphaned deadline
+          expect(await connection.getOrphanedQueries()).toEqual([]);
+
+          return [key];
+        });
+      });
+
+      test('getQueriesToCancel reports each item once', async () => {
+        await withConnections(1, async (connection) => {
+          const key: QueryKey = ['cancel-once', []];
+          const hash = connection.redisHash(key);
+
+          await addWithOrphanedTimeout(connection, key, 'cancel-once');
+          await pausePromise(1000 + 500 /* additional timeout on CI */);
+
+          const toCancel = await connection.getQueriesToCancel();
+          expect(toCancel.filter(([queryKey]) => queryKey === hash)).toHaveLength(1);
+
+          return [key];
+        });
+      });
+
+      test('setResultAndRemoveQuery reports failure for a removed item', async () => {
+        await withConnections(1, async (connection) => {
+          const key: QueryKey = ['ack-removed', []];
+          const hash = connection.redisHash(key);
+
+          const [, queueId] = await addQuery(connection, key, 'ack-removed');
+          await connection.retrieveForProcessing(hash);
+
+          // Emulates the query being cancelled or orphaned while it was executing
+          const [removed] = await connection.getQueryAndRemove(hash, queueId);
+          expect(removed).toBeTruthy();
+
+          expect(await connection.setResultAndRemoveQuery(hash, { result: 'late' }, queueId)).toBe(false);
+
+          return [];
+        });
+      });
+
+      test('stalled queries only cover active items with an old heartbeat', async () => {
+        // heartBeatTimeout is derived from heartBeatInterval * 4, which is way too long here,
+        // so this needs its own driver instance
+        const driver = createQueueDriver({
+          redisQueuePrefix: `${crypto.randomBytes(6).toString('hex')}#stalled`,
+          concurrency: 1,
+          continueWaitTimeout: 1,
+          orphanedTimeout: 60,
+          heartBeatTimeout: 1,
+        });
+
+        const connection: any = await driver.createConnection();
+        const key: QueryKey = ['stalled', []];
+        const hash = connection.redisHash(key);
+
+        try {
+          const [, queueId] = await addQuery(connection, key, 'stalled');
+
+          // Pending items are never stalled, no matter how long they sit there
+          await pausePromise(1500);
+          expect(await connection.getStalledQueries()).toEqual([]);
+
+          const [added] = await connection.retrieveForProcessing(hash);
+          expect(added).toBe(1);
+          expect(await connection.getStalledQueries()).toEqual([]);
+
+          await pausePromise(1500);
+          expect(await connection.getStalledQueries()).toEqual([[hash, queueId]]);
+
+          await connection.updateHeartBeat(hash, queueId);
+          expect(await connection.getStalledQueries()).toEqual([]);
+        } finally {
+          await connection.getQueryAndRemove(hash, null);
+          driver.release(connection);
+        }
+      });
     });
 
     // eslint-disable-next-line no-unused-expressions

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -291,7 +291,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         expect(await connection.getOrphanedQueries()).toEqual([]);
 
         let orphanedTimeout = 2;
-        await connection.addToQueue(['1', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['1', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 1,
           stageQueryKey: '1',
           requestId: '1',
@@ -302,7 +302,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         orphanedTimeout = 60;
 
-        await connection.addToQueue(['2', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['2', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 2,
           stageQueryKey: '2',
           requestId: '2',
@@ -381,7 +381,6 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       const addQuery = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
         queryKey,
-        new Date().getTime() + 60 * 1000,
         'delay',
         <any>{ isJob: true },
         priority,
@@ -487,11 +486,10 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         });
       });
 
-      // `QUEUE ADD ... ORPHANED n` takes seconds and derives the deadline itself, so the
-      // only way to get an orphaned item is to wait it out
+      // orphanedTimeout is in seconds and the deadline is derived from it, so the only way to
+      // get an orphaned item is to wait it out
       const addWithOrphanedTimeout = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
         queryKey,
-        new Date().getTime() + 1000,
         'delay',
         <any>{ isJob: true },
         priority,

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -287,12 +287,11 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       try {
         const priority = 10;
         const time = new Date().getTime();
-        const keyScore = time + (10000 - priority) * 1E14;
 
         expect(await connection.getOrphanedQueries()).toEqual([]);
 
         let orphanedTimeout = 2;
-        await connection.addToQueue(keyScore, ['1', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['1', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 1,
           stageQueryKey: '1',
           requestId: '1',
@@ -303,7 +302,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         orphanedTimeout = 60;
 
-        await connection.addToQueue(keyScore, ['2', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['2', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 2,
           stageQueryKey: '2',
           requestId: '2',
@@ -380,19 +379,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     describe('queue driver semantics', () => {
       const priority = 10;
 
-      const addQuery = (connection: any, queryKey: QueryKey, requestId: string) => {
-        const time = new Date().getTime();
-
-        return connection.addToQueue(
-          time + (10000 - priority) * 1E14,
-          queryKey,
-          time + 60 * 1000,
-          'delay',
-          <any>{ isJob: true },
-          priority,
-          { stageQueryKey: queryKey, requestId, orphanedTimeout: 60 }
-        );
-      };
+      const addQuery = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
+        queryKey,
+        new Date().getTime() + 60 * 1000,
+        'delay',
+        <any>{ isJob: true },
+        priority,
+        { stageQueryKey: queryKey, requestId, orphanedTimeout: 60 }
+      );
 
       const withConnections = async (count: number, fn: (...connections: any[]) => Promise<QueryKey[]>) => {
         const connections = await Promise.all(
@@ -498,19 +492,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       // `QUEUE ADD ... ORPHANED n` takes seconds and derives the deadline itself, so the
       // only way to get an orphaned item is to wait it out
-      const addWithOrphanedTimeout = (connection: any, queryKey: QueryKey, requestId: string) => {
-        const time = new Date().getTime();
-
-        return connection.addToQueue(
-          time + (10000 - priority) * 1E14,
-          queryKey,
-          time + 1000,
-          'delay',
-          <any>{ isJob: true },
-          priority,
-          { stageQueryKey: queryKey, requestId, orphanedTimeout: 1 }
-        );
-      };
+      const addWithOrphanedTimeout = (connection: any, queryKey: QueryKey, requestId: string) => connection.addToQueue(
+        queryKey,
+        new Date().getTime() + 1000,
+        'delay',
+        <any>{ isJob: true },
+        priority,
+        { stageQueryKey: queryKey, requestId, orphanedTimeout: 1 }
+      );
 
       test('orphaned queries only cover pending items', async () => {
         await withConnections(1, async (connection) => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -474,12 +474,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         await withConnections(1, async (connection) => {
           const hash = connection.redisHash(['never-added', []]);
 
-          const result = await connection.retrieveForProcessing(hash);
-          // Old Cube Store without EXTENDED support answers with null here
-          if (result) {
-            expect(result[0]).toBe(0);
-            expect(result[4]).toBe(null);
-          }
+          const [added, , , , def] = await connection.retrieveForProcessing(hash);
+          expect(added).toBe(0);
+          expect(def).toBe(null);
 
           const [active, toProcess] = await connection.getQueryStageState(true);
           expect(active).not.toContain(hash);

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -387,6 +387,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         { stageQueryKey: queryKey, requestId, orphanedTimeout: 60 }
       );
 
+      // Cleanup is best-effort: keys come from fn's resolved value, so a failed assertion leaves
+      // its items in the queue. That is fine because the queue prefix is randomized per run
+      // (see tenantPrefix), so nothing can bleed into another run sharing the same Cube Store.
       const withConnections = async (count: number, fn: (...connections: any[]) => Promise<QueryKey[]>) => {
         const connections = await Promise.all(
           Array.from({ length: count }, () => queue.queueDriver.createConnection())


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

`LocalQueueDriver` kept six parallel maps keyed by query hash plus a Redis-era `processingLocks[hash] = processingId` lease that had to be released via `freeProcessingLock`, whereas Cube Store has no lock token at all — a queue item's `status == Active` *is* the lock, set atomically by `QUEUE RETRIEVE` and released only by `QUEUE ACK`/`QUEUE CANCEL` — which is why `freeProcessingLock` was already a no-op there and `processingId` was never sent to Cube Store in any command. This collapses those maps into one Cube Store shaped record per key (`id`, `status`, `priority`, `created`, `heartbeat`, `orphaned`, `payload`, `extra`) plus a `byId` index and drops the processing-lock and `processingId` concepts from `QueueDriverConnectionInterface`, both drivers and `QueryQueue`; removing the lock is safe because `retrieveForProcessing` is inverted from mutate-then-discover to discover-then-mutate, so every failure path leaves the queue untouched and there is nothing left to roll back. As a result the memory driver stops reporting *running* queries as orphaned (`recent` used to survive activation, which cancelled `isJob: true` builds mid-flight), stops activating unknown keys, stops returning duplicate hashes from `getQueriesToCancel`, and returns the existing item id on dedup instead of the caller's fresh one. The two `onlyLocalTest` tests existed only to exercise the separate lock and are replaced by eight parity tests that run against **both** drivers; verified with 74/74 unit tests, clean `tsc`/lint, and the same abstract suite green against a real Cube Store 1.7.23 (25/25).

> [!NOTE]
> This removes `freeProcessingLock`, `getNextProcessingId` and the `ProcessingId` type from `QueueDriverConnectionInterface` in `@cubejs-backend/base-driver`. Both implementations are in-repo and updated here; no other caller exists.
>
> Unrelated pre-existing issue found while verifying: `yarn integration:cubestore` cannot start against published `cubejs/cubestore` images because `beforeAll` issues `QUEUE CLEAR`, which even the `v1.7.23` image rejects (the release image lags its tag). I ran the suite via a local harness without that statement.
