### PR TITLE
docs(monitoring): document log fields and metric labels (CUB-2879)

### DIFF
--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -155,7 +155,7 @@ Before a log record reaches a sink, the following fields are attached to it:
 | `deployment_name` | Name of the deployment. |
 | `hostname` | Host name of the node that the record comes from. |
 | `pod_name` | Name of the pod that the record comes from. |
-| `service` | Name of the component that the record comes from, matching the input name: `cubejs-server`, `refresh-scheduler`, `warmup-job`, or `cubestore`. |
+| `service` | Name of the component that the record comes from, matching the input name: `cubejs-server`, `refresh-scheduler`, `warmup-job`, or `cubestore`. Records from the `query-history` input use `query-history` on `datadog_logs` sinks. |
 | `level` | Severity of the record, lower-cased: `error`, `warn`, `info`, or `debug`. Records with the `trace` severity are exported as `debug`, and records that carry no severity as `info`. |
 | `status` | Duplicate of `level`, for tools that expect the severity in a `status` field, e.g. Datadog. |
 | `origin` | Always `cube_cloud`. |
@@ -171,19 +171,14 @@ uses for attribution:
 | Field | Description |
 | --- | --- |
 | `ddsource` | Name of the pod that the record comes from, or `query-history` for records from the `query-history` input. |
-| `ddtags` | Comma-separated list of tags, `$DEPLOYMENT_NAME,$HOSTNAME` by default. |
+| `ddtags` | Comma-separated list of tags. By default, the deployment name and the host name. |
 
 To send your own tags to Datadog, list them in the `ddtags` option of the sink.
 They are appended to the default ones:
 
 ```toml
 [sinks.datadog]
-type = "datadog_logs"
-inputs = [
-  "cubejs-server",
-  "refresh-scheduler"
-]
-default_api_key = "$CUBE_CLOUD_MONITORING_DATADOG_API_KEY"
+# type, inputs, default_api_key, etc.
 ddtags = [
   "env:production",
   "team:analytics"

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -145,6 +145,51 @@ refresh scheduler, use the [`CUBEJS_LOG_LEVEL`](/reference/configuration/environ
 
 </Info>
 
+### Fields in exported logs
+
+Before a log record reaches a sink, the following fields are attached to it:
+
+| Field | Description |
+| --- | --- |
+| `deployment_id` | Identifier of the [deployment][ref-deployments]. |
+| `deployment_name` | Name of the deployment. |
+| `hostname` | Host name of the node that the record comes from. |
+| `pod_name` | Name of the pod that the record comes from. |
+| `service` | Name of the component that the record comes from, matching the input name: `cubejs-server`, `refresh-scheduler`, `warmup-job`, or `cubestore`. |
+| `level` | Severity of the record, lower-cased: `error`, `warn`, `info`, or `debug`. Records with the `trace` severity are exported as `debug`, and records that carry no severity as `info`. |
+| `status` | Duplicate of `level`, for tools that expect the severity in a `status` field, e.g. Datadog. |
+| `origin` | Always `cube_cloud`. |
+
+Records from the `query-history` input carry a different set of fields, see
+[Query History export](#query-history-export).
+
+#### Datadog attributes
+
+Sinks of the `datadog_logs` type additionally get the two fields that Datadog
+uses for attribution:
+
+| Field | Description |
+| --- | --- |
+| `ddsource` | Name of the pod that the record comes from, or `query-history` for records from the `query-history` input. |
+| `ddtags` | Comma-separated list of tags, `$DEPLOYMENT_NAME,$HOSTNAME` by default. |
+
+To send your own tags to Datadog, list them in the `ddtags` option of the sink.
+They are appended to the default ones:
+
+```toml
+[sinks.datadog]
+type = "datadog_logs"
+inputs = [
+  "cubejs-server",
+  "refresh-scheduler"
+]
+default_api_key = "$CUBE_CLOUD_MONITORING_DATADOG_API_KEY"
+ddtags = [
+  "env:production",
+  "team:analytics"
+]
+```
+
 ### Sinks for logs
 
 You can use a [wide range of destinations][vector-docs-sinks] for logs,
@@ -231,6 +276,25 @@ list = [
 inputs = [
   "cubejs-server"
 ]
+```
+
+### Labels on exported metrics
+
+Metrics are exported with the following Prometheus labels:
+
+| Label | Metrics | Description |
+| --- | --- | --- |
+| `pod_name` | `cube_cpu_usage_ratio`, `cube_memory_usage_ratio` | Name of the pod that the measurement was taken on. |
+| `deployment_id` | `cube_requests_*` | Identifier of the [deployment][ref-deployments]. |
+| `api_type` | `cube_requests_*` | Type of [data API][ref-apis] that served the requests (`rest`, `sql`, etc.), the same values as in [Query History][ref-query-history]. `unknown` if the API type is not known. |
+| `request_source` | `cube_requests_*` | Source of the requests: `ai-engineer` for requests coming from AI features, `other` for any other source, `unknown` if the requests carry no source. |
+
+Request metrics are reported per `api_type` and `request_source` combination, so
+you can break down request counts and latency by data API:
+
+```text
+cube_requests_total{deployment_id="12345",api_type="rest",request_source="unknown"} 42
+cube_requests_total{deployment_id="12345",api_type="sql",request_source="ai-engineer"} 7
 ```
 
 ### Sinks for metrics
@@ -338,6 +402,7 @@ Exported data includes the following fields:
 | --- | --- |
 | `trace_id` | Unique identifier of the API request. |
 | `account_name` | Name of the Cube Cloud account. |
+| `query_history_link` | Link to the request in [Query History][ref-query-history]. |
 | `deployment_id` | Identifier of the [deployment][ref-deployments]. |
 | `environment_name` | Name of the [environment][ref-environments], `NULL` for production. |
 | `api_type` | Type of [data API][ref-apis] used (`rest`, `sql`, etc.), `NULL` for errors. |
@@ -349,6 +414,11 @@ Exported data includes the following fields:
 | `end_time_unix_ms` | End time of the execution, Unix timestamp in milliseconds. |
 | `api_response_duration_ms` | Duration of the execution in milliseconds. |
 | `cache_type` | [Cache type][ref-cache-type]: `no_cache`, `pre_aggregations_in_cube_store`, etc. |
+
+Unlike other logs, Query History records don't carry the
+[fields listed above](#fields-in-exported-logs), except for `origin`. On sinks of
+the `datadog_logs` type, they also get `service` and `ddsource` set to
+`query-history`, and `ddtags`.
 
 <Note>
 


### PR DESCRIPTION
## Summary

The Monitoring Integrations page documented *inputs*, *sinks*, metric *names* and the Query History field list, but said nothing about the tags actually attached to what gets exported. This adds three things to that page:

- **Fields in exported logs** — `deployment_id`, `deployment_name`, `hostname`, `pod_name`, `service`, `level`, `status`, `origin`, plus a `#### Datadog attributes` subsection for the `datadog_logs`-only `ddsource` / `ddtags` and the **previously undocumented per-sink `ddtags = [...]` option** (its values are appended to the defaults).
- **Labels on exported metrics** — the Prometheus labels on `cube_*` metrics, which is what gives the per-API request/latency breakdown asked for in CUB-2871, including that `request_source` is one of `ai-engineer` / `other` / `unknown`.
- **Query History export** — the missing `query_history_link` row, and a note that Query History records carry a *different* field set than container logs.

Every value was read out of the Cube Cloud log and metrics export pipeline rather than inferred from the ticket wording. That pipeline is not part of this repository, so the field lists cannot be verified against this checkout.

## Two deviations from the ticket

1. **Page location.** The ticket names `docs/content/product/administration/deployment/monitoring/index.mdx`. That is the legacy Nextra site, which `CLAUDE.md` and `docs-mintlify/CLAUDE.md` both mark deprecated ("do not add or edit content there"); its last touch was the #10544 reorg, while the live equivalent — `docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx` — carries the same three sections and is actively maintained (most recently #11577, also a monitoring change). The change landed on the live page. No new page was created.
2. **Metric labels are not uniform across metrics.** The ticket says every `cube_*` metric carries all four labels; in practice a label is emitted only where it is set, and the resource metrics and the request metrics carry different ones. So `cube_cpu_usage_ratio` and `cube_memory_usage_ratio` carry `pod_name` only, while `cube_requests_*` carry `deployment_id`, `api_type` and `request_source` but no `pod_name`. The table documents it per metric family rather than as one blanket list.

Two smaller details documented the same way: `ddsource` is the pod name on container logs but `query-history` on Query History records, and `trace`-severity records are exported with `level`/`status` set to `debug` while remaining selectable as `trace` via the `levels` option.

Per the ticket's out-of-scope list: no tag was added or renamed, no product code changed, and the REST API request-id docs were not touched.

## Verification

- `npx mintlify@4 broken-links --check-anchors` over the whole site: **1 broken link, in `reference/control-plane-api.mdx`** — a file this PR does not touch. Every link and anchor added here resolves, including the new `#fields-in-exported-logs` cross-reference.
- Structural check of the edited file: code fences balanced, no table column mismatches, no undefined `[ref-*]` link references.
- The `yarn build` script in `docs-mintlify/package.json` is stale — `build` is not a command in the Mintlify 4 CLI, so it could not be run. `docs-mintlify` has no lint or format script, and this repo has no `.husky` hooks, so nothing else applies to an MDX-only change.
