### PR TITLE
docs: deprecate the Hive / SparkSQL driver

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -70,6 +70,7 @@ features:
 | Removed    | [Elasticsearch driver](#elasticsearch-driver)                                                                                     | v1.6.0     | v1.7.0    |
 | Removed    | [`context_to_roles`](#context-to-roles)                                                                                           | v1.6.4     | v1.7.0    |
 | Deprecated | [Node.js 22](#nodejs-22)                                                                                                          | v1.7.0     |           |
+| Deprecated | [Hive driver](#hive-driver)                                                                                                       | v1.7.25    |           |
 
 ### Node.js 8
 
@@ -454,3 +455,13 @@ The `context_to_roles` configuration option has been removed. Please use `contex
 
 Node.js 22 is in maintenance mode from [October 21, 2025][link-nodejs-eol]. This means
 no more new features, only security updates. Please upgrade to Node.js 24 or higher.
+
+### Hive driver
+
+**Deprecated in Release: v1.7.25**
+
+The Hive / SparkSQL driver (`@cubejs-backend/hive-driver`) is deprecated and will be
+removed in a future release. It is community-supported and is not maintained by Cube or
+the database vendor. There is no drop-in replacement; `@cubejs-backend/jdbc-driver`
+ships Hive/SparkSQL connection settings that can be used through a custom
+[`driverFactory`](https://docs.cube.dev/reference/configuration/configuration-options#driverfactory).

--- a/docs-mintlify/admin/connect-to-data/data-sources/hive.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/hive.mdx
@@ -1,7 +1,13 @@
 ---
 title: Hive / SparkSQL
-description: The driver for Hive / SparkSQL is community-supported and is not maintained by Cube or the database vendor.
+description: The driver for Hive / SparkSQL is deprecated and community-supported, and is not maintained by Cube or the database vendor.
 ---
+
+<Warning>
+
+The driver for Hive / SparkSQL is deprecated and will be removed in a future release.
+
+</Warning>
 
 <Warning>
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/hive.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/hive.mdx
@@ -5,13 +5,9 @@ description: The driver for Hive / SparkSQL is deprecated and community-supporte
 
 <Warning>
 
-The driver for Hive / SparkSQL is deprecated and will be removed in a future release.
-
-</Warning>
-
-<Warning>
-
-The driver for Hive / SparkSQL is community-supported and is not maintained by Cube or the database vendor.
+The driver for Hive / SparkSQL is deprecated and will be removed in a future
+release. It is community-supported and is not maintained by Cube or the database
+vendor.
 
 </Warning>
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Marks the Hive / SparkSQL driver (`@cubejs-backend/hive-driver`) as deprecated in v1.7.25, so it can be removed in a future release. It is community-supported, not maintained by Cube or the database vendor, and has no unit or integration test coverage in this repo. Adds a `DEPRECATION.md` table row plus detail section, and a deprecation `<Warning>` on the Hive data source docs page. This is docs-only and mirrors the Elasticsearch driver deprecation precedent (#91d7840517, deprecated v1.6.0 → removed v1.7.0) — nothing is removed here and the driver stays fully functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)