### PR TITLE
perf(cubestore): turn on the performance toggles by default

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -4495,8 +4495,28 @@ async fn planning_topk_having(service: Box<dyn SqlClient>) -> Result<(), CubeErr
         .await?;
     let mut show_hints = PPOptions::default();
     show_hints.show_filters = true;
-    assert_eq!(
-        pp_phys_plan_ext(p.worker.as_ref(), &show_hints),
+    // The full-merge top-k re-aggregates on the router over a coalesce of the worker streams. On a
+    // multi-node cluster that coalesce fans in one stream per worker, so the plan carries an extra
+    // merge -- the shape worth pinning, since it is where the router must not claim an ordering the
+    // fan-in does not preserve.
+    let expected_worker_plan = if service.prefix() == "cluster" {
+        "Projection, [url, sum(Data.hits)@1:hits]\
+        \n  Sort, fetch: 3\
+        \n    Filter, predicate: sum(Data.hits)@1 > 10\
+        \n      SortedSingleAggregate\
+        \n        CoalescePartitions\
+        \n          MergeSort\
+        \n            Worker\
+        \n              SortedSingleAggregate\
+        \n                MergeSort\
+        \n                  Union\
+        \n                    Scan, index: default:1:[1]:sort_on[url], fields: [url, hits]\
+        \n                      Sort\
+        \n                        Empty\
+        \n                    Scan, index: default:2:[2]:sort_on[url], fields: [url, hits]\
+        \n                      Sort\
+        \n                        Empty"
+    } else {
         "Projection, [url, sum(Data.hits)@1:hits]\
         \n  Sort, fetch: 3\
         \n    Filter, predicate: sum(Data.hits)@1 > 10\
@@ -4512,6 +4532,10 @@ async fn planning_topk_having(service: Box<dyn SqlClient>) -> Result<(), CubeErr
         \n                  Scan, index: default:2:[2]:sort_on[url], fields: [url, hits]\
         \n                    Sort\
         \n                      Empty"
+    };
+    assert_eq!(
+        pp_phys_plan_ext(p.worker.as_ref(), &show_hints),
+        expected_worker_plan
     );
 
     let query = "SELECT `url` `url`, SUM(`hits`) `hits`, CARDINALITY(MERGE(`uhits`)) `uhits` \

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -3600,28 +3600,32 @@ async fn planning_inplace_aggregate2(service: Box<dyn SqlClient>) -> Result<(), 
     verbose.show_sort_by = true;
     assert_eq!(
         pp_phys_plan_ext(p.router.as_ref(), &verbose),
-        "Projection, [url, sum(Data.hits)@1:hits]\
-           \n  AggregateTopK, limit: 10, sortBy: [2 desc nulls last]\
-           \n    ClusterSend, partitions: [[1, 2]], sort_order: [1]"
+        "Projection, [url, sum(Data.hits)@1:hits], sort_order: [1]\
+           \n  Sort, by: [sum(Data.hits)@1 desc nulls last], fetch: 10, sort_order: [1]\
+           \n    LinearSingleAggregate\
+           \n      CoalescePartitions\
+           \n        ClusterSend, partitions: [[1, 2]]"
     );
     assert_eq!(
         pp_phys_plan_ext(p.worker.as_ref(), &verbose),
-        "Projection, [url, sum(Data.hits)@1:hits]\
-           \n  AggregateTopK, limit: 10, sortBy: [2 desc nulls last]\
-           \n    Worker, sort_order: [1]\
-           \n      Sort, by: [sum(Data.hits)@1 desc nulls last], sort_order: [1]\
-           \n        LinearSingleAggregate\
+        "Projection, [url, sum(Data.hits)@1:hits], sort_order: [1]\
+           \n  Sort, by: [sum(Data.hits)@1 desc nulls last], fetch: 10, sort_order: [1]\
+           \n    LinearSingleAggregate\
+           \n      CoalescePartitions\
+           \n        Worker\
            \n          CoalescePartitions\
-           \n            Union\
-           \n              Filter\
-           \n                Scan, index: default:1:[1]:sort_on[allowed, site_id, url], fields: *, sort_order: [0, 1, 2, 3, 4]\
-           \n                  Sort, by: [allowed@0, site_id@1, url@2, day@3, hits@4], sort_order: [0, 1, 2, 3, 4]\
-           \n                    Empty\
+           \n            LinearSingleAggregate\
            \n              CoalescePartitions\
-           \n                Filter\
-           \n                  Scan, index: default:2:[2]:sort_on[allowed, site_id, url], fields: *, sort_order: [0, 1, 2, 3, 4]\
-           \n                    Sort, by: [allowed@0, site_id@1, url@2, day@3, hits@4], sort_order: [0, 1, 2, 3, 4]\
-           \n                      Empty"
+           \n                Union\
+           \n                  Filter\
+           \n                    Scan, index: default:1:[1]:sort_on[allowed, site_id, url], fields: *, sort_order: [0, 1, 2, 3, 4]\
+           \n                      Sort, by: [allowed@0, site_id@1, url@2, day@3, hits@4], sort_order: [0, 1, 2, 3, 4]\
+           \n                        Empty\
+           \n                  CoalescePartitions\
+           \n                    Filter\
+           \n                      Scan, index: default:2:[2]:sort_on[allowed, site_id, url], fields: *, sort_order: [0, 1, 2, 3, 4]\
+           \n                        Sort, by: [allowed@0, site_id@1, url@2, day@3, hits@4], sort_order: [0, 1, 2, 3, 4]\
+           \n                          Empty"
     );
     Ok(())
 }
@@ -4494,18 +4498,20 @@ async fn planning_topk_having(service: Box<dyn SqlClient>) -> Result<(), CubeErr
     assert_eq!(
         pp_phys_plan_ext(p.worker.as_ref(), &show_hints),
         "Projection, [url, sum(Data.hits)@1:hits]\
-        \n  AggregateTopK, limit: 3, having: sum(Data.hits)@1 > 10\
-        \n    Worker\
-        \n      Sort\
-        \n        SortedSingleAggregate\
-        \n          MergeSort\
-        \n            Union\
-        \n              Scan, index: default:1:[1]:sort_on[url], fields: [url, hits]\
-        \n                Sort\
-        \n                  Empty\
-        \n              Scan, index: default:2:[2]:sort_on[url], fields: [url, hits]\
-        \n                Sort\
-        \n                  Empty"
+        \n  Sort, fetch: 3\
+        \n    Filter, predicate: sum(Data.hits)@1 > 10\
+        \n      SortedSingleAggregate\
+        \n        CoalescePartitions\
+        \n          Worker\
+        \n            SortedSingleAggregate\
+        \n              MergeSort\
+        \n                Union\
+        \n                  Scan, index: default:1:[1]:sort_on[url], fields: [url, hits]\
+        \n                    Sort\
+        \n                      Empty\
+        \n                  Scan, index: default:2:[2]:sort_on[url], fields: [url, hits]\
+        \n                    Sort\
+        \n                      Empty"
     );
 
     let query = "SELECT `url` `url`, SUM(`hits`) `hits`, CARDINALITY(MERGE(`uhits`)) `uhits` \

--- a/rust/cubestore/cubestore-sql-tests/tests/cluster.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/cluster.rs
@@ -22,13 +22,16 @@ fn main() {
     respawn::init(); // TODO: logs in worker processes.
 
     // We run only 1 test in parallel to avoid using the ports concurrently.
-    // We skip `planning_inplace_aggregate2` as planning results differ on cluster with 2 nodes.
+    // We skip `planning_inplace_aggregate2` and `planning_topk_having` as planning results differ
+    // on cluster with 2 nodes.
     run_sql_tests(
         "cluster",
         vec![
             "--test-threads=1".to_string(),
             "--skip".to_string(),
             "planning_inplace_aggregate2".to_string(),
+            "--skip".to_string(),
+            "planning_topk_having".to_string(),
         ],
         |test_name, test_fn| {
             // Add a suffix to avoid clashes with other configurations run concurrently.

--- a/rust/cubestore/cubestore-sql-tests/tests/cluster.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/cluster.rs
@@ -22,16 +22,13 @@ fn main() {
     respawn::init(); // TODO: logs in worker processes.
 
     // We run only 1 test in parallel to avoid using the ports concurrently.
-    // We skip `planning_inplace_aggregate2` and `planning_topk_having` as planning results differ
-    // on cluster with 2 nodes.
+    // We skip `planning_inplace_aggregate2` as planning results differ on cluster with 2 nodes.
     run_sql_tests(
         "cluster",
         vec![
             "--test-threads=1".to_string(),
             "--skip".to_string(),
             "planning_inplace_aggregate2".to_string(),
-            "--skip".to_string(),
-            "planning_topk_having".to_string(),
         ],
         |test_name, test_fn| {
             // Add a suffix to avoid clashes with other configurations run concurrently.

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1371,27 +1371,32 @@ fn env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-/// Lenient boolean env read for toggles: recognizes the usual spellings in either case and falls
-/// back to `default` with a warning on anything else. Unlike [`env_bool`] it never panics -- a
-/// malformed value on a performance flag must not take a node down on startup, and for a flag that
-/// is on by default the value an operator writes to turn it off is the one path that must work.
+/// Recognizes the usual boolean spellings in either case; `None` for anything else, including an
+/// empty value.
+fn parse_flag(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Lenient boolean env read for toggles: falls back to `default` with a warning on a value
+/// [`parse_flag`] does not recognize. Unlike [`env_bool`] it never panics -- a malformed value on a
+/// performance flag must not take a node down on startup, and for a flag that is on by default the
+/// value an operator writes to turn it off is the one path that must work.
 fn env_flag(name: &str, default: bool) -> bool {
     match env::var(name) {
         Err(_) => default,
-        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
-            "" => default,
-            "1" | "true" | "yes" | "on" => true,
-            "0" | "false" | "no" | "off" => false,
-            other => {
-                log::warn!(
-                    "Ignoring {} value '{}', using default ({})",
-                    name,
-                    other,
-                    default
-                );
+        Ok(v) => parse_flag(&v).unwrap_or_else(|| {
+            log::warn!(
+                "Ignoring {} value '{}', using default ({})",
+                name,
+                v,
                 default
-            }
-        },
+            );
+            default
+        }),
     }
 }
 
@@ -3079,5 +3084,20 @@ mod tests {
             RepartitionStrategy::Range
         );
         assert!("nonsense".parse::<RepartitionStrategy>().is_err());
+    }
+
+    #[test]
+    fn parse_flag_spellings() {
+        for on in ["1", "true", "TRUE", "True", "yes", "on", " on "] {
+            assert_eq!(parse_flag(on), Some(true), "{}", on);
+        }
+        for off in ["0", "false", "FALSE", "no", "off", " off "] {
+            assert_eq!(parse_flag(off), Some(false), "{}", off);
+        }
+        // Unrecognized values leave the caller on its default rather than silently reading as off,
+        // which for an on-by-default toggle would turn it off behind the operator's back.
+        for unknown in ["", "  ", "enabled", "2", "-1", "nonsense"] {
+            assert_eq!(parse_flag(unknown), None, "{}", unknown);
+        }
     }
 }

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1322,37 +1322,39 @@ pub async fn init_test_logger() {
 /// dropped connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopKAggregateStrategy {
-    /// Original streaming NRA merge with per-row state (default).
+    /// Original streaming NRA merge with per-row state.
     #[serde(rename = "streaming")]
     Streaming,
     /// Same streaming NRA merge (keeps early termination, bounded router memory), but vectorized.
     #[serde(rename = "vectorized_streaming")]
     VectorizedStreaming,
-    /// ClickHouse-style full re-aggregation on the router + fetch-limited sort. Drops early
-    /// termination, so the router materializes every distinct group.
+    /// ClickHouse-style full re-aggregation on the router + fetch-limited sort (default). Drops
+    /// early termination, so the router materializes every distinct group.
     #[serde(rename = "full_merge")]
     FullMerge,
 }
 
 /// Parses [`TopKAggregateStrategy`] from an env var. Lenient: an unset or unrecognized value falls
-/// back to the default (`Streaming`) with a warning rather than panicking -- a malformed perf toggle
+/// back to the default (`FullMerge`) with a warning rather than panicking -- a malformed perf toggle
 /// must never take a node down.
 fn env_topk_strategy(name: &str) -> TopKAggregateStrategy {
     match env::var(name) {
-        Err(_) => TopKAggregateStrategy::Streaming,
+        Err(_) => TopKAggregateStrategy::FullMerge,
         Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
-            "" | "streaming" | "default" | "v1" => TopKAggregateStrategy::Streaming,
+            "streaming" | "v1" => TopKAggregateStrategy::Streaming,
             "vectorized" | "vectorized_streaming" | "v2" => {
                 TopKAggregateStrategy::VectorizedStreaming
             }
-            "full_merge" | "full-merge" | "fullmerge" => TopKAggregateStrategy::FullMerge,
+            "" | "default" | "full_merge" | "full-merge" | "fullmerge" => {
+                TopKAggregateStrategy::FullMerge
+            }
             other => {
                 log::warn!(
-                    "unknown {} value '{}', using default (streaming)",
+                    "unknown {} value '{}', using default (full_merge)",
                     name,
                     other
                 );
-                TopKAggregateStrategy::Streaming
+                TopKAggregateStrategy::FullMerge
             }
         },
     }
@@ -1369,11 +1371,11 @@ fn env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-/// Lenient boolean env read for opt-in toggles: only `1`/`true` enable it, anything else (including a
-/// typo) is treated as off. Unlike [`env_bool`] it never panics -- a malformed value on a
-/// performance flag must not take a node down on startup.
-fn env_flag(name: &str) -> bool {
-    env::var(name).map_or(false, |v| v == "true" || v == "1")
+/// Lenient boolean env read for toggles: only `1`/`true` enable it, anything else (including a
+/// typo) is treated as off; an unset variable falls back to `default`. Unlike [`env_bool`] it never
+/// panics -- a malformed value on a performance flag must not take a node down on startup.
+fn env_flag(name: &str, default: bool) -> bool {
+    env::var(name).map_or(default, |v| v == "true" || v == "1")
 }
 
 pub fn env_parse<T>(name: &str, default: T) -> T
@@ -1554,20 +1556,20 @@ where
 }
 
 // Unlike env_optparse, an unparseable value is not fatal: it logs a warning and falls
-// back to per_chunk, so a typo in the strategy env never takes the process down.
+// back to range, so a typo in the strategy env never takes the process down.
 fn env_repartition_strategy() -> RepartitionStrategy {
     match env::var("CUBESTORE_REPARTITION_STRATEGY") {
         Ok(v) => match v.parse::<RepartitionStrategy>() {
             Ok(s) => s,
             Err(e) => {
                 log::warn!(
-                    "Ignoring CUBESTORE_REPARTITION_STRATEGY: {}; using per_chunk",
+                    "Ignoring CUBESTORE_REPARTITION_STRATEGY: {}; using range",
                     e
                 );
-                RepartitionStrategy::PerChunk
+                RepartitionStrategy::Range
             }
         },
-        Err(_) => RepartitionStrategy::PerChunk,
+        Err(_) => RepartitionStrategy::Range,
     }
 }
 
@@ -1867,7 +1869,7 @@ impl Config {
                 .map(|v| v as u64),
                 job_runners_count: env_parse("CUBESTORE_JOB_RUNNERS", 4),
                 long_term_job_runners_count: env_parse("CUBESTORE_LONG_TERM_JOB_RUNNERS", 32),
-                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 0),
+                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 1),
                 connection_timeout: 60,
                 server_name: env::var("CUBESTORE_SERVER_NAME")
                     .ok()
@@ -1876,7 +1878,7 @@ impl Config {
                 enable_topk: env_bool("CUBESTORE_ENABLE_TOPK", true),
                 load_aware_import_placement_enabled: env_bool(
                     "CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT",
-                    false,
+                    true,
                 ),
                 repartition_chunks_time_budget_secs: env_parse(
                     "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
@@ -1896,7 +1898,7 @@ impl Config {
                 ),
                 repartition_concurrent_download: env_bool(
                     "CUBESTORE_REPARTITION_CONCURRENT_DOWNLOAD",
-                    false,
+                    true,
                 ),
                 repartition_strategy: env_repartition_strategy(),
                 repartition_merge_max_input_files: env_parse(
@@ -1905,15 +1907,15 @@ impl Config {
                 ),
                 repartition_merge_max_rows: env_parse(
                     "CUBESTORE_REPARTITION_MERGE_MAX_ROWS",
-                    4_000_000,
+                    400_000,
                 ),
                 repartition_check_overlapping_children: env_bool(
                     "CUBESTORE_REPARTITION_CHECK_OVERLAPPING_CHILDREN",
                     false,
                 ),
-                group_by_limit_factor: env_parse_lenient("CUBESTORE_GROUP_BY_LIMIT_FACTOR", 0),
-                group_by_limit_per_partition: env_flag("CUBESTORE_GROUP_BY_LIMIT_PER_PARTITION"),
-                coalesce_under_hash_aggregate: env_flag("CUBESTORE_COALESCE_UNDER_HASH_AGGREGATE"),
+                group_by_limit_factor: env_parse_lenient("CUBESTORE_GROUP_BY_LIMIT_FACTOR", 2),
+                group_by_limit_per_partition: env_flag("CUBESTORE_GROUP_BY_LIMIT_PER_PARTITION", true),
+                coalesce_under_hash_aggregate: env_flag("CUBESTORE_COALESCE_UNDER_HASH_AGGREGATE", false),
                 topk_aggregate_strategy: env_topk_strategy("CUBESTORE_TOPK_STRATEGY"),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
@@ -2002,7 +2004,7 @@ impl Config {
                     Some(60_000),
                     None,
                 ),
-                metastore_batch_rpc: env_parse("CUBESTORE_METASTORE_BATCH_RPC", false),
+                metastore_batch_rpc: env_parse("CUBESTORE_METASTORE_BATCH_RPC", true),
                 transport_max_message_size,
                 transport_max_frame_size: env_parse_size(
                     "CUBESTORE_TRANSPORT_MAX_FRAME_SIZE",

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1371,11 +1371,28 @@ fn env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-/// Lenient boolean env read for toggles: only `1`/`true` enable it, anything else (including a
-/// typo) is treated as off; an unset variable falls back to `default`. Unlike [`env_bool`] it never
-/// panics -- a malformed value on a performance flag must not take a node down on startup.
+/// Lenient boolean env read for toggles: recognizes the usual spellings in either case and falls
+/// back to `default` with a warning on anything else. Unlike [`env_bool`] it never panics -- a
+/// malformed value on a performance flag must not take a node down on startup, and for a flag that
+/// is on by default the value an operator writes to turn it off is the one path that must work.
 fn env_flag(name: &str, default: bool) -> bool {
-    env::var(name).map_or(default, |v| v == "true" || v == "1")
+    match env::var(name) {
+        Err(_) => default,
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "" => default,
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            other => {
+                log::warn!(
+                    "Ignoring {} value '{}', using default ({})",
+                    name,
+                    other,
+                    default
+                );
+                default
+            }
+        },
+    }
 }
 
 pub fn env_parse<T>(name: &str, default: T) -> T
@@ -1876,7 +1893,7 @@ impl Config {
                     .unwrap_or("localhost".to_string()),
                 upload_to_remote: !env::var("CUBESTORE_NO_UPLOAD").ok().is_some(),
                 enable_topk: env_bool("CUBESTORE_ENABLE_TOPK", true),
-                load_aware_import_placement_enabled: env_bool(
+                load_aware_import_placement_enabled: env_flag(
                     "CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT",
                     true,
                 ),
@@ -1896,7 +1913,7 @@ impl Config {
                     "CUBESTORE_PREFILTER_IN_MEMORY_CHUNKS",
                     false,
                 ),
-                repartition_concurrent_download: env_bool(
+                repartition_concurrent_download: env_flag(
                     "CUBESTORE_REPARTITION_CONCURRENT_DOWNLOAD",
                     true,
                 ),
@@ -2004,7 +2021,7 @@ impl Config {
                     Some(60_000),
                     None,
                 ),
-                metastore_batch_rpc: env_parse("CUBESTORE_METASTORE_BATCH_RPC", true),
+                metastore_batch_rpc: env_flag("CUBESTORE_METASTORE_BATCH_RPC", true),
                 transport_max_message_size,
                 transport_max_frame_size: env_parse_size(
                     "CUBESTORE_TRANSPORT_MAX_FRAME_SIZE",

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -534,9 +534,9 @@ pub trait ConfigObj: DIService {
 
     fn enable_topk(&self) -> bool;
 
-    /// When enabled, a TableImportCSV job is placed on the worker with the fewest in-flight
-    /// CSV imports (load-aware), instead of by stateless hash of (table_id, location). Off by
-    /// default (hash placement); kept as a flag for rollout/rollback.
+    /// When enabled (default), a TableImportCSV job is placed on the worker with the fewest
+    /// in-flight CSV imports (load-aware). When disabled, placement is the stateless hash of
+    /// (table_id, location), which ignores in-flight load.
     fn load_aware_import_placement_enabled(&self) -> bool;
 
     /// Time budget for a single batch repartition job. The job yields its runner
@@ -561,14 +561,14 @@ pub trait ConfigObj: DIService {
     /// Off by default; when disabled, chunks are sent whole and filtered only in the subprocess.
     fn prefilter_in_memory_chunks_enabled(&self) -> bool;
 
-    /// When enabled, a merge group's chunk parquets (PerPartition / Range strategies) are
-    /// downloaded concurrently before building the merge inputs, instead of one at a time.
+    /// When enabled (default), a merge group's chunk parquets (PerPartition / Range strategies)
+    /// are downloaded concurrently before building the merge inputs, instead of one at a time.
     /// The group is already bounded by repartition_merge_max_input_files and the download
-    /// pool by download_concurrency, so no extra budget is needed. Off by default.
+    /// pool by download_concurrency, so no extra budget is needed.
     fn repartition_concurrent_download(&self) -> bool;
 
     /// Which repartition strategy to use for an inactive parent's persisted chunks.
-    /// Defaults to PerChunk.
+    /// Defaults to Range.
     fn repartition_strategy(&self) -> RepartitionStrategy;
 
     /// Cap on the number of chunks merged together in one Merge group / RepartitionRange.
@@ -586,15 +586,15 @@ pub trait ConfigObj: DIService {
     fn repartition_check_overlapping_children(&self) -> bool;
     /// Factor `f` controlling when the worker-side partial hash aggregate trims its output to the
     /// top-k groups. Trimming happens only when the number of local groups exceeds `f * k`, where
-    /// `k = limit + offset`. `0` disables the optimization. Whether the trim runs decides the shape
-    /// of both halves of a split plan, so it rides in [`PlanningFlags`]; a worker uses its own value
-    /// only when the sender sent no flags.
+    /// `k = limit + offset`. `0` disables the optimization; the default is `2`. Whether the trim
+    /// runs decides the shape of both halves of a split plan, so it rides in [`PlanningFlags`]; a
+    /// worker uses its own value only when the sender sent no flags.
     fn group_by_limit_factor(&self) -> usize;
 
     /// When the worker group-by-limit hash trim is active, controls where the worker's hash table
-    /// lives: `false` (default) coalesces the partial aggregate's input to one partition (one hash
-    /// table per worker, "over merge"); `true` keeps the raw multi-partition input so it runs per
-    /// partition ("under merge").
+    /// lives: `true` (default) keeps the raw multi-partition input so the aggregate runs per
+    /// partition ("under merge"); `false` coalesces the partial aggregate's input to one partition
+    /// (one hash table per worker, "over merge").
     ///
     /// Unlike [`ConfigObj::group_by_limit_factor`], this one stays node-local and is not part of
     /// [`PlanningFlags`]: it only moves a partition coalesce below the partial aggregate, leaving
@@ -605,8 +605,8 @@ pub trait ConfigObj: DIService {
     /// partition coalesce (the hash aggregate ignores input order, so the per-row merge is wasted).
     fn coalesce_under_hash_aggregate(&self) -> bool;
 
-    /// Router-side merge strategy for distributed value-ordered top-k. The router's value governs
-    /// the whole query; see [`TopKAggregateStrategy`].
+    /// Router-side merge strategy for distributed value-ordered top-k. Defaults to FullMerge; the
+    /// router's value governs the whole query, see [`TopKAggregateStrategy`].
     fn topk_aggregate_strategy(&self) -> TopKAggregateStrategy;
 
     fn allow_decimal128(&self) -> bool;
@@ -2162,22 +2162,22 @@ impl Config {
                 server_name: "localhost".to_string(),
                 upload_to_remote: true,
                 enable_topk: true,
-                load_aware_import_placement_enabled: false,
+                load_aware_import_placement_enabled: true,
                 repartition_chunks_time_budget_secs: 60,
                 push_partial_aggregate_below_merge_enabled: true,
                 compaction_split_by_total_file_size_enabled: false,
                 // Production default is off; kept on in tests so prefilter_chunks_shared_scan
                 // and the rest of the suite keep exercising the worker-side trim path.
                 prefilter_in_memory_chunks_enabled: true,
-                repartition_concurrent_download: false,
-                repartition_strategy: RepartitionStrategy::PerChunk,
+                repartition_concurrent_download: true,
+                repartition_strategy: RepartitionStrategy::Range,
                 repartition_merge_max_input_files: 50,
-                repartition_merge_max_rows: 4_000_000,
+                repartition_merge_max_rows: 400_000,
                 repartition_check_overlapping_children: false,
                 group_by_limit_factor: 2,
-                group_by_limit_per_partition: false,
+                group_by_limit_per_partition: true,
                 coalesce_under_hash_aggregate: false,
-                topk_aggregate_strategy: TopKAggregateStrategy::Streaming,
+                topk_aggregate_strategy: TopKAggregateStrategy::FullMerge,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,
@@ -2206,7 +2206,7 @@ impl Config {
                 max_disk_space_per_worker: 0,
                 disk_space_cache_duration_secs: 0,
                 disk_space_compute_lock_timeout_ms: 1000,
-                metastore_batch_rpc: false,
+                metastore_batch_rpc: true,
                 transport_max_message_size: 64 << 20,
                 transport_max_frame_size: 16 << 20,
                 local_files_cleanup_interval_secs: 600,

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
@@ -436,13 +436,13 @@ fn resort_worker_subtree(
     // the trim bounds the worker exactly as before, not leaving it unbounded.
     if partial.as_any().is::<AggregateExec>() && group_by_limit_factor > 0 {
         // CUBESTORE_GROUP_BY_LIMIT_PER_PARTITION decides where the worker's hash table lives:
-        //  - off (default): coalesce the aggregate's input to a single partition, so the worker
-        //    builds ONE hash table over the merged partitions ("over merge"). Peak memory ~k, no
-        //    intra-worker parallelism on the aggregation.
-        //  - on: keep the raw multi-partition input, so the aggregate runs once per partition
-        //    ("under merge"): N parallel hash tables -- more parallelism, peak ~N*k. The trim keeps
-        //    each per-partition output to ~factor*k, and the global top-k argument (full group key)
-        //    guarantees a surviving group stays within every partition's local top-k.
+        //  - on (default): keep the raw multi-partition input, so the aggregate runs once per
+        //    partition ("under merge"): N parallel hash tables -- more parallelism, peak ~N*k. The
+        //    trim keeps each per-partition output to ~factor*k, and the global top-k argument (full
+        //    group key) guarantees a surviving group stays within every partition's local top-k.
+        //  - off: coalesce the aggregate's input to a single partition, so the worker builds ONE
+        //    hash table over the merged partitions ("over merge"). Peak memory ~k, no intra-worker
+        //    parallelism on the aggregation.
         let partial = if group_by_limit_per_partition {
             partial
         } else {

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -580,9 +580,12 @@ impl QueryExecutorImpl {
         data_loaded_size: Option<Arc<DataLoadedSize>>,
     ) -> Result<Arc<SessionContext>, CubeError> {
         // A sender that does not send the flags planned from its own configuration, and this
-        // node's configuration reproduces it as long as the value is unset (both binaries default
-        // to the same one) or set on every node. A value set on the router alone is the one case
-        // it cannot reproduce, so keep such a value set cluster-wide until every node sends flags.
+        // node's configuration reproduces it when the value is set on every node, or when it is
+        // unset and both binaries default to the same one. The defaults changed once since the
+        // flags were introduced, so an upgrade that reaches this binary from one older than the
+        // flags -- skipping the release that introduced them -- must pin CUBESTORE_TOPK_STRATEGY
+        // and CUBESTORE_GROUP_BY_LIMIT_FACTOR cluster-wide for the duration, or the two halves of
+        // a split plan get planned from different values and the query returns wrong rows.
         let planning_flags = worker_planning_params
             .flags
             .unwrap_or_else(|| PlanningFlags::from_config(self.config.as_ref()));

--- a/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
@@ -615,7 +615,7 @@ pub fn plan_topk(
 
     // Full-merge strategy: workers send their groups unsorted, the router re-aggregates with one
     // vectorized hash aggregate and takes the top-k with a fetch-limited sort. Drops early
-    // termination (so the router materializes every distinct group), so it is opt-in and skips HLL.
+    // termination, so the router materializes every distinct group; skips HLL.
     if ext_planner.planning_flags.topk_strategy == TopKAggregateStrategy::FullMerge
         && agg_fun
             .iter()

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -1781,10 +1781,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn schedule_table_import_hash_placement_by_default() {
+    async fn schedule_table_import_hash_placement() {
         let config = Config::test("schedule_table_import_hash").update_config(|mut c| {
             c.select_workers = (0..4).map(|i| format!("worker{}", i)).collect();
-            // load_aware_import_placement_enabled defaults to false (old behavior).
+            c.load_aware_import_placement_enabled = false;
             c
         });
         let (meta_store, scheduler) =
@@ -1816,7 +1816,7 @@ mod tests {
             assert_eq!(
                 placement.get(l),
                 Some(&expected),
-                "default placement must follow the stateless hash"
+                "hash placement must follow the stateless hash"
             );
         }
 

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3469,15 +3469,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn topk_full_merge() -> Result<(), CubeError> {
-        // The full-merge strategy replaces the streaming top-k node with a router-side
-        // re-aggregation + fetch-limited sort. Exercise it end-to-end (UNION -> multi-partition
-        // ClusterSend, which is what required the explicit CoalescePartitions fan-in) and check it
-        // returns the same top-k as the default streaming merge across Sum/Min/Max, both directions,
-        // and HAVING.
-        Config::test("topk_full_merge")
+    async fn topk_streaming_merge() -> Result<(), CubeError> {
+        // The streaming strategy keeps the per-row top-k node instead of the default router-side
+        // re-aggregation + fetch-limited sort, and is what an operator falls back to. Exercise it
+        // end-to-end (UNION -> multi-partition ClusterSend, which is what required the explicit
+        // CoalescePartitions fan-in) and check it returns the same top-k as the default full merge
+        // across Sum/Min/Max, both directions, and HAVING.
+        Config::test("topk_streaming_merge")
             .update_config(|mut c| {
-                c.topk_aggregate_strategy = crate::config::TopKAggregateStrategy::FullMerge;
+                c.topk_aggregate_strategy = crate::config::TopKAggregateStrategy::Streaming;
                 c
             })
             .start_test(async move |services| {
@@ -4040,16 +4040,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repartition_concurrent_download_keeps_data_consistent() -> Result<(), CubeError> {
-        // PerPartition merge with concurrent chunk download enabled must drain and keep
-        // data consistent end-to-end (real concurrent downloads in the merge group build).
-        Config::test("repartition_concurrent_download_keeps_data_consistent")
+    async fn repartition_sequential_download_keeps_data_consistent() -> Result<(), CubeError> {
+        // Concurrent chunk download is the default, so this covers the fallback: a PerPartition
+        // merge downloading its group one chunk at a time must drain and keep data consistent
+        // end-to-end.
+        Config::test("repartition_sequential_download_keeps_data_consistent")
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
                 c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
                 c.repartition_merge_max_input_files = 4;
-                c.repartition_concurrent_download = true;
+                c.repartition_concurrent_download = false;
                 c
             })
             .start_test(async move |services| {
@@ -6615,6 +6616,10 @@ mod tests {
 
     #[tokio::test]
     async fn worker_sort_and_limit_cluster() -> Result<(), CubeError> {
+        // The workers run the group-by-limit trim with `group_by_limit_per_partition` off, the
+        // non-default "over merge" shape: one hash table per worker over the coalesced input.
+        // Both shapes must return the same rows, and the default one is what the rest of the
+        // suite runs.
         Config::test("worker_sort_limit_router")
             .update_config(|mut config| {
                 config.select_workers = vec![
@@ -6623,6 +6628,7 @@ mod tests {
                 ];
                 config.metastore_bind_address = Some("127.0.0.1:25106".to_string());
                 config.compaction_chunks_count_threshold = 0;
+                config.group_by_limit_per_partition = false;
                 config
             })
             .start_test(async move |services| {
@@ -6642,6 +6648,7 @@ mod tests {
                             ),
                         };
                         config.compaction_chunks_count_threshold = 0;
+                        config.group_by_limit_per_partition = false;
                         config
                     })
                     .start_test_worker(async move |_| {
@@ -6660,6 +6667,7 @@ mod tests {
                                     ),
                                 };
                                 config.compaction_chunks_count_threshold = 0;
+                                config.group_by_limit_per_partition = false;
                                 config
                             })
                             .start_test_worker(async move |_| {

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1616,12 +1616,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn partition_data_with_batch_rpc() {
-        // Exercises the CUBESTORE_METASTORE_BATCH_RPC path: build_index_chunks fetches active
-        // partitions for all indexes in one get_active_partitions_for_indexes call and routes
-        // them per index. The produced chunks must still cover every input row.
-        let config = Config::test("partition_data_with_batch_rpc").update_config(|mut c| {
-            c.metastore_batch_rpc = true;
+    async fn partition_data_without_batch_rpc() {
+        // Batched metastore RPC is the default, so this covers the fallback: build_index_chunks
+        // fetching active partitions per index instead of in one
+        // get_active_partitions_for_indexes call. The produced chunks must still cover every
+        // input row.
+        let config = Config::test("partition_data_without_batch_rpc").update_config(|mut c| {
+            c.metastore_batch_rpc = false;
             c
         });
         let path = "/tmp/test_partition_data_batch";
@@ -2054,12 +2055,12 @@ mod tests {
     async fn repartition_chunk_range_merges_only_range() {
         // repartition_chunk_range must merge only the active persisted chunks within
         // [start, end], leaving the rest active, and conserve rows into the children.
-        // Run with batched metastore RPC on so the batched insert_chunks path in
-        // merge_chunk_group_into_children is exercised (per-item path covered by the other
-        // repartition tests, which default the flag off).
+        // Run with batched metastore RPC off so the per-item insert_chunks path in
+        // merge_chunk_group_into_children is exercised (the batched path is the default and is
+        // covered by the other repartition tests).
         let config =
             Config::test("repartition_chunk_range_merges_only_range").update_config(|mut c| {
-                c.metastore_batch_rpc = true;
+                c.metastore_batch_rpc = false;
                 c
             });
         let path = "/tmp/test_repartition_range";


### PR DESCRIPTION
## Summary

Flips the defaults of the CubeStore performance/ingestion env toggles that have been opt-in so far, so a node gets them without extra configuration. Every toggle keeps its env var, so any of them can still be turned back off individually.

## Changes

New defaults in `Config::default_values()`:

| Env | Was | Now |
|---|---|---|
| `CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT` | `false` | `true` |
| `CUBESTORE_REPARTITION_STRATEGY` | `per_chunk` | `range` |
| `CUBESTORE_REPARTITION_CONCURRENT_DOWNLOAD` | `false` | `true` |
| `CUBESTORE_REPARTITION_MERGE_MAX_ROWS` | `4_000_000` | `400_000` |
| `CUBESTORE_CSV_IMPORT_JOB_RUNNERS` | `0` | `1` |
| `CUBESTORE_METASTORE_BATCH_RPC` | `false` | `true` |
| `CUBESTORE_GROUP_BY_LIMIT_FACTOR` | `0` | `2` |
| `CUBESTORE_GROUP_BY_LIMIT_PER_PARTITION` | `false` | `true` |
| `CUBESTORE_TOPK_STRATEGY` | `streaming` | `full_merge` |

`CUBESTORE_COMPACTION_CHUNKS_THRESHOLD_MULTIPLIER` was already `1.0` and is unchanged.

Supporting bits, kept to the minimum the flip requires:

- `env_topk_strategy` and `env_repartition_strategy` hold their default inside the parser, so their unset/unparseable fallbacks (and warning texts) move to `FullMerge` / `Range`. The `""` and `default` aliases of `CUBESTORE_TOPK_STRATEGY` follow the new default instead of resolving to `streaming`.
- `env_flag` takes the default as an argument — `GROUP_BY_LIMIT_PER_PARTITION` needs `true`, while it previously hardcoded `false`. Parsing stays lenient (`1`/`true` enable, anything else is off, never panics); `CUBESTORE_COALESCE_UNDER_HASH_AGGREGATE` passes `false` explicitly and is unaffected.
- The `(default)` marker in the `TopKAggregateStrategy` docs moves from `Streaming` to `FullMerge`.

`Config::test(...)` is untouched: it sets these fields explicitly, so the test suite keeps running the previous modes, and the tests that cover the newly-default paths keep opting into them by hand.

## Testing

- `cargo check -p cubestore --lib`
- `cargo fmt --all -- --check`