### PR TITLE
docs: document donut totals, table row grouping, bar orientation, and chat-driven dbt pulls

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/bar.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/bar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bar
-description: Compare values across categories with grouped, stacked, percentage, and horizontal variants.
+description: Compare values across categories with grouped, stacked, and percentage variants, in either orientation.
 ---
 
 Bar charts compare values across discrete categories. Use them when the magnitude of individual values matters and direct comparison between categories is the goal.
@@ -33,17 +33,25 @@ Each stack is normalized to 100%, showing each series as a proportion of the tot
 
 {/* Screenshot: percentage stacked bar — same data as stacked but normalized to 100%. Place directly below this heading, full-width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-### Horizontal
-
-All three vertical variants are also available horizontally. Horizontal bars work well for long category labels, many categories, or when a left-to-right reading direction feels more natural.
-
-{/* Screenshot: horizontal stacked bar chart. Place directly below this heading, full-width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
-
 ### Composite (bar + line)
 
 Assign one series to the right Y axis and set its mark type to **Line** in [series configuration](/docs/explore-analyze/charts/configuration/series-configuration). This creates a dual-axis chart — useful for overlaying a rate on top of volume data (e.g. order count as bars, revenue per order as a line).
 
 {/* Screenshot: composite bar+line chart with dual Y axes — order count (bars, left axis) and average order value (line, right axis). Place directly below this heading, full-width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Orientation
+
+The **Bars** control at the top of the Style tab switches the chart between
+**Vertical** and **Horizontal** without picking a different variant — it swaps the
+category and value axes on the existing chart, keeping your stacking, sorting, and
+data-label settings. Horizontal works well for long category labels, many
+categories, or when a left-to-right reading direction feels more natural.
+
+{/* Screenshot: Style tab with the Bars orientation control at the top, set to Horizontal. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+The control is disabled — with a tooltip explaining why — when the chart has no
+axes to swap (e.g. a composite bar + line chart) or when it's missing a dimension
+or measure.
 
 ## Stacking
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -25,6 +25,13 @@ Drag the **Inner radius** slider in the Style tab or enter a pixel value. Settin
 
 {/* Screenshot: Style tab with the Inner radius control highlighted. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
+## Total
+
+Donuts show the measure's total in the center hole by default, formatted using the
+measure's own number format. Toggle it off with **Show total** next to the data
+labels controls in the Style tab. The total only appears once the inner radius is
+non-zero — a full pie has no hole to show it in.
+
 ## Color and slice ordering
 
 Slices are colored using the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking) in palette order, matched to the sort order of your query results. To change which slice appears first, adjust the sort in the results table.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -32,6 +32,24 @@ Pivot behavior:
 - Pivot columns can also be sorted by row values — click a row number to sort by that row, including the totals row.
 - Pivoted columns can be hidden, but hiding is indexed to the specific value (e.g. hiding `status: returned`), not position.
 
+## Row grouping
+
+With two or more row dimensions and no pivot active, enable **Group rows** in the
+**Row grouping** section of the **Style** tab to nest rows under a collapsible
+header for each dimension value, instead of repeating that value on every row.
+
+{/* TODO screenshot: table with row grouping enabled — nested, collapsible group headers by dimension */}
+
+- Each group header shows its dimension value once; **Expand all groups** /
+  **Collapse all groups** toggle every level at once.
+- Per column, set whether its groups start **Expanded** or **Collapsed** from that
+  column's card in the **Row grouping** section.
+- Group headers have their own text color, background color, and text format,
+  set alongside the expand/collapse defaults.
+
+Row grouping is unavailable when the table has fewer than two row dimensions or
+when a column pivot is active.
+
 ## Column field options
 
 Configure individual columns in the **Columns** section of the **Style** tab (or via the dropdown arrow on a field in the **Fields** section):

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -384,6 +384,16 @@ under the output path, on your development branch.
 Review the generated cubes in the **Changes** view, then commit and merge the branch
 through your normal workflow.
 
+## Run a pull from Cube AI chat
+
+You can also ask the [agent](/docs/explore-analyze/analytics-chat) to run a pull
+instead of using the pull dialog — for example, "check for dbt updates and pull
+them." The agent starts a sync, follows its progress, opens the review branch it
+creates, and summarizes the generated cubes when it finishes.
+
+Ask "what happened with my recent dbt syncs?" to have the agent read back sync
+history — including past runs' status and logs — without starting a new one.
+
 ## Keep Cube in sync automatically
 
 Automated syncs run the same pipeline as a manual pull, but instead of committing to


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Found by cross-checking recent `cubedevinc/cubejs-enterprise` merges against docs-mintlify for undocumented customer-facing changes. These four small, already-shipped (no feature flag) features had no docs:

- **Donut center total** (`pie.mdx`) — the "Show total" toggle that displays a measure's total in a donut's hole, on by default.
- **Table row grouping** (`table.mdx`) — the new "Row grouping" Style-tab section that nests rows under collapsible group headers when 2+ row dimensions are used with no pivot.
- **Bar orientation** (`bar.mdx`) — the bar chart's variant picker was collapsed from 6 entries to 3, with a separate **Bars** orientation control (Vertical/Horizontal) replacing the old dedicated horizontal variants. Updated the Variants list and added an Orientation section accordingly.
- **dbt pulls from Cube AI chat** (`dbt.mdx`) — a new section describing how to ask the agent to run/check on a dbt pull and read back sync history, as an alternative to the manual pull dialog.

Each was verified against the underlying source diff and i18n strings in the enterprise repo to get UI labels and behavior right. No new pages were needed, so `docs.json` navigation is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_018CMpvXNfP3LRBUH8XapcPp)_