### PR TITLE
docs: document bins and value groups in workbooks

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -30,7 +30,7 @@ metric or dimension for the analysis in front of you.
 ## Creating calculated fields in UI
 
 You can also build and edit calculated fields directly in the workbook. New
-fields appear in the **Calculated fields** section of the field picker sidebar.
+fields appear in the **Query fields** section of the field picker sidebar.
 
 ### Aggregations from existing dimensions
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -90,7 +90,12 @@ the field picker sidebar and choose **Create bins…** on a number dimension, or
 **Group values…** on a string one. Time dimensions have granularities instead,
 and an already derived field cannot be bucketed again.
 
-{/* TODO: screenshot — the bins panel with its bucket preview and generated SQL */}
+<Frame>
+  <img
+    src="https://ucarecdn.com/b9890dd7-d82c-4126-a2e5-2f3948eafa72/772aa0f9-light.png"
+    alt="The Create bins panel on a number dimension, showing typed boundaries, the label styles, a preview of the five buckets, and the generated Semantic SQL"
+  />
+</Frame>
 
 **Bins** take their boundaries either as a list (**Custom ranges**) or from a
 **Start**, **Width**, and number of **Ranges** (**Equal width**). Each boundary
@@ -110,6 +115,13 @@ Bucket labels carry their position as a prefix (`1.`, `2.`, zero-padded past nin
 buckets) so that sorting the column sorts it by value rather than alphabetically,
 which would put `>= 25` before `[0, 18)`. The prefix is visible in results, chart
 legends, and axes.
+
+<Frame>
+  <img
+    src="https://ucarecdn.com/23ac9cbb-7503-4326-b74c-134ad54e5e7a/6cffb52c-light.png"
+    alt="A workbook result grouped by the bucketed field: one row per bucket, with the created field listed under Query fields in the sidebar"
+  />
+</Frame>
 
 The panel previews the Semantic SQL it generates as you build:
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -83,6 +83,56 @@ The option appears only for **native** measures on pivoted columns, not for
 calculated fields. The same flow works in **Explore** when results are pivoted
 the same way.
 
+### Bins and value groups
+
+You can also bucket an existing dimension without writing SQL. Open its menu in
+the field picker sidebar and choose **Create bins…** on a number dimension, or
+**Group values…** on a string one. Time dimensions have granularities instead,
+and an already derived field cannot be bucketed again.
+
+{/* TODO: screenshot — the bins panel with its bucket preview and generated SQL */}
+
+**Bins** take their boundaries either as a list (**Custom ranges**) or from a
+**Start**, **Width**, and number of **Ranges** (**Equal width**). Each boundary
+opens a bucket that includes its lower bound and excludes the upper one, and two
+open-ended buckets are added at the edges—so `0, 18, 25` yields `< 0`, `[0, 18)`,
+`[18, 25)`, `>= 25`, and no row is dropped. **Label style** renders a bucket as
+`[10, 20)`, `>= 10 and < 20`, or `10 to 19`; the last is offered only while every
+boundary is a whole number. Rows where the dimension is `NULL` are reported as
+`Unknown`.
+
+**Value groups** collect the dimension's values into named sets: pick values, name
+the group, and choose **Add group**. A value belongs to one group at a time.
+Whatever you did not pick—including empty values—falls under **Everything else**,
+which defaults to `Other`.
+
+Bucket labels carry their position as a prefix (`1.`, `2.`, zero-padded past nine
+buckets) so that sorting the column sorts it by value rather than alphabetically,
+which would put `>= 25` before `[0, 18)`. The prefix is visible in results, chart
+legends, and axes.
+
+The panel previews the Semantic SQL it generates as you build:
+
+```sql
+CASE WHEN orders_view.age IS NULL THEN 'Unknown'
+  WHEN orders_view.age < 0 THEN '1. < 0'
+  WHEN orders_view.age < 18 THEN '2. [0, 18)'
+  ELSE '3. >= 18' END
+```
+
+<Info>
+
+**Equal width** ranges are resolved into boundaries when the field is created, not
+recomputed from the data. Values arriving later outside the range join the first
+and last buckets instead of extending them.
+
+</Info>
+
+To change a bucketed field, choose **Edit bins…** or **Edit groups…** from its
+menu—either in the sidebar or on its column header in the results. Only fields
+this panel generated offer the action; a `CASE` expression written by hand does
+not.
+
 ### Editing a calculated field
 
 Select a calculated field in the sidebar to open the editor. You can change its


### PR DESCRIPTION
Bins and value groups shipped in the workbook a while back and had no docs. This adds them to the calculated-fields page rather than a page of their own: a bin is not a new kind of member — it is a query-scoped custom dimension with the same storage, the same **Query fields** section, and the same delete action as any calculated field, so a reader who lands there and finds no mention of the panel that produced their field is on the wrong page.

What the section covers, chosen as the things the panel does not say and a user would otherwise get wrong:

- two open-ended buckets are always added at the edges, so `n` boundaries give `n + 1` buckets and no row is dropped;
- `NULL` is reported as `Unknown`, and whatever no group claims falls under **Everything else** (`Other`);
- equal-width ranges are resolved into boundaries once, at creation, not recomputed as data arrives;
- bucket labels carry an ordering prefix (`1.`, `2.`, zero-padded past nine), which is why sorting the column sorts by value — and why the prefix shows up in the grid, legends and axes.

Two screenshots, taken against a running workbook: the panel itself, and a result grouped by a bucketed field.

One fix on the way in, in its own commit: the page said new calculated fields appear in a **Calculated fields** section of the field picker. The section is **Query fields**; there was nothing under the old name to look for.

Verified with `mintlify broken-links --check-anchors` (one hit, pre-existing, in `reference/control-plane-api.mdx`) and a local `mintlify dev` — the page compiles and both images resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)