### PR TITLE
fix(query-orchestrator): key refresh key cache entries consistently

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -191,7 +191,7 @@ export class PreAggregationLoadCache {
   }
 
   public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: QueuePriority) {
-    const memoKey = this.queryCache.refreshKeyCacheKey(sqlQuery);
+    const memoKey = this.queryCache.refreshKeyCacheKey(sqlQuery, this.dataSource);
 
     if (!this.queryResults[memoKey]) {
       this.queryResults[memoKey] = await this.queryCache.cacheRefreshKeyResult(
@@ -209,7 +209,7 @@ export class PreAggregationLoadCache {
   }
 
   public hasKeyQueryResult(keyQuery: QueryWithParams) {
-    return !!this.queryResults[this.queryCache.refreshKeyCacheKey(keyQuery)];
+    return !!this.queryResults[this.queryCache.refreshKeyCacheKey(keyQuery, this.dataSource)];
   }
 
   public async getQueryStage(stageQueryKey) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -191,32 +191,25 @@ export class PreAggregationLoadCache {
   }
 
   public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: QueuePriority) {
-    const [query, values, queryOptions] = sqlQuery;
+    const memoKey = this.queryCache.refreshKeyCacheKey(sqlQuery);
 
-    if (!this.queryResults[this.queryCache.queryRedisKey([query, values])]) {
-      this.queryResults[this.queryCache.queryRedisKey([query, values])] = await this.queryCache.cacheQueryResult(
-        query,
-        values,
-        [query, values],
+    if (!this.queryResults[memoKey]) {
+      this.queryResults[memoKey] = await this.queryCache.cacheRefreshKeyResult(
+        sqlQuery,
         60 * 60,
         {
-          renewalThreshold: this.queryCache.options.refreshKeyRenewalThreshold
-            || queryOptions?.renewalThreshold || 2 * 60,
-          renewalKey: [query, values],
           waitForRenew,
           priority,
           requestId: this.requestId,
           dataSource: this.dataSource,
-          useInMemory: true,
-          external: queryOptions?.external
         }
       );
     }
-    return this.queryResults[this.queryCache.queryRedisKey([query, values])];
+    return this.queryResults[memoKey];
   }
 
-  public hasKeyQueryResult(keyQuery) {
-    return !!this.queryResults[this.queryCache.queryRedisKey(keyQuery)];
+  public hasKeyQueryResult(keyQuery: QueryWithParams) {
+    return !!this.queryResults[this.queryCache.refreshKeyCacheKey(keyQuery)];
   }
 
   public async getQueryStage(stageQueryKey) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -132,15 +132,14 @@ export class PreAggregationLoader {
   public async loadPreAggregation(
     throwOnMissingPartition: boolean,
   ): Promise<null | LoadPreAggregationResult> {
-    // Hashes a cache key per invalidation key, so it stays a thunk — the branches above it decide
-    // the outcome on their own for every request an `externalRefresh` instance serves.
+    // A thunk: hashing a cache key per invalidation key is wasted whenever the cheaper terms of
+    // the condition below already decide it.
     const invalidationKeysLoaded = () => (this.preAggregation.invalidateKeyQueries || [])
       .every(keyQuery => this.loadCache.hasKeyQueryResult(keyQuery));
 
     // Outside of a build job, `externalRefresh` must reach the branch below: it owns the "partition
     // is not built yet" handling and may not enqueue a build here.
     if (this.isJob || (!this.externalRefresh && (this.waitForRenew || invalidationKeysLoaded()))) {
-      // Renew synchronously so the current request returns the most current data.
       const result = await this.loadPreAggregationWithKeys();
       const refreshKeyValues = await this.getInvalidationKeyValues();
       return {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -132,14 +132,15 @@ export class PreAggregationLoader {
   public async loadPreAggregation(
     throwOnMissingPartition: boolean,
   ): Promise<null | LoadPreAggregationResult> {
-    const invalidationKeysLoaded = (this.preAggregation.invalidateKeyQueries || [])
+    // Hashes a cache key per invalidation key, so it stays a thunk — the branches above it decide
+    // the outcome on their own for every request an `externalRefresh` instance serves.
+    const invalidationKeysLoaded = () => (this.preAggregation.invalidateKeyQueries || [])
       .every(keyQuery => this.loadCache.hasKeyQueryResult(keyQuery));
 
-    // `externalRefresh` must stay on the Case 3 path below: it owns the "partition is not built
-    // yet" handling and must never enqueue a build on this instance.
-    if (this.isJob || this.waitForRenew || (invalidationKeysLoaded && !this.externalRefresh)) {
-      // Renew synchronously so the current request returns the most current data, unlike Case 3
-      // below which serves what already exists and refreshes in the background.
+    // Outside of a build job, `externalRefresh` must reach the branch below: it owns the "partition
+    // is not built yet" handling and may not enqueue a build here.
+    if (this.isJob || (!this.externalRefresh && (this.waitForRenew || invalidationKeysLoaded()))) {
+      // Renew synchronously so the current request returns the most current data.
       const result = await this.loadPreAggregationWithKeys();
       const refreshKeyValues = await this.getInvalidationKeyValues();
       return {
@@ -154,7 +155,7 @@ export class PreAggregationLoader {
           : undefined,
       };
     } else {
-      // Case 3: pre-agg exists
+      // Serve whatever version already exists rather than making this request wait for a build
       const structureVersion = getStructureVersion(this.preAggregation);
       const getVersionsStarted = new Date();
       const { byStructure } = await this.loadCache.getVersionEntries(this.preAggregation);

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -132,14 +132,14 @@ export class PreAggregationLoader {
   public async loadPreAggregation(
     throwOnMissingPartition: boolean,
   ): Promise<null | LoadPreAggregationResult> {
-    const notLoadedKey = (this.preAggregation.invalidateKeyQueries || [])
-      .find(keyQuery => !this.loadCache.hasKeyQueryResult(keyQuery));
+    const invalidationKeysLoaded = (this.preAggregation.invalidateKeyQueries || [])
+      .every(keyQuery => this.loadCache.hasKeyQueryResult(keyQuery));
 
-    if (this.isJob || !(notLoadedKey && !this.waitForRenew)) {
-      // Case 1: pre-agg build job processing.
-      // Case 2: either we have no data cached for this rollup or waitForRenew
-      // is true, either way, synchronously renew what data is needed so that
-      // the most current data will be returned fo the current request.
+    // `externalRefresh` must stay on the Case 3 path below: it owns the "partition is not built
+    // yet" handling and must never enqueue a build on this instance.
+    if (this.isJob || this.waitForRenew || (invalidationKeysLoaded && !this.externalRefresh)) {
+      // Renew synchronously so the current request returns the most current data, unlike Case 3
+      // below which serves what already exists and refreshes in the background.
       const result = await this.loadPreAggregationWithKeys();
       const refreshKeyValues = await this.getInvalidationKeyValues();
       return {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
@@ -86,11 +86,7 @@ export class PreAggregationPartitionRangeLoader {
 
   private async loadRangeQuery(rangeQuery: QueryWithParams, partitionRange?: QueryDateRange) {
     const [query, values, queryOptions]: QueryWithParams = rangeQuery;
-    // Must stay identical to the read side in PreAggregations.checkPartitionsBuildRangeCache.
-    const invalidate =
-      this.preAggregation.invalidateKeyQueries?.[0]
-        ? QueryCache.refreshKeyIdentity(this.preAggregation.invalidateKeyQueries[0])
-        : false;
+    const invalidate = QueryCache.buildRangeInvalidateKey(this.preAggregation);
 
     return this.queryCache.cacheQueryResult(
       query,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
@@ -86,9 +86,10 @@ export class PreAggregationPartitionRangeLoader {
 
   private async loadRangeQuery(rangeQuery: QueryWithParams, partitionRange?: QueryDateRange) {
     const [query, values, queryOptions]: QueryWithParams = rangeQuery;
+    // Must stay identical to the read side in PreAggregations.checkPartitionsBuildRangeCache.
     const invalidate =
       this.preAggregation.invalidateKeyQueries?.[0]
-        ? this.preAggregation.invalidateKeyQueries[0].slice(0, 2)
+        ? QueryCache.refreshKeyIdentity(this.preAggregation.invalidateKeyQueries[0])
         : false;
 
     return this.queryCache.cacheQueryResult(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -625,9 +625,10 @@ export class PreAggregations {
     return Promise.all(
       preAggregations.map(async (preAggregation) => {
         const { preAggregationStartEndQueries } = preAggregation;
+        // Must stay identical to the write side in PreAggregationPartitionRangeLoader.loadRangeQuery.
         const invalidate =
           preAggregation?.invalidateKeyQueries[0]
-            ? preAggregation.invalidateKeyQueries[0].slice(0, 2)
+            ? QueryCache.refreshKeyIdentity(preAggregation.invalidateKeyQueries[0])
             : false;
         const isCached = preAggregation.partitionGranularity
           ? (

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -625,11 +625,6 @@ export class PreAggregations {
     return Promise.all(
       preAggregations.map(async (preAggregation) => {
         const { preAggregationStartEndQueries } = preAggregation;
-        // Must stay identical to the write side in PreAggregationPartitionRangeLoader.loadRangeQuery.
-        const invalidate =
-          preAggregation?.invalidateKeyQueries[0]
-            ? QueryCache.refreshKeyIdentity(preAggregation.invalidateKeyQueries[0])
-            : false;
         const isCached = preAggregation.partitionGranularity
           ? (
             await Promise.all(
@@ -637,7 +632,7 @@ export class PreAggregations {
                 this.queryCache.resultFromCacheIfExists({
                   query,
                   values,
-                  invalidate,
+                  invalidate: QueryCache.buildRangeInvalidateKey(preAggregation),
                 })
               ))
             )

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -46,10 +46,8 @@ export type CacheQueryResultOptions = {
 };
 
 /**
- * What a caller of `cacheRefreshKeyResult` is allowed to decide — scheduling, plus the data source
- * it routes to. The cache key, the renewal key and the renewal threshold are derived from the query
- * tuple and that data source instead, so no caller can store an entry under a key it will later
- * look up by a different one.
+ * Deliberately narrow: the cache key, the renewal key and the renewal threshold are derived inside
+ * `cacheRefreshKeyResult`, so no caller can store an entry under a key it later looks up by another.
  */
 export type RefreshKeyCacheOptions =
   Pick<CacheQueryResultOptions, 'priority' | 'requestId' | 'waitForRenew' | 'dataSource'>;
@@ -429,29 +427,26 @@ export class QueryCache {
   }
 
   /**
-   * Identity of a refresh key query: the SQL, its params, and where it runs — `external` selects the
-   * engine and `dataSource` selects the queue and driver, which is every dimension
-   * `cacheQueryResult` routes on. The rest of the options element is policy applied to the result
-   * rather than part of it, and `replacePartitionSqlAndParams` recomputes `renewalThreshold` from
-   * `new Date()` for incremental keys, so covering it would make the key drift within a single
-   * request.
+   * Identity of a refresh key query: the SQL, its params, and where it runs. `external` and
+   * `dataSource` are every dimension `cacheQueryResult` routes on; the rest of the options element
+   * is policy applied to the result rather than part of it, and `replacePartitionSqlAndParams`
+   * recomputes `renewalThreshold` from `new Date()`, so covering it would make the key drift within
+   * a single request.
    */
   public static refreshKeyIdentity(
     sqlQuery: QueryWithParams,
     dataSource: string,
   ): [string, string[], boolean, string] {
     const [query, values, options] = sqlQuery;
-    // Producers spell "runs against the source database" as both `false` and an absent option, and
-    // JSON.stringify renders the latter as null — they have to collapse to one key. `dataSource` is
-    // normalized for the same reason: `getQueue` resolves an absent one to `default`, so the two
-    // reach the same driver and must reach the same entry.
+    // Both spellings of each default have to collapse to one key: producers write "source database"
+    // as `false` or as an absent option, and `getQueue` resolves an absent `dataSource` to `default`.
     return [query, values, !!options?.external, dataSource || 'default'];
   }
 
   /**
-   * The `invalidate` discriminator both sides of the partition build range cache fold into their
-   * key: the write side in `PreAggregationPartitionRangeLoader.loadRangeQuery` and the read side in
-   * `PreAggregations.checkPartitionsBuildRangeCache`. Deriving it here is what keeps them equal —
+   * The `invalidate` discriminator of the partition build range cache, written by
+   * `PreAggregationPartitionRangeLoader.loadRangeQuery` and read by
+   * `PreAggregations.checkPartitionsBuildRangeCache`. Derived here so the two cannot drift apart —
    * when each spelled it out itself, the read stopped finding what the write had stored.
    */
   public static buildRangeInvalidateKey(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -46,9 +46,10 @@ export type CacheQueryResultOptions = {
 };
 
 /**
- * What a caller of `cacheRefreshKeyResult` is allowed to decide — scheduling only. The cache key,
- * the renewal key and the renewal threshold are all derived from the query tuple instead, so no
- * caller can store an entry under a key it will later look up by a different one.
+ * What a caller of `cacheRefreshKeyResult` is allowed to decide — scheduling, plus the data source
+ * it routes to. The cache key, the renewal key and the renewal threshold are derived from the query
+ * tuple and that data source instead, so no caller can store an entry under a key it will later
+ * look up by a different one.
  */
 export type RefreshKeyCacheOptions =
   Pick<CacheQueryResultOptions, 'priority' | 'requestId' | 'waitForRenew' | 'dataSource'>;
@@ -428,16 +429,23 @@ export class QueryCache {
   }
 
   /**
-   * Identity of a refresh key query: the SQL, its params, and the engine it runs against. The rest
-   * of the options element is policy applied to the result rather than part of it, and
-   * `replacePartitionSqlAndParams` recomputes `renewalThreshold` from `new Date()` for incremental
-   * keys, so covering it would make the key drift within a single request.
+   * Identity of a refresh key query: the SQL, its params, and where it runs — `external` selects the
+   * engine and `dataSource` selects the queue and driver, which is every dimension
+   * `cacheQueryResult` routes on. The rest of the options element is policy applied to the result
+   * rather than part of it, and `replacePartitionSqlAndParams` recomputes `renewalThreshold` from
+   * `new Date()` for incremental keys, so covering it would make the key drift within a single
+   * request.
    */
-  public static refreshKeyIdentity(sqlQuery: QueryWithParams): [string, string[], boolean] {
+  public static refreshKeyIdentity(
+    sqlQuery: QueryWithParams,
+    dataSource: string,
+  ): [string, string[], boolean, string] {
     const [query, values, options] = sqlQuery;
     // Producers spell "runs against the source database" as both `false` and an absent option, and
-    // JSON.stringify renders the latter as null — they have to collapse to one key.
-    return [query, values, !!options?.external];
+    // JSON.stringify renders the latter as null — they have to collapse to one key. `dataSource` is
+    // normalized for the same reason: `getQueue` resolves an absent one to `default`, so the two
+    // reach the same driver and must reach the same entry.
+    return [query, values, !!options?.external, dataSource || 'default'];
   }
 
   /**
@@ -447,10 +455,10 @@ export class QueryCache {
    * when each spelled it out itself, the read stopped finding what the write had stored.
    */
   public static buildRangeInvalidateKey(
-    preAggregation: { invalidateKeyQueries?: QueryWithParams[] },
-  ): [string, string[], boolean] | false {
+    preAggregation: { invalidateKeyQueries?: QueryWithParams[], dataSource?: string },
+  ): [string, string[], boolean, string] | false {
     const keyQuery = preAggregation.invalidateKeyQueries?.[0];
-    return keyQuery ? QueryCache.refreshKeyIdentity(keyQuery) : false;
+    return keyQuery ? QueryCache.refreshKeyIdentity(keyQuery, preAggregation.dataSource) : false;
   }
 
   public async cacheRefreshKeyResult(
@@ -459,7 +467,7 @@ export class QueryCache {
     options: RefreshKeyCacheOptions,
   ) {
     const [query, values, queryOptions] = sqlQuery;
-    const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery);
+    const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery, options.dataSource);
 
     return this.cacheQueryResult(query, values, cacheKey, expiration, {
       ...options,
@@ -471,8 +479,8 @@ export class QueryCache {
     });
   }
 
-  public refreshKeyCacheKey(sqlQuery: QueryWithParams): string {
-    return this.queryRedisKey(QueryCache.refreshKeyIdentity(sqlQuery));
+  public refreshKeyCacheKey(sqlQuery: QueryWithParams, dataSource: string): string {
+    return this.queryRedisKey(QueryCache.refreshKeyIdentity(sqlQuery, dataSource));
   }
 
   public static extractRequestUUID(requestId: string): string {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -45,6 +45,14 @@ export type CacheQueryResultOptions = {
   renewCycle?: boolean,
 };
 
+/**
+ * What a caller of `cacheRefreshKeyResult` is allowed to decide. Everything identifying the entry —
+ * the cache key, the renewal key, the renewal threshold — is derived from the query tuple instead,
+ * so no caller can store one under a key it will later look up by a different one.
+ */
+export type RefreshKeyCacheOptions =
+  Pick<CacheQueryResultOptions, 'priority' | 'requestId' | 'waitForRenew' | 'dataSource'>;
+
 type QueryOptions = {
   external?: boolean;
   renewalThreshold?: number;
@@ -114,7 +122,7 @@ export type PreAggTableToTempTable = [
 
 export type PreAggTableToTempTableNames = [string, { targetTableName: string; }];
 
-export type CacheKeyItem = string | string[] | QueryWithParams | QueryWithParams[] | undefined;
+export type CacheKeyItem = string | string[] | boolean | QueryWithParams | QueryWithParams[] | undefined;
 
 export type CacheKey =
   [CacheKeyItem, CacheKeyItem] |
@@ -417,6 +425,44 @@ export class QueryCache {
     // @ts-ignore
     key.persistent = queryBody.persistent;
     return key;
+  }
+
+  /**
+   * Identity of a refresh key query: the SQL, its params, and the engine it runs against. The rest
+   * of the options element is policy applied to the result rather than part of it, and
+   * `replacePartitionSqlAndParams` recomputes `renewalThreshold` from `new Date()` for incremental
+   * keys, so covering it would make the key drift within a single request.
+   */
+  public static refreshKeyIdentity(sqlQuery: QueryWithParams): [string, string[], boolean] {
+    const [query, values, options] = sqlQuery;
+    // Producers spell "runs against the source database" as both `false` and an absent option, and
+    // JSON.stringify renders the latter as null — they have to collapse to one key.
+    return [query, values, !!options?.external];
+  }
+
+  /**
+   * Cache the result of a refresh key query, identified by the query tuple itself.
+   */
+  public async cacheRefreshKeyResult(
+    sqlQuery: QueryWithParams,
+    expiration: number,
+    options: RefreshKeyCacheOptions,
+  ) {
+    const [query, values, queryOptions] = sqlQuery;
+    const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery);
+
+    return this.cacheQueryResult(query, values, cacheKey, expiration, {
+      ...options,
+      renewalThreshold: this.options.refreshKeyRenewalThreshold
+        || queryOptions?.renewalThreshold || 2 * 60,
+      renewalKey: cacheKey,
+      useInMemory: true,
+      external: queryOptions?.external,
+    });
+  }
+
+  public refreshKeyCacheKey(sqlQuery: QueryWithParams): string {
+    return this.queryRedisKey(QueryCache.refreshKeyIdentity(sqlQuery));
   }
 
   public static extractRequestUUID(requestId: string): string {
@@ -884,21 +930,13 @@ export class QueryCache {
 
   @AsyncDebounce()
   public async loadRefreshKey(q: QueryWithParams, expireSecs: number, options: LoadRefreshKeyOptions) {
-    const [query, values, queryOptions] = q;
-
-    return this.cacheQueryResult(
-      query,
-      values,
-      [query, values],
+    return this.cacheRefreshKeyResult(
+      q,
       expireSecs,
       {
-        renewalThreshold: this.options.refreshKeyRenewalThreshold || queryOptions?.renewalThreshold || 2 * 60,
-        renewalKey: q,
         waitForRenew: !options.skipRefreshKeyWaitForRenew,
         requestId: options.requestId,
         dataSource: options.dataSource,
-        useInMemory: true,
-        external: queryOptions?.external,
       },
     );
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -475,7 +475,7 @@ export class QueryCache {
   }
 
   public refreshKeyCacheKey(sqlQuery: QueryWithParams, dataSource: string): string {
-    return this.queryRedisKey(QueryCache.refreshKeyIdentity(sqlQuery, dataSource));
+    return this.queryCacheKey(QueryCache.refreshKeyIdentity(sqlQuery, dataSource));
   }
 
   public static extractRequestUUID(requestId: string): string {
@@ -900,7 +900,7 @@ export class QueryCache {
               renewalKey: cacheKeyQueryResults && [
                 cacheKeyQueries,
                 cacheKeyQueryResults,
-                this.queryRedisKey([query, values]),
+                this.queryCacheKey([query, values]),
               ],
               waitForRenew: true,
               forceNoCache: options.forceNoCache,
@@ -1028,14 +1028,14 @@ export class QueryCache {
       renewCycle: options.renewCycle,
     };
 
-    const redisKey = this.queryRedisKey(cacheKey);
+    const redisKey = this.queryCacheKey(cacheKey);
 
     return {
       cacheKey,
       redisKey,
       // Refresh key entries renew against their own key, so hashing it a second time is wasted work
       renewalKey: options.renewalKey && (
-        options.renewalKey === cacheKey ? redisKey : this.queryRedisKey(options.renewalKey)
+        options.renewalKey === cacheKey ? redisKey : this.queryCacheKey(options.renewalKey)
       ),
       expiration,
       spanId,
@@ -1206,13 +1206,13 @@ export class QueryCache {
   }
 
   protected async lastRefreshTime(cacheKey) {
-    const cachedValue = await this.cacheDriver.get(this.queryRedisKey(cacheKey));
+    const cachedValue = await this.cacheDriver.get(this.queryCacheKey(cacheKey));
     return cachedValue && new Date(cachedValue.time);
   }
 
   public async resultFromCacheIfExists(queryBody) {
     const cacheKey = QueryCache.queryCacheKey(queryBody);
-    const cachedValue = await this.cacheDriver.get(this.queryRedisKey(cacheKey));
+    const cachedValue = await this.cacheDriver.get(this.queryCacheKey(cacheKey));
     if (cachedValue) {
       return {
         data: cachedValue.result,
@@ -1222,7 +1222,7 @@ export class QueryCache {
     return null;
   }
 
-  public queryRedisKey(cacheKey: CacheKey): string {
+  public queryCacheKey(cacheKey: CacheKey): string {
     return this.getKey('SQL_QUERY_RESULT', getCacheHash(cacheKey) as any);
   }
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -46,9 +46,9 @@ export type CacheQueryResultOptions = {
 };
 
 /**
- * What a caller of `cacheRefreshKeyResult` is allowed to decide. Everything identifying the entry —
- * the cache key, the renewal key, the renewal threshold — is derived from the query tuple instead,
- * so no caller can store one under a key it will later look up by a different one.
+ * What a caller of `cacheRefreshKeyResult` is allowed to decide — scheduling only. The cache key,
+ * the renewal key and the renewal threshold are all derived from the query tuple instead, so no
+ * caller can store an entry under a key it will later look up by a different one.
  */
 export type RefreshKeyCacheOptions =
   Pick<CacheQueryResultOptions, 'priority' | 'requestId' | 'waitForRenew' | 'dataSource'>;
@@ -441,8 +441,18 @@ export class QueryCache {
   }
 
   /**
-   * Cache the result of a refresh key query, identified by the query tuple itself.
+   * The `invalidate` discriminator both sides of the partition build range cache fold into their
+   * key: the write side in `PreAggregationPartitionRangeLoader.loadRangeQuery` and the read side in
+   * `PreAggregations.checkPartitionsBuildRangeCache`. Deriving it here is what keeps them equal —
+   * when each spelled it out itself, the read stopped finding what the write had stored.
    */
+  public static buildRangeInvalidateKey(
+    preAggregation: { invalidateKeyQueries?: QueryWithParams[] },
+  ): [string, string[], boolean] | false {
+    const keyQuery = preAggregation.invalidateKeyQueries?.[0];
+    return keyQuery ? QueryCache.refreshKeyIdentity(keyQuery) : false;
+  }
+
   public async cacheRefreshKeyResult(
     sqlQuery: QueryWithParams,
     expiration: number,
@@ -457,7 +467,7 @@ export class QueryCache {
         || queryOptions?.renewalThreshold || 2 * 60,
       renewalKey: cacheKey,
       useInMemory: true,
-      external: queryOptions?.external,
+      external: cacheKey[2],
     });
   }
 
@@ -1015,10 +1025,15 @@ export class QueryCache {
       renewCycle: options.renewCycle,
     };
 
+    const redisKey = this.queryRedisKey(cacheKey);
+
     return {
       cacheKey,
-      redisKey: this.queryRedisKey(cacheKey),
-      renewalKey: options.renewalKey && this.queryRedisKey(options.renewalKey),
+      redisKey,
+      // Refresh key entries renew against their own key, so hashing it a second time is wasted work
+      renewalKey: options.renewalKey && (
+        options.renewalKey === cacheKey ? redisKey : this.queryRedisKey(options.renewalKey)
+      ),
       expiration,
       spanId,
       options,

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -176,6 +176,8 @@ describe('PreAggregations', () => {
           executionTimeout: 1,
           concurrency: 2,
         }),
+        // Lazily used: only a query carrying `external: true` reaches the external queue.
+        externalDriverFactory: mockExternalDriverFactory as any,
       },
     );
 
@@ -309,6 +311,126 @@ describe('PreAggregations', () => {
           'job-token',
         )
       ).resolves.toEqual([true, 'done']);
+    });
+  });
+
+  describe('refresh key memoization', () => {
+    let preAggregations: PreAggregations;
+
+    const preAggregation = {
+      preAggregationsSchema: 'stb_pre_aggregations',
+      tableName: 'stb_pre_aggregations.orders_memo',
+      dataSource: 'default',
+      external: false,
+      loadSql: ['CREATE TABLE stb_pre_aggregations.orders_memo AS SELECT 1', []],
+      invalidateKeyQueries: [defaultCacheKeyQuery],
+    };
+
+    const createLoadCache = () => new PreAggregationLoadCache(
+      mockDriverFactory as any,
+      queryCache!,
+      preAggregations,
+      { dataSource: 'default' },
+    );
+
+    const createPreAggLoader = (loadCache: PreAggregationLoadCache, options: Record<string, any> = {}) => new PreAggregationLoader(
+      mockDriverFactory as any,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
+      queryCache!,
+      preAggregations,
+      preAggregation,
+      [],
+      loadCache,
+      { requestId: 'refresh-key-memo', ...options },
+    );
+
+    beforeEach(() => {
+      preAggregations = new PreAggregations(
+        'TEST',
+        mockDriverFactory as any,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => {},
+        queryCache!,
+        {
+          queueOptions: async () => ({
+            executionTimeout: 1,
+            concurrency: 2,
+          }),
+        },
+      );
+    });
+
+    test('refresh key identity covers sql, params and engine, but not policy', async () => {
+      const loadCache = createLoadCache();
+      const [sql] = defaultCacheKeyQuery;
+
+      expect(loadCache.hasKeyQueryResult(defaultCacheKeyQuery)).toBe(false);
+      await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
+
+      expect(loadCache.hasKeyQueryResult(defaultCacheKeyQuery)).toBe(true);
+      // Policy is not identity: callers legitimately hold differing options objects, because
+      // replacePartitionSqlAndParams rebuilds that element on every call with a clock-dependent
+      // renewalThreshold for incremental keys.
+      expect(loadCache.hasKeyQueryResult([sql, [], { renewalThreshold: 1, external: false }])).toBe(true);
+      // An absent `external` means the same thing as `external: false` and has to collapse to it.
+      expect(loadCache.hasKeyQueryResult(defaultCacheKeyQuery.slice(0, 2) as any)).toBe(true);
+      expect(loadCache.hasKeyQueryResult([sql, [], { renewalThreshold: 1 }])).toBe(true);
+      // The engine does change identity — same SQL run against Cube Store is a different query.
+      expect(loadCache.hasKeyQueryResult([sql, [], { external: true }])).toBe(false);
+      expect(loadCache.hasKeyQueryResult(['SELECT NOW() as unrelated', [], {}])).toBe(false);
+    });
+
+    test('a refresh key resolved against each engine gets its own cache entry', async () => {
+      const [sql] = defaultCacheKeyQuery;
+      const loadCache = createLoadCache();
+
+      await loadCache.keyQueryResult([sql, [], { external: false }], false, 10);
+      await loadCache.keyQueryResult([sql, [], { external: true }], false, 10);
+
+      // Same SQL, different engine: conflating them would serve one engine's result for the other.
+      expect(mockDriver!.executedQueries.filter(q => q === sql).length).toEqual(1);
+      expect(mockExternalDriver!.executedQueries.filter(q => q === sql).length).toEqual(1);
+    });
+
+    test('both refresh key paths store the same renewal key', async () => {
+      const cacheKey = queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery);
+      const storedRenewalKey = async () => (await queryCache!.getCacheDriver().get(cacheKey)).renewalKey;
+
+      await queryCache!.loadRefreshKey(defaultCacheKeyQuery, 3600, { dataSource: 'default', requestId: 'loadRefreshKey' });
+      const throughLoadRefreshKey = await storedRenewalKey();
+
+      // Each path has to write the entry itself, otherwise the second one just reads what the
+      // first stored and any disagreement stays invisible.
+      (queryCache!.getCacheDriver() as LocalCacheDriver).reset();
+      await createLoadCache().keyQueryResult(defaultCacheKeyQuery, false, 10);
+      const throughKeyQueryResult = await storedRenewalKey();
+
+      // A cube level cacheKeyQuery and a pre-aggregation invalidateKeyQuery can be the same SQL and
+      // then share this entry. Differing renewal keys make each path look stale to the other, so
+      // they re-fetch on every touch.
+      expect(throughLoadRefreshKey).toEqual(throughKeyQueryResult);
+    });
+
+    test('warm invalidation keys are confirmed synchronously', async () => {
+      const loadCache = createLoadCache();
+      await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
+
+      const result = await createPreAggLoader(loadCache, { waitForRenew: false }).loadPreAggregation(true);
+
+      // A populated refreshKeyValues is the marker of the inline path; the deferred one reports [].
+      expect(result!.refreshKeyValues.length).toEqual(1);
+    });
+
+    test('warm invalidation keys do not let externalRefresh build a pre-aggregation', async () => {
+      const loadCache = createLoadCache();
+      await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
+
+      // externalRefresh owns the "partition is not built yet" handling, so it must stay on the
+      // deferred path even when nothing has to be queried to confirm the refresh keys.
+      await expect(createPreAggLoader(loadCache, { externalRefresh: true }).loadPreAggregation(true))
+        .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
+      expect(mockDriver!.tables).toEqual([]);
     });
   });
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -185,6 +185,21 @@ describe('PreAggregations', () => {
     (queryCache.getCacheDriver() as LocalCacheDriver).reset();
   });
 
+  const createPreAggregations = (options: Record<string, any> = {}) => new PreAggregations(
+    'TEST',
+    mockDriverFactory as any,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    () => {},
+    queryCache!,
+    {
+      queueOptions: async () => ({
+        executionTimeout: 1,
+        concurrency: 2,
+      }),
+      ...options,
+    },
+  );
+
   describe('touch/used cache key cleanup', () => {
     let preAggregations: PreAggregations;
 
@@ -346,19 +361,7 @@ describe('PreAggregations', () => {
     );
 
     beforeEach(() => {
-      preAggregations = new PreAggregations(
-        'TEST',
-        mockDriverFactory as any,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        () => {},
-        queryCache!,
-        {
-          queueOptions: async () => ({
-            executionTimeout: 1,
-            concurrency: 2,
-          }),
-        },
-      );
+      preAggregations = createPreAggregations();
     });
 
     test('refresh key identity covers sql, params and engine, but not policy', async () => {
@@ -369,11 +372,8 @@ describe('PreAggregations', () => {
       await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
 
       expect(loadCache.hasKeyQueryResult(defaultCacheKeyQuery)).toBe(true);
-      // Policy is not identity: callers legitimately hold differing options objects, because
-      // replacePartitionSqlAndParams rebuilds that element on every call with a clock-dependent
-      // renewalThreshold for incremental keys.
-      expect(loadCache.hasKeyQueryResult([sql, [], { renewalThreshold: 1, external: false }])).toBe(true);
-      // An absent `external` means the same thing as `external: false` and has to collapse to it.
+      // Missing options element, and differing policy with `external` left absent — see
+      // QueryCache.refreshKeyIdentity for why neither may move the key.
       expect(loadCache.hasKeyQueryResult(defaultCacheKeyQuery.slice(0, 2) as any)).toBe(true);
       expect(loadCache.hasKeyQueryResult([sql, [], { renewalThreshold: 1 }])).toBe(true);
       // The engine does change identity — same SQL run against Cube Store is a different query.
@@ -406,9 +406,9 @@ describe('PreAggregations', () => {
       await createLoadCache().keyQueryResult(defaultCacheKeyQuery, false, 10);
       const throughKeyQueryResult = await storedRenewalKey();
 
-      // A cube level cacheKeyQuery and a pre-aggregation invalidateKeyQuery can be the same SQL and
-      // then share this entry. Differing renewal keys make each path look stale to the other, so
-      // they re-fetch on every touch.
+      // The same SQL can arrive as a cube cacheKeyQuery and as a pre-aggregation
+      // invalidateKeyQuery, sharing this entry — disagreeing renewal keys would make each path look
+      // stale to the other and re-fetch on every touch.
       expect(throughLoadRefreshKey).toEqual(throughKeyQueryResult);
     });
 
@@ -426,8 +426,7 @@ describe('PreAggregations', () => {
       const loadCache = createLoadCache();
       await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
 
-      // externalRefresh owns the "partition is not built yet" handling, so it must stay on the
-      // deferred path even when nothing has to be queried to confirm the refresh keys.
+      // Warm refresh keys must not promote an externalRefresh instance onto the building path.
       await expect(createPreAggLoader(loadCache, { externalRefresh: true }).loadPreAggregation(true))
         .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
       expect(mockDriver!.tables).toEqual([]);

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -176,7 +176,7 @@ describe('PreAggregations', () => {
           executionTimeout: 1,
           concurrency: 2,
         }),
-        // Lazily used: only a query carrying `external: true` reaches the external queue.
+        // Only reached by a query carrying `external: true`.
         externalDriverFactory: mockExternalDriverFactory as any,
       },
     );
@@ -403,15 +403,14 @@ describe('PreAggregations', () => {
       await createLoadCache('default').keyQueryResult(defaultCacheKeyQuery, false, 10);
       await createLoadCache('staging').keyQueryResult(defaultCacheKeyQuery, false, 10);
 
-      // `SELECT MAX(updated_at) FROM orders` means something different in each database, and the
-      // cache prefix only separates tenants — without the data source in the key the second load
-      // cache would serve the first one's row.
+      // The cache prefix only separates tenants, so without the data source in the key the second
+      // load cache would serve the first one's row for a different database.
       expect(mockDriver!.executedQueries.filter(q => q === sql).length).toEqual(2);
     });
 
     test('an absent data source hashes as default', () => {
-      // `loadRefreshKeysFromQuery` forwards `query.dataSource` untouched and `getQueue` resolves an
-      // absent one to `default`, so both spellings reach the same driver and must share an entry.
+      // `loadRefreshKeysFromQuery` forwards `query.dataSource` untouched, so an absent one reaches
+      // the same driver as `default` and must share its entry.
       expect(queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery, undefined))
         .toEqual(queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery, 'default'));
     });
@@ -449,7 +448,6 @@ describe('PreAggregations', () => {
       const loadCache = createLoadCache();
       await loadCache.keyQueryResult(defaultCacheKeyQuery, false, 10);
 
-      // Warm refresh keys must not promote an externalRefresh instance onto the building path.
       await expect(createPreAggLoader(loadCache, { externalRefresh: true }).loadPreAggregation(true))
         .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
       expect(mockDriver!.tables).toEqual([]);
@@ -458,9 +456,8 @@ describe('PreAggregations', () => {
     test('a pre-aggregation with no invalidation keys does not let externalRefresh build either', async () => {
       const noKeys = { invalidateKeyQueries: [] };
 
-      // The one combination whose behaviour this guard changes: an empty key list used to leave
-      // `notLoadedKey` undefined, which sent even an externalRefresh instance onto the building
-      // path. It now reports the partition as missing like every other externalRefresh request.
+      // The one combination whose behaviour the guard changes: an empty key list used to leave
+      // `notLoadedKey` undefined, which sent even an externalRefresh instance onto the building path.
       await expect(createPreAggLoader(createLoadCache(), { externalRefresh: true }, noKeys).loadPreAggregation(true))
         .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
       await expect(createPreAggLoader(createLoadCache(), { externalRefresh: true }, noKeys).loadPreAggregation(false))

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -341,20 +341,24 @@ describe('PreAggregations', () => {
       invalidateKeyQueries: [defaultCacheKeyQuery],
     };
 
-    const createLoadCache = () => new PreAggregationLoadCache(
+    const createLoadCache = (dataSource: string = 'default') => new PreAggregationLoadCache(
       mockDriverFactory as any,
       queryCache!,
       preAggregations,
-      { dataSource: 'default' },
+      { dataSource },
     );
 
-    const createPreAggLoader = (loadCache: PreAggregationLoadCache, options: Record<string, any> = {}) => new PreAggregationLoader(
+    const createPreAggLoader = (
+      loadCache: PreAggregationLoadCache,
+      options: Record<string, any> = {},
+      preAggOverrides: Record<string, any> = {},
+    ) => new PreAggregationLoader(
       mockDriverFactory as any,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       () => {},
       queryCache!,
       preAggregations,
-      preAggregation,
+      { ...preAggregation, ...preAggOverrides },
       [],
       loadCache,
       { requestId: 'refresh-key-memo', ...options },
@@ -393,8 +397,27 @@ describe('PreAggregations', () => {
       expect(mockExternalDriver!.executedQueries.filter(q => q === sql).length).toEqual(1);
     });
 
+    test('a refresh key resolved against each data source gets its own cache entry', async () => {
+      const [sql] = defaultCacheKeyQuery;
+
+      await createLoadCache('default').keyQueryResult(defaultCacheKeyQuery, false, 10);
+      await createLoadCache('staging').keyQueryResult(defaultCacheKeyQuery, false, 10);
+
+      // `SELECT MAX(updated_at) FROM orders` means something different in each database, and the
+      // cache prefix only separates tenants — without the data source in the key the second load
+      // cache would serve the first one's row.
+      expect(mockDriver!.executedQueries.filter(q => q === sql).length).toEqual(2);
+    });
+
+    test('an absent data source hashes as default', () => {
+      // `loadRefreshKeysFromQuery` forwards `query.dataSource` untouched and `getQueue` resolves an
+      // absent one to `default`, so both spellings reach the same driver and must share an entry.
+      expect(queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery, undefined))
+        .toEqual(queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery, 'default'));
+    });
+
     test('both refresh key paths store the same renewal key', async () => {
-      const cacheKey = queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery);
+      const cacheKey = queryCache!.refreshKeyCacheKey(defaultCacheKeyQuery, 'default');
       const storedRenewalKey = async () => (await queryCache!.getCacheDriver().get(cacheKey)).renewalKey;
 
       await queryCache!.loadRefreshKey(defaultCacheKeyQuery, 3600, { dataSource: 'default', requestId: 'loadRefreshKey' });
@@ -429,6 +452,20 @@ describe('PreAggregations', () => {
       // Warm refresh keys must not promote an externalRefresh instance onto the building path.
       await expect(createPreAggLoader(loadCache, { externalRefresh: true }).loadPreAggregation(true))
         .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
+      expect(mockDriver!.tables).toEqual([]);
+    });
+
+    test('a pre-aggregation with no invalidation keys does not let externalRefresh build either', async () => {
+      const noKeys = { invalidateKeyQueries: [] };
+
+      // The one combination whose behaviour this guard changes: an empty key list used to leave
+      // `notLoadedKey` undefined, which sent even an externalRefresh instance onto the building
+      // path. It now reports the partition as missing like every other externalRefresh request.
+      await expect(createPreAggLoader(createLoadCache(), { externalRefresh: true }, noKeys).loadPreAggregation(true))
+        .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
+      await expect(createPreAggLoader(createLoadCache(), { externalRefresh: true }, noKeys).loadPreAggregation(false))
+        .resolves.toBeNull();
+
       expect(mockDriver!.tables).toEqual([]);
     });
   });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -126,7 +126,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       const renewalKeyNew = QueryCache.queryCacheKey({ query: 'key-new', values: [] });
 
       const seedCache = async (cacheKey: CacheKey, entry: CacheKeyItem) => {
-        const redisKey = cache.queryRedisKey(cacheKey);
+        const redisKey = cache.queryCacheKey(cacheKey);
         await cache.getCacheDriver().set(redisKey, entry, 3600);
       };
 
@@ -141,12 +141,12 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
           renewCycle?: boolean;
         }
       ) => {
-        // cacheQueryResult hashes options.renewalKey via queryRedisKey(),
+        // cacheQueryResult hashes options.renewalKey via queryCacheKey(),
         // and fetchNew() stores that hash in the entry. Replicate that for seeding.
         const seededEntry = {
           ...cacheEntry,
           renewalKey: cacheEntry.renewalKey
-            ? cache.queryRedisKey(cacheEntry.renewalKey)
+            ? cache.queryCacheKey(cacheEntry.renewalKey)
             : cacheEntry.renewalKey,
         };
         await seedCache(cacheKey, seededEntry);

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -839,17 +839,17 @@ describe('QueryOrchestrator', () => {
     await queryOrchestrator.fetchQuery(query);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[0])
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[0], 'default')
       )
     ).toBe(true);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[1])
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[1], 'default')
       )
     ).toBe(false);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.refreshKeyCacheKey(query.preAggregations[0].invalidateKeyQueries[0])
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.preAggregations[0].invalidateKeyQueries[0], 'default')
       )
     ).toBe(true);
   });
@@ -1518,6 +1518,7 @@ describe('QueryOrchestrator', () => {
           'SELECT refreshKey in source database',
           [],
           false,
+          'default',
         ],
         query: 'SELECT refreshKey in source database',
         values: [],
@@ -1536,6 +1537,7 @@ describe('QueryOrchestrator', () => {
           'SELECT refreshKey in external database',
           [],
           true,
+          'default',
         ],
         query: 'SELECT refreshKey in external database',
         values: [],

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -1,6 +1,7 @@
 /* globals jest, describe, beforeEach, afterEach, test, expect */
 import { Readable } from 'stream';
 import { QueryOrchestrator } from '../../src/orchestrator/QueryOrchestrator';
+import { QueryCache } from '../../src/orchestrator/QueryCache';
 
 class MockDriver {
   constructor({ csvImport, schemaData } = {}) {
@@ -839,17 +840,17 @@ describe('QueryOrchestrator', () => {
     await queryOrchestrator.fetchQuery(query);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(query.cacheKeyQueries.queries[0].slice(0, 2))
+        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.cacheKeyQueries.queries[0]))
       )
     ).toBe(true);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(query.cacheKeyQueries.queries[1].slice(0, 2))
+        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.cacheKeyQueries.queries[1]))
       )
     ).toBe(false);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(query.preAggregations[0].invalidateKeyQueries[0].slice(0, 2))
+        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.preAggregations[0].invalidateKeyQueries[0]))
       )
     ).toBe(true);
   });
@@ -1517,6 +1518,7 @@ describe('QueryOrchestrator', () => {
         queryKey: [
           'SELECT refreshKey in source database',
           [],
+          false,
         ],
         query: 'SELECT refreshKey in source database',
         values: [],
@@ -1534,6 +1536,7 @@ describe('QueryOrchestrator', () => {
         queryKey: [
           'SELECT refreshKey in external database',
           [],
+          true,
         ],
         query: 'SELECT refreshKey in external database',
         values: [],

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -1,7 +1,6 @@
 /* globals jest, describe, beforeEach, afterEach, test, expect */
 import { Readable } from 'stream';
 import { QueryOrchestrator } from '../../src/orchestrator/QueryOrchestrator';
-import { QueryCache } from '../../src/orchestrator/QueryCache';
 
 class MockDriver {
   constructor({ csvImport, schemaData } = {}) {
@@ -840,17 +839,17 @@ describe('QueryOrchestrator', () => {
     await queryOrchestrator.fetchQuery(query);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.cacheKeyQueries.queries[0]))
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[0])
       )
     ).toBe(true);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.cacheKeyQueries.queries[1]))
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.cacheKeyQueries.queries[1])
       )
     ).toBe(false);
     expect(
       queryOrchestrator.queryCache.memoryCache.has(
-        queryOrchestrator.queryCache.queryRedisKey(QueryCache.refreshKeyIdentity(query.preAggregations[0].invalidateKeyQueries[0]))
+        queryOrchestrator.queryCache.refreshKeyCacheKey(query.preAggregations[0].invalidateKeyQueries[0])
       )
     ).toBe(true);
   });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Refresh key queries were stored under one cache key and looked up under another. Three things
followed from that: the per-request memo in `PreAggregationLoadCache` could never hit, so every
`waitForRenew: false` request took the deferred path; the refresh scheduler and the pre-aggregation
loader marked each other's entry stale whenever a cube `refreshKey` and a pre-aggregation
`invalidateKeyQuery` resolved to the same SQL; and the same SQL run against different engines or
different data sources shared a single entry and served each other's rows.

This PR gives a refresh key one identity — `[sql, params, external, dataSource]` — computed in one
place (`QueryCache.refreshKeyIdentity`) and applied by one helper (`cacheRefreshKeyResult`) that
owns the cache key, the renewal key and the renewal threshold, so a caller can no longer store an
entry under a key it will later look up by a different one.

---

### How it broke, and how it is fixed

**One entity, three different hashes**

```
                       ONE refresh key query
   [ "SELECT FLOOR(EXTRACT(EPOCH FROM NOW())/86400) refresh_key",  [],
     { renewalThreshold: 86400, external: false, incremental: false } ]     dataSource: "default"
        └──── sql ────┘                          └──── options ────┘

  BEFORE                                              AFTER
  ─────────────────────────────────────────────       ────────────────────────────────────
  H2 = md5([sql, params])           <- cacheKey       H = md5([sql, params,
  H2                    <- renewalKey (loader)                  !!external,
  H3 = md5([sql, params, options])                              dataSource || 'default'])
                        <- renewalKey (scheduler)         ^
  H3                    <- memo lookup                    |  refreshKeyIdentity()
                                                          |  one hash everywhere
  H2 != H3  =>  the bugs below                            +-- cacheKey = renewalKey = memo key
```

**Bug 1 — the load cache memo could never hit**

`PreAggregationLoadCache` lives for one request and memoizes resolved refresh key values so that
several partitions or pre-aggregations do not each re-run the same SQL.

```
   PreAggregationLoadCache.queryResults  (in memory, one per request)
   +--------------------------------------------------------------+
   |  { "H2": Promise<[{refresh_key: 20685}]> }                    |
   +--------------------------------------------------------------+
        ^ WRITE                                    READ ^
        | keyQueryResult()                              | hasKeyQueryResult()
        | queryCacheKey([query, values])                | queryCacheKey(keyQuery)
        |            = H2                               |      = H3  <- the whole 3-tuple
        |                                               |
   -----+-----------------------------------------------+-----
                          H2 != H3  ->  miss, 100% of the time, for four years
                     (regression from #3061: `options` moved into the tuple,
                      only the store side was updated)
```

Both sides now go through `refreshKeyCacheKey()` -> `refreshKeyIdentity()`, so they agree on `H`.

**Bug 1, consequence — a dead branch in `loadPreAggregation`**

```
BEFORE                                     AFTER
────────────────────────────────────       ──────────────────────────────────────
notLoadedKey = keys.find(k => !warm(k))    allWarm = keys.every(k => warm(k))
       warm() === false  ----+                    warm() actually works
       => always truthy      |
                             v
if (isJob || !(notLoadedKey && !waitForRenew))   if (isJob || (!externalRefresh &&
                                                      (waitForRenew || allWarm)))
     collapses to:
     isJob || waitForRenew        <- "keys are warm" never contributed
```

On a live request against a partitioned rollup:

```
POST /v1/load  (default cache mode => waitForRenew = false)
   |
   +- PartitionRangeLoader.loadRangeQuery()
   |     +- getInvalidationKeyValues() --> keyQueryResult(q) --> queryResults{ H: 20685 }
   |                                                              ^ memo warmed here
   +- partition 2025-06 -+
   +- partition 2025-07 -+--> loadPreAggregation()
   +- partition 2025-08 -+        |
                                  +-- BEFORE: hasKeyQueryResult -> H3 -> miss
                                  |        => Case 3: serve what exists, refresh in background
                                  |        => refreshKeyValues: []
                                  |
                                  +-- AFTER:  hasKeyQueryResult -> H  -> hit
                                           => Case 1: confirm freshness inline
                                           => refreshKeyValues: [{refresh_key: 20685}]
```

Re-enabling that branch needed a guard, which also closes a hole that exists on master today:

```
externalRefresh:
  BEFORE     warm-key path unreachable (always a miss)          => Case 3            [ok]
             but invalidateKeyQueries: [] left notLoadedKey undefined,
             so !(undefined && ...) was true                    => Case 1, BUILDS    [bug]
  naive fix  warm keys now route those requests into            => Case 1, BUILDS    [bug]
  THIS PR    !externalRefresh guard: both cases report the partition as missing      [ok]
```

**Bug 2 — renewal key ping-pong between the scheduler and the loader**

When a cube level `refreshKey` and a pre-aggregation `invalidateKeyQuery` resolve to the same SQL,
both paths write **the same cache entry** with a different `renewalKey`, and `decideCacheAction`
treats `entry.renewalKey !== renewalKey` as a reason to re-fetch.

```
 t0  refresh scheduler - loadRefreshKey(q) ------> entry{ value: 20685, renewalKey: H3 }
                                                                                  |
 t1  /v1/load - keyQueryResult(q) -> reads entry                                  |
        expects H2, finds H3 --> isKeyMismatch --> SQL --> entry{ 20685, H2 } -----+
                                                                                  |
 t2  refresh scheduler - loadRefreshKey(q) -> reads entry                         |
        expects H3, finds H2 --> isKeyMismatch --> SQL --> entry{ 20685, H3 } -----+
                                                     ^
 t3  ... on every touch, while the value never changed

 AFTER:  both paths -> cacheRefreshKeyResult() -> renewalKey = cacheKey = H
         +----------------------------------------------------------+
         |  entry{ value: 20685, renewalKey: H }   <- both read, hit |
         +----------------------------------------------------------+
```

The same mismatch also disqualifies the in-memory entry (`isMemoryEntryUsable` requires equality
too), so the miss was doubled.

**Bug 3 — entries collided across engines and across data sources**

`cacheQueryResult` routes a refresh key query on two dimensions — `external` picks the engine,
`dataSource` picks the queue and the driver — and the cache prefix separates tenants, not data
sources. Neither dimension was in the key.

```
 BEFORE:  identity = [sql, params]
          "SELECT MAX(updated_at) FROM orders"
             +-- prod    / source DB  --+
             +-- staging / source DB  --+--> md5([sql, params]) = H2 --> ONE entry
             +-- prod    / Cube Store --+     whoever ran first served everyone

 AFTER:   identity = [sql, params, !!external, dataSource || 'default']
             prod    / source DB  --> Hp  -+
             staging / source DB  --> Hs  -+-> three distinct entries
             prod    / Cube Store --> Hx  -+

          both defaults normalized:  external: undefined | false          -> false
                                     dataSource: undefined | 'default'    -> 'default'
          (JSON.stringify renders undefined as null, so the spellings had to collapse;
           `getQueue` already resolves an absent dataSource to `default`)
```

**Not a bug, just deduplicated**

`invalidateKeyQueries[0].slice(0, 2)` was spelled out twice — on the write side (`loadRangeQuery`)
and on the read side (`checkPartitionsBuildRangeCache`), each with a comment telling the reader to
keep it identical to the other. There is now one definition.

```
 loadRangeQuery()      -+                          -+
                        +- buildRangeInvalidateKey -+  one call, nothing left to drift
 checkPartitionsBuild… -+                          -+
```

Also in this series: `QueryCache.queryRedisKey` is renamed to `queryCacheKey` — the cache driver has
not been Redis-specific since the driver abstraction landed. Mechanical, byte-identical output, no
entry moves. `LocalQueueDriverConnection.queryRedisKey` keeps its name: it builds queue keys, not
cache keys.

---

### Verification

Confirmed end to end against a live Cube instance over Postgres with a partitioned rollup
(`orders_by_status`, three monthly partitions, refresh key `every: 1 day`):

| build | cache mode | rows | `usedPreAggregations[].refreshKeyValues` |
| --- | --- | --- | --- |
| master | default | 4 | `[[],[],[]]` |
| master | `must-revalidate` | 4 | `[[{refresh_key:20685}]]` x3 |
| this PR | default | 4 | `[[{refresh_key:20685}]]` x3 |

Eight new tests in `PreAggregations.test.ts`, each verified load-bearing against the branch with its
own fix reverted — including the two `externalRefresh` guard tests, which fail if the cache key is
fixed without the guard.

Notes for the reviewer: this is rebased on #11608, which removed the now-dead `Array.isArray`
normalization in the same functions but left `hasKeyQueryResult` untyped and still hashing the whole
tuple, so the two changes are complementary rather than overlapping. Tests live in
`PreAggregations.test.ts` because `QueryOrchestrator.test.js` is not matched by
`testMatch: ['<rootDir>/test/**/*.test.ts']` and never runs; its call sites are updated anyway, and
run manually against the compiled copy its failure set is 5, a subset of master's 7. Separately,
while testing I found a **pre-existing** bug worth its own issue: on a cold refresh key cache,
`usedPreAggregations[*].refreshKeyValues` serializes raw native `ResultWrapper` internals
(`isWrapper`, `cache`, `rootResultObject`) instead of plain rows — it reproduces on master via
`cache: must-revalidate`, and this PR widens the exposure to the default path without introducing it.

**Upgrade note:** the refresh key cache keys and the partition build range cache keys move, so both
are cold once on the first start after the upgrade — refresh keys and build ranges are re-resolved,
pre-aggregation data itself is not rebuilt. Bounded by `@AsyncDebounce` and the in-memory cache;
old entries age out on their own (1h / 24h TTLs).
