### PR TITLE
refactor(query-orchestrator): normalize pre-aggregation SQL to tuples

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -1,6 +1,6 @@
 import { TableStructure } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
-import { QueryCache, QueryWithParams } from './QueryCache';
+import { assertQueryWithParams, QueryCache, QueryWithParams } from './QueryCache';
 import {
   PreAggregationDescription,
   PreAggregations,
@@ -191,7 +191,7 @@ export class PreAggregationLoadCache {
   }
 
   public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: number) {
-    const [query, values, queryOptions]: QueryWithParams = Array.isArray(sqlQuery) ? sqlQuery : [sqlQuery, [], {}];
+    const [query, values, queryOptions] = assertQueryWithParams(sqlQuery, 'invalidateKeyQueries entry');
 
     if (!this.queryResults[this.queryCache.queryRedisKey([query, values])]) {
       this.queryResults[this.queryCache.queryRedisKey([query, values])] = await this.queryCache.cacheQueryResult(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -1,6 +1,6 @@
 import { TableStructure } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
-import { assertQueryWithParams, QueryCache, QueryWithParams } from './QueryCache';
+import { QueryCache, QueryWithParams } from './QueryCache';
 import {
   PreAggregationDescription,
   PreAggregations,
@@ -191,7 +191,7 @@ export class PreAggregationLoadCache {
   }
 
   public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: number) {
-    const [query, values, queryOptions] = assertQueryWithParams(sqlQuery, 'invalidateKeyQueries entry');
+    const [query, values, queryOptions] = sqlQuery;
 
     if (!this.queryResults[this.queryCache.queryRedisKey([query, values])]) {
       this.queryResults[this.queryCache.queryRedisKey([query, values])] = await this.queryCache.cacheQueryResult(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -13,7 +13,7 @@ import {
   UnloadOptions
 } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
-import { assertQueryWithParams, PreAggTableToTempTableNames, QueryCache, QueryWithParams } from './QueryCache';
+import { PreAggTableToTempTableNames, QueryCache, QueryWithParams } from './QueryCache';
 import { ContinueWaitError } from './ContinueWaitError';
 import { LargeStreamWarning } from './StreamObjectsCounter';
 import {
@@ -544,7 +544,7 @@ export class PreAggregationLoader {
     saveCancelFn: SaveCancelFn,
     invalidationKeys: InvalidationKeys
   ) {
-    const [loadSql, params] = assertQueryWithParams(this.preAggregation.loadSql, 'preAggregation.loadSql');
+    const [loadSql, params] = this.preAggregation.loadSql;
     const targetTableName = this.targetTableName(newVersionEntry);
     const query = QueryCache.replacePreAggregationTableNamesInSql(
       loadSql,
@@ -691,7 +691,7 @@ export class PreAggregationLoader {
     withTempTable: boolean
   ): Promise<QueryOptions> {
     if (withTempTable) {
-      const [loadSql, params] = assertQueryWithParams(this.preAggregation.loadSql, 'preAggregation.loadSql');
+      const [loadSql, params] = this.preAggregation.loadSql;
 
       const query = QueryCache.replacePreAggregationTableNamesInSql(
         loadSql,
@@ -715,7 +715,7 @@ export class PreAggregationLoader {
 
       return queryOptions;
     } else {
-      const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
+      const [sql, params] = this.preAggregation.sql;
       const queryOptions = this.queryOptions(invalidationKeys, sql, params, targetTableName, newVersionEntry);
       this.logExecutingSql(queryOptions);
       return queryOptions;
@@ -731,7 +731,7 @@ export class PreAggregationLoader {
     saveCancelFn: SaveCancelFn,
     invalidationKeys: InvalidationKeys
   ) {
-    const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
+    const [sql, params] = this.preAggregation.sql;
 
     const queryOptions = this.queryOptions(invalidationKeys, sql, params, this.targetTableName(newVersionEntry), newVersionEntry);
     this.logExecutingSql(queryOptions);
@@ -887,7 +887,7 @@ export class PreAggregationLoader {
    * prepares download data when temp table = false
    */
   protected async getTableDataWithoutTempTable(client: DriverInterface, table: string, saveCancelFn: SaveCancelFn, queryOptions: QueryOptions, externalDriverCapabilities: DriverCapabilities) {
-    const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
+    const [sql, params] = this.preAggregation.sql;
 
     let tableData: DownloadTableData;
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -13,7 +13,7 @@ import {
   UnloadOptions
 } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
-import { PreAggTableToTempTableNames, QueryCache, QueryWithParams } from './QueryCache';
+import { assertQueryWithParams, PreAggTableToTempTableNames, QueryCache, QueryWithParams } from './QueryCache';
 import { ContinueWaitError } from './ContinueWaitError';
 import { LargeStreamWarning } from './StreamObjectsCounter';
 import {
@@ -544,14 +544,11 @@ export class PreAggregationLoader {
     saveCancelFn: SaveCancelFn,
     invalidationKeys: InvalidationKeys
   ) {
-    const [loadSql, params] =
-      Array.isArray(this.preAggregation.loadSql) ? this.preAggregation.loadSql : [this.preAggregation.loadSql, []];
+    const [loadSql, params] = assertQueryWithParams(this.preAggregation.loadSql, 'preAggregation.loadSql');
     const targetTableName = this.targetTableName(newVersionEntry);
-    const query = (
-      <string>QueryCache.replacePreAggregationTableNames(
-        loadSql,
-        this.preAggregationsTablesToTempTables,
-      )
+    const query = QueryCache.replacePreAggregationTableNamesInSql(
+      loadSql,
+      this.preAggregationsTablesToTempTables,
     ).replace(
       this.preAggregation.tableName,
       targetTableName
@@ -694,14 +691,11 @@ export class PreAggregationLoader {
     withTempTable: boolean
   ): Promise<QueryOptions> {
     if (withTempTable) {
-      const [loadSql, params] =
-        Array.isArray(this.preAggregation.loadSql) ? this.preAggregation.loadSql : [this.preAggregation.loadSql, []];
+      const [loadSql, params] = assertQueryWithParams(this.preAggregation.loadSql, 'preAggregation.loadSql');
 
-      const query = (
-        <string>QueryCache.replacePreAggregationTableNames(
-          loadSql,
-          this.preAggregationsTablesToTempTables,
-        )
+      const query = QueryCache.replacePreAggregationTableNamesInSql(
+        loadSql,
+        this.preAggregationsTablesToTempTables,
       ).replace(
         this.preAggregation.tableName,
         targetTableName
@@ -721,8 +715,7 @@ export class PreAggregationLoader {
 
       return queryOptions;
     } else {
-      const [sql, params] =
-        Array.isArray(this.preAggregation.sql) ? this.preAggregation.sql : [this.preAggregation.sql, []];
+      const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
       const queryOptions = this.queryOptions(invalidationKeys, sql, params, targetTableName, newVersionEntry);
       this.logExecutingSql(queryOptions);
       return queryOptions;
@@ -738,8 +731,7 @@ export class PreAggregationLoader {
     saveCancelFn: SaveCancelFn,
     invalidationKeys: InvalidationKeys
   ) {
-    const [sql, params] =
-      Array.isArray(this.preAggregation.sql) ? this.preAggregation.sql : [this.preAggregation.sql, []];
+    const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
 
     const queryOptions = this.queryOptions(invalidationKeys, sql, params, this.targetTableName(newVersionEntry), newVersionEntry);
     this.logExecutingSql(queryOptions);
@@ -895,8 +887,7 @@ export class PreAggregationLoader {
    * prepares download data when temp table = false
    */
   protected async getTableDataWithoutTempTable(client: DriverInterface, table: string, saveCancelFn: SaveCancelFn, queryOptions: QueryOptions, externalDriverCapabilities: DriverCapabilities) {
-    const [sql, params] =
-      Array.isArray(this.preAggregation.sql) ? this.preAggregation.sql : [this.preAggregation.sql, []];
+    const [sql, params] = assertQueryWithParams(this.preAggregation.sql, 'preAggregation.sql');
 
     let tableData: DownloadTableData;
 
@@ -990,7 +981,7 @@ export class PreAggregationLoader {
       };
       this.logger('Creating pre-aggregation index', queryOptions);
       const preAggTableToTempTableNames = this.preAggregationsTablesToTempTables as PreAggTableToTempTableNames[];
-      const resultingSql = QueryCache.replacePreAggregationTableNames(
+      const resultingSql = QueryCache.replacePreAggregationTableNamesInSql(
         query,
         preAggTableToTempTableNames.concat([
           [this.preAggregation.tableName, { targetTableName: this.targetTableName(newVersionEntry) }],

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -58,11 +58,6 @@ export type QueryWithParams = [
   options?: QueryOptions
 ];
 
-/**
- * Every producer of pre-aggregation SQL emits a `[sql, params, options?]` tuple.
- * A bare SQL string used to be silently widened to `[sql, [], {}]`, which hid
- * malformed descriptions until they surfaced as a query missing its params.
- */
 export function assertQueryWithParams(value: unknown, field: string): QueryWithParams {
   if (!Array.isArray(value)) {
     throw new Error(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -58,6 +58,21 @@ export type QueryWithParams = [
   options?: QueryOptions
 ];
 
+/**
+ * Every producer of pre-aggregation SQL emits a `[sql, params, options?]` tuple.
+ * A bare SQL string used to be silently widened to `[sql, [], {}]`, which hid
+ * malformed descriptions until they surfaced as a query missing its params.
+ */
+export function assertQueryWithParams(value: unknown, field: string): QueryWithParams {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `${field} is expected to be a [sql, params, options?] tuple, but got: ${JSON.stringify(value)}`
+    );
+  }
+
+  return value as QueryWithParams;
+}
+
 export type LoadRefreshKeyOptions = {
   requestId?: string;
   skipRefreshKeyWaitForRenew?: boolean;
@@ -206,15 +221,10 @@ export class QueryCache {
     queryBody: QueryBody,
     preAggregationsTablesToTempTables: PreAggTableToTempTable[],
   ) {
-    const replacePreAggregationTableNames =
-      (queryAndParams: string | QueryWithParams) => (
-        QueryCache.replacePreAggregationTableNames(
-          queryAndParams,
-          preAggregationsTablesToTempTables,
-        )
-      );
-
-    const query = replacePreAggregationTableNames(queryBody.query);
+    const query = QueryCache.replacePreAggregationTableNamesInSql(
+      queryBody.query,
+      preAggregationsTablesToTempTables,
+    );
 
     const inlineTables = preAggregationsTablesToTempTables.flatMap(
       ([_, preAggregation]) => (
@@ -234,7 +244,10 @@ export class QueryCache {
 
     const cacheKeyQueries = this
       .cacheKeyQueriesFrom(queryBody)
-      .map(replacePreAggregationTableNames);
+      .map((queryAndParams) => QueryCache.replacePreAggregationTableNames(
+        queryAndParams,
+        preAggregationsTablesToTempTables,
+      ));
 
     const renewalThreshold = queryBody.cacheKeyQueries?.renewalThreshold;
 
@@ -414,19 +427,21 @@ export class QueryCache {
     );
   }
 
-  public static replacePreAggregationTableNames(
-    queryAndParams: string | QueryWithParams,
+  public static replacePreAggregationTableNamesInSql(
+    sql: string,
     preAggregationsTablesToTempTables: PreAggTableToTempTableNames[],
-  ): string | QueryWithParams {
-    const [keyQuery, params, queryOptions] = Array.isArray(queryAndParams)
-      ? queryAndParams
-      : [queryAndParams, []];
+  ): string {
     // Single-pass replacement with longest-first alternation: sequential
     // per-name replacement would corrupt names that are prefixes of other
     // names (e.g. `name1` vs `name10`) and rescan already inserted target
     // names, which contain the source name as a prefix
     const sorted = [...preAggregationsTablesToTempTables]
       .sort(([a], [b]) => b.length - a.length);
+
+    if (!sorted.length) {
+      return sql;
+    }
+
     const replacements = new Map(
       sorted.map(([tableName, { targetTableName }]) => [tableName, targetTableName])
     );
@@ -436,12 +451,21 @@ export class QueryCache {
         .join('|'),
       'g'
     );
-    const replacedKeyQuery: string = sorted.length
-      ? keyQuery.replace(replaceRegex, (match) => replacements.get(match) as string)
-      : keyQuery;
-    return Array.isArray(queryAndParams)
-      ? [replacedKeyQuery, params, queryOptions]
-      : replacedKeyQuery;
+
+    return sql.replace(replaceRegex, (match) => replacements.get(match) as string);
+  }
+
+  public static replacePreAggregationTableNames(
+    queryAndParams: QueryWithParams,
+    preAggregationsTablesToTempTables: PreAggTableToTempTableNames[],
+  ): QueryWithParams {
+    const [sql, params, queryOptions] = assertQueryWithParams(queryAndParams, 'queryAndParams');
+
+    return [
+      QueryCache.replacePreAggregationTableNamesInSql(sql, preAggregationsTablesToTempTables),
+      params,
+      queryOptions,
+    ];
   }
 
   /**
@@ -745,9 +769,9 @@ export class QueryCache {
   }
 
   public startRenewCycle(
-    query: string | QueryWithParams,
+    query: string,
     values: string[],
-    cacheKeyQueries: (string | QueryWithParams)[],
+    cacheKeyQueries: QueryWithParams[],
     expireSecs: number,
     cacheKey: CacheKey,
     renewalThreshold: any,
@@ -780,9 +804,9 @@ export class QueryCache {
   }
 
   public renewQuery(
-    query: string | QueryWithParams,
+    query: string,
     values: string[],
-    cacheKeyQueries: (string | QueryWithParams)[],
+    cacheKeyQueries: QueryWithParams[],
     expireSecs: number,
     cacheKey: CacheKey,
     renewalThreshold: any,
@@ -800,7 +824,7 @@ export class QueryCache {
   ) {
     options = options || { dataSource: 'default' };
     return Promise.all(
-      this.loadRefreshKeys(<QueryWithParams[]>cacheKeyQueries, expireSecs, options),
+      this.loadRefreshKeys(cacheKeyQueries, expireSecs, options),
     )
       .catch(e => {
         if (e instanceof ContinueWaitError) {
@@ -864,7 +888,7 @@ export class QueryCache {
 
   @AsyncDebounce()
   public async loadRefreshKey(q: QueryWithParams, expireSecs: number, options: LoadRefreshKeyOptions) {
-    const [query, values, queryOptions]: QueryWithParams = Array.isArray(q) ? q : [q, [], {}];
+    const [query, values, queryOptions] = assertQueryWithParams(q, 'cacheKeyQueries entry');
 
     return this.cacheQueryResult(
       query,
@@ -889,6 +913,9 @@ export class QueryCache {
     callback: () => MaybeCancelablePromise<T>,
   ) => this.cacheDriver.withLock(`lock:${key}`, callback, ttl, true);
 
+  // `query` may be a whole QueryWithParams tuple: metadata operations
+  // (`METADATA:*`, see QueryOrchestrator.createMetadataQuery) are dispatched by
+  // the driver on `query[0]` rather than executed as SQL.
   public async cacheQueryResult(
     query: string | QueryWithParams,
     values: string[],

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -183,9 +183,6 @@ export class QueryCache {
     });
   }
 
-  /**
-   * Returns cache driver instance.
-   */
   public getCacheDriver(): CacheDriverInterface {
     return this.cacheDriver;
   }
@@ -402,14 +399,6 @@ export class QueryCache {
 
   public static extractRequestUUID(requestId: string): string {
     return extractRequestUUID(requestId);
-  }
-
-  protected static replaceAll(replaceThis, withThis, inThis) {
-    withThis = withThis.replace(/\$/g, '$$$$');
-    return inThis.replace(
-      new RegExp(replaceThis.replace(/([/,!\\^${}[\]().*+?|<>\-&])/g, '\\$&'), 'g'),
-      withThis
-    );
   }
 
   public static replacePreAggregationTableNamesInSql(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -58,16 +58,6 @@ export type QueryWithParams = [
   options?: QueryOptions
 ];
 
-export function assertQueryWithParams(value: unknown, field: string): QueryWithParams {
-  if (!Array.isArray(value)) {
-    throw new Error(
-      `${field} is expected to be a [sql, params, options?] tuple, but got: ${JSON.stringify(value)}`
-    );
-  }
-
-  return value as QueryWithParams;
-}
-
 export type LoadRefreshKeyOptions = {
   requestId?: string;
   skipRefreshKeyWaitForRenew?: boolean;
@@ -454,7 +444,7 @@ export class QueryCache {
     queryAndParams: QueryWithParams,
     preAggregationsTablesToTempTables: PreAggTableToTempTableNames[],
   ): QueryWithParams {
-    const [sql, params, queryOptions] = assertQueryWithParams(queryAndParams, 'queryAndParams');
+    const [sql, params, queryOptions] = queryAndParams;
 
     return [
       QueryCache.replacePreAggregationTableNamesInSql(sql, preAggregationsTablesToTempTables),
@@ -883,7 +873,7 @@ export class QueryCache {
 
   @AsyncDebounce()
   public async loadRefreshKey(q: QueryWithParams, expireSecs: number, options: LoadRefreshKeyOptions) {
-    const [query, values, queryOptions] = assertQueryWithParams(q, 'cacheKeyQueries entry');
+    const [query, values, queryOptions] = q;
 
     return this.cacheQueryResult(
       query,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -908,9 +908,6 @@ export class QueryCache {
     callback: () => MaybeCancelablePromise<T>,
   ) => this.cacheDriver.withLock(`lock:${key}`, callback, ttl, true);
 
-  // `query` may be a whole QueryWithParams tuple: metadata operations
-  // (`METADATA:*`, see QueryOrchestrator.createMetadataQuery) are dispatched by
-  // the driver on `query[0]` rather than executed as SQL.
   public async cacheQueryResult(
     query: string | QueryWithParams,
     values: string[],

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -280,34 +280,6 @@ describe('PreAggregations', () => {
     });
   });
 
-  describe('refresh key tuple validation', () => {
-    test('keyQueryResult rejects a bare SQL string instead of running it without params', async () => {
-      const preAggregations = new PreAggregations(
-        'TEST',
-        mockDriverFactory as any,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        () => {},
-        queryCache!,
-        {},
-      );
-
-      const loadCache = new PreAggregationLoadCache(
-        mockDriverFactory as any,
-        queryCache!,
-        preAggregations,
-        { dataSource: 'default' },
-      );
-
-      await expect(loadCache.keyQueryResult('SELECT NOW()' as any, false, 10))
-        .rejects.toThrow('invalidateKeyQueries entry is expected to be a [sql, params, options?] tuple, but got: "SELECT NOW()"');
-    });
-
-    test('loadRefreshKey rejects a bare SQL string', async () => {
-      await expect(queryCache!.loadRefreshKey('SELECT NOW()' as any, 60, { dataSource: 'default' }))
-        .rejects.toThrow('cacheKeyQueries entry is expected to be a [sql, params, options?] tuple, but got: "SELECT NOW()"');
-    });
-  });
-
   describe('loadAllPreAggregationsIfNeeded', () => {
     let preAggregations: PreAggregations | null = null;
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -280,6 +280,34 @@ describe('PreAggregations', () => {
     });
   });
 
+  describe('refresh key tuple validation', () => {
+    test('keyQueryResult rejects a bare SQL string instead of running it without params', async () => {
+      const preAggregations = new PreAggregations(
+        'TEST',
+        mockDriverFactory as any,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => {},
+        queryCache!,
+        {},
+      );
+
+      const loadCache = new PreAggregationLoadCache(
+        mockDriverFactory as any,
+        queryCache!,
+        preAggregations,
+        { dataSource: 'default' },
+      );
+
+      await expect(loadCache.keyQueryResult('SELECT NOW()' as any, false, 10))
+        .rejects.toThrow('invalidateKeyQueries entry is expected to be a [sql, params, options?] tuple, but got: "SELECT NOW()"');
+    });
+
+    test('loadRefreshKey rejects a bare SQL string', async () => {
+      await expect(queryCache!.loadRefreshKey('SELECT NOW()' as any, 60, { dataSource: 'default' }))
+        .rejects.toThrow('cacheKeyQueries entry is expected to be a [sql, params, options?] tuple, but got: "SELECT NOW()"');
+    });
+  });
+
   describe('loadAllPreAggregationsIfNeeded', () => {
     let preAggregations: PreAggregations | null = null;
 

--- a/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
@@ -82,11 +82,4 @@ describe('QueryCache.replacePreAggregationTableNames', () => {
       { external: true },
     ]);
   });
-
-  test('throws for a bare SQL string instead of widening it to an empty params tuple', () => {
-    expect(() => QueryCache.replacePreAggregationTableNames(
-      'SELECT 1' as any,
-      [],
-    )).toThrow('queryAndParams is expected to be a [sql, params, options?] tuple, but got: "SELECT 1"');
-  });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
@@ -1,9 +1,9 @@
 import { QueryCache } from '../../src';
 import type { PreAggTableToTempTableNames } from '../../src';
 
-describe('QueryCache.replacePreAggregationTableNames', () => {
+describe('QueryCache.replacePreAggregationTableNamesInSql', () => {
   test('replaces a single table name', () => {
-    const result = QueryCache.replacePreAggregationTableNames(
+    const result = QueryCache.replacePreAggregationTableNamesInSql(
       'SELECT * FROM dev_pre_aggregations.orders_rollup',
       [['dev_pre_aggregations.orders_rollup', { targetTableName: 'dev_pre_aggregations.orders_rollup_20250401_abc' }]],
     );
@@ -23,7 +23,7 @@ describe('QueryCache.replacePreAggregationTableNames', () => {
       .map(([tableName], i) => `SELECT * FROM ${tableName} AS "alias${i}"`)
       .join(' UNION ALL ');
 
-    const result = QueryCache.replacePreAggregationTableNames(query, entries) as string;
+    const result = QueryCache.replacePreAggregationTableNamesInSql(query, entries);
 
     entries.forEach(([, { targetTableName }], i) => {
       expect(result).toContain(`${targetTableName} AS "alias${i}"`);
@@ -40,13 +40,37 @@ describe('QueryCache.replacePreAggregationTableNames', () => {
       ['pa.rollup1', { targetTableName: 'pa.rollup1_aaa_bbb_111' }],
       ['pa.rollup10', { targetTableName: 'pa.rollup10_ccc_ddd_222' }],
     ];
-    const result = QueryCache.replacePreAggregationTableNames(
+    const result = QueryCache.replacePreAggregationTableNamesInSql(
       'SELECT * FROM pa.rollup10 JOIN pa.rollup1',
       entries,
     );
     expect(result).toBe('SELECT * FROM pa.rollup10_ccc_ddd_222 JOIN pa.rollup1_aaa_bbb_111');
   });
 
+  test('returns query as is for empty replacements', () => {
+    const result = QueryCache.replacePreAggregationTableNamesInSql('SELECT 1', []);
+    expect(result).toBe('SELECT 1');
+  });
+
+  test('treats $ in target names literally', () => {
+    const result = QueryCache.replacePreAggregationTableNamesInSql(
+      'SELECT * FROM pa.rollup',
+      [['pa.rollup', { targetTableName: 'pa.rollup_$&_$1' }]],
+    );
+    expect(result).toBe('SELECT * FROM pa.rollup_$&_$1');
+  });
+
+  test('does not mutate the incoming array order', () => {
+    const entries: PreAggTableToTempTableNames[] = [
+      ['name1', { targetTableName: 'target1' }],
+      ['name10', { targetTableName: 'target10' }],
+    ];
+    QueryCache.replacePreAggregationTableNamesInSql('SELECT * FROM name1, name10', entries);
+    expect(entries.map(([tableName]) => tableName)).toEqual(['name1', 'name10']);
+  });
+});
+
+describe('QueryCache.replacePreAggregationTableNames', () => {
   test('keeps params and query options for QueryWithParams input', () => {
     const result = QueryCache.replacePreAggregationTableNames(
       ['SELECT * FROM dev_pre_aggregations.orders_rollup WHERE id = ?', ['1'], { external: true }],
@@ -59,25 +83,10 @@ describe('QueryCache.replacePreAggregationTableNames', () => {
     ]);
   });
 
-  test('returns query as is for empty replacements', () => {
-    const result = QueryCache.replacePreAggregationTableNames('SELECT 1', []);
-    expect(result).toBe('SELECT 1');
-  });
-
-  test('treats $ in target names literally', () => {
-    const result = QueryCache.replacePreAggregationTableNames(
-      'SELECT * FROM pa.rollup',
-      [['pa.rollup', { targetTableName: 'pa.rollup_$&_$1' }]],
-    );
-    expect(result).toBe('SELECT * FROM pa.rollup_$&_$1');
-  });
-
-  test('does not mutate the incoming array order', () => {
-    const entries: PreAggTableToTempTableNames[] = [
-      ['name1', { targetTableName: 'target1' }],
-      ['name10', { targetTableName: 'target10' }],
-    ];
-    QueryCache.replacePreAggregationTableNames('SELECT * FROM name1, name10', entries);
-    expect(entries.map(([tableName]) => tableName)).toEqual(['name1', 'name10']);
+  test('throws for a bare SQL string instead of widening it to an empty params tuple', () => {
+    expect(() => QueryCache.replacePreAggregationTableNames(
+      'SELECT 1' as any,
+      [],
+    )).toThrow('queryAndParams is expected to be a [sql, params, options?] tuple, but got: "SELECT 1"');
   });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Seven call sites carried a `Array.isArray(x) ? x : [x, [], {}]` branch that widened a bare SQL string into a `[sql, params, options?]` tuple. It was vestigial: it dates to #2993/#3061, when the third `options` element was appended and this code was still untyped JS. Every producer emits tuples today (`BaseQuery.refreshKeysByCubes`, `BaseQuery.preAggregationInvalidateKeyQueries`, `KsqlQuery.partitionInvalidateKeyQueries`), and the consumers already disagreed about honoring it — `loadRangeQuery`, `replacePartitionSqlAndParams` and `prepareIndexesSql` destructure the tuple bare, so a string would have crashed there anyway. Those seven branches now destructure directly, leaving `QueryWithParams` to carry the contract.

The rest is making that contract visible in the signatures. `replacePreAggregationTableNames` took and returned `string | QueryWithParams`; the union on the *input* was legitimate (`queryBody.query` is a string, `cacheKeyQueries` are tuples) but the union on the *return* leaked outward into casts at unrelated call sites, so it is split by input type:

| signature | before | after |
| --- | --- | --- |
| `replacePreAggregationTableNamesInSql` | — | `string -> string` |
| `replacePreAggregationTableNames` | `string \| QueryWithParams` both ways | `QueryWithParams -> QueryWithParams` |
| `renewQuery` / `startRenewCycle` | `string \| QueryWithParams` | `string` |

That removes two `<string>` casts in `PreAggregationLoader` and one `<QueryWithParams[]>` cast in `renewQuery`. Also drops the dead `QueryCache.replaceAll` — its last caller was the per-name replacement loop that the single-pass longest-first rewrite replaced, and deleting it removes the duplicated regex-metacharacter escape, leaving one live copy.

`cacheQueryResult` and `queryWithRetryAndRelease` deliberately keep `string | QueryWithParams`: `QueryOrchestrator.createMetadataQuery` returns a real tuple whose `[0]` is a `METADATA:*` sentinel that the driver dispatches on instead of executing as SQL, so narrowing those two would break `queryDataSourceSchemas` / `queryTablesForSchemas` / `queryColumnsForTables`.

**Verification**

`yarn tsc` clean in `query-orchestrator`, `api-gateway`, `server-core` and `schema-compiler`. `yarn unit` 68/68 in `query-orchestrator`; `yarn lint` 0 errors. `schema-compiler`'s `base-query` + `pre-aggregations` suites 140/140, confirming no producer regressed to strings.

Note there is no runtime validation in this PR — an earlier revision added an `assertQueryWithParams` guard and it was removed, because it threw from `cachedQueryResult` before the persistent/`skipExternalCacheAndQueue` early-return (failing paths that never read `cacheKeyQueries`) and embedded the offending value in an error that reaches HTTP clients. The tuple contract is type-enforced only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)