### PR TITLE
test(query-orchestrator): make the orphaned queue test deterministic

### DIFF
--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -276,7 +276,8 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(cancelledQuery).toBe('123');
 
       // every client gave up on ContinueWaitError long before this point
-      await Promise.all(pending);
+      const outcomes = await Promise.all(pending);
+      outcomes.forEach((e) => expect(e).toBeInstanceOf(ContinueWaitError));
       await awaitProcessing();
 
       // 123 was cancelled before the worker could pick it up

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -250,29 +250,39 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     const onlyLocalTest = options.cacheAndQueueDriver !== 'cubestore' ? test : xtest;
 
     test('orphaned', async () => {
-      // recover if previous test broken something
-      for (let i = 1; i <= 4; i++) {
-        await queue.executeInQueue('delay', `11${i}`, { delay: 50, result: `${i}` }, 0);
+      cancelledQuery = null;
+
+      // Two queries hold the single worker slot. orphanedTimeout keeps them out of the
+      // orphaned set themselves: the memory driver reports active queries as orphaned once
+      // their timeout passes, Cube Store does not.
+      const pending = [
+        queue.executeInQueue('delay', '121', { delay: 1200, result: '1', orphanedTimeout: 60 }, 0).catch(e => e),
+      ];
+      await delayFn(null, 50);
+      pending.push(queue.executeInQueue('delay', '122', { delay: 1200, result: '2', orphanedTimeout: 60 }, 0).catch(e => e));
+      await delayFn(null, 50);
+      // 121 and 122 keep the worker busy for ~2.4s, so this one is still queued when its
+      // 1s orphaned timeout expires
+      pending.push(queue.executeInQueue('delay', '123', { delay: 50, result: '3', orphanedTimeout: 1 }, 0).catch(e => e));
+
+      // Reconciliation is what cancels orphaned queries and nothing else triggers it while
+      // the worker is busy.
+      const deadline = Date.now() + 2000;
+      while (cancelledQuery !== '123' && Date.now() < deadline) {
+        await queue.reconcileQueue();
+        await delayFn(null, 100);
       }
 
-      cancelledQuery = null;
-      delayCount = 0;
+      expect(cancelledQuery).toBe('123');
 
-      let result = queue.executeInQueue('delay', '111', { delay: 800, result: '1' }, 0);
-      delayFn(null, 50).then(() => queue.executeInQueue('delay', '112', { delay: 800, result: '2' }, 0)).catch(e => e);
-      delayFn(null, 75).then(() => queue.executeInQueue('delay', '113', { delay: 800, result: '3' }, 0)).catch(e => e);
-      // orphaned timeout should be applied
-      delayFn(null, 100).then(() => queue.executeInQueue('delay', '114', { delay: 900, result: '4' }, 0)).catch(e => e);
+      // every client gave up on ContinueWaitError long before this point
+      await Promise.all(pending);
+      await awaitProcessing();
 
-      expect(await result).toBe('10');
-      await queue.executeInQueue('delay', '112', { delay: 800, result: '2' }, 0);
-
-      result = await queue.executeInQueue('delay', '113', { delay: 900, result: '3' }, 0);
-      expect(result).toBe('32');
-
-      await delayFn(null, 500);
-      expect(cancelledQuery).toBe('114');
-      await queue.executeInQueue('delay', '114', { delay: 50, result: '4' }, 0);
+      // 123 was cancelled before the worker could pick it up
+      expect(delayCount).toBe(2);
+      // cancellation removed it from the queue, so the same key can be queued again
+      expect(await queue.executeInQueue('delay', '123', { delay: 50, result: '3' }, 0)).toBe('32');
     });
 
     test('orphaned with custom ttl', async () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

`QueryQueue.abstract.ts`'s `orphaned` test is a long-standing flake — most recently it failed [#11608's `integration-cubestore` job](https://github.com/cube-js/cube/actions/runs/32410444220/job/96560908997) with `Continue wait` at `QueryQueue.abstract.ts:270`, and its magic numbers had already been nudged in #6090, #6094, #6125, #6189 and #9705. The cause is that one 800ms delay value had to satisfy two hostile constraints: with `continueWaitTimeout: 1s` / `executionTimeout: 2s` / `orphanedTimeout: 2s` / `concurrency: 1`, each awaited `executeInQueue` must return inside its own 1s window (`delay < 1000`) while `114` must stay queued past the 2s orphaned timeout behind three sequential queries (`3 * delay > 2000`), leaving ~200ms of slack per step minus several Cube Store round trips. Timing now comes from explicit per-query orphaned timeouts and an explicit `reconcileQueue()` poll instead of that ratio — two blockers hold the single worker for ~2.4s with `orphanedTimeout: 60` so they are never orphan-eligible themselves, and the orphan candidate carries `orphanedTimeout: 1`, so it can be added ~1.4s late and the test still holds. `expect(delayCount).toBe(2)` also proves the orphaned query never executed, which the old version never checked, and fresh keys `121`-`123` drop the coupling to `sequence`'s `111`-`114` (ordering stays covered by `sequence` and `negative priority`).

**Verification**

Run against docker `cubejs/cubestore:v1.7.23`, with 12 busy-loops saturating the box to reproduce CI conditions — under that load the old test reproduced both signatures (`Continue wait` at line 270, and `Expected "114", Received "113"`).

| run | before | after |
| --- | --- | --- |
| Cube Store suite, idle, 5x | pass | pass |
| Cube Store `orphaned`, under load | 5/8 passed | 8/8 passed |
| memory driver suite, under load | — | 4/4 passed |

`yarn unit` 68/68 in `query-orchestrator`, `yarn tsc` and `eslint` clean. Test runtime drops from 3675ms to ~2.5s.

Note one thing left untouched: `LocalQueueDriverConnection` reports *actively executing* queries as orphaned (`state.recent` survives `retrieveForProcessing`), so on the memory driver a reconcile can cancel a query mid-flight, while Cube Store only cancels active queries on heartbeat timeout. That divergence is why the blockers here need `orphanedTimeout: 60`; changing dev-mode driver behaviour doesn't belong in a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
