### PR TITLE
docs: document undocumented customer-facing changes from the last week

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -17,6 +17,8 @@ Standard filled circle. Each slice's arc length is proportional to its value.
 
 A pie with a hollow center. Increase the **Inner radius** value in the Style tab to any non-zero value to switch to a donut. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
 
+By default, a donut also shows the measure's total in the hole, formatted with the measure's own number format. Toggle it with **Show total**, next to the **Data labels** controls in the Style tab.
+
 {/* Screenshot: donut chart — same data as the pie variant, with inner radius applied. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Inner radius

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -32,6 +32,32 @@ Pivot behavior:
 - Pivot columns can also be sorted by row values — click a row number to sort by that row, including the totals row.
 - Pivoted columns can be hidden, but hiding is indexed to the specific value (e.g. hiding `status: returned`), not position.
 
+## Row grouping
+
+Group rows by their leading dimensions into collapsible headers, so each grouped
+dimension's value is shown once for the whole group instead of repeated on every row.
+
+Turn it on with the **Group rows** toggle in the **Values** section of the **Style**
+tab. The toggle is disabled — with a tooltip explaining why — unless the table has at
+least two row dimensions and no column pivot. You can also ask [Analytics
+Chat](/docs/explore-analyze/analytics-chat) to group the table's rows.
+
+With grouping on, every row dimension except the innermost becomes a group level: rows
+nest one header per level, kept contiguous by that dimension's first-appearance order,
+with the header showing the dimension's value once instead of on every row underneath.
+
+Turning it on also adds a **Row grouping** section to the **Style** tab, with:
+
+- **Expand all groups** / **Collapse all groups** — set every group's expand state at once.
+- Text color, background color, and text formatting for the group header rows.
+
+Each group-level column's card in the **Columns** section gets a **Default state**
+control (**Expanded** or **Collapsed**) that sets whether new groups on that level start
+open or closed. It only sets the default — a viewer's own expand/collapse of an
+individual group isn't affected by changing it afterwards.
+
+{/* TODO screenshot: table with collapsed row groups and the Style tab's Row grouping section */}
+
 ## Column field options
 
 Configure individual columns in the **Columns** section of the **Style** tab (or via the dropdown arrow on a field in the **Fields** section):

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -18,8 +18,8 @@ commits the generated files to a branch where you review them before they reach
 production.
 
 Pulls can run manually, from your CI/CD pipeline, automatically on every push to your
-dbt repository, or from [Cube AI chat](#trigger-from-cube-ai-chat) — so your semantic
-layer stays in sync with dbt as it evolves.
+dbt repository, or from [Analytics Chat](#trigger-from-analytics-chat) — so your
+semantic layer stays in sync with dbt as it evolves.
 
 <Info>
 
@@ -420,7 +420,7 @@ to the branch you're syncing.
   />
 </Frame>
 
-### Trigger from Cube AI chat
+### Trigger from Analytics Chat
 
 Ask [the agent](/docs/explore-analyze/analytics-chat) to check for and pull dbt updates —
 for example, "check for dbt updates and pull them." The agent starts a sync, follows its

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -17,8 +17,9 @@ model into a cube — including dimensions, measures, descriptions, and joins �
 commits the generated files to a branch where you review them before they reach
 production.
 
-Pulls can run manually, from your CI/CD pipeline, or automatically on every push to
-your dbt repository — so your semantic layer stays in sync with dbt as it evolves.
+Pulls can run manually, from your CI/CD pipeline, automatically on every push to your
+dbt repository, or from [Cube AI chat](#trigger-from-cube-ai-chat) — so your semantic
+layer stays in sync with dbt as it evolves.
 
 <Info>
 
@@ -418,6 +419,13 @@ to the branch you're syncing.
     alt="Webhook section of the dbt settings card with the signing secret and callback URL"
   />
 </Frame>
+
+### Trigger from Cube AI chat
+
+Ask [the agent](/docs/explore-analyze/analytics-chat) to check for and pull dbt updates —
+for example, "check for dbt updates and pull them." The agent starts a sync, follows its
+progress, opens the review branch it produces, and summarizes the generated cubes. Ask
+"what happened with my recent dbt syncs?" to have it answer from sync history instead.
 
 ### Review notifications
 

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -42,15 +42,22 @@ tools][ref-viz-tools]. Some of the features with partial support are listed belo
 
 ## Personal Core Data API Token
 
-Cube users can generate a personal token to authenticate SQL API connections from
-external tools like BI dashboards, notebooks, and SQL clients. Navigate to
-**Preferences → Personal Core Data API Token** and click
-**Generate Token**.
+Cube users can generate a personal token to authenticate SQL API and
+[REST (JSON) API][ref-rest-api] connections from external tools like BI
+dashboards, notebooks, and SQL clients. Navigate to **Preferences → Personal
+Core Data API Token** and click **Generate Token**.
 
 The token authenticates as that user, so all [groups][ref-groups],
 [user attributes][ref-user-attributes], and [data access policies][ref-dap]
 are applied to queries made with this token. The page also provides connection
-instructions including host, port, and database name for your deployment.
+instructions for your deployment: host, port, and database name for the SQL
+API, and a sample `curl` request using the token as a bearer token for the
+REST (JSON) API:
+
+```bash
+curl <deployment-url>/cubejs-api/v1/meta \
+  -H "Authorization: Bearer YOUR-CORE-DATA-API-TOKEN"
+```
 
 ## Authentication methods
 
@@ -63,6 +70,7 @@ tools][ref-viz-tools]:
 | Kerberos and NTLM | [MDX API][ref-mdx-api] |
 | [Identity provider][ref-auth-idp] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
+| [Personal Core Data API Token](#personal-core-data-api-token) | [SQL API][ref-sql-api]<br/>[REST (JSON) API][ref-rest-api] |
 
 [cube-issbi]: https://cube.dev/use-cases/semantic-layer
 [cube-ea]: https://cube.dev/use-cases/embedded-analytics

--- a/docs-mintlify/reference/cubestore/sql-commands.mdx
+++ b/docs-mintlify/reference/cubestore/sql-commands.mdx
@@ -232,6 +232,7 @@ Synopsis:
 
 ```sql
 QUEUE ADD [EXCLUSIVE] [PRIORITY priority] [ORPHANED timeout] [EXTERNAL_ID 'id'] key 'value';
+QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY priority] [ORPHANED timeout] [EXTERNAL_ID 'id'] key 'value' concurrency;
 QUEUE GET key;
 QUEUE LIST [WITH_PAYLOAD] prefix;
 QUEUE PENDING [WITH_PAYLOAD] prefix;
@@ -257,6 +258,11 @@ add, claim, acknowledge, and cancel individual jobs.
 `QUEUE ADD`'s options may be given in any order. For `GET`, `ACK`, `CANCEL`,
 `HEARTBEAT`, `RESULT`, `RESULT_BLOCKING`, and `MERGE_EXTRA`, `key` is either the
 job's path or its numeric queue id.
+
+`QUEUE ADD_AND_RETRIEVE` adds an item and, in the same atomic operation, claims
+it — moving it straight to the active status — if the prefix's `concurrency`
+budget allows. It combines what otherwise takes a separate `QUEUE ADD`
+followed by `QUEUE RETRIEVE`.
 
 `QUEUE CLEAR` empties the queue by iterating over its entries, the same way
 `CACHE CLEAR` does.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (not applicable — docs only)
- [ ] Linter has been run for changed code (not applicable — docs only)
- [ ] Tests for the changes have been added if not covered yet (not applicable — docs only)

**Description of Changes Made**

Routine documentation audit: cross-checked recent merges in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify` and found five small, genuinely undocumented customer-facing changes. Each gets its own commit:

- **CubeStore `QUEUE ADD_AND_RETRIEVE`** (cube-js/cube #11590) — new command that adds a queue item and claims it atomically in one step. Documented in the `QUEUE` synopsis/prose in `reference/cubestore/sql-commands.mdx`.
- **Donut chart center total** (cubejs-enterprise CUB-3186) — donuts now show the measure's total in the hole by default, via a **Show total** toggle. Documented in `docs/explore-analyze/charts/chart-types/pie.mdx`.
- **Table chart row grouping** (cubejs-enterprise #14204) — collapsible row grouping by leading dimensions, with per-level default expand state. Documented as a new section in `docs/explore-analyze/charts/chart-types/table.mdx`.
- **Personal Core Data API Token → REST (JSON) API** (cubejs-enterprise CUB-3143) — the personal token can now also authenticate REST (JSON) API requests as a bearer token, not just the SQL API. Updated `reference/core-data-apis/index.mdx` (intro text, `curl` example, and the authentication-methods table).
- **dbt pull from Cube AI chat** (cubejs-enterprise CUB-4001) — the agent can drive a full dbt pull from chat and answer questions about sync history. Added a "Trigger from Cube AI chat" subsection to `docs/integrations/dbt.mdx`.

No large/new-page-worthy gaps were found in this window.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NPCJAgQvur9CmB1E5pNZY6)_