### PR TITLE
feat(query-orchestrator): compute interval refresh keys locally instead of querying

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1419,26 +1419,34 @@ this variable.
 
 ## `CUBEJS_REFRESH_KEY_LOCAL_TIME`
 
-If `true`, interval and cron based [`refresh_key`](/reference/data-modeling/cube#refresh_key)
-values are computed from the Cube instance's own clock instead of being fetched with a
-`SELECT FLOOR(...) as refresh_key` query. This removes a database round trip per refresh
-key check, which for the default 10 second refresh key means one fewer query on nearly
-every request.
+When a [`refresh_key`](/reference/data-modeling/cube#refresh_key) is defined with `every`,
+Cube normally asks the database what time it is — it sends a small
+`SELECT FLOOR(...) as refresh_key` query and rounds the answer down to the current
+interval. The answer is just arithmetic on a timestamp, so Cube can work it out itself.
+
+If `true`, Cube computes those values from its own clock and skips the query. With the
+default 10 second refresh key, that saves a database round trip on nearly every request.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `false`                | `false`               |
 
-Only `every`-based refresh keys are affected. Refresh keys defined with `sql`, and those
-using [`incremental`](/reference/data-modeling/pre-aggregations#incremental), still run
-against the database because their values cannot be derived from a time interval alone.
+This only applies to `every`-based refresh keys, including cron expressions. Refresh keys
+written with `sql`, and those marked
+[`incremental`](/reference/data-modeling/pre-aggregations#incremental), keep querying the
+database — their values depend on your data, not just on the time.
+
+Refresh keys also stay on the database path if you have set
+[`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options], since
+that setting works by caching the query result and there is no query left to cache.
 
 <Warning>
 
-Set this variable to the same value on **every** API instance and refresh worker, and keep
-their clocks synchronized (for example with NTP). Instances whose clocks straddle an
-interval boundary compute different refresh keys, which can cause the same
-pre-aggregation to be built more than once.
+Cube is now trusting the machine's clock instead of a single shared source of time, so all
+the clocks have to agree. Set this variable to the same value on **every** API instance
+and refresh worker, and keep them synchronized with NTP. If two instances sit on opposite
+sides of an interval boundary they will disagree about the current refresh key, and the
+same pre-aggregation can end up being built twice.
 
 </Warning>
 
@@ -2332,6 +2340,7 @@ The port for a Cube deployment to listen to API connections on.
   https://motherduck.com/docs/authenticating-to-motherduck/#authentication-using-a-service-token
 [ref-config-db]: /admin/connect-to-data/data-sources
 [ref-config-driver-factory]: /reference/configuration/config#driver_factory
+[ref-config-query-cache-options]: /reference/configuration/config#orchestrator_options
 [ref-config-multiple-ds-cloud]: /admin/connect-to-data/multiple-data-sources
 [ref-config-multiple-ds-decorating-env]: /admin/connect-to-data/multiple-data-sources#under-the-hood
 [ref-preagg-data-source]: /docs/pre-aggregations/refreshing-pre-aggregations#pre-aggregation-data-source

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1419,34 +1419,27 @@ this variable.
 
 ## `CUBEJS_REFRESH_KEY_LOCAL_TIME`
 
-When a [`refresh_key`](/reference/data-modeling/cube#refresh_key) is defined with `every`,
-Cube normally asks the database what time it is — it sends a small
-`SELECT FLOOR(...) as refresh_key` query and rounds the answer down to the current
-interval. The answer is just arithmetic on a timestamp, so Cube can work it out itself.
-
-If `true`, Cube computes those values from its own clock and skips the query. With the
-default 10 second refresh key, that saves a database round trip on nearly every request.
+To check an `every`-based [`refresh_key`](/reference/data-modeling/cube#refresh_key), Cube
+asks the database what time it is. If `true`, it uses its own clock instead, saving a round
+trip on nearly every request.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `false`                | `false`               |
 
-This only applies to `every`-based refresh keys, including cron expressions. Refresh keys
-written with `sql`, and those marked
-[`incremental`](/reference/data-modeling/pre-aggregations#incremental), keep querying the
-database — their values depend on your data, not just on the time.
-
-Refresh keys also stay on the database path if you have set
-[`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options], since
-that setting works by caching the query result and there is no query left to cache.
+Refresh keys written with `sql` or marked
+[`incremental`](/reference/data-modeling/pre-aggregations#incremental) keep querying the
+database, since their values depend on your data and not just on the time. So do all
+refresh keys if you have set
+[`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options], which
+works by caching the query result.
 
 <Warning>
 
-Cube is now trusting the machine's clock instead of a single shared source of time, so all
-the clocks have to agree. Set this variable to the same value on **every** API instance
-and refresh worker, and keep them synchronized with NTP. If two instances sit on opposite
-sides of an interval boundary they will disagree about the current refresh key, and the
-same pre-aggregation can end up being built twice.
+Cube now trusts each machine's clock, so they all have to agree. Set this variable to the
+same value on **every** API instance and refresh worker and keep them synchronized with
+NTP. Instances on opposite sides of an interval boundary compute different refresh keys,
+which can build the same pre-aggregation twice.
 
 </Warning>
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1417,6 +1417,31 @@ this variable.
 | ------------------------- | ---------------------- | --------------------- |
 | A valid number in seconds | `600`                  | `600`                 |
 
+## `CUBEJS_REFRESH_KEY_LOCAL_TIME`
+
+If `true`, interval and cron based [`refresh_key`](/reference/data-modeling/cube#refresh_key)
+values are computed from the Cube instance's own clock instead of being fetched with a
+`SELECT FLOOR(...) as refresh_key` query. This removes a database round trip per refresh
+key check, which for the default 10 second refresh key means one fewer query on nearly
+every request.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
+Only `every`-based refresh keys are affected. Refresh keys defined with `sql`, and those
+using [`incremental`](/reference/data-modeling/pre-aggregations#incremental), still run
+against the database because their values cannot be derived from a time interval alone.
+
+<Warning>
+
+Set this variable to the same value on **every** API instance and refresh worker, and keep
+their clocks synchronized (for example with NTP). Instances whose clocks straddle an
+interval boundary compute different refresh keys, which can cause the same
+pre-aggregation to be built more than once.
+
+</Warning>
+
 ## `CUBEJS_REFRESH_WORKER`
 
 If `true`, this instance of Cube will **only** refresh pre-aggregations.

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1420,12 +1420,16 @@ this variable.
 ## `CUBEJS_REFRESH_KEY_LOCAL_TIME`
 
 To check an `every`-based [`refresh_key`](/reference/data-modeling/cube#refresh_key), Cube
-asks the database what time it is. If `true`, it uses its own clock instead, saving a round
-trip on nearly every request.
+asks the database what time it is. If `true`, it uses its own clock instead and those
+queries stop entirely, including the ones scheduled refresh issues to warm them.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `false`                | `false`               |
+
+Cube already caches each result for a fraction of the interval, so this is not one query
+saved per request — it is one per refresh key per renewal window, multiplied by every cube,
+tenant, and timezone in the deployment.
 
 Refresh keys written with `sql` or marked
 [`incremental`](/reference/data-modeling/pre-aggregations#incremental) keep querying the

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -368,6 +368,15 @@ const variables: Record<string, (...args: any) => any> = {
   preciseDecimalInCubestore: () => get('CUBEJS_DB_PRECISE_DECIMAL_IN_CUBESTORE')
     .default('false')
     .asBoolStrict(),
+  /**
+   * Evaluates interval and cron based `refreshKey` values from the API instance
+   * clock instead of issuing `SELECT FLOOR(...) as refresh_key`. Requires clocks
+   * to be in sync across all API instances and refresh workers, otherwise nodes
+   * straddling an interval boundary disagree and rebuild pre-aggregations twice.
+   */
+  refreshKeyLocalTime: () => get('CUBEJS_REFRESH_KEY_LOCAL_TIME')
+    .default('false')
+    .asBoolStrict(),
 
   /** ****************************************************************
    * Common db options                                               *

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -368,12 +368,6 @@ const variables: Record<string, (...args: any) => any> = {
   preciseDecimalInCubestore: () => get('CUBEJS_DB_PRECISE_DECIMAL_IN_CUBESTORE')
     .default('false')
     .asBoolStrict(),
-  /**
-   * Evaluates interval and cron based `refreshKey` values from the API instance
-   * clock instead of issuing `SELECT FLOOR(...) as refresh_key`. Requires clocks
-   * to be in sync across all API instances and refresh workers, otherwise nodes
-   * straddling an interval boundary disagree and rebuild pre-aggregations twice.
-   */
   refreshKeyLocalTime: () => get('CUBEJS_REFRESH_KEY_LOCAL_TIME')
     .default('false')
     .asBoolStrict(),

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -107,6 +107,25 @@ describe('getEnv', () => {
     ).toBe(10);
   });
 
+  test('refreshKeyLocalTime', () => {
+    delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+    expect(getEnv('refreshKeyLocalTime')).toBe(false);
+
+    process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'true';
+    expect(getEnv('refreshKeyLocalTime')).toBe(true);
+
+    process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'false';
+    expect(getEnv('refreshKeyLocalTime')).toBe(false);
+  });
+
+  test('refreshKeyLocalTime(exception)', () => {
+    process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'yes';
+
+    expect(() => getEnv('refreshKeyLocalTime')).toThrowError();
+
+    delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+  });
+
   test('livePreview', () => {
     expect(getEnv('livePreview')).toBe(true);
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -228,7 +228,7 @@ export class QueryCache {
     this.memoryCache = new LRUCache<string, CacheEntry>({
       max: options.maxInMemoryCacheEntries || 10000
     });
-    this.localRefreshKeyEnabled = options.localRefreshKey ?? getEnv('refreshKeyLocalTime');
+    this.localRefreshKeyEnabled = options.localRefreshKey ?? false;
   }
 
   /**

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -60,10 +60,6 @@ export type RefreshKeyCacheOptions =
 /**
  * Everything needed to evaluate an `every` based refreshKey without touching a
  * database: `FLOOR((utcOffset + unixTimestamp - dayOffset) / interval)`.
- *
- * `utcOffset` is frozen at compile time, exactly as it already is when baked into
- * the emitted SQL string — the orchestrator must never recompute it, or the local
- * and SQL paths would stop agreeing across a DST transition.
  */
 export type LocalRefreshKeyDescriptor = {
   interval: number;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -510,7 +510,6 @@ export class QueryCache {
   ) {
     const [query, values, queryOptions] = sqlQuery;
 
-    // A locally evaluated key is free: nothing to cache, no queue to wait on.
     const local = this.localRefreshKeyResult(queryOptions);
     if (local) {
       return local;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -25,7 +25,12 @@ import { ContinueWaitError } from './ContinueWaitError';
 import { LocalCacheDriver } from './LocalCacheDriver';
 import { DriverFactory, DriverFactoryByDataSource } from './DriverFactory';
 import { LoadPreAggregationResult, PreAggregationDescription } from './PreAggregations';
-import { getCacheHash, extractRequestUUID } from './utils';
+import {
+  getCacheHash,
+  extractRequestUUID,
+  evaluateLocalRefreshKey,
+  isValidLocalRefreshKey,
+} from './utils';
 import { CacheAndQueryDriverType, MetadataOperationType } from './QueryOrchestrator';
 
 export type CacheQueryResultOptions = {
@@ -52,12 +57,28 @@ export type CacheQueryResultOptions = {
 export type RefreshKeyCacheOptions =
   Pick<CacheQueryResultOptions, 'priority' | 'requestId' | 'waitForRenew' | 'dataSource'>;
 
+/**
+ * Everything needed to evaluate an `every` based refreshKey without touching a
+ * database: `FLOOR((utcOffset + unixTimestamp - dayOffset) / interval)`.
+ *
+ * `utcOffset` is frozen at compile time, exactly as it already is when baked into
+ * the emitted SQL string — the orchestrator must never recompute it, or the local
+ * and SQL paths would stop agreeing across a DST transition.
+ */
+export type LocalRefreshKeyDescriptor = {
+  interval: number;
+  utcOffset: number;
+  dayOffset: number;
+  cron?: boolean;
+};
+
 type QueryOptions = {
   external?: boolean;
   renewalThreshold?: number;
   updateWindowSeconds?: number;
   renewalThresholdOutsideUpdateWindow?: number;
   incremental?: boolean;
+  localRefreshKey?: LocalRefreshKeyDescriptor;
 };
 
 export type QueryWithParams = [
@@ -182,6 +203,10 @@ export class QueryCache {
 
   protected static readonly IN_MEMORY_CACHE_DISABLE_PERIOD = 5 * 60 * 1000;
 
+  protected readonly localRefreshKeyEnabled: boolean;
+
+  protected localRefreshKeyLogged: boolean = false;
+
   public constructor(
     protected readonly cachePrefix: string,
     protected readonly driverFactory: DriverFactoryByDataSource,
@@ -208,6 +233,49 @@ export class QueryCache {
     this.memoryCache = new LRUCache<string, CacheEntry>({
       max: options.maxInMemoryCacheEntries || 10000
     });
+
+    // Read from the environment rather than an option: the emitting half in the schema
+    // compiler is wired straight from the same variable, and an option here could be set
+    // on its own, turning the feature into a no-op where no descriptor is ever emitted.
+    this.localRefreshKeyEnabled = getEnv('refreshKeyLocalTime');
+  }
+
+  public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: number }] | null {
+    if (!this.localRefreshKeyEnabled || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
+      return null;
+    }
+
+    // `refreshKeyRenewalThreshold` throttles how often the SQL result is re-read, and that is
+    // also what bounds how often the key advances: a value cached for a day advances daily,
+    // whatever `every` says. A locally evaluated key has no cache entry to age out, so the only
+    // way to keep honouring the override is to leave these keys on the SQL path.
+    if (this.options.refreshKeyRenewalThreshold) {
+      this.logLocalRefreshKeyOnce('Local refresh key evaluation skipped', {
+        warning: 'refreshKeyRenewalThreshold is set, which throttles refresh key advancement. ' +
+          'Interval based refresh keys keep running as queries. Unset it to evaluate them locally.',
+        refreshKeyRenewalThreshold: this.options.refreshKeyRenewalThreshold,
+      });
+
+      return null;
+    }
+
+    this.logLocalRefreshKeyOnce('Local refresh key evaluation enabled', {
+      warning: 'Interval based refresh keys are evaluated from this instance clock. ' +
+        'Clocks must be in sync across all API instances and refresh workers.',
+    });
+
+    return evaluateLocalRefreshKey(<LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey);
+  }
+
+  // Logged on first use rather than from the constructor, where subclass field
+  // initialization has not run yet and `this.logger` may not be usable.
+  private logLocalRefreshKeyOnce(message: string, meta: Record<string, unknown>) {
+    if (this.localRefreshKeyLogged) {
+      return;
+    }
+
+    this.localRefreshKeyLogged = true;
+    this.logger(message, meta);
   }
 
   public getCacheDriver(): CacheDriverInterface {
@@ -462,6 +530,15 @@ export class QueryCache {
     options: RefreshKeyCacheOptions,
   ) {
     const [query, values, queryOptions] = sqlQuery;
+
+    // A locally evaluated key is free: nothing to cache, no queue to wait on. Short-circuiting
+    // here rather than in each caller leaves the identity work below as the single owner of the
+    // cache key, and keeps `PreAggregationLoadCache`'s per-request memo wrapping this call.
+    const local = this.localRefreshKeyResult(queryOptions);
+    if (local) {
+      return local;
+    }
+
     const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery, options.dataSource);
 
     return this.cacheQueryResult(query, values, cacheKey, expiration, {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -531,9 +531,7 @@ export class QueryCache {
   ) {
     const [query, values, queryOptions] = sqlQuery;
 
-    // A locally evaluated key is free: nothing to cache, no queue to wait on. Short-circuiting
-    // here rather than in each caller leaves the identity work below as the single owner of the
-    // cache key, and keeps `PreAggregationLoadCache`'s per-request memo wrapping this call.
+    // A locally evaluated key is free: nothing to cache, no queue to wait on.
     const local = this.localRefreshKeyResult(queryOptions);
     if (local) {
       return local;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -244,7 +244,7 @@ export class QueryCache {
     return this.localRefreshKeyEnabled && !this.options.refreshKeyRenewalThreshold;
   }
 
-  public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: number }] | null {
+  public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: string }] | null {
     if (!this.localRefreshKeyEnabled || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
       return null;
     }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -171,6 +171,7 @@ type CacheOperationContext = {
 
 export interface QueryCacheOptions {
   refreshKeyRenewalThreshold?: number;
+  localRefreshKey?: boolean;
   externalQueueOptions?: any;
   externalDriverFactory?: DriverFactory;
   backgroundRenew?: Boolean;
@@ -201,8 +202,6 @@ export class QueryCache {
 
   protected readonly localRefreshKeyEnabled: boolean;
 
-  protected localRefreshKeyLogged: boolean = false;
-
   public constructor(
     protected readonly cachePrefix: string,
     protected readonly driverFactory: DriverFactoryByDataSource,
@@ -229,11 +228,7 @@ export class QueryCache {
     this.memoryCache = new LRUCache<string, CacheEntry>({
       max: options.maxInMemoryCacheEntries || 10000
     });
-
-    // Read from the environment rather than an option: the emitting half in the schema
-    // compiler is wired straight from the same variable, and an option here could be set
-    // on its own, turning the feature into a no-op where no descriptor is ever emitted.
-    this.localRefreshKeyEnabled = getEnv('refreshKeyLocalTime');
+    this.localRefreshKeyEnabled = options.localRefreshKey ?? getEnv('refreshKeyLocalTime');
   }
 
   /**
@@ -253,28 +248,13 @@ export class QueryCache {
     // also what bounds how often the key advances: a value cached for a day advances daily,
     // whatever `every` says. A locally evaluated key has no cache entry to age out, so the only
     // way to keep honouring the override is to leave these keys on the SQL path.
+    // TODO: support the two together by snapping the local value to the threshold instead of
+    // falling back to a query.
     if (!this.isLocalRefreshKeyActive()) {
-      this.logLocalRefreshKeyOnce('Local refresh key evaluation skipped', {
-        warning: 'refreshKeyRenewalThreshold is set, which throttles refresh key advancement. ' +
-          'Interval based refresh keys keep running as queries. Unset it to evaluate them locally.',
-        refreshKeyRenewalThreshold: this.options.refreshKeyRenewalThreshold,
-      });
-
       return null;
     }
 
     return evaluateLocalRefreshKey(<LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey);
-  }
-
-  // Logged on first use rather than from the constructor, where subclass field
-  // initialization has not run yet and `this.logger` may not be usable.
-  private logLocalRefreshKeyOnce(message: string, meta: Record<string, unknown>) {
-    if (this.localRefreshKeyLogged) {
-      return;
-    }
-
-    this.localRefreshKeyLogged = true;
-    this.logger(message, meta);
   }
 
   public getCacheDriver(): CacheDriverInterface {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -236,6 +236,14 @@ export class QueryCache {
     this.localRefreshKeyEnabled = getEnv('refreshKeyLocalTime');
   }
 
+  /**
+   * Whether interval based refresh keys are answered from this instance clock instead of being
+   * run as queries and cached.
+   */
+  public isLocalRefreshKeyActive(): boolean {
+    return this.localRefreshKeyEnabled && !this.options.refreshKeyRenewalThreshold;
+  }
+
   public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: number }] | null {
     if (!this.localRefreshKeyEnabled || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
       return null;
@@ -245,7 +253,7 @@ export class QueryCache {
     // also what bounds how often the key advances: a value cached for a day advances daily,
     // whatever `every` says. A locally evaluated key has no cache entry to age out, so the only
     // way to keep honouring the override is to leave these keys on the SQL path.
-    if (this.options.refreshKeyRenewalThreshold) {
+    if (!this.isLocalRefreshKeyActive()) {
       this.logLocalRefreshKeyOnce('Local refresh key evaluation skipped', {
         warning: 'refreshKeyRenewalThreshold is set, which throttles refresh key advancement. ' +
           'Interval based refresh keys keep running as queries. Unset it to evaluate them locally.',
@@ -254,11 +262,6 @@ export class QueryCache {
 
       return null;
     }
-
-    this.logLocalRefreshKeyOnce('Local refresh key evaluation enabled', {
-      warning: 'Interval based refresh keys are evaluated from this instance clock. ' +
-        'Clocks must be in sync across all API instances and refresh workers.',
-    });
 
     return evaluateLocalRefreshKey(<LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey);
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -47,10 +47,6 @@ export function evaluateLocalRefreshKey(
   return [{ refresh_key: Math.floor((utcOffset + nowMs / 1000 - dayOffset) / interval) }];
 }
 
-/**
- * A malformed descriptor must fall back to the SQL path rather than produce a
- * garbage refresh key, which would silently invalidate everything downstream.
- */
 export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): boolean {
   return !!descriptor &&
     Number.isFinite(descriptor.interval) && descriptor.interval > 0 &&

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 
 import { getProcessUid } from '@cubejs-backend/shared';
 import { QueryKey, QueryKeyHash } from '@cubejs-backend/base-driver';
-import { CacheKey } from './QueryCache';
+import { CacheKey, LocalRefreshKeyDescriptor } from './QueryCache';
 
 /**
  * Unique process ID regexp.
@@ -30,6 +30,32 @@ export function getCacheHash(queryKey: QueryKey | CacheKey, processUid?: string)
       .update(JSON.stringify(queryKey))
       .digest('hex') as any;
   }
+}
+
+/**
+ * `nowMs` is not floored to whole seconds first: for integer `x`, fractional
+ * `f` in [0, 1) and `interval >= 1`, floor((x + f) / interval) === floor(x / interval),
+ * which is also why the fractional seconds of `EXTRACT(EPOCH FROM NOW())` never
+ * mattered on the SQL path.
+ */
+export function evaluateLocalRefreshKey(
+  descriptor: LocalRefreshKeyDescriptor,
+  nowMs: number = Date.now(),
+): [{ refresh_key: number }] {
+  const { utcOffset, interval, dayOffset } = descriptor;
+
+  return [{ refresh_key: Math.floor((utcOffset + nowMs / 1000 - dayOffset) / interval) }];
+}
+
+/**
+ * A malformed descriptor must fall back to the SQL path rather than produce a
+ * garbage refresh key, which would silently invalidate everything downstream.
+ */
+export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): boolean {
+  return !!descriptor &&
+    Number.isFinite(descriptor.interval) && descriptor.interval > 0 &&
+    Number.isFinite(descriptor.utcOffset) &&
+    Number.isFinite(descriptor.dayOffset);
 }
 
 /**

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -37,14 +37,22 @@ export function getCacheHash(queryKey: QueryKey | CacheKey, processUid?: string)
  * `f` in [0, 1) and `interval >= 1`, floor((x + f) / interval) === floor(x / interval),
  * which is also why the fractional seconds of `EXTRACT(EPOCH FROM NOW())` never
  * mattered on the SQL path.
+ *
+ * The number is formatted as a string to stay byte-identical to the row the SQL path
+ * returned. Both `contentVersion` and the query cache `renewalKey` hash these values
+ * through `JSON.stringify`, so `2980310` and `"2980310"` are different keys and every
+ * pre-aggregation would rebuild the first time the flag is switched on. String is what
+ * the SQL path yields: an `every` refresh key runs against Cube Store whenever an
+ * external store is configured, and Cube Store's protocol carries every column as a
+ * string.
  */
 export function evaluateLocalRefreshKey(
   descriptor: LocalRefreshKeyDescriptor,
   nowMs: number = Date.now(),
-): [{ refresh_key: number }] {
+): [{ refresh_key: string }] {
   const { utcOffset, interval, dayOffset } = descriptor;
 
-  return [{ refresh_key: Math.floor((utcOffset + nowMs / 1000 - dayOffset) / interval) }];
+  return [{ refresh_key: String(Math.floor((utcOffset + nowMs / 1000 - dayOffset) / interval)) }];
 }
 
 export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): boolean {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -33,18 +33,15 @@ export function getCacheHash(queryKey: QueryKey | CacheKey, processUid?: string)
 }
 
 /**
- * `nowMs` is not floored to whole seconds first: for integer `x`, fractional
- * `f` in [0, 1) and `interval >= 1`, floor((x + f) / interval) === floor(x / interval),
- * which is also why the fractional seconds of `EXTRACT(EPOCH FROM NOW())` never
- * mattered on the SQL path.
+ * `nowMs` is not floored to whole seconds first: for an integer `interval >= 1` the
+ * fractional part cannot cross a boundary, which is also why the fractional seconds of
+ * `EXTRACT(EPOCH FROM NOW())` never mattered on the SQL path.
  *
- * The number is formatted as a string to stay byte-identical to the row the SQL path
- * returned. Both `contentVersion` and the query cache `renewalKey` hash these values
- * through `JSON.stringify`, so `2980310` and `"2980310"` are different keys and every
- * pre-aggregation would rebuild the first time the flag is switched on. String is what
- * the SQL path yields: an `every` refresh key runs against Cube Store whenever an
- * external store is configured, and Cube Store's protocol carries every column as a
- * string.
+ * The key is a string because `contentVersion` and the query cache `renewalKey` hash it
+ * through `JSON.stringify`: `2980310` and `"2980310"` are different keys, so a number here
+ * would rebuild every pre-aggregation the first time the flag is switched on. A string is
+ * also what the SQL path yields — an `every` key runs against Cube Store whenever an
+ * external store is configured, and Cube Store carries every column as a string.
  */
 export function evaluateLocalRefreshKey(
   descriptor: LocalRefreshKeyDescriptor,

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -467,6 +467,129 @@ describe('PreAggregations', () => {
     });
   });
 
+  describe('local refresh key', () => {
+    const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
+    const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
+
+    // The flag is read from the environment in the constructor, so it has to be toggled
+    // around construction rather than passed in as an option.
+    const newQueryCache = (localRefreshKey?: boolean) => {
+      const previous = process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+      if (localRefreshKey === undefined) {
+        delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+      } else {
+        process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = String(localRefreshKey);
+      }
+
+      try {
+        return new QueryCache(
+          'TEST',
+          mockDriverFactory as any,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          () => {},
+          {
+            cacheAndQueueDriver: 'memory',
+            queueOptions: async () => ({ executionTimeout: 1, concurrency: 2 }),
+          },
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+        } else {
+          process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = previous;
+        }
+      }
+    };
+
+    const newLoadCache = (localRefreshKey?: boolean) => {
+      const cache = newQueryCache(localRefreshKey);
+      (cache.getCacheDriver() as LocalCacheDriver).reset();
+
+      const preAggregations = new PreAggregations(
+        'TEST',
+        mockDriverFactory as any,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => {},
+        cache,
+        { queueOptions: async () => ({ executionTimeout: 1, concurrency: 2 }) },
+      );
+
+      return new PreAggregationLoadCache(
+        mockDriverFactory as any,
+        cache,
+        preAggregations,
+        { dataSource: 'default' },
+      );
+    };
+
+    test('keyQueryResult evaluates locally without querying the datasource', async () => {
+      const loadCache = newLoadCache(true);
+
+      const result = await loadCache.keyQueryResult(
+        [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }],
+        false,
+        10,
+      );
+
+      expect(result).toEqual([{ refresh_key: Math.floor(Date.now() / 1000 / descriptor.interval) }]);
+      expect(mockDriver!.executedQueries).toEqual([]);
+    });
+
+    test('keyQueryResult still queries when the flag is off', async () => {
+      const loadCache = newLoadCache(false);
+
+      await loadCache.keyQueryResult(
+        [REFRESH_KEY_SQL, [], { external: false, renewalThreshold: 60, localRefreshKey: descriptor }],
+        false,
+        10,
+      );
+
+      expect(mockDriver!.executedQueries).toEqual([REFRESH_KEY_SQL]);
+    });
+
+    test('keyQueryResult still queries an incremental key that carries no descriptor', async () => {
+      const loadCache = newLoadCache(true);
+      const incrementalSql = 'SELECT CASE WHEN NOW() < $1 THEN FLOOR((UNIX_TIMESTAMP()) / 3600) END as refresh_key';
+
+      await loadCache.keyQueryResult(
+        [incrementalSql, [], {
+          external: false,
+          renewalThreshold: 300,
+          incremental: true,
+          renewalThresholdOutsideUpdateWindow: 86400,
+        }],
+        false,
+        10,
+      );
+
+      expect(mockDriver!.executedQueries).toEqual([incrementalSql]);
+    });
+
+    // The per-request memo must pin the value for the life of one load. A single
+    // load reads the invalidation keys several times (contentVersion, the returned
+    // refreshKeyValues, the refresh queue key); if the clock were re-read, a load
+    // crossing an interval boundary would look a table up under one content version
+    // and enqueue it under another.
+    test('keyQueryResult is stable across an interval boundary within one load cache', async () => {
+      const loadCache = newLoadCache(true);
+      const key: [string, any[], Record<string, any>] =
+        [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }];
+
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(600_000);
+      try {
+        const first = await loadCache.keyQueryResult(key, false, 10);
+        expect(first).toEqual([{ refresh_key: 1 }]);
+
+        nowSpy.mockReturnValue(1_200_000);
+        const second = await loadCache.keyQueryResult(key, false, 10);
+
+        expect(second).toEqual(first);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
   describe('loadAllPreAggregationsIfNeeded', () => {
     let preAggregations: PreAggregations | null = null;
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -531,7 +531,7 @@ describe('PreAggregations', () => {
         10,
       );
 
-      expect(result).toEqual([{ refresh_key: Math.floor(Date.now() / 1000 / descriptor.interval) }]);
+      expect(result).toEqual([{ refresh_key: String(Math.floor(Date.now() / 1000 / descriptor.interval)) }]);
       expect(mockDriver!.executedQueries).toEqual([]);
     });
 
@@ -577,7 +577,7 @@ describe('PreAggregations', () => {
       const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(600_000);
       try {
         const first = await loadCache.keyQueryResult(key, false, 10);
-        expect(first).toEqual([{ refresh_key: 1 }]);
+        expect(first).toEqual([{ refresh_key: '1' }]);
 
         nowSpy.mockReturnValue(1_200_000);
         const second = await loadCache.keyQueryResult(key, false, 10);

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -471,35 +471,17 @@ describe('PreAggregations', () => {
     const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
     const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
 
-    // The flag is read from the environment in the constructor, so it has to be toggled
-    // around construction rather than passed in as an option.
-    const newQueryCache = (localRefreshKey?: boolean) => {
-      const previous = process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-      if (localRefreshKey === undefined) {
-        delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-      } else {
-        process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = String(localRefreshKey);
-      }
-
-      try {
-        return new QueryCache(
-          'TEST',
-          mockDriverFactory as any,
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          () => {},
-          {
-            cacheAndQueueDriver: 'memory',
-            queueOptions: async () => ({ executionTimeout: 1, concurrency: 2 }),
-          },
-        );
-      } finally {
-        if (previous === undefined) {
-          delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-        } else {
-          process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = previous;
-        }
-      }
-    };
+    const newQueryCache = (localRefreshKey?: boolean) => new QueryCache(
+      'TEST',
+      mockDriverFactory as any,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
+      {
+        cacheAndQueueDriver: 'memory',
+        localRefreshKey,
+        queueOptions: async () => ({ executionTimeout: 1, concurrency: 2 }),
+      },
+    );
 
     const newLoadCache = (localRefreshKey?: boolean) => {
       const cache = newQueryCache(localRefreshKey);

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -565,11 +565,10 @@ describe('PreAggregations', () => {
       expect(mockDriver!.executedQueries).toEqual([incrementalSql]);
     });
 
-    // The per-request memo must pin the value for the life of one load. A single
-    // load reads the invalidation keys several times (contentVersion, the returned
-    // refreshKeyValues, the refresh queue key); if the clock were re-read, a load
-    // crossing an interval boundary would look a table up under one content version
-    // and enqueue it under another.
+    // A single load reads the invalidation keys several times (contentVersion, the returned
+    // refreshKeyValues, the refresh queue key). If the clock were re-read, a load crossing an
+    // interval boundary would look a table up under one content version and enqueue it under
+    // another.
     test('keyQueryResult is stable across an interval boundary within one load cache', async () => {
       const loadCache = newLoadCache(true);
       const key: [string, any[], Record<string, any>] =

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -474,38 +474,27 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
       const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
 
-      // The flag is read from the environment in the constructor, so it has to be toggled
-      // around construction rather than passed in as an option.
-      const newCache = (localRefreshKey?: boolean, cacheOptions: Record<string, unknown> = {}) => {
-        const previous = process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-        if (localRefreshKey === undefined) {
-          delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-        } else {
-          process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = String(localRefreshKey);
-        }
-
-        try {
-          return new QueryCacheOpened(
-            crypto.randomBytes(16).toString('hex'),
-            () => {
-              throw new Error('driverFactory is not implemented, mock should be used...');
-            },
-            jest.fn(),
-            { ...options, ...cacheOptions },
-          );
-        } finally {
-          if (previous === undefined) {
-            delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
-          } else {
-            process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = previous;
-          }
-        }
-      };
+      const newCache = (localRefreshKey?: boolean, cacheOptions: Partial<QueryCacheOptions> = {}) => (
+        new QueryCacheOpened(
+          crypto.randomBytes(16).toString('hex'),
+          () => {
+            throw new Error('driverFactory is not implemented, mock should be used...');
+          },
+          jest.fn(),
+          {
+            ...options,
+            // `localRefreshKey` left undefined falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, which is
+            // unset under test, so it stands for a deployment that never set the flag.
+            localRefreshKey: undefined,
+            ...cacheOptions
+          },
+        )
+      );
 
       const loadRefreshKey = async (
         localRefreshKey: boolean | undefined,
         queryOptions: any,
-        cacheOptions: Record<string, unknown> = {},
+        cacheOptions: Partial<QueryCacheOptions> = {},
       ) => {
         const localCache = newCache(localRefreshKey, cacheOptions);
         const spy = jest.spyOn(localCache, 'queryWithRetryAndRelease')
@@ -520,7 +509,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
             )
           );
 
-          return { result, executed: spy.mock.calls.length };
+          return { result, executed: spy.mock.calls.length, logged: localCache.logger.mock.calls };
         } finally {
           spy.mockRestore();
           await localCache.cleanup();
@@ -595,6 +584,93 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         } finally {
           await Promise.all([enabled.cleanup(), disabled.cleanup(), throttled.cleanup()]);
         }
+      });
+
+      it('runs the query when the flag is unset', async () => {
+        const { result, executed } = await loadRefreshKey(undefined, {
+          external: true,
+          renewalThreshold: 60,
+          localRefreshKey: descriptor,
+        });
+
+        expect(executed).toBe(1);
+        expect(result).toEqual([{ refresh_key: 12345 }]);
+      });
+
+      // Falling back to the SQL path is the intended behaviour for every declined branch, not an
+      // anomaly worth a log line on the hot path: only the ordinary cache messages are expected.
+      it.each([
+        { name: 'the flag is off', flag: false, cacheOptions: {} },
+        { name: 'the flag is unset', flag: undefined, cacheOptions: {} },
+        {
+          name: 'refreshKeyRenewalThreshold is configured',
+          flag: true,
+          cacheOptions: { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+        },
+      ])('does not report the declined local evaluation when $name', async ({ flag, cacheOptions }) => {
+        const { logged } = await loadRefreshKey(
+          flag,
+          { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
+          cacheOptions,
+        );
+
+        expect(logged.map(([message]) => message).filter(m => /local/i.test(m))).toEqual([]);
+      });
+
+      describe('localRefreshKeyResult', () => {
+        const withCache = async (
+          flag: boolean | undefined,
+          cacheOptions: Partial<QueryCacheOptions>,
+          fn: (localCache: QueryCacheOpened) => void,
+        ) => {
+          const localCache = newCache(flag, cacheOptions);
+
+          try {
+            fn(localCache);
+            expect(localCache.logger).not.toHaveBeenCalled();
+          } finally {
+            await localCache.cleanup();
+          }
+        };
+
+        const queryOptions = (localRefreshKey?: unknown) => <any>{ localRefreshKey };
+
+        it('evaluates a valid descriptor', () => withCache(true, {}, localCache => {
+          expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
+            .toEqual([{ refresh_key: String(Math.floor(Date.now() / 1000 / 600)) }]);
+        }));
+
+        // Cube Store returns every column as a string, so a locally evaluated key has to be
+        // a string too or flipping the flag invalidates every pre-aggregation once.
+        it('returns the key as a string', () => withCache(true, {}, localCache => {
+          const [{ refresh_key: value }] = localCache
+            .localRefreshKeyResult(queryOptions(descriptor))!;
+
+          expect(typeof value).toBe('string');
+        }));
+
+        it('declines when the flag is off', () => withCache(false, {}, localCache => {
+          expect(localCache.localRefreshKeyResult(queryOptions(descriptor))).toBeNull();
+        }));
+
+        it('declines without a descriptor', () => withCache(true, {}, localCache => {
+          expect(localCache.localRefreshKeyResult()).toBeNull();
+          expect(localCache.localRefreshKeyResult(queryOptions())).toBeNull();
+        }));
+
+        it('declines a malformed descriptor', () => withCache(true, {}, localCache => {
+          expect(localCache.localRefreshKeyResult(
+            queryOptions({ ...descriptor, interval: 0 }),
+          )).toBeNull();
+        }));
+
+        it('declines when refreshKeyRenewalThreshold is configured', () => withCache(
+          true,
+          { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          localCache => {
+            expect(localCache.localRefreshKeyResult(queryOptions(descriptor))).toBeNull();
+          },
+        ));
       });
     });
 

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -580,6 +580,22 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(executed).toBe(1);
         expect(result).toEqual([{ refresh_key: 12345 }]);
       });
+
+      // The refresh scheduler reads this to decide whether warming a refresh key is pointless,
+      // so it has to agree with the branches above.
+      it('reports whether local evaluation is in effect', async () => {
+        const enabled = newCache(true);
+        const disabled = newCache(false);
+        const throttled = newCache(true, { refreshKeyRenewalThreshold: 24 * 60 * 60 });
+
+        try {
+          expect(enabled.isLocalRefreshKeyActive()).toBe(true);
+          expect(disabled.isLocalRefreshKeyActive()).toBe(false);
+          expect(throttled.isLocalRefreshKeyActive()).toBe(false);
+        } finally {
+          await Promise.all([enabled.cleanup(), disabled.cleanup(), throttled.cleanup()]);
+        }
+      });
     });
 
     it('queryCacheKey format', () => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -535,7 +535,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         });
 
         expect(executed).toBe(0);
-        expect(result).toEqual([{ refresh_key: Math.floor(Date.now() / 1000 / 600) }]);
+        expect(result).toEqual([{ refresh_key: String(Math.floor(Date.now() / 1000 / 600)) }]);
       });
 
       it('runs the query when the flag is off', async () => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -470,6 +470,118 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       });
     });
 
+    describe('local refresh key', () => {
+      const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
+      const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
+
+      // The flag is read from the environment in the constructor, so it has to be toggled
+      // around construction rather than passed in as an option.
+      const newCache = (localRefreshKey?: boolean, cacheOptions: Record<string, unknown> = {}) => {
+        const previous = process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+        if (localRefreshKey === undefined) {
+          delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+        } else {
+          process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = String(localRefreshKey);
+        }
+
+        try {
+          return new QueryCacheOpened(
+            crypto.randomBytes(16).toString('hex'),
+            () => {
+              throw new Error('driverFactory is not implemented, mock should be used...');
+            },
+            jest.fn(),
+            { ...options, ...cacheOptions },
+          );
+        } finally {
+          if (previous === undefined) {
+            delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
+          } else {
+            process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = previous;
+          }
+        }
+      };
+
+      const loadRefreshKey = async (
+        localRefreshKey: boolean | undefined,
+        queryOptions: any,
+        cacheOptions: Record<string, unknown> = {},
+      ) => {
+        const localCache = newCache(localRefreshKey, cacheOptions);
+        const spy = jest.spyOn(localCache, 'queryWithRetryAndRelease')
+          .mockImplementation(async () => [{ refresh_key: 12345 }]);
+
+        try {
+          const [result] = await Promise.all(
+            localCache.loadRefreshKeys(
+              [[REFRESH_KEY_SQL, [], queryOptions]],
+              60,
+              { dataSource: 'default' },
+            )
+          );
+
+          return { result, executed: spy.mock.calls.length };
+        } finally {
+          spy.mockRestore();
+          await localCache.cleanup();
+        }
+      };
+
+      it('evaluates locally without touching the driver', async () => {
+        const { result, executed } = await loadRefreshKey(true, {
+          external: true,
+          renewalThreshold: 60,
+          localRefreshKey: descriptor,
+        });
+
+        expect(executed).toBe(0);
+        expect(result).toEqual([{ refresh_key: Math.floor(Date.now() / 1000 / 600) }]);
+      });
+
+      it('runs the query when the flag is off', async () => {
+        const { result, executed } = await loadRefreshKey(false, {
+          external: true,
+          renewalThreshold: 60,
+          localRefreshKey: descriptor,
+        });
+
+        expect(executed).toBe(1);
+        expect(result).toEqual([{ refresh_key: 12345 }]);
+      });
+
+      it('runs the query when there is no descriptor', async () => {
+        const { executed } = await loadRefreshKey(true, {
+          external: false,
+          renewalThreshold: 10,
+        });
+
+        expect(executed).toBe(1);
+      });
+
+      it('runs the query when the descriptor is malformed', async () => {
+        const { executed } = await loadRefreshKey(true, {
+          external: true,
+          renewalThreshold: 60,
+          localRefreshKey: { ...descriptor, interval: 0 },
+        });
+
+        expect(executed).toBe(1);
+      });
+
+      // Local evaluation would advance the key on every interval boundary, ignoring the
+      // throttle a deployment asked for and multiplying pre-aggregation rebuilds.
+      it('runs the query when refreshKeyRenewalThreshold is configured', async () => {
+        const { result, executed } = await loadRefreshKey(
+          true,
+          { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
+          { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+        );
+
+        expect(executed).toBe(1);
+        expect(result).toEqual([{ refresh_key: 12345 }]);
+      });
+    });
+
     it('queryCacheKey format', () => {
       const key1 = QueryCache.queryCacheKey({
         query: 'select data',

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -575,8 +575,6 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         }
       });
 
-      // An unset flag falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, unset under test, so this
-      // stands for a deployment that never set it.
       it('runs the query when the flag is unset', async () => {
         const { result, executed } = await loadRefreshKey({
           external: true,

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -474,25 +474,22 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
       const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
 
-      const newCache = (localRefreshKey?: boolean, cacheOptions: Partial<QueryCacheOptions> = {}) => (
+      const newCache = (additionalOptions: Partial<QueryCacheOptions> = {}) => (
         new QueryCacheOpened(
           crypto.randomBytes(16).toString('hex'),
           () => {
             throw new Error('driverFactory is not implemented, mock should be used...');
           },
           jest.fn(),
-          // `localRefreshKey` left undefined falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, which is
-          // unset under test, so it stands for a deployment that never set the flag.
-          { ...options, localRefreshKey, ...cacheOptions },
+          { ...options, ...additionalOptions },
         )
       );
 
       const loadRefreshKey = async (
-        localRefreshKey: boolean | undefined,
         queryOptions: any,
-        cacheOptions: Partial<QueryCacheOptions> = {},
+        additionalOptions: Partial<QueryCacheOptions> = {},
       ) => {
-        const localCache = newCache(localRefreshKey, cacheOptions);
+        const localCache = newCache(additionalOptions);
         const spy = jest.spyOn(localCache, 'queryWithRetryAndRelease')
           .mockImplementation(async () => [{ refresh_key: 12345 }]);
 
@@ -513,42 +510,39 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       };
 
       it('evaluates locally without touching the driver', async () => {
-        const { result, executed } = await loadRefreshKey(true, {
-          external: true,
-          renewalThreshold: 60,
-          localRefreshKey: descriptor,
-        });
+        const { result, executed } = await loadRefreshKey(
+          { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
+          { localRefreshKey: true },
+        );
 
         expect(executed).toBe(0);
         expect(result).toEqual([{ refresh_key: String(Math.floor(Date.now() / 1000 / 600)) }]);
       });
 
       it('runs the query when the flag is off', async () => {
-        const { result, executed } = await loadRefreshKey(false, {
-          external: true,
-          renewalThreshold: 60,
-          localRefreshKey: descriptor,
-        });
+        const { result, executed } = await loadRefreshKey(
+          { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
+          { localRefreshKey: false },
+        );
 
         expect(executed).toBe(1);
         expect(result).toEqual([{ refresh_key: 12345 }]);
       });
 
       it('runs the query when there is no descriptor', async () => {
-        const { executed } = await loadRefreshKey(true, {
-          external: false,
-          renewalThreshold: 10,
-        });
+        const { executed } = await loadRefreshKey(
+          { external: false, renewalThreshold: 10 },
+          { localRefreshKey: true },
+        );
 
         expect(executed).toBe(1);
       });
 
       it('runs the query when the descriptor is malformed', async () => {
-        const { executed } = await loadRefreshKey(true, {
-          external: true,
-          renewalThreshold: 60,
-          localRefreshKey: { ...descriptor, interval: 0 },
-        });
+        const { executed } = await loadRefreshKey(
+          { external: true, renewalThreshold: 60, localRefreshKey: { ...descriptor, interval: 0 } },
+          { localRefreshKey: true },
+        );
 
         expect(executed).toBe(1);
       });
@@ -557,9 +551,8 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       // throttle a deployment asked for and multiplying pre-aggregation rebuilds.
       it('runs the query when refreshKeyRenewalThreshold is configured', async () => {
         const { result, executed } = await loadRefreshKey(
-          true,
           { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
-          { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
         );
 
         expect(executed).toBe(1);
@@ -569,9 +562,9 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       // The refresh scheduler reads this to decide whether warming a refresh key is pointless,
       // so it has to agree with the branches above.
       it('reports whether local evaluation is in effect', async () => {
-        const enabled = newCache(true);
-        const disabled = newCache(false);
-        const throttled = newCache(true, { refreshKeyRenewalThreshold: 24 * 60 * 60 });
+        const enabled = newCache({ localRefreshKey: true });
+        const disabled = newCache({ localRefreshKey: false });
+        const throttled = newCache({ localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 });
 
         try {
           expect(enabled.isLocalRefreshKeyActive()).toBe(true);
@@ -582,8 +575,10 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         }
       });
 
+      // An unset flag falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, unset under test, so this
+      // stands for a deployment that never set it.
       it('runs the query when the flag is unset', async () => {
-        const { result, executed } = await loadRefreshKey(undefined, {
+        const { result, executed } = await loadRefreshKey({
           external: true,
           renewalThreshold: 60,
           localRefreshKey: descriptor,
@@ -596,18 +591,16 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       // Falling back to the SQL path is intended for every declined branch, so nothing reports
       // it; the ordinary cache messages are still expected.
       it.each([
-        { name: 'the flag is off', flag: false, cacheOptions: {} },
-        { name: 'the flag is unset', flag: undefined, cacheOptions: {} },
+        { name: 'the flag is off', additionalOptions: { localRefreshKey: false } },
+        { name: 'the flag is unset', additionalOptions: {} },
         {
           name: 'refreshKeyRenewalThreshold is configured',
-          flag: true,
-          cacheOptions: { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          additionalOptions: { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
         },
-      ])('does not report the declined local evaluation when $name', async ({ flag, cacheOptions }) => {
+      ])('does not report the declined local evaluation when $name', async ({ additionalOptions }) => {
         const { logged } = await loadRefreshKey(
-          flag,
           { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
-          cacheOptions,
+          additionalOptions,
         );
 
         expect(logged.map(([message]) => message).filter(m => /local/i.test(m))).toEqual([]);
@@ -615,11 +608,10 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
 
       describe('localRefreshKeyResult', () => {
         const withCache = async (
-          flag: boolean | undefined,
-          cacheOptions: Partial<QueryCacheOptions>,
+          additionalOptions: Partial<QueryCacheOptions>,
           fn: (localCache: QueryCacheOpened) => void,
         ) => {
-          const localCache = newCache(flag, cacheOptions);
+          const localCache = newCache(additionalOptions);
 
           try {
             fn(localCache);
@@ -631,38 +623,37 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
 
         const queryOptions = (localRefreshKey?: unknown) => <any>{ localRefreshKey };
 
-        it('evaluates a valid descriptor', () => withCache(true, {}, localCache => {
+        it('evaluates a valid descriptor', () => withCache({ localRefreshKey: true }, localCache => {
           expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
             .toEqual([{ refresh_key: String(Math.floor(Date.now() / 1000 / 600)) }]);
         }));
 
         // Cube Store returns every column as a string, so a locally evaluated key has to be
         // a string too or flipping the flag invalidates every pre-aggregation once.
-        it('returns the key as a string', () => withCache(true, {}, localCache => {
+        it('returns the key as a string', () => withCache({ localRefreshKey: true }, localCache => {
           const [{ refresh_key: value }] = localCache
             .localRefreshKeyResult(queryOptions(descriptor))!;
 
           expect(typeof value).toBe('string');
         }));
 
-        it('declines when the flag is off', () => withCache(false, {}, localCache => {
+        it('declines when the flag is off', () => withCache({ localRefreshKey: false }, localCache => {
           expect(localCache.localRefreshKeyResult(queryOptions(descriptor))).toBeNull();
         }));
 
-        it('declines without a descriptor', () => withCache(true, {}, localCache => {
+        it('declines without a descriptor', () => withCache({ localRefreshKey: true }, localCache => {
           expect(localCache.localRefreshKeyResult()).toBeNull();
           expect(localCache.localRefreshKeyResult(queryOptions())).toBeNull();
         }));
 
-        it('declines a malformed descriptor', () => withCache(true, {}, localCache => {
+        it('declines a malformed descriptor', () => withCache({ localRefreshKey: true }, localCache => {
           expect(localCache.localRefreshKeyResult(
             queryOptions({ ...descriptor, interval: 0 }),
           )).toBeNull();
         }));
 
         it('declines when refreshKeyRenewalThreshold is configured', () => withCache(
-          true,
-          { refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
           localCache => {
             expect(localCache.localRefreshKeyResult(queryOptions(descriptor))).toBeNull();
           },

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -481,13 +481,9 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
             throw new Error('driverFactory is not implemented, mock should be used...');
           },
           jest.fn(),
-          {
-            ...options,
-            // `localRefreshKey` left undefined falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, which is
-            // unset under test, so it stands for a deployment that never set the flag.
-            localRefreshKey: undefined,
-            ...cacheOptions
-          },
+          // `localRefreshKey` left undefined falls back to CUBEJS_REFRESH_KEY_LOCAL_TIME, which is
+          // unset under test, so it stands for a deployment that never set the flag.
+          { ...options, localRefreshKey, ...cacheOptions },
         )
       );
 
@@ -597,8 +593,8 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(result).toEqual([{ refresh_key: 12345 }]);
       });
 
-      // Falling back to the SQL path is the intended behaviour for every declined branch, not an
-      // anomaly worth a log line on the hot path: only the ordinary cache messages are expected.
+      // Falling back to the SQL path is intended for every declined branch, so nothing reports
+      // it; the ordinary cache messages are still expected.
       it.each([
         { name: 'the flag is off', flag: false, cacheOptions: {} },
         { name: 'the flag is unset', flag: undefined, cacheOptions: {} },

--- a/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
@@ -4,15 +4,15 @@ describe('evaluateLocalRefreshKey', () => {
   const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
 
   test('returns the same row shape as SELECT FLOOR(...) as refresh_key', () => {
-    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: 1 }]);
-    expect(evaluateLocalRefreshKey(tenMinutes, 6_000_000)).toEqual([{ refresh_key: 10 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: '1' }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 6_000_000)).toEqual([{ refresh_key: '10' }]);
   });
 
   test('changes exactly at the interval boundary', () => {
-    expect(evaluateLocalRefreshKey(tenMinutes, 599_999)).toEqual([{ refresh_key: 0 }]);
-    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: 1 }]);
-    expect(evaluateLocalRefreshKey(tenMinutes, 1_199_999)).toEqual([{ refresh_key: 1 }]);
-    expect(evaluateLocalRefreshKey(tenMinutes, 1_200_000)).toEqual([{ refresh_key: 2 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 599_999)).toEqual([{ refresh_key: '0' }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: '1' }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 1_199_999)).toEqual([{ refresh_key: '1' }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 1_200_000)).toEqual([{ refresh_key: '2' }]);
   });
 
   test('sub-second precision never changes the result', () => {
@@ -26,7 +26,7 @@ describe('evaluateLocalRefreshKey', () => {
   test('applies a negative utcOffset', () => {
     // America/Los_Angeles in PST: -8 hours
     expect(evaluateLocalRefreshKey({ interval: 3600, utcOffset: -28800, dayOffset: 0 }, 28_800_000))
-      .toEqual([{ refresh_key: 0 }]);
+      .toEqual([{ refresh_key: '0' }]);
   });
 
   test('applies dayOffset for cron based keys', () => {
@@ -34,9 +34,9 @@ describe('evaluateLocalRefreshKey', () => {
     const daily = { interval: 86400, utcOffset: 0, dayOffset: 36000, cron: true };
 
     // 09:59:59 UTC on the epoch day is still before the first fire time
-    expect(evaluateLocalRefreshKey(daily, 35_999_000)).toEqual([{ refresh_key: -1 }]);
-    expect(evaluateLocalRefreshKey(daily, 36_000_000)).toEqual([{ refresh_key: 0 }]);
-    expect(evaluateLocalRefreshKey(daily, 36_000_000 + 86_400_000)).toEqual([{ refresh_key: 1 }]);
+    expect(evaluateLocalRefreshKey(daily, 35_999_000)).toEqual([{ refresh_key: '-1' }]);
+    expect(evaluateLocalRefreshKey(daily, 36_000_000)).toEqual([{ refresh_key: '0' }]);
+    expect(evaluateLocalRefreshKey(daily, 36_000_000 + 86_400_000)).toEqual([{ refresh_key: '1' }]);
   });
 
   test('defaults to the current clock', () => {
@@ -44,8 +44,9 @@ describe('evaluateLocalRefreshKey', () => {
     const [{ refresh_key: value }] = evaluateLocalRefreshKey(tenMinutes);
     const after = Math.floor(Date.now() / 1000 / tenMinutes.interval);
 
-    expect(value).toBeGreaterThanOrEqual(before);
-    expect(value).toBeLessThanOrEqual(after);
+    expect(typeof value).toBe('string');
+    expect(Number(value)).toBeGreaterThanOrEqual(before);
+    expect(Number(value)).toBeLessThanOrEqual(after);
   });
 });
 

--- a/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
@@ -1,0 +1,67 @@
+import { evaluateLocalRefreshKey, isValidLocalRefreshKey } from '../../src/orchestrator/utils';
+
+describe('evaluateLocalRefreshKey', () => {
+  const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
+
+  test('returns the same row shape as SELECT FLOOR(...) as refresh_key', () => {
+    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: 1 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 6_000_000)).toEqual([{ refresh_key: 10 }]);
+  });
+
+  test('changes exactly at the interval boundary', () => {
+    expect(evaluateLocalRefreshKey(tenMinutes, 599_999)).toEqual([{ refresh_key: 0 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 600_000)).toEqual([{ refresh_key: 1 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 1_199_999)).toEqual([{ refresh_key: 1 }]);
+    expect(evaluateLocalRefreshKey(tenMinutes, 1_200_000)).toEqual([{ refresh_key: 2 }]);
+  });
+
+  test('sub-second precision never changes the result', () => {
+    for (const ms of [0, 1, 250, 500, 999]) {
+      expect(evaluateLocalRefreshKey(tenMinutes, 600_000 + ms)).toEqual(
+        evaluateLocalRefreshKey(tenMinutes, 600_000)
+      );
+    }
+  });
+
+  test('applies a negative utcOffset', () => {
+    // America/Los_Angeles in PST: -8 hours
+    expect(evaluateLocalRefreshKey({ interval: 3600, utcOffset: -28800, dayOffset: 0 }, 28_800_000))
+      .toEqual([{ refresh_key: 0 }]);
+  });
+
+  test('applies dayOffset for cron based keys', () => {
+    // every '0 10 * * *' => interval 1 day, dayOffset 10 hours
+    const daily = { interval: 86400, utcOffset: 0, dayOffset: 36000, cron: true };
+
+    // 09:59:59 UTC on the epoch day is still before the first fire time
+    expect(evaluateLocalRefreshKey(daily, 35_999_000)).toEqual([{ refresh_key: -1 }]);
+    expect(evaluateLocalRefreshKey(daily, 36_000_000)).toEqual([{ refresh_key: 0 }]);
+    expect(evaluateLocalRefreshKey(daily, 36_000_000 + 86_400_000)).toEqual([{ refresh_key: 1 }]);
+  });
+
+  test('defaults to the current clock', () => {
+    const before = Math.floor(Date.now() / 1000 / tenMinutes.interval);
+    const [{ refresh_key: value }] = evaluateLocalRefreshKey(tenMinutes);
+    const after = Math.floor(Date.now() / 1000 / tenMinutes.interval);
+
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('isValidLocalRefreshKey', () => {
+  test('accepts a well formed descriptor', () => {
+    expect(isValidLocalRefreshKey({ interval: 600, utcOffset: 0, dayOffset: 0 })).toBe(true);
+    expect(isValidLocalRefreshKey({ interval: 1, utcOffset: -28800, dayOffset: 36000 })).toBe(true);
+  });
+
+  test('rejects anything that would produce a garbage key', () => {
+    expect(isValidLocalRefreshKey(undefined)).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: 0, utcOffset: 0, dayOffset: 0 })).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: -600, utcOffset: 0, dayOffset: 0 })).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: NaN, utcOffset: 0, dayOffset: 0 })).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: Infinity, utcOffset: 0, dayOffset: 0 })).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: 600, utcOffset: NaN, dayOffset: 0 })).toBe(false);
+    expect(isValidLocalRefreshKey({ interval: 600, utcOffset: 0, dayOffset: NaN })).toBe(false);
+  });
+});

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -287,6 +287,7 @@ export class BaseQuery {
       memberToAlias: this.options.memberToAlias,
       expressionParams: this.options.expressionParams,
       convertTzForRawTimeDimension: this.options.convertTzForRawTimeDimension,
+      localRefreshKey: this.options.localRefreshKey,
       from: this.options.from,
       multiStageQuery: this.options.multiStageQuery,
       multiStageDimensions: this.options.multiStageDimensions,
@@ -362,6 +363,9 @@ export class BaseQuery {
     // toggled independently. The neverUseSqlPlannerPreaggregation() guard still opts
     // specific query types (e.g. CubeStoreQuery) out for correctness.
     this.canUseNativeSqlPlannerPreAggregation = this.useNativeSqlPlanner && !this.neverUseSqlPlannerPreaggregation();
+    // Gated at emit time so that with the flag off the refresh key tuples stay
+    // byte-identical and nothing downstream re-hashes to a new cache key.
+    this.localRefreshKey = this.options.localRefreshKey ?? getEnv('refreshKeyLocalTime');
     this.queryLevelJoinHints = this.options.joinHints ?? [];
     this.prebuildJoin();
 
@@ -4227,6 +4231,7 @@ export class BaseQuery {
       externalQueryClass: this.options.externalQueryClass,
       queryFactory: this.options.queryFactory,
       useNativeSqlPlanner: this.options.useNativeSqlPlanner,
+      localRefreshKey: this.options.localRefreshKey,
       ...options,
     };
   }
@@ -4265,19 +4270,22 @@ export class BaseQuery {
             this.refreshKeySelect(sql),
             {
               external,
-              renewalThreshold: this.refreshKeyRenewalThresholdForInterval(cubeFromPath.refreshKey)
+              renewalThreshold: this.refreshKeyRenewalThresholdForInterval(cubeFromPath.refreshKey),
+              ...this.localRefreshKeyOptions(cubeFromPath.refreshKey, query)
             },
             query
           ];
         }
       }
 
-      const [sql, external, query] = this.everyRefreshKeySql(this.defaultEveryRefreshKey());
+      const defaultEveryRefreshKey = this.defaultEveryRefreshKey();
+      const [sql, external, query] = this.everyRefreshKeySql(defaultEveryRefreshKey);
       return [
         this.refreshKeySelect(sql),
         {
           external,
-          renewalThreshold: this.defaultRefreshKeyRenewalThreshold()
+          renewalThreshold: this.defaultRefreshKeyRenewalThreshold(),
+          ...this.localRefreshKeyOptions(defaultEveryRefreshKey, query)
         },
         query
       ];
@@ -4851,20 +4859,52 @@ export class BaseQuery {
     };
   }
 
+  /**
+   * The interval arithmetic behind an `every` based refreshKey, with no SQL in it.
+   * Both the rendered SQL and the descriptor handed to the orchestrator for local
+   * evaluation derive from this, so they cannot disagree on the formula.
+   *
+   * @param {Object} refreshKey
+   * @return {{ utcOffset: number, interval: number, dayOffset: number, cron: boolean }}
+   */
+  everyRefreshKeyParts(refreshKey) {
+    const every = refreshKey.every || '1 hour';
+
+    if (/^(\d+) (second|minute|hour|day|week)s?$/.test(every)) {
+      return {
+        utcOffset: this.timezone ? moment.tz(this.timezone).utcOffset() * 60 : 0,
+        interval: this.parseSecondDuration(every),
+        dayOffset: 0,
+        cron: false,
+      };
+    }
+
+    return { ...this.calcIntervalForCronString(refreshKey), cron: true };
+  }
+
+  /**
+   * @protected
+   * @param {Object} refreshKey
+   * @param {BaseQuery} [query] the instance that rendered the SQL, when it differs from `this`
+   * @return {Object}
+   */
+  localRefreshKeyOptions(refreshKey, query) {
+    return this.localRefreshKey
+      ? { localRefreshKey: (query || this).everyRefreshKeyParts(refreshKey) }
+      : {};
+  }
+
   everyRefreshKeySql(refreshKey, external = false) {
     if (this.externalQueryClass) {
       return this.externalQuery().everyRefreshKeySql(refreshKey, true);
     }
 
-    const every = refreshKey.every || '1 hour';
+    const { utcOffset, interval, dayOffset, cron } = this.everyRefreshKeyParts(refreshKey);
 
-    if (/^(\d+) (second|minute|hour|day|week)s?$/.test(every)) {
-      const utcOffset = this.timezone ? moment.tz(this.timezone).utcOffset() * 60 : 0;
+    if (!cron) {
       const utcOffsetPrefix = utcOffset ? `${utcOffset} + ` : '';
-      return [this.floorSql(`(${utcOffsetPrefix}${this.unixTimestampSql()}) / ${this.parseSecondDuration(every)}`), external, this];
+      return [this.floorSql(`(${utcOffsetPrefix}${this.unixTimestampSql()}) / ${interval}`), external, this];
     }
-
-    const { dayOffset, utcOffset, interval } = this.calcIntervalForCronString(refreshKey);
 
     /**
      * Small explanation how it works for every `0 8 * * *`
@@ -5057,6 +5097,14 @@ export class BaseQuery {
           }
 
           if (preAggregation.refreshKey.every || preAggregation.refreshKey.incremental) {
+            // An incremental key is wrapped into `CASE WHEN NOW() < <dateTo + updateWindow>`
+            // against an allocated partition range param, and its options drive the
+            // renewalThresholdOutsideUpdateWindow shortening — neither is reproducible
+            // from a time interval alone.
+            const localRefreshKeyOptions = preAggregation.refreshKey.incremental
+              ? {}
+              : this.localRefreshKeyOptions(preAggregation.refreshKey, refreshKeyQuery);
+
             return [
               refreshKeyQuery.paramAllocator.buildSqlAndParams(this.refreshKeySelect(refreshKey)).concat({
                 external: refreshKeyExternal,
@@ -5065,7 +5113,8 @@ export class BaseQuery {
                 updateWindowSeconds: preAggregation.refreshKey.updateWindow &&
                   this.parseSecondDuration(preAggregation.refreshKey.updateWindow),
                 renewalThresholdOutsideUpdateWindow: preAggregation.refreshKey.incremental &&
-                  24 * 60 * 60
+                  24 * 60 * 60,
+                ...localRefreshKeyOptions
               })
             ];
           }
@@ -5089,15 +5138,15 @@ export class BaseQuery {
             () => preAggregationQueryForSql.cacheKeyQueries(
               (refreshKeyCube, [refreshKeySQL, refreshKeyQueryOptions, refreshKeyQuery]) => {
                 if (!cubeFromPath.refreshKey) {
-                  const [sql, external, query] = this.everyRefreshKeySql({
-                    every: '1 hour'
-                  });
+                  const hourlyRefreshKey = { every: '1 hour' };
+                  const [sql, external, query] = this.everyRefreshKeySql(hourlyRefreshKey);
 
                   return [
                     this.refreshKeySelect(sql),
                     {
                       external,
                       renewalThreshold: this.defaultRefreshKeyRenewalThreshold(),
+                      ...this.localRefreshKeyOptions(hourlyRefreshKey, query)
                     },
                     query
                   ];

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4863,7 +4863,6 @@ export class BaseQuery {
    * Both the rendered SQL and the descriptor handed to the orchestrator for local
    * evaluation derive from this, so they cannot disagree on the formula.
    *
-   * @param {Object} refreshKey
    * @return {{ utcOffset: number, interval: number, dayOffset: number, cron: boolean }}
    */
   everyRefreshKeyParts(refreshKey) {
@@ -4883,7 +4882,6 @@ export class BaseQuery {
 
   /**
    * @protected
-   * @param {Object} refreshKey
    * @param {BaseQuery} [query] the instance that rendered the SQL, when it differs from `this`
    */
   localRefreshKeyOptions(refreshKey, query) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4860,7 +4860,6 @@ export class BaseQuery {
   }
 
   /**
-   * The interval arithmetic behind an `every` based refreshKey, with no SQL in it.
    * Both the rendered SQL and the descriptor handed to the orchestrator for local
    * evaluation derive from this, so they cannot disagree on the formula.
    *
@@ -4886,7 +4885,6 @@ export class BaseQuery {
    * @protected
    * @param {Object} refreshKey
    * @param {BaseQuery} [query] the instance that rendered the SQL, when it differs from `this`
-   * @return {Object}
    */
   localRefreshKeyOptions(refreshKey, query) {
     return this.localRefreshKey
@@ -5098,9 +5096,8 @@ export class BaseQuery {
 
           if (preAggregation.refreshKey.every || preAggregation.refreshKey.incremental) {
             // An incremental key is wrapped into `CASE WHEN NOW() < <dateTo + updateWindow>`
-            // against an allocated partition range param, and its options drive the
-            // renewalThresholdOutsideUpdateWindow shortening — neither is reproducible
-            // from a time interval alone.
+            // against an allocated partition range param, so it is not reproducible from
+            // a time interval alone.
             const localRefreshKeyOptions = preAggregation.refreshKey.incremental
               ? {}
               : this.localRefreshKeyOptions(preAggregation.refreshKey, refreshKeyQuery);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -4,6 +4,7 @@ import R from 'ramda';
 import {
   AccessPolicyDefinition,
   CubeDefinitionExtended,
+  CubeRefreshKey,
   CubeSymbols,
   Folder,
   FolderInclude,
@@ -199,6 +200,7 @@ export type EvaluatedCube = {
   isView?: boolean;
   includedMembers?: ViewIncludedMember[];
   defaultFilters?: ViewDefaultValueFilter[];
+  refreshKey?: CubeRefreshKey;
 };
 
 export class CubeEvaluator extends CubeSymbols {

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1367,6 +1367,75 @@ describe('SQL Generation', () => {
         expect(error).toBeInstanceOf(UserError);
       }
     });
+
+    it('Test for everyRefreshKeyParts', async () => {
+      await compilers.compiler.compile();
+
+      const timezone = 'America/Los_Angeles';
+      const query = new PostgresQuery(compilers, {
+        measures: ['cards.count'],
+        timeDimensions: [],
+        filters: [],
+        timezone,
+      });
+
+      const utcOffset = moment.tz(timezone).utcOffset() * 60;
+
+      expect(query.everyRefreshKeyParts({ every: '1 hour' }))
+        .toEqual({ utcOffset, interval: 3600, dayOffset: 0, cron: false });
+      expect(query.everyRefreshKeyParts({ every: '10 seconds' }))
+        .toEqual({ utcOffset, interval: 10, dayOffset: 0, cron: false });
+      expect(query.everyRefreshKeyParts({ every: '10 minute' }))
+        .toEqual({ utcOffset, interval: 600, dayOffset: 0, cron: false });
+
+      expect(query.everyRefreshKeyParts({ every: '0 * * * *', timezone }))
+        .toEqual({ utcOffset, interval: 3600, dayOffset: 0, cron: true });
+      expect(query.everyRefreshKeyParts({ every: '0 10 * * *', timezone }))
+        .toEqual({ utcOffset, interval: 86400, dayOffset: 36000, cron: true });
+      expect(query.everyRefreshKeyParts({ every: '30 5 * * 5', timezone }))
+        .toEqual({ utcOffset, interval: 604800, dayOffset: 106200, cron: true });
+    });
+
+    it('everyRefreshKeyParts agrees with the SQL it renders', async () => {
+      await compilers.compiler.compile();
+
+      const timezone = 'America/Los_Angeles';
+      const query = new PostgresQuery(compilers, {
+        measures: ['cards.count'],
+        timeDimensions: [],
+        filters: [],
+        timezone,
+      });
+
+      // Evaluates the emitted FLOOR(...) expression as JS with the clock pinned to `t`,
+      // which is what the orchestrator now computes from the descriptor instead.
+      const evalSql = (sql: string, t: number) => {
+        const asJs = sql
+          .split('EXTRACT(EPOCH FROM NOW())').join(String(t))
+          .split('FLOOR').join('Math.floor');
+        // eslint-disable-next-line no-new-func
+        return Function(`"use strict"; return (${asJs});`)();
+      };
+
+      const refreshKeys = [
+        { every: '10 seconds' },
+        { every: '10 minute' },
+        { every: '1 hour' },
+        { every: '7 day' },
+        { every: '0 * * * *', timezone },
+        { every: '0 10 * * *', timezone },
+        { every: '30 5 * * 5', timezone },
+      ];
+
+      for (const refreshKey of refreshKeys) {
+        const [sql] = query.everyRefreshKeySql(refreshKey);
+        const { utcOffset, interval, dayOffset } = query.everyRefreshKeyParts(refreshKey);
+
+        for (const t of [0, 1, 1_500_000_000, 1_767_225_600]) {
+          expect(Math.floor((utcOffset + t - dayOffset) / interval)).toEqual(evalSql(sql, t));
+        }
+      }
+    });
   });
 
   describe('refreshKey from schema', () => {
@@ -1589,6 +1658,188 @@ describe('SQL Generation', () => {
           }
         ]
       ]);
+    });
+  });
+
+  describe('refreshKey local time evaluation', () => {
+    const compilers = /** @type Compilers */ prepareJsCompiler(
+      createCubeSchema({
+        name: 'cards',
+        refreshKey: `
+        refreshKey: {
+          every: '10 minute',
+        },
+      `,
+        preAggregations: `
+        countCreatedAt: {
+            type: 'rollup',
+            external: true,
+            measureReferences: [count],
+            timeDimensionReference: createdAt,
+            granularity: \`day\`,
+            partitionGranularity: \`month\`,
+            refreshKey: {
+              every: '1 hour',
+            },
+            scheduledRefresh: true,
+        },
+        maxCreatedAt: {
+            type: 'rollup',
+            external: true,
+            measureReferences: [max],
+            timeDimensionReference: createdAt,
+            granularity: \`day\`,
+            partitionGranularity: \`month\`,
+            refreshKey: {
+              sql: 'SELECT MAX(created_at) FROM cards',
+            },
+            scheduledRefresh: true,
+        },
+        minCreatedAt: {
+            type: 'rollup',
+            external: false,
+            measureReferences: [min],
+            timeDimensionReference: createdAt,
+            granularity: \`day\`,
+            partitionGranularity: \`month\`,
+            refreshKey: {
+              every: '1 hour',
+              incremental: true,
+            },
+            scheduledRefresh: true,
+        },
+      `
+      })
+    );
+
+    const timezone = 'America/Los_Angeles';
+
+    const newQuery = (query: any) => new PostgresQuery(compilers, {
+      timeDimensions: [],
+      filters: [],
+      timezone,
+      localRefreshKey: true,
+      ...query,
+    });
+
+    it('carries the descriptor on a cube refreshKey.every', async () => {
+      await compilers.compiler.compile();
+
+      const utcOffset = moment.tz(timezone).utcOffset() * 60;
+      const query = newQuery({ measures: ['cards.sum'], externalQueryClass: MssqlQuery });
+
+      expect(query.cacheKeyQueries()).toEqual([
+        [
+          `SELECT FLOOR((${utcOffset} + DATEDIFF(SECOND,'1970-01-01', GETUTCDATE())) / 600) as refresh_key`,
+          [],
+          {
+            external: true,
+            renewalThreshold: 60,
+            localRefreshKey: { utcOffset, interval: 600, dayOffset: 0, cron: false },
+          }
+        ]
+      ]);
+    });
+
+    it('carries the descriptor on a pre-aggregation refreshKey.every', async () => {
+      await compilers.compiler.compile();
+
+      const utcOffset = moment.tz(timezone).utcOffset() * 60;
+      const query = newQuery({ measures: ['cards.count'], externalQueryClass: MssqlQuery });
+
+      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
+      expect(preAggregations.length).toEqual(1);
+      expect(preAggregations[0].invalidateKeyQueries).toEqual([
+        [
+          `SELECT FLOOR((${utcOffset} + DATEDIFF(SECOND,'1970-01-01', GETUTCDATE())) / 3600) as refresh_key`,
+          [],
+          {
+            external: true,
+            renewalThreshold: 300,
+            localRefreshKey: { utcOffset, interval: 3600, dayOffset: 0, cron: false },
+          }
+        ]
+      ]);
+    });
+
+    it('leaves refreshKey.sql on the SQL path', async () => {
+      await compilers.compiler.compile();
+
+      const query = newQuery({ measures: ['cards.max'], externalQueryClass: MssqlQuery });
+
+      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
+      expect(preAggregations.length).toEqual(1);
+      expect(preAggregations[0].invalidateKeyQueries[0][2]).not.toHaveProperty('localRefreshKey');
+    });
+
+    it('leaves an incremental refreshKey on the SQL path', async () => {
+      await compilers.compiler.compile();
+
+      const query = newQuery({
+        measures: ['cards.min'],
+        timeDimensions: [{
+          dimension: 'cards.createdAt',
+          granularity: 'day',
+          dateRange: ['2016-12-30', '2017-01-05']
+        }],
+        externalQueryClass: MssqlQuery,
+      });
+
+      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
+      expect(preAggregations.length).toEqual(1);
+      expect(preAggregations[0].invalidateKeyQueries[0][2]).toMatchObject({ incremental: true });
+      expect(preAggregations[0].invalidateKeyQueries[0][2]).not.toHaveProperty('localRefreshKey');
+    });
+  });
+
+  describe('refreshKey local time evaluation (cube without refreshKey)', () => {
+    const compilers = /** @type Compilers */ prepareJsCompiler(
+      createCubeSchema({
+        name: 'cards',
+        preAggregations: `
+        countCreatedAt: {
+            type: 'rollup',
+            external: true,
+            measureReferences: [count],
+            timeDimensionReference: createdAt,
+            granularity: \`day\`,
+            partitionGranularity: \`month\`,
+            scheduledRefresh: true,
+        },
+      `
+      })
+    );
+
+    it('falls back to the hourly default with a descriptor', async () => {
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['cards.count'],
+        timeDimensions: [],
+        filters: [],
+        timezone: 'UTC',
+        localRefreshKey: true,
+      });
+
+      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
+      expect(preAggregations.length).toEqual(1);
+      expect(preAggregations[0].invalidateKeyQueries[0][2].localRefreshKey)
+        .toEqual({ utcOffset: 0, interval: 3600, dayOffset: 0, cron: false });
+    });
+
+    it('emits no descriptor when the flag is off', async () => {
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['cards.count'],
+        timeDimensions: [],
+        filters: [],
+        timezone: 'UTC',
+      });
+
+      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
+      expect(preAggregations.length).toEqual(1);
+      expect(preAggregations[0].invalidateKeyQueries[0][2]).not.toHaveProperty('localRefreshKey');
     });
   });
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1407,8 +1407,8 @@ describe('SQL Generation', () => {
         timezone,
       });
 
-      // Evaluates the emitted FLOOR(...) expression as JS with the clock pinned to `t`,
-      // which is what the orchestrator now computes from the descriptor instead.
+      // Pins the clock to `t` so the emitted SQL can be compared against what the
+      // orchestrator now computes from the descriptor instead.
       const evalSql = (sql: string, t: number) => {
         const asJs = sql
           .split('EXTRACT(EPOCH FROM NOW())').join(String(t))

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -37,6 +37,7 @@ export interface CompilerApiOptions {
   preAggregationsSchema?: string | ((context: Context) => string | Promise<string>);
   allowUngroupedWithoutPrimaryKey?: boolean;
   convertTzForRawTimeDimension?: boolean;
+  localRefreshKey?: boolean;
   schemaVersion?: () => string | object | Promise<string | object>;
   contextToGroups?: (context: Context) => string[] | Promise<string[]>;
   compileContext?: any;
@@ -105,6 +106,8 @@ export class CompilerApi {
 
   protected readonly convertTzForRawTimeDimension?: boolean;
 
+  protected readonly localRefreshKey?: boolean;
+
   public schemaVersion?: () => string | object | Promise<string | object>;
 
   protected readonly contextToGroups?: (context: Context) => string[] | Promise<string[]>;
@@ -146,6 +149,7 @@ export class CompilerApi {
     this.preAggregationsSchema = this.options.preAggregationsSchema;
     this.allowUngroupedWithoutPrimaryKey = this.options.allowUngroupedWithoutPrimaryKey;
     this.convertTzForRawTimeDimension = this.options.convertTzForRawTimeDimension;
+    this.localRefreshKey = this.options.localRefreshKey;
     this.schemaVersion = this.options.schemaVersion;
     this.contextToGroups = this.options.contextToGroups;
     this.compileContext = options.compileContext;
@@ -967,6 +971,7 @@ export class CompilerApi {
         preAggregationsSchema: this.preAggregationsSchema,
         allowUngroupedWithoutPrimaryKey: this.allowUngroupedWithoutPrimaryKey,
         convertTzForRawTimeDimension: this.convertTzForRawTimeDimension,
+        localRefreshKey: this.localRefreshKey,
         queryFactory: this.queryFactory,
       }
     );

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -602,8 +602,10 @@ export class OptsHandler {
       ? clone.rollupOnlyMode
       : getEnv('rollupOnlyMode');
 
-    // query queue options
     clone.queryCacheOptions = clone.queryCacheOptions || {};
+    clone.queryCacheOptions.localRefreshKey = getEnv('refreshKeyLocalTime');
+
+    // query queue options
     clone.queryCacheOptions.queueOptions = this.queueOptionsWrapper(
       context,
       clone.queryCacheOptions.queueOptions,

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -2,7 +2,7 @@ import R from 'ramda';
 import pLimit from 'p-limit';
 import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
-import { Required } from '@cubejs-backend/shared';
+import { getEnv, Required } from '@cubejs-backend/shared';
 import {
   PreAggregationDescription,
   PreAggregationPartitionRangeLoader,
@@ -343,11 +343,21 @@ export class RefreshScheduler {
     const compilers = await compilerApi.getCompilers();
     const queryForEvaluation = await compilerApi.createQueryByDataSource(compilers, {});
 
+    const localRefreshKey = getEnv('refreshKeyLocalTime');
+
     await Promise.all(queryForEvaluation.cubeEvaluator.cubeNames().map(async cube => {
       const cubeFromPath = queryForEvaluation.cubeEvaluator.cubeFromPath(cube);
       const measuresCount = Object.keys(cubeFromPath.measures || {}).length;
       const dimensionsCount = Object.keys(cubeFromPath.dimensions || {}).length;
       if (measuresCount === 0 && dimensionsCount === 0) {
+        return;
+      }
+      // This method exists only to warm the shared refresh key cache. An interval based key is
+      // evaluated from the local clock instead, so there is nothing to warm and the getSql plus
+      // executeQuery per timezone would be spent on a result that is thrown away. A `sql` key
+      // still runs against the data source, so those cubes keep being warmed.
+      const sqlRefreshKey = !!cubeFromPath.refreshKey && 'sql' in cubeFromPath.refreshKey;
+      if (localRefreshKey && !sqlRefreshKey) {
         return;
       }
       await Promise.all(queryingOptions.timezones.map(async timezone => {

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -2,7 +2,7 @@ import R from 'ramda';
 import pLimit from 'p-limit';
 import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
-import { getEnv, Required } from '@cubejs-backend/shared';
+import { Required } from '@cubejs-backend/shared';
 import {
   PreAggregationDescription,
   PreAggregationPartitionRangeLoader,
@@ -343,7 +343,11 @@ export class RefreshScheduler {
     const compilers = await compilerApi.getCompilers();
     const queryForEvaluation = await compilerApi.createQueryByDataSource(compilers, {});
 
-    const localRefreshKey = getEnv('refreshKeyLocalTime');
+    const orchestratorApi = await this.serverCore.getOrchestratorApi(context);
+    const localRefreshKey = orchestratorApi
+      .getQueryOrchestrator()
+      .getQueryCache()
+      .isLocalRefreshKeyActive();
 
     await Promise.all(queryForEvaluation.cubeEvaluator.cubeNames().map(async cube => {
       const cubeFromPath = queryForEvaluation.cubeEvaluator.cubeFromPath(cube);
@@ -352,13 +356,16 @@ export class RefreshScheduler {
       if (measuresCount === 0 && dimensionsCount === 0) {
         return;
       }
-      // This method exists only to warm the shared refresh key cache, and an interval based
+
+      // This method exists only to warm the shared refresh key cache, and a locally evaluated
       // key has no cache entry to warm — the getSql plus executeQuery per timezone below would
-      // be spent on a result that is thrown away. A `sql` key still hits the data source.
+      // be spent on a result that is thrown away. A `sql` key still hits the data source, and
+      // so do interval keys whenever the cache declines to evaluate them locally.
       const sqlRefreshKey = !!cubeFromPath.refreshKey && 'sql' in cubeFromPath.refreshKey;
       if (localRefreshKey && !sqlRefreshKey) {
         return;
       }
+
       await Promise.all(queryingOptions.timezones.map(async timezone => {
         const query = {
           ...queryingOptions,
@@ -373,7 +380,6 @@ export class RefreshScheduler {
           timezone
         };
         const sqlQuery = await compilerApi.getSql(query);
-        const orchestratorApi = await this.serverCore.getOrchestratorApi(context);
         await orchestratorApi.executeQuery({
           ...sqlQuery,
           sql: null,

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -352,10 +352,9 @@ export class RefreshScheduler {
       if (measuresCount === 0 && dimensionsCount === 0) {
         return;
       }
-      // This method exists only to warm the shared refresh key cache. An interval based key is
-      // evaluated from the local clock instead, so there is nothing to warm and the getSql plus
-      // executeQuery per timezone would be spent on a result that is thrown away. A `sql` key
-      // still runs against the data source, so those cubes keep being warmed.
+      // This method exists only to warm the shared refresh key cache, and an interval based
+      // key has no cache entry to warm — the getSql plus executeQuery per timezone below would
+      // be spent on a result that is thrown away. A `sql` key still hits the data source.
       const sqlRefreshKey = !!cubeFromPath.refreshKey && 'sql' in cubeFromPath.refreshKey;
       if (localRefreshKey && !sqlRefreshKey) {
         return;

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -738,6 +738,7 @@ export class CubejsServerCore {
           this.options.allowUngroupedWithoutPrimaryKey ||
           getEnv('allowUngroupedWithoutPrimaryKey'),
       convertTzForRawTimeDimension: getEnv('convertTzForRawTimeDimension'),
+      localRefreshKey: getEnv('refreshKeyLocalTime'),
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -60,6 +60,7 @@ export interface QueueInitedOptions {
 
 export interface QueryInitedOptions {
   queueOptions: (dataSource: string) => Promise<QueueInitedOptions>;
+  localRefreshKey: boolean;
   refreshKeyRenewalThreshold?: number;
   backgroundRenew?: boolean;
   externalQueueOptions?: QueueOptions;

--- a/packages/cubejs-server-core/test/unit/RefreshScheduler.test.ts
+++ b/packages/cubejs-server-core/test/unit/RefreshScheduler.test.ts
@@ -232,6 +232,43 @@ cube('Bar', {
   ]),
 };
 
+const repositoryWithRefreshKeys: SchemaFileRepository = {
+  localPath: () => __dirname,
+  dataSchemaFiles: () => Promise.resolve([
+    {
+      fileName: 'main.js', content: `
+cube('Interval', {
+  sql: 'select * from interval_cube',
+
+  refreshKey: {
+    every: '1 hour'
+  },
+
+  measures: {
+    count: {
+      type: 'count'
+    }
+  }
+});
+
+cube('Sql', {
+  sql: 'select * from sql_cube',
+
+  refreshKey: {
+    sql: 'SELECT MAX(updated_at) FROM sql_cube_refresh'
+  },
+
+  measures: {
+    count: {
+      type: 'count'
+    }
+  }
+});
+`,
+    },
+  ]),
+};
+
 class MockDriver extends BaseDriver {
   public tables: any[] = [];
 
@@ -350,10 +387,11 @@ class MockDriver extends BaseDriver {
 
 let testCounter = 1;
 
-const setupScheduler = ({ repository, useOriginalSqlPreAggregations, skipAssertSecurityContext }: {
+const setupScheduler = ({ repository, useOriginalSqlPreAggregations, skipAssertSecurityContext, refreshKeyRenewalThreshold }: {
   repository: SchemaFileRepository,
   useOriginalSqlPreAggregations?: boolean,
-  skipAssertSecurityContext?: true
+  skipAssertSecurityContext?: true,
+  refreshKeyRenewalThreshold?: number
 }) => {
   const mockDriver = new MockDriver();
   const externalDriver = new MockDriver();
@@ -390,6 +428,7 @@ const setupScheduler = ({ repository, useOriginalSqlPreAggregations, skipAssertS
         queueOptions: () => ({
           concurrency: 2,
         }),
+        ...(refreshKeyRenewalThreshold && { refreshKeyRenewalThreshold }),
       },
       preAggregationsOptions: {
         queueOptions: () => ({
@@ -427,6 +466,7 @@ describe('Refresh Scheduler', () => {
     delete process.env.CUBEJS_DROP_PRE_AGG_WITHOUT_TOUCH;
     delete process.env.CUBEJS_TOUCH_PRE_AGG_TIMEOUT;
     delete process.env.CUBEJS_DB_QUERY_TIMEOUT;
+    delete process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME;
   });
 
   afterAll(async () => {
@@ -1239,5 +1279,53 @@ describe('Refresh Scheduler', () => {
     expect(backoffDataStillActive).not.toBeNull();
     // backoffDataStillActive exists, which means backoff is still in place
     // (nextTimestamp may be close to current time due to test execution delays)
+  });
+
+  describe('Local refresh key', () => {
+    const ctx = { authInfo: { tenantId: 'tenant1' }, securityContext: { tenantId: 'tenant1' }, requestId: 'local refresh key' };
+
+    const runRefresh = async (refreshKeyRenewalThreshold?: number) => {
+      const { refreshScheduler, mockDriver } = setupScheduler({
+        repository: repositoryWithRefreshKeys,
+        refreshKeyRenewalThreshold,
+      });
+
+      await refreshScheduler.runScheduledRefresh(ctx, {
+        concurrency: 1,
+        workerIndices: [0],
+        throwErrors: true,
+      });
+
+      return {
+        // `every` keys render as `SELECT FLOOR(...) as refresh_key`, a `sql` key renders as itself
+        intervalKeyQueries: mockDriver.executedQueries.filter(q => q.match(/refresh_key/)),
+        sqlKeyQueries: mockDriver.executedQueries.filter(q => q.match(/sql_cube_refresh/)),
+      };
+    };
+
+    test('warms both kinds of refresh key with the flag off', async () => {
+      const { intervalKeyQueries, sqlKeyQueries } = await runRefresh();
+
+      expect(intervalKeyQueries.length).toBeGreaterThan(0);
+      expect(sqlKeyQueries.length).toBeGreaterThan(0);
+    });
+
+    test('skips interval keys that are evaluated locally', async () => {
+      process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'true';
+
+      const { intervalKeyQueries, sqlKeyQueries } = await runRefresh();
+
+      expect(intervalKeyQueries).toEqual([]);
+      expect(sqlKeyQueries.length).toBeGreaterThan(0);
+    });
+
+    test('keeps warming interval keys when refreshKeyRenewalThreshold vetoes local evaluation', async () => {
+      process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'true';
+
+      const { intervalKeyQueries, sqlKeyQueries } = await runRefresh(120);
+
+      expect(intervalKeyQueries.length).toBeGreaterThan(0);
+      expect(sqlKeyQueries.length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

A cube's default `refresh_key` (`every: '10 seconds'`) is a query — Cube sends `SELECT FLOOR(...) as refresh_key` to the database or Cube Store on nearly every request, just to find out what time it is. With the new `CUBEJS_REFRESH_KEY_LOCAL_TIME=true` (off by default) Cube computes those interval and cron based keys from its own clock instead, so the round trip goes away; `refreshKey.sql` and `incremental` keys are untouched and still run as queries, and with the flag off nothing about the generated SQL changes. It is opt-in because clocks drift: two nodes on either side of an interval boundary can disagree and rebuild the same pre-aggregation twice, so it is safe with a single refresh worker but not with several.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
