### PR TITLE
fix(query-orchestrator): initialize missing data source queue in isPa…

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -468,9 +468,10 @@ export class PreAggregations {
     tables = tables.filter(row => `${schema}.${row.table_name}` === table);
 
     // fetching query result
-    const conn = await this.queue[dataSource].getQueueDriver().createConnection();
+    const queue = await this.getQueue(dataSource);
+    const conn = await queue.getQueueDriver().createConnection();
     const result = await conn.getResult(key);
-    this.queue[dataSource].getQueueDriver().release(conn);
+    queue.getQueueDriver().release(conn);
 
     // calculating status
     let status: string;

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -280,6 +280,38 @@ describe('PreAggregations', () => {
     });
   });
 
+  describe('isPartitionExist', () => {
+    test('initializes a missing data source queue before checking the job result', async () => {
+      const preAggregations = new PreAggregations(
+        'TEST',
+        mockDriverFactory as any,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        () => {},
+        queryCache!,
+        {
+          cacheAndQueueDriver: 'memory',
+          queueOptions: async () => ({
+            executionTimeout: 1,
+            concurrency: 2,
+          }),
+        },
+      );
+      mockDriver!.tables.push('stb_pre_aggregations.orders_main');
+
+      await expect(
+        preAggregations.isPartitionExist(
+          'request-id',
+          false,
+          'named_data_source',
+          'stb_pre_aggregations',
+          'stb_pre_aggregations.orders_main',
+          ['job-key'],
+          'job-token',
+        )
+      ).resolves.toEqual([true, 'done']);
+    });
+  });
+
   describe('loadAllPreAggregationsIfNeeded', () => {
     let preAggregations: PreAggregations | null = null;
 


### PR DESCRIPTION
…rtitionExist

Polling job status from a replica that never built that data source crashed on this.queue[dataSource].getQueueDriver(). Create the queue via getQueue() first, matching the other queue accessors.

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
Related to #11313 (queue lookup used only default). That did not cover this crash.
Created a new one #11615

**Description of Changes Made (if issue reference is not provided)**
`POST /cubejs-api/v1/pre-aggregations/jobs` `{ "action": "get" }` calls `isPartitionExist`, which did `this.queue[dataSource].getQueueDriver(). this.queue` is per process. On a replica that never built that data source the key is missing, so the poll 500s with Cannot read properties of undefined (reading 'getQueueDriver') even when Cube Store already has the result.