### PR TITLE
feat: Queue - support fast track feature

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -195,7 +195,10 @@ and we don't recommend enabling it in production yet.
 
 Enables the preview fast-track path for Cube Store query queues. When enabled,
 Cube can atomically enqueue and claim a query when queue concurrency is
-available, reducing queue coordination round trips. This requires Cube Store
+available, reducing queue coordination round trips. It applies to queries at
+queue priority 10 and above, which is where user-facing queries and the
+pre-aggregation builds a request waits on are submitted; background refresh runs
+below that and keeps using the regular path. This requires Cube Store
 1.7.25 or newer; against an older version Cube keeps using the regular path.
 
 | Possible Values | Default in Development | Default in Production |

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -184,6 +184,24 @@ The port of the Cube Store deployment.
 | ------------------- | ---------------------- | --------------------- |
 | A valid port number | `3030`                 | `3030`                |
 
+## `CUBEJS_QUEUE_FAST_TRACK`
+
+<Warning>
+
+The fast-track path is experimental and off by default. Its behavior may still change,
+and we don't recommend enabling it in production yet.
+
+</Warning>
+
+Enables the preview fast-track path for Cube Store query queues. When enabled,
+Cube can atomically enqueue and claim a query when queue concurrency is
+available, reducing queue coordination round trips. This requires Cube Store
+1.7.25 or newer; against an older version Cube keeps using the regular path.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
 ## `CUBEJS_DATASOURCES`
 
 A comma-separated list of data source names. Data sources defined here can be

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -194,7 +194,7 @@ and we don't recommend enabling it in production yet.
 </Warning>
 
 Enables the preview fast-track path for Cube Store query queues. When enabled,
-Cube can atomically enqueue and claim a query when queue concurrency is
+Cube can atomically enqueue and retrieve a query when queue concurrency is
 available, reducing queue coordination round trips. It applies to queries at
 queue priority 10 and above, which is where user-facing queries and the
 pre-aggregation builds a request waits on are submitted; background refresh runs

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -2025,6 +2025,7 @@ const variables: Record<string, (...args: any) => any> = {
     .default('true')
     .asBoolStrict(),
   queueExternalId: () => get('CUBEJS_QUEUE_EXTERNAL_ID').default('false').asBool(),
+  queueFastTrack: () => get('CUBEJS_QUEUE_FAST_TRACK').default('false').asBool(),
   scheduledRefreshDefault: () => get(
     'CUBEJS_SCHEDULED_REFRESH_DEFAULT'
   ).default('true').asBoolStrict(),

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -35,9 +35,7 @@ export type AddToQueueResponse = [
   queueId: QueueId | null,
   queueSize: number,
   addedToQueueTime: number,
-  // `null` when the item was not claimed - the concurrency budget was full, the item is
-  // already active, or the driver does not claim on insert at all. A claim is an ownership
-  // transfer: the caller owns an active item and must execute and acknowledge it, otherwise
+  // `null` when the item was not claimed
   // the query stalls until the stalled/orphaned reclaim picks it up.
   claim: RetrieveForProcessingSuccess | null,
 ];

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -30,16 +30,15 @@ export type RetrieveForProcessingFail = [
   lockAquired: false
 ];
 export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | RetrieveForProcessingFail | null;
-export type AddToQueueResponse = [added: number, queueId: QueueId | null, queueSize: number, addedToQueueTime: number];
-export type AddAndRetrieveResponse = [
+export type AddToQueueResponse = [
   added: number,
   queueId: QueueId | null,
   queueSize: number,
   addedToQueueTime: number,
   // `null` when the item was not claimed - the concurrency budget was full, the item is
-  // already active, or the driver has no fast track at all. A claim is an ownership transfer:
-  // the caller owns an active item and must execute and acknowledge it, otherwise the query
-  // stalls until the stalled/orphaned reclaim picks it up.
+  // already active, or the driver does not claim on insert at all. A claim is an ownership
+  // transfer: the caller owns an active item and must execute and acknowledge it, otherwise
+  // the query stalls until the stalled/orphaned reclaim picks it up.
   claim: RetrieveForProcessingSuccess | null,
 ];
 
@@ -73,7 +72,8 @@ export interface QueueDriverConnectionInterface {
   getResult(queryKey: QueryKey, externalId?: string): Promise<any>;
   /**
    * Adds specified by the queryKey query to the queue, returns tuple
-   * with the operation result.
+   * with the operation result. A driver may also claim the item for processing in the same
+   * operation, which saves the caller a retrieval round-trip.
    *
    * @param queryKey
    * @param queryHandler Our queue allows using different handlers. For example, query, cvsQuery, etc.
@@ -82,12 +82,6 @@ export interface QueueDriverConnectionInterface {
    * @param options
    */
   addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
-  /**
-   * Same as {@link addToQueue}, but the driver also tries to claim the item for processing
-   * in the same operation, which saves the caller a retrieval round-trip. A driver which
-   * cannot claim returns a `null` claim and the caller falls back to the normal flow.
-   */
-  addAndRetrieve(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -40,6 +40,22 @@ export type AddToQueueResponse = [
   claim: RetrieveForProcessingSuccess | null,
 ];
 
+/**
+ * Higher priority wins, older wins within a priority. Only the rungs below carry meaning,
+ * the range between them is open: `queuePriority` in a query body and `priority` on a
+ * pre-aggregation are arbitrary integers from -10000 to 10000.
+ */
+export enum QueuePriority {
+  /** A request is blocked on it: a user query, an awaited build, a refresh key */
+  Interactive = 10,
+  /** Warmup sweep, above the background builds it warms */
+  Warmup = 1,
+  /** A build nobody is waiting for */
+  Background = 0,
+  /** Scheduled refresh, newest partition first from here downwards */
+  Scheduled = -1,
+}
+
 export interface AddToQueueQuery {
   isJob: boolean,
   orphanedTimeout: unknown
@@ -79,7 +95,7 @@ export interface QueueDriverConnectionInterface {
    * @param priority
    * @param options
    */
-  addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
+  addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: QueuePriority, options: AddToQueueOptions): Promise<AddToQueueResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -35,9 +35,9 @@ export type AddToQueueResponse = [
   queueId: QueueId | null,
   queueSize: number,
   addedToQueueTime: number,
-  // `null` when the item was not claimed
+  // `null` when the item was not retrieved
   // the query stalls until the stalled/orphaned reclaim picks it up.
-  claim: RetrieveForProcessingSuccess | null,
+  retrieved: RetrieveForProcessingSuccess | null,
 ];
 
 /**
@@ -86,7 +86,7 @@ export interface QueueDriverConnectionInterface {
   getResult(queryKey: QueryKey, externalId?: string): Promise<any>;
   /**
    * Adds specified by the queryKey query to the queue, returns tuple
-   * with the operation result. A driver may also claim the item for processing in the same
+   * with the operation result. A driver may also retrieve the item for processing in the same
    * operation, which saves the caller a retrieval round-trip.
    *
    * @param queryKey

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -10,7 +10,6 @@ export type QueryKeyHash = string & { __type: 'QueryKeyHash' };
 
 export type QueryKeysTuple = [keyHash: QueryKeyHash, queueId: QueueId | null /** Supported by new Cube Store and Memory */];
 export type GetActiveAndToProcessResponse = [active: QueryKeysTuple[], toProcess: QueryKeysTuple[]];
-export type AddToQueueResponse = [added: number, queueId: QueueId | null, queueSize: number, addedToQueueTime: number];
 export type QueryStageStateResponse = [active: string[], toProcess: string[]] | [active: string[], toProcess: string[], defs: Record<string, QueryDef>];
 export type RetrieveForProcessingSuccess = [
   added: unknown,
@@ -31,6 +30,18 @@ export type RetrieveForProcessingFail = [
   lockAquired: false
 ];
 export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | RetrieveForProcessingFail | null;
+export type AddToQueueResponse = [added: number, queueId: QueueId | null, queueSize: number, addedToQueueTime: number];
+export type AddAndRetrieveResponse = [
+  added: number,
+  queueId: QueueId | null,
+  queueSize: number,
+  addedToQueueTime: number,
+  // `null` when the item was not claimed - the concurrency budget was full, the item is
+  // already active, or the driver has no fast track at all. A claim is an ownership transfer:
+  // the caller owns an active item and must execute and acknowledge it, otherwise the query
+  // stalls until the stalled/orphaned reclaim picks it up.
+  claim: RetrieveForProcessingSuccess | null,
+];
 
 export interface AddToQueueQuery {
   isJob: boolean,
@@ -73,6 +84,14 @@ export interface QueueDriverConnectionInterface {
    * @param options
    */
   addToQueue(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
+  /**
+   * Same as {@link addToQueue}, but the driver also tries to claim the item for processing
+   * in the same operation, which saves the caller a retrieval round-trip. A driver which
+   * cannot claim returns a `null` claim and the caller falls back to the normal flow.
+   *
+   * @see AddAndRetrieveResponse for what owning a claim means.
+   */
+  addAndRetrieve(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -75,23 +75,19 @@ export interface QueueDriverConnectionInterface {
    * Adds specified by the queryKey query to the queue, returns tuple
    * with the operation result.
    *
-   * @param keyScore Redis specific thing
    * @param queryKey
-   * @param orphanedTime
    * @param queryHandler Our queue allows using different handlers. For example, query, cvsQuery, etc.
    * @param query
    * @param priority
    * @param options
    */
-  addToQueue(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
+  addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse>;
   /**
    * Same as {@link addToQueue}, but the driver also tries to claim the item for processing
    * in the same operation, which saves the caller a retrieval round-trip. A driver which
    * cannot claim returns a `null` claim and the caller falls back to the normal flow.
-   *
-   * @see AddAndRetrieveResponse for what owning a claim means.
    */
-  addAndRetrieve(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse>;
+  addAndRetrieve(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse>;
   // Return query keys which was sorted by priority and time
   getToProcessQueries(): Promise<QueryKeysTuple[]>;
   getActiveQueries(): Promise<QueryKeysTuple[]>;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
@@ -30,6 +30,7 @@ import { QueryResultFormat } from '../codegen';
 const CubeStoreCapabilityMinVersion = {
   queueExclusive: '1.6.22',
   queueExternalId: '1.6.26',
+  queueAddAndRetrieve: '1.7.25',
   sendableParameters: '1.6.38',
   arrowFormat: '1.6.66',
 } satisfies Record<string, string>;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -52,6 +52,8 @@ type CubeStoreClaimResponse = {
 export class CubestoreQueueDriverConnection implements QueueDriverConnectionInterface {
   protected readonly externalIdEnabled: boolean;
 
+  protected readonly fastTrackEnabled: boolean;
+
   protected readonly sendParameters: boolean;
 
   public constructor(
@@ -59,7 +61,16 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     protected readonly options: QueueDriverOptions,
   ) {
     this.externalIdEnabled = getEnv('queueExternalId');
+    this.fastTrackEnabled = getEnv('queueFastTrack');
     this.sendParameters = getEnv('cubestoreSendableParameters');
+  }
+
+  public async useFastTrack(): Promise<boolean> {
+    if (this.fastTrackEnabled) {
+      return this.driver.hasCapability('queueAddAndRetrieve');
+    }
+
+    return false;
   }
 
   public async useExternalId(): Promise<boolean> {
@@ -78,10 +89,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return `${this.options.redisQueuePrefix}:${queryKey}`;
   }
 
-  /**
-   * Builds everything `QUEUE ADD` and `QUEUE ADD_AND_RETRIEVE` have in common, they accept
-   * the same modifiers and the same trailing path and payload.
-   */
   protected async buildAddCommand(
     queryKey: QueryKey,
     queryHandler: string,
@@ -125,9 +132,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async addToQueue(
-    _keyScore: number,
     queryKey: QueryKey,
-    _orphanedTime: number,
     queryHandler: string,
     query: AddToQueueQuery,
     priority: number,
@@ -149,17 +154,15 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async addAndRetrieve(
-    keyScore: number,
     queryKey: QueryKey,
-    orphanedTime: number,
     queryHandler: string,
     query: AddToQueueQuery,
     priority: number,
     options: AddToQueueOptions
   ): Promise<AddAndRetrieveResponse> {
-    if (!await this.driver.hasCapability('queueAddAndRetrieve')) {
+    if (!await this.useFastTrack()) {
       const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
-        keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
+        queryKey, queryHandler, query, priority, options
       );
 
       return [added, queueId, queueSize, addedToQueueTime, null];
@@ -383,8 +386,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   /**
-   * An empty payload means the item was not claimed by this call. Shared by
-   * `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE` so that they cannot drift apart.
+   * Shared by `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE` so that they cannot drift apart.
    */
   protected decodeClaimFromRow(row: CubeStoreClaimResponse, method: string): RetrieveForProcessingSuccess | null {
     if (!row.payload) {

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -10,7 +10,6 @@ import {
   AddToQueueQuery,
   AddToQueueOptions,
   AddToQueueResponse,
-  AddAndRetrieveResponse,
   QueryKey,
   QueryKeyHash,
   ProcessingId,
@@ -140,38 +139,13 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   ): Promise<AddToQueueResponse> {
     const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);
 
-    const rows = await this.driver.query<{ id: string, added: string, pending: string }>(`QUEUE ADD${modifiers}`, values);
-    if (rows && rows.length) {
-      return [
-        rows[0].added === 'true' ? 1 : 0,
-        rows[0].id ? parseInt(rows[0].id, 10) : null,
-        parseInt(rows[0].pending, 10),
-        addedToQueueTime
-      ];
+    const fastTrack = await this.useFastTrack();
+    if (fastTrack) {
+      values.push(this.options.concurrency);
     }
 
-    throw new Error('Empty response on QUEUE ADD');
-  }
-
-  public async addAndRetrieve(
-    queryKey: QueryKey,
-    queryHandler: string,
-    query: AddToQueueQuery,
-    priority: number,
-    options: AddToQueueOptions
-  ): Promise<AddAndRetrieveResponse> {
-    if (!await this.useFastTrack()) {
-      const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
-        queryKey, queryHandler, query, priority, options
-      );
-
-      return [added, queueId, queueSize, addedToQueueTime, null];
-    }
-
-    const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);
-    values.push(this.options.concurrency);
-
-    const rows = await this.driver.query<CubeStoreClaimResponse & { added: string }>(`QUEUE ADD_AND_RETRIEVE${modifiers} ?`, values);
+    const command = fastTrack ? 'ADD_AND_RETRIEVE' : 'ADD';
+    const rows = await this.driver.query<CubeStoreClaimResponse & { added: string }>(`QUEUE ${command}${modifiers}${fastTrack ? ' ?' : ''}`, values);
     if (rows && rows.length) {
       return [
         rows[0].added === 'true' ? 1 : 0,
@@ -179,11 +153,11 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
         parseInt(rows[0].pending, 10),
         addedToQueueTime,
         // An item which already existed is never added twice, but it still can be claimed
-        this.decodeClaimFromRow(rows[0], 'addAndRetrieve'),
+        fastTrack ? this.decodeClaimFromRow(rows[0], 'addToQueue') : null,
       ];
     }
 
-    throw new Error('Empty response on QUEUE ADD_AND_RETRIEVE');
+    throw new Error(`Empty response on QUEUE ${command}`);
   }
 
   public async getQueryAndRemove(hash: QueryKeyHash, queueId: QueueId | null): Promise<[QueryDef]> {

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -5,10 +5,12 @@ import {
   QueryStageStateResponse,
   QueryDef,
   RetrieveForProcessingResponse,
+  RetrieveForProcessingSuccess,
   QueueDriverOptions,
   AddToQueueQuery,
   AddToQueueOptions,
   AddToQueueResponse,
+  AddAndRetrieveResponse,
   QueryKey,
   QueryKeyHash,
   ProcessingId,
@@ -36,6 +38,15 @@ type CubeStoreListResponse = {
   // eslint-disable-next-line camelcase
   queue_id?: string
   status: string
+};
+
+// cube store convert int64 to string
+type CubeStoreClaimResponse = {
+  id: string,
+  active: string | null,
+  pending: string,
+  payload: string | null,
+  extra: string | null,
 };
 
 export class CubestoreQueueDriverConnection implements QueueDriverConnectionInterface {
@@ -67,15 +78,17 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return `${this.options.redisQueuePrefix}:${queryKey}`;
   }
 
-  public async addToQueue(
-    _keyScore: number,
+  /**
+   * Builds everything `QUEUE ADD` and `QUEUE ADD_AND_RETRIEVE` have in common, they accept
+   * the same modifiers and the same trailing path and payload.
+   */
+  protected async buildAddCommand(
     queryKey: QueryKey,
-    _orphanedTime: number,
     queryHandler: string,
     query: AddToQueueQuery,
     priority: number,
     options: AddToQueueOptions
-  ): Promise<AddToQueueResponse> {
+  ) {
     const data = {
       queryHandler,
       query,
@@ -103,17 +116,71 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     values.push(JSON.stringify(data));
 
     const exclusive = queryKey.persistent && await this.driver.hasCapability('queueExclusive');
-    const rows = await this.driver.query(`QUEUE ADD${exclusive ? ' EXCLUSIVE' : ''} PRIORITY ?${options.orphanedTimeout ? ' ORPHANED ?' : ''}${useExternalId ? ' EXTERNAL_ID ?' : ''} ? ?`, values);
+
+    return {
+      addedToQueueTime: data.addedToQueueTime,
+      values,
+      modifiers: `${exclusive ? ' EXCLUSIVE' : ''} PRIORITY ?${options.orphanedTimeout ? ' ORPHANED ?' : ''}${useExternalId ? ' EXTERNAL_ID ?' : ''} ? ?`,
+    };
+  }
+
+  public async addToQueue(
+    _keyScore: number,
+    queryKey: QueryKey,
+    _orphanedTime: number,
+    queryHandler: string,
+    query: AddToQueueQuery,
+    priority: number,
+    options: AddToQueueOptions
+  ): Promise<AddToQueueResponse> {
+    const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);
+
+    const rows = await this.driver.query<{ id: string, added: string, pending: string }>(`QUEUE ADD${modifiers}`, values);
     if (rows && rows.length) {
       return [
         rows[0].added === 'true' ? 1 : 0,
         rows[0].id ? parseInt(rows[0].id, 10) : null,
         parseInt(rows[0].pending, 10),
-        data.addedToQueueTime
+        addedToQueueTime
       ];
     }
 
     throw new Error('Empty response on QUEUE ADD');
+  }
+
+  public async addAndRetrieve(
+    keyScore: number,
+    queryKey: QueryKey,
+    orphanedTime: number,
+    queryHandler: string,
+    query: AddToQueueQuery,
+    priority: number,
+    options: AddToQueueOptions
+  ): Promise<AddAndRetrieveResponse> {
+    if (!await this.driver.hasCapability('queueAddAndRetrieve')) {
+      const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
+        keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
+      );
+
+      return [added, queueId, queueSize, addedToQueueTime, null];
+    }
+
+    const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);
+    values.push(this.options.concurrency);
+
+    const rows = await this.driver.query<CubeStoreClaimResponse & { added: string }>(`QUEUE ADD_AND_RETRIEVE${modifiers} ?`, values);
+    if (rows && rows.length) {
+      return [
+        rows[0].added === 'true' ? 1 : 0,
+        rows[0].id ? parseInt(rows[0].id, 10) : null,
+        parseInt(rows[0].pending, 10),
+        addedToQueueTime,
+        // An item which already existed is never added twice, but it still can be claimed
+        this.decodeClaimFromRow(rows[0], 'addAndRetrieve'),
+      ];
+    }
+
+    throw new Error('Empty response on QUEUE ADD_AND_RETRIEVE');
   }
 
   public async getQueryAndRemove(hash: QueryKeyHash, queueId: QueueId | null): Promise<[QueryDef]> {
@@ -311,31 +378,43 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     // nothing to release
   }
 
+  protected decodeActiveKeysFromRow(active: string | null): QueryKeyHash[] {
+    return active ? active.split(',') as unknown as QueryKeyHash[] : [];
+  }
+
+  /**
+   * An empty payload means the item was not claimed by this call. Shared by
+   * `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE` so that they cannot drift apart.
+   */
+  protected decodeClaimFromRow(row: CubeStoreClaimResponse, method: string): RetrieveForProcessingSuccess | null {
+    if (!row.payload) {
+      return null;
+    }
+
+    return [
+      1,
+      row.id ? parseInt(row.id, 10) : null,
+      this.decodeActiveKeysFromRow(row.active),
+      parseInt(row.pending, 10),
+      this.decodeQueryDefFromRow(row as { payload: string, extra?: string | null }, method),
+      true
+    ];
+  }
+
   public async retrieveForProcessing(hash: QueryKeyHash, _processingId: string): Promise<RetrieveForProcessingResponse> {
-    const rows = await this.driver.query<{ id: string /* cube store convert int64 to string */, active: string | null, pending: string, payload: string, extra: string | null }>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
+    const rows = await this.driver.query<CubeStoreClaimResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
     ]);
     if (rows && rows.length) {
-      const active = rows[0].active ? (rows[0].active).split(',') as unknown as QueryKeyHash[] : [];
-      const pending = parseInt(rows[0].pending, 10);
-
-      if (rows[0].payload) {
-        const def = this.decodeQueryDefFromRow(rows[0], 'retrieveForProcessing');
-
-        return [
-          1,
-          rows[0].id ? parseInt(rows[0].id, 10) : null,
-          active,
-          pending,
-          def,
-          true
-        ];
-      } else {
-        return [
-          0, null, active, pending, null, false
-        ];
-      }
+      return this.decodeClaimFromRow(rows[0], 'retrieveForProcessing') || [
+        0,
+        null,
+        this.decodeActiveKeysFromRow(rows[0].active),
+        parseInt(rows[0].pending, 10),
+        null,
+        false
+      ];
     }
 
     return null;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -41,7 +41,7 @@ type CubeStoreListResponse = {
 };
 
 // cube store convert int64 to string
-type CubeStoreClaimResponse = {
+type CubeStoreRetrieveResponse = {
   id: string,
   active: string | null,
   pending: string,
@@ -67,7 +67,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
 
   /**
    * Below `Interactive` nothing is blocked on the query, and that is the regime where the
-   * queue runs at its concurrency ceiling for minutes, so the claim never succeeds anyway
+   * queue runs at its concurrency ceiling for minutes, so the retrieval never succeeds anyway
    */
   public async useFastTrack(priority: QueuePriority): Promise<boolean> {
     if (this.fastTrackEnabled && priority >= QueuePriority.Interactive) {
@@ -150,15 +150,15 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     }
 
     const command = fastTrack ? 'ADD_AND_RETRIEVE' : 'ADD';
-    const rows = await this.driver.query<CubeStoreClaimResponse & { added: string }>(`QUEUE ${command}${modifiers}${fastTrack ? ' ?' : ''}`, values);
+    const rows = await this.driver.query<CubeStoreRetrieveResponse & { added: string }>(`QUEUE ${command}${modifiers}${fastTrack ? ' ?' : ''}`, values);
     if (rows && rows.length) {
       return [
         rows[0].added === 'true' ? 1 : 0,
         rows[0].id ? parseInt(rows[0].id, 10) : null,
         parseInt(rows[0].pending, 10),
         addedToQueueTime,
-        // An item which already existed is never added twice, but it still can be claimed
-        fastTrack ? this.decodeClaimFromRow(rows[0], 'addToQueue') : null,
+        // An item which already existed is never added twice, but it still can be retrieved
+        fastTrack ? this.decodeRetrievedFromRow(rows[0], 'addToQueue') : null,
       ];
     }
 
@@ -367,7 +367,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   /**
    * Shared by `QUEUE RETRIEVE` and `QUEUE ADD_AND_RETRIEVE` so that they cannot drift apart.
    */
-  protected decodeClaimFromRow(row: CubeStoreClaimResponse, method: string): RetrieveForProcessingSuccess | null {
+  protected decodeRetrievedFromRow(row: CubeStoreRetrieveResponse, method: string): RetrieveForProcessingSuccess | null {
     if (!row.payload) {
       return null;
     }
@@ -383,12 +383,12 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async retrieveForProcessing(hash: QueryKeyHash, _processingId: string): Promise<RetrieveForProcessingResponse> {
-    const rows = await this.driver.query<CubeStoreClaimResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
+    const rows = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
     ]);
     if (rows && rows.length) {
-      return this.decodeClaimFromRow(rows[0], 'retrieveForProcessing') || [
+      return this.decodeRetrievedFromRow(rows[0], 'retrieveForProcessing') || [
         0,
         null,
         this.decodeActiveKeysFromRow(rows[0].active),

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -39,6 +39,11 @@ type CubeStoreListResponse = {
   status: string
 };
 
+// Latency-sensitive queries arrive at priority 10 or above: QueryCache uses 10 for a user
+// query, PreAggregationLoader for a build a query is waiting on. Background refresh work
+// sits below that, and it is the regime where claiming on insert buys nothing
+const FastTrackMinPriority = 10;
+
 // cube store convert int64 to string
 type CubeStoreClaimResponse = {
   id: string,
@@ -64,8 +69,8 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     this.sendParameters = getEnv('cubestoreSendableParameters');
   }
 
-  public async useFastTrack(): Promise<boolean> {
-    if (this.fastTrackEnabled) {
+  public async useFastTrack(priority: number): Promise<boolean> {
+    if (this.fastTrackEnabled && priority >= FastTrackMinPriority) {
       return this.driver.hasCapability('queueAddAndRetrieve');
     }
 
@@ -139,7 +144,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   ): Promise<AddToQueueResponse> {
     const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);
 
-    const fastTrack = await this.useFastTrack();
+    const fastTrack = await this.useFastTrack(priority);
     if (fastTrack) {
       values.push(this.options.concurrency);
     }

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -16,6 +16,7 @@ import {
   QueueId,
   GetActiveAndToProcessResponse,
   QueryKeysTuple,
+  QueuePriority,
 } from '@cubejs-backend/base-driver';
 import { getEnv, getProcessUid } from '@cubejs-backend/shared';
 
@@ -38,11 +39,6 @@ type CubeStoreListResponse = {
   queue_id?: string
   status: string
 };
-
-// Latency-sensitive queries arrive at priority 10 or above: QueryCache uses 10 for a user
-// query, PreAggregationLoader for a build a query is waiting on. Background refresh work
-// sits below that, and it is the regime where claiming on insert buys nothing
-const FastTrackMinPriority = 10;
 
 // cube store convert int64 to string
 type CubeStoreClaimResponse = {
@@ -69,8 +65,12 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     this.sendParameters = getEnv('cubestoreSendableParameters');
   }
 
-  public async useFastTrack(priority: number): Promise<boolean> {
-    if (this.fastTrackEnabled && priority >= FastTrackMinPriority) {
+  /**
+   * Below `Interactive` nothing is blocked on the query, and that is the regime where the
+   * queue runs at its concurrency ceiling for minutes, so the claim never succeeds anyway
+   */
+  public async useFastTrack(priority: QueuePriority): Promise<boolean> {
+    if (this.fastTrackEnabled && priority >= QueuePriority.Interactive) {
       return this.driver.hasCapability('queueAddAndRetrieve');
     }
 
@@ -97,7 +97,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     queryKey: QueryKey,
     queryHandler: string,
     query: AddToQueueQuery,
-    priority: number,
+    priority: QueuePriority,
     options: AddToQueueOptions
   ) {
     const data = {
@@ -139,7 +139,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     queryKey: QueryKey,
     queryHandler: string,
     query: AddToQueueQuery,
-    priority: number,
+    priority: QueuePriority,
     options: AddToQueueOptions
   ): Promise<AddToQueueResponse> {
     const { modifiers, values, addedToQueueTime } = await this.buildAddCommand(queryKey, queryHandler, query, priority, options);

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -284,7 +284,7 @@ sequenceDiagram
     participant QueryOrchestrator
 
     Caller->>QueryQueue: executeInQueue
-    QueryQueue->>QueueDriver: addAndRetrieve
+    QueryQueue->>QueueDriver: addToQueue
 
     QueueDriver->>CubeStore: QUEUE ADD_AND_RETRIEVE PRIORITY ?n ?path ?payload ?concurrency
     Note over CubeStore: One atomic batch:<br/>insert, then claim if the prefix allows it
@@ -346,14 +346,14 @@ budget is exhausted, which is exactly when the condition should stop firing.
 
 ### Enabling it
 
-`QueryQueue` always calls `addAndRetrieve` and whether anything is claimed is up to the
-driver. The Cube Store one claims when `CUBEJS_QUEUE_FAST_TRACK=true` (off by default) and
-the `queueAddAndRetrieve` capability negotiates the same way `queueExclusive` and
-`queueExternalId` do, otherwise it falls back to `QUEUE ADD`. The memory one never claims.
-Either way an unclaimed response carries a `null` claim and the caller continues through
-reconcile with nothing lost.
+There is one `addToQueue` and whether anything is claimed is up to the driver. The Cube
+Store one claims when `CUBEJS_QUEUE_FAST_TRACK=true` (off by default) and the
+`queueAddAndRetrieve` capability negotiates the same way `queueExclusive` and
+`queueExternalId` do — that is what picks `QUEUE ADD_AND_RETRIEVE` over `QUEUE ADD`. The
+memory one never claims. Either way an unclaimed response carries a `null` claim and the
+caller continues through reconcile with nothing lost.
 
-A claim is an ownership transfer: from the moment `addAndRetrieve` returns one, the calling
+A claim is an ownership transfer: from the moment `addToQueue` returns one, the calling
 process owns an active queue item and **must** execute and acknowledge it. `executeInQueue`
 turns it into the same `ClaimedQuery` that `claimQueryForProcessing` produces and hands it
 to `sendProcessMessageFn`, so a custom implementation needs no changes — but a receiver

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -269,6 +269,13 @@ The item is claimed when the prefix has a concurrency slot for it *and* for ever
 already queued — `active + pending < concurrency`, where `concurrency` is the same budget
 `QUEUE RETRIEVE CONCURRENCY` uses and `pending` does not count the item itself.
 
+The driver only emits the command for queries at **priority 10 or above**. That is where
+the latency-sensitive work sits — `QueryCache` submits a user query at 10, and
+`PreAggregationLoader` uses 10 for a build a request is waiting on — while background
+refresh comes in below it. A background sweep runs the queue at its concurrency ceiling for
+minutes, which is the one regime where the claim never succeeds and the extra `concurrency`
+parameter is pure overhead.
+
 `payload IS NULL` in the response means the item was not claimed — the condition failed,
 the item was already active, or it belongs to another process — and the caller falls back
 to the normal path with nothing lost, because the item is enqueued either way.

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -200,6 +200,13 @@ Two consequences of retrieving before the hand-off:
   recovered by the stalled-heartbeat / `TO_CANCEL` path; `freeProcessingLock` is a no-op on
   Cube Store, so the retrieval cannot be cheaply undone.
 
+A stream query is dispatched while `executeInQueue` is still running, so `waitForQueryStream`
+subscribes to `streamStarted` *before* the dispatch — a handler which starts fast would
+otherwise emit into no listener. Two things have to fail before that costs a request: the
+event, and the `streams` map lookup `waitForQueryStream` does before it arms its timeout.
+That fallback is why reverting the subscribe order does not break the streaming tests, and
+why the ordering has a test of its own asserting the call sequence.
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -346,12 +346,12 @@ budget is exhausted, which is exactly when the condition should stop firing.
 
 ### Enabling it
 
-`CUBEJS_QUEUE_FAST_TRACK=true` makes `QueryQueue` call `addAndRetrieve` instead of
-`addToQueue`, it is off by default. Claiming is up to the driver from there: the Cube Store
-one negotiates the `queueAddAndRetrieve` capability the same way `queueExclusive` and
-`queueExternalId` are negotiated and falls back to `QUEUE ADD`, and the memory one never
-claims at all. Either way an unclaimed response carries a `null` claim and the caller
-continues through reconcile with nothing lost.
+`QueryQueue` always calls `addAndRetrieve` and whether anything is claimed is up to the
+driver. The Cube Store one claims when `CUBEJS_QUEUE_FAST_TRACK=true` (off by default) and
+the `queueAddAndRetrieve` capability negotiates the same way `queueExclusive` and
+`queueExternalId` do, otherwise it falls back to `QUEUE ADD`. The memory one never claims.
+Either way an unclaimed response carries a `null` claim and the caller continues through
+reconcile with nothing lost.
 
 A claim is an ownership transfer: from the moment `addAndRetrieve` returns one, the calling
 process owns an active queue item and **must** execute and acknowledge it. `executeInQueue`

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Two participants matter when reading the diagrams:
   through `executeQuery`, which run detached from the request (in cluster mode they can
   even run on another node).
 
-Claiming and executing are two separate steps: `processQuery` claims an item and then hands
-the claim to `sendProcessMessageFn`, which executes it through `executeQuery`. See
+Retrieving and executing are two separate steps: `processQuery` retrieves an item and then hands
+the retrieval to `sendProcessMessageFn`, which executes it through `executeQuery`. See
 "Background execution" below.
 
 ## Cube Store responses as TS types
@@ -32,7 +32,7 @@ type AddToQueueResponse = {
 // QUEUE ADD_AND_RETRIEVE, extends AddToQueueResponse (see "Fast track" below)
 type AddAndRetrieveResponse = AddToQueueResponse & {
     active: string | null,  // comma separated keys, NULL when empty
-    payload: string | null, // NULL means "the item was not claimed"
+    payload: string | null, // NULL means "the item was not retrieved"
     extra: string | null,
 }
 // QUEUE RETRIEVE [EXTENDED] CONCURRENCY
@@ -77,7 +77,7 @@ enum ResultStatus {
 }
 ```
 
-`EXTENDED` on `QUEUE RETRIEVE` changes only the failure shape: without it a failed claim
+`EXTENDED` on `QUEUE RETRIEVE` changes only the failure shape: without it a failed retrieval
 returns zero rows, with it a single row where `payload` and `id` are `NULL` but `pending`
 and `active` are filled. The driver always sends `EXTENDED`.
 
@@ -174,15 +174,15 @@ sequenceDiagram
 
         loop for every query within toProcessLimit
             QueryQueue->>QueryQueue: processQuery
-            Note over QueryQueue,Background: Awaits the claim only, not the execution
+            Note over QueryQueue,Background: Awaits the retrieval only, not the execution
         end
     end
 ```
 
 ## Background execution: `processQuery` → `executeQuery`
 
-`processQuery` claims the item and nothing else. What it hands to `sendProcessMessageFn` is a
-`ClaimedQuery` — `{ queryKeyHash, queueId, processingId, queueSize, query }`, plain data on
+`processQuery` retrieves the item and nothing else. What it hands to `sendProcessMessageFn` is a
+`RetrievedQuery` — `{ queryKeyHash, queueId, processingId, queueSize, query }`, plain data on
 purpose, so a custom implementation can serialize it and let another process run
 `executeQuery`. The default implementation calls `executeQuery` in-process.
 
@@ -190,15 +190,15 @@ purpose, so a custom implementation can serialize it and let another process run
 executed: reconcile awaits it, and `executeQuery` ends with `reconcileQueue`, which is
 single-flight — awaiting the execution from inside reconcile deadlocks.
 
-Two consequences of claiming before the hand-off:
+Two consequences of retrieving before the hand-off:
 
-- Stream queries have to be executed by the process that claimed them, their streams live in
+- Stream queries have to be executed by the process that retrieved them, their streams live in
   the in-process `QueryQueue.streams` map. Reconcile only picks up persistent keys whose
   `@<processUid>` suffix matches, so `sendProcessMessageFn` is always called on the owning
   process for them — it just must not route them elsewhere.
-- A claimed item is already active. If a custom hand-off loses the message, the item is only
+- A retrieved item is already active. If a custom hand-off loses the message, the item is only
   recovered by the stalled-heartbeat / `TO_CANCEL` path; `freeProcessingLock` is a no-op on
-  Cube Store, so the claim cannot be cheaply undone.
+  Cube Store, so the retrieval cannot be cheaply undone.
 
 ```mermaid
 sequenceDiagram
@@ -213,10 +213,10 @@ sequenceDiagram
     QueueDriver->>CubeStore: QUEUE RETRIEVE EXTENDED CONCURRENCY ?n ?path
     CubeStore-->>QueueDriver: RetrieveResponse
     QueueDriver-->>QueryQueue: [added, queueId, activeKeys, queueSize, def, lockAcquired]
-    Note over QueueDriver,CubeStore: The claim is atomic in Cube Store:<br/>only one node moves the item to active
+    Note over QueueDriver,CubeStore: The retrieval is atomic in Cube Store:<br/>only one node moves the item to active
 
     alt def && added && activeKeys includes our key && lockAcquired
-        QueryQueue-)Background: sendProcessMessageFn(ClaimedQuery)
+        QueryQueue-)Background: sendProcessMessageFn(RetrievedQuery)
         Note over QueryQueue,Background: Detached from here on: the hand-off returns,<br/>the execution keeps running
 
         Background->>QueueDriver: optimisticQueryUpdate
@@ -243,7 +243,7 @@ sequenceDiagram
 
         Background->>Background: reconcileQueue
         Note over Background: The freed concurrency slot is<br/>immediately given to the next query
-    else the claim did not succeed
+    else the retrieval did not succeed
         QueryQueue->>QueueDriver: freeProcessingLock
         Note over QueryQueue,QueueDriver: Another node is running it, or the<br/>concurrency budget is full. No-op for Cube Store
     end
@@ -257,7 +257,7 @@ active and returns the payload. Between those two calls another node can take th
 concurrency slot, so the enqueueing node often pays for the second round-trip and gets
 nothing back.
 
-`QUEUE ADD_AND_RETRIEVE` inserts **and** claims the item in one atomic operation, so the
+`QUEUE ADD_AND_RETRIEVE` inserts **and** retrieves the item in one atomic operation, so the
 enqueueing request can go straight to executing:
 
 ```
@@ -265,7 +265,7 @@ QUEUE ADD_AND_RETRIEVE [EXCLUSIVE] [PRIORITY ?n] [ORPHANED ?ttl] [EXTERNAL_ID ?i
     ?path ?payload ?concurrency
 ```
 
-The item is claimed when the prefix has a concurrency slot for it *and* for everything
+The item is retrieved when the prefix has a concurrency slot for it *and* for everything
 already queued — `active + pending < concurrency`, where `concurrency` is the same budget
 `QUEUE RETRIEVE CONCURRENCY` uses and `pending` does not count the item itself.
 
@@ -273,10 +273,10 @@ The driver only emits the command for queries at **priority 10 or above**. That 
 the latency-sensitive work sits — `QueryCache` submits a user query at 10, and
 `PreAggregationLoader` uses 10 for a build a request is waiting on — while background
 refresh comes in below it. A background sweep runs the queue at its concurrency ceiling for
-minutes, which is the one regime where the claim never succeeds and the extra `concurrency`
+minutes, which is the one regime where the retrieval never succeeds and the extra `concurrency`
 parameter is pure overhead.
 
-`payload IS NULL` in the response means the item was not claimed — the condition failed,
+`payload IS NULL` in the response means the item was not retrieved — the condition failed,
 the item was already active, or it belongs to another process — and the caller falls back
 to the normal path with nothing lost, because the item is enqueued either way.
 
@@ -294,12 +294,12 @@ sequenceDiagram
     QueryQueue->>QueueDriver: addToQueue
 
     QueueDriver->>CubeStore: QUEUE ADD_AND_RETRIEVE PRIORITY ?n ?path ?payload ?concurrency
-    Note over CubeStore: One atomic batch:<br/>insert, then claim if the prefix allows it
+    Note over CubeStore: One atomic batch:<br/>insert, then retrieve if the prefix allows it
     CubeStore-->>QueueDriver: AddAndRetrieveResponse
-    QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, claim]
+    QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, retrieved]
 
     alt fast track: payload is not NULL, we own the item
-        QueryQueue-)Background: sendProcessMessageFn(ClaimedQuery)
+        QueryQueue-)Background: sendProcessMessageFn(RetrievedQuery)
         Note over QueryQueue,Background: No reconcile, no QUEUE RETRIEVE.<br/>The payload from the response is the QueryDef
         Background->>QueryOrchestrator: execute
     else payload IS NULL, the item stays pending
@@ -319,17 +319,17 @@ What the fast track saves per query, when the slot is free:
 | `QUEUE ADD` | 1 round-trip | folded into one command |
 | `QUEUE TO_CANCEL` + `QUEUE LIST` (reconcile) | 2 round-trips | skipped |
 | `QUEUE RETRIEVE` | 1 round-trip | folded into one command |
-| `QUEUE LIST` (the `Waiting for query` event) | 1 round-trip | skipped, the claim carries the state |
+| `QUEUE LIST` (the `Waiting for query` event) | 1 round-trip | skipped, the retrieval carries the state |
 | Window for another node to steal the slot | between ADD and RETRIEVE | none |
 
-Everything after the claim is unchanged: `MERGE_EXTRA`, `HEARTBEAT`, `ACK` and
+Everything after the retrieval is unchanged: `MERGE_EXTRA`, `HEARTBEAT`, `ACK` and
 `RESULT_BLOCKING` behave exactly as in the normal path, and a fast-tracked item is a
 regular active item — `TO_CANCEL` will reclaim it if the heartbeat stops.
 
 Two side effects are worth knowing about:
 
 - `QUEUE ADD` reports the queue depth *including* the item it just made pending, while a
-  claimed item never becomes pending, so the `queueSize` of the `Added to queue` and
+  retrieved item never becomes pending, so the `queueSize` of the `Added to queue` and
   `Waiting for query` log events drops by one on the fast track. The events carry
   `fastTrack` so the two can be told apart.
 - `reconcileQueue` is the only caller of `QUEUE TO_CANCEL`, and the fast track skips it, so
@@ -338,15 +338,15 @@ Two side effects are worth knowing about:
   and a submission only skips reconcile while the concurrency budget is free — which is
   exactly when there is no budget to reclaim.
 
-Priority ordering is enforced by the *selection* step, not by the claim: `QUEUE PENDING`
+Priority ordering is enforced by the *selection* step, not by the retrieval: `QUEUE PENDING`
 returns items highest priority first (oldest first within a priority) and reconcile takes
 `toProcessLimit` off the top of that list. `QUEUE RETRIEVE <path>` itself is priority blind
 — it is safe only because the path it is given came from that sorted list.
 
 The fast track selects itself, so it is priority blind with nothing to compensate. That is
-what the `active + pending < concurrency` condition rules out: claiming leaves a free slot
+what the `active + pending < concurrency` condition rules out: retrieving leaves a free slot
 for every item already pending, so no item is jumped over, and once the budget gets tight
-the fast track steps aside and lets reconcile pick by priority. Note that a claimed item
+the fast track steps aside and lets reconcile pick by priority. Note that a retrieved item
 goes straight to active and never becomes pending, so a burst onto an idle queue still
 fast-tracks every query — items only start accumulating in pending once the concurrency
 budget is exhausted, which is exactly when the condition should stop firing.

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -343,19 +343,3 @@ the fast track steps aside and lets reconcile pick by priority. Note that a clai
 goes straight to active and never becomes pending, so a burst onto an idle queue still
 fast-tracks every query — items only start accumulating in pending once the concurrency
 budget is exhausted, which is exactly when the condition should stop firing.
-
-### Enabling it
-
-There is one `addToQueue` and whether anything is claimed is up to the driver. The Cube
-Store one claims when `CUBEJS_QUEUE_FAST_TRACK=true` (off by default) and the
-`queueAddAndRetrieve` capability negotiates the same way `queueExclusive` and
-`queueExternalId` do — that is what picks `QUEUE ADD_AND_RETRIEVE` over `QUEUE ADD`. The
-memory one never claims. Either way an unclaimed response carries a `null` claim and the
-caller continues through reconcile with nothing lost.
-
-A claim is an ownership transfer: from the moment `addToQueue` returns one, the calling
-process owns an active queue item and **must** execute and acknowledge it. `executeInQueue`
-turns it into the same `ClaimedQuery` that `claimQueryForProcessing` produces and hands it
-to `sendProcessMessageFn`, so a custom implementation needs no changes — but a receiver
-which drops the hand-off leaves the item active with nobody running it, and the query
-stalls until `TO_CANCEL` reclaims it. That is why the flag is opt-in.

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -284,12 +284,12 @@ sequenceDiagram
     participant QueryOrchestrator
 
     Caller->>QueryQueue: executeInQueue
-    QueryQueue->>QueueDriver: addToQueue
+    QueryQueue->>QueueDriver: addAndRetrieve
 
     QueueDriver->>CubeStore: QUEUE ADD_AND_RETRIEVE PRIORITY ?n ?path ?payload ?concurrency
     Note over CubeStore: One atomic batch:<br/>insert, then claim if the prefix allows it
     CubeStore-->>QueueDriver: AddAndRetrieveResponse
-    QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, def?]
+    QueueDriver-->>QueryQueue: [added, queueId, queueSize, addedToQueueTime, claim]
 
     alt fast track: payload is not NULL, we own the item
         QueryQueue-)Background: sendProcessMessageFn(ClaimedQuery)
@@ -310,13 +310,26 @@ What the fast track saves per query, when the slot is free:
 | Step | Normal | Fast track |
 |---|---|---|
 | `QUEUE ADD` | 1 round-trip | folded into one command |
-| `QUEUE ACTIVE` + `QUEUE PENDING` (reconcile) | 2 round-trips | skipped |
+| `QUEUE TO_CANCEL` + `QUEUE LIST` (reconcile) | 2 round-trips | skipped |
 | `QUEUE RETRIEVE` | 1 round-trip | folded into one command |
+| `QUEUE LIST` (the `Waiting for query` event) | 1 round-trip | skipped, the claim carries the state |
 | Window for another node to steal the slot | between ADD and RETRIEVE | none |
 
 Everything after the claim is unchanged: `MERGE_EXTRA`, `HEARTBEAT`, `ACK` and
 `RESULT_BLOCKING` behave exactly as in the normal path, and a fast-tracked item is a
 regular active item — `TO_CANCEL` will reclaim it if the heartbeat stops.
+
+Two side effects are worth knowing about:
+
+- `QUEUE ADD` reports the queue depth *including* the item it just made pending, while a
+  claimed item never becomes pending, so the `queueSize` of the `Added to queue` and
+  `Waiting for query` log events drops by one on the fast track. The events carry
+  `fastTrack` so the two can be told apart.
+- `reconcileQueue` is the only caller of `QUEUE TO_CANCEL`, and the fast track skips it, so
+  orphaned and stalled items are no longer collected at submission time. They still are
+  after every completed query (`executeQuery` reconciles once it acknowledges the result),
+  and a submission only skips reconcile while the concurrency budget is free — which is
+  exactly when there is no budget to reclaim.
 
 Priority ordering is enforced by the *selection* step, not by the claim: `QUEUE PENDING`
 returns items highest priority first (oldest first within a priority) and reconcile takes
@@ -331,8 +344,18 @@ goes straight to active and never becomes pending, so a burst onto an idle queue
 fast-tracks every query — items only start accumulating in pending once the concurrency
 budget is exhausted, which is exactly when the condition should stop firing.
 
-> **Status:** the `QUEUE ADD_AND_RETRIEVE` command exists in Cube Store. The driver still
-> emits `QUEUE ADD`; wiring the fast track into `CubeStoreQueueDriver.addToQueue` needs a
-> capability gate (the same version negotiation as `queueExclusive` / `queueExternalId`).
-> The `QueryQueue` side is in place: `executeInQueue` can build a `ClaimedQuery` out of the
-> response and hand it to `sendProcessMessageFn` without going through reconcile.
+### Enabling it
+
+`CUBEJS_QUEUE_FAST_TRACK=true` makes `QueryQueue` call `addAndRetrieve` instead of
+`addToQueue`, it is off by default. Claiming is up to the driver from there: the Cube Store
+one negotiates the `queueAddAndRetrieve` capability the same way `queueExclusive` and
+`queueExternalId` are negotiated and falls back to `QUEUE ADD`, and the memory one never
+claims at all. Either way an unclaimed response carries a `null` claim and the caller
+continues through reconcile with nothing lost.
+
+A claim is an ownership transfer: from the moment `addAndRetrieve` returns one, the calling
+process owns an active queue item and **must** execute and acknowledge it. `executeInQueue`
+turns it into the same `ClaimedQuery` that `claimQueryForProcessing` produces and hands it
+to `sendProcessMessageFn`, so a custom implementation needs no changes — but a receiver
+which drops the hand-off leaves the item active with nobody running it, and the query
+stalls until `TO_CANCEL` reclaims it. That is why the flag is opt-in.

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -9,6 +9,7 @@ import {
   AddToQueueQuery,
   AddToQueueOptions,
   AddToQueueResponse,
+  AddAndRetrieveResponse,
   QueryKeysTuple,
   GetActiveAndToProcessResponse,
   QueryStageStateResponse,
@@ -203,6 +204,17 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
       Object.keys(this.state.toProcess).length,
       queryQueueObj.addedToQueueTime
     ];
+  }
+
+  /**
+   * There is no round-trip to save in memory, the item is always left for reconcile to pick up.
+   */
+  public async addAndRetrieve(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse> {
+    const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
+      keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
+    );
+
+    return [added, queueId, queueSize, addedToQueueTime, null];
   }
 
   public async getToProcessQueries(): Promise<QueryKeysTuple[]> {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -9,7 +9,6 @@ import {
   AddToQueueQuery,
   AddToQueueOptions,
   AddToQueueResponse,
-  AddAndRetrieveResponse,
   QueryKeysTuple,
   GetActiveAndToProcessResponse,
   QueryStageStateResponse,
@@ -207,19 +206,10 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
       added,
       queryQueueObj.queueId,
       Object.keys(this.state.toProcess).length,
-      queryQueueObj.addedToQueueTime
+      queryQueueObj.addedToQueueTime,
+      // There is no round-trip to save in memory, the item is left for reconcile to pick up
+      null
     ];
-  }
-
-  /**
-   * There is no round-trip to save in memory, the item is always left for reconcile to pick up.
-   */
-  public async addAndRetrieve(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse> {
-    const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
-      queryKey, queryHandler, query, priority, options
-    );
-
-    return [added, queueId, queueSize, addedToQueueTime, null];
   }
 
   public async getToProcessQueries(): Promise<QueryKeysTuple[]> {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -73,6 +73,8 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
   private concurrency: number;
 
+  private orphanedTimeout: number;
+
   private driver: LocalQueueDriver;
 
   private state: LocalQueueDriverConnectionState;
@@ -82,6 +84,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     this.continueWaitTimeout = options.continueWaitTimeout;
     this.heartBeatTimeout = options.heartBeatTimeout;
     this.concurrency = options.concurrency;
+    this.orphanedTimeout = options.orphanedTimeout;
     this.driver = driver;
     this.state = state;
   }
@@ -162,7 +165,8 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     )(queueObj);
   }
 
-  public async addToQueue(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse> {
+  public async addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse> {
+    const time = new Date().getTime();
     const queryQueueObj: QueryDefObject = {
       queueId: options.queueId,
       queryHandler,
@@ -171,7 +175,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
       stageQueryKey: options.stageQueryKey,
       priority,
       requestId: options.requestId,
-      addedToQueueTime: new Date().getTime()
+      addedToQueueTime: time
     };
 
     const key = this.redisHash(queryKey);
@@ -184,7 +188,8 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
     if (!this.state.toProcess[key] && !this.state.active[key]) {
       this.state.toProcess[key] = {
-        order: keyScore,
+        // Highest priority first, oldest first within a priority
+        order: time + (10000 - priority) * 1E14,
         queueId: options.queueId,
         key
       };
@@ -193,7 +198,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     }
 
     this.state.recent[key] = {
-      order: orphanedTime,
+      order: time + ((options.orphanedTimeout ?? this.orphanedTimeout) * 1000),
       key,
       queueId: options.queueId,
     };
@@ -209,9 +214,9 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
   /**
    * There is no round-trip to save in memory, the item is always left for reconcile to pick up.
    */
-  public async addAndRetrieve(keyScore: number, queryKey: QueryKey, orphanedTime: number, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse> {
+  public async addAndRetrieve(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddAndRetrieveResponse> {
     const [added, queueId, queueSize, addedToQueueTime] = await this.addToQueue(
-      keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
+      queryKey, queryHandler, query, priority, options
     );
 
     return [added, queueId, queueSize, addedToQueueTime, null];

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -13,7 +13,8 @@ import {
   GetActiveAndToProcessResponse,
   QueryStageStateResponse,
   RetrieveForProcessingResponse,
-  QueueDriverOptions
+  QueueDriverOptions,
+  QueuePriority
 } from '@cubejs-backend/base-driver';
 import {
   LocalQueueDriver
@@ -164,7 +165,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     )(queueObj);
   }
 
-  public async addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: number, options: AddToQueueOptions): Promise<AddToQueueResponse> {
+  public async addToQueue(queryKey: QueryKey, queryHandler: string, query: AddToQueueQuery, priority: QueuePriority, options: AddToQueueOptions): Promise<AddToQueueResponse> {
     const time = new Date().getTime();
     const queryQueueObj: QueryDefObject = {
       queueId: options.queueId,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoadCache.ts
@@ -1,4 +1,4 @@
-import { TableStructure } from '@cubejs-backend/base-driver';
+import { QueuePriority, TableStructure } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
 import { QueryCache, QueryWithParams } from './QueryCache';
 import {
@@ -190,7 +190,7 @@ export class PreAggregationLoadCache {
     return this.versionEntries[redisKey];
   }
 
-  public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: number) {
+  public async keyQueryResult(sqlQuery: QueryWithParams, waitForRenew: boolean, priority: QueuePriority) {
     const [query, values, queryOptions] = sqlQuery;
 
     if (!this.queryResults[this.queryCache.queryRedisKey([query, values])]) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -8,6 +8,7 @@ import {
   DriverCapabilities,
   DriverInterface,
   isDownloadTableCSVData,
+  QueuePriority,
   SaveCancelFn,
   StreamOptions,
   UnloadOptions
@@ -297,7 +298,7 @@ export class PreAggregationLoader {
         // We don't want to wait for the jobed build query result. So we run the
         // executeInQueue method and immediately return the LoadPreAggregationResult object.
         this
-          .executeInQueue(invalidationKeys, this.priority(10), newVersionEntry)
+          .executeInQueue(invalidationKeys, this.priority(QueuePriority.Interactive), newVersionEntry)
           .catch((e: any) => {
             this.logger('Pre-aggregations build job error', {
               preAggregation: this.preAggregation,
@@ -315,7 +316,7 @@ export class PreAggregationLoader {
           buildRangeEnd: this.preAggregation.buildRangeEnd,
         };
       } else {
-        await this.executeInQueue(invalidationKeys, this.priority(10), newVersionEntry);
+        await this.executeInQueue(invalidationKeys, this.priority(QueuePriority.Interactive), newVersionEntry);
         return mostRecentResult();
       }
     }
@@ -328,7 +329,7 @@ export class PreAggregationLoader {
           queryKey: this.preAggregationQueryKey(invalidationKeys),
           newVersionEntry
         });
-        await this.executeInQueue(invalidationKeys, this.priority(10), newVersionEntry);
+        await this.executeInQueue(invalidationKeys, this.priority(QueuePriority.Interactive), newVersionEntry);
         return mostRecentResult();
       } else if (versionEntry.content_version !== newVersionEntry.content_version) {
         if (this.waitForRenew) {
@@ -338,7 +339,7 @@ export class PreAggregationLoader {
             queryKey: this.preAggregationQueryKey(invalidationKeys),
             newVersionEntry
           });
-          await this.executeInQueue(invalidationKeys, this.priority(0), newVersionEntry);
+          await this.executeInQueue(invalidationKeys, this.priority(QueuePriority.Background), newVersionEntry);
           return mostRecentResult();
         } else {
           this.scheduleRefresh(invalidationKeys, newVersionEntry);
@@ -351,7 +352,7 @@ export class PreAggregationLoader {
         queryKey: this.preAggregationQueryKey(invalidationKeys),
         newVersionEntry
       });
-      await this.executeInQueue(invalidationKeys, this.priority(10), newVersionEntry);
+      await this.executeInQueue(invalidationKeys, this.priority(QueuePriority.Interactive), newVersionEntry);
       return mostRecentResult();
     }
     const targetTableName = this.targetTableName(versionEntry);
@@ -387,14 +388,14 @@ export class PreAggregationLoader {
     return version(versionArray);
   }
 
-  protected priority(defaultValue: number): number {
+  protected priority(defaultValue: QueuePriority): QueuePriority {
     return this.preAggregation.priority != null ? this.preAggregation.priority : defaultValue;
   }
 
   protected getInvalidationKeyValues() {
     return Promise.all(
       (this.preAggregation.invalidateKeyQueries || []).map(
-        (sqlQuery) => this.loadCache.keyQueryResult(sqlQuery, this.waitForRenew, this.priority(10))
+        (sqlQuery) => this.loadCache.keyQueryResult(sqlQuery, this.waitForRenew, this.priority(QueuePriority.Interactive))
       )
     );
   }
@@ -403,7 +404,7 @@ export class PreAggregationLoader {
     if (this.preAggregation.partitionInvalidateKeyQueries) {
       return Promise.all(
         (this.preAggregation.partitionInvalidateKeyQueries || []).map(
-          (sqlQuery) => this.loadCache.keyQueryResult(sqlQuery, this.waitForRenew, this.priority(10))
+          (sqlQuery) => this.loadCache.keyQueryResult(sqlQuery, this.waitForRenew, this.priority(QueuePriority.Interactive))
         )
       );
     } else {
@@ -418,7 +419,7 @@ export class PreAggregationLoader {
       queryKey: this.preAggregationQueryKey(invalidationKeys),
       newVersionEntry
     });
-    this.executeInQueue(invalidationKeys, this.priority(0), newVersionEntry)
+    this.executeInQueue(invalidationKeys, this.priority(QueuePriority.Background), newVersionEntry)
       .catch(e => {
         if (!(e instanceof ContinueWaitError)) {
           this.logger('Error refreshing pre-aggregation', {
@@ -428,7 +429,7 @@ export class PreAggregationLoader {
       });
   }
 
-  protected async executeInQueue(invalidationKeys: InvalidationKeys, priority: number, newVersionEntry: VersionEntry) {
+  protected async executeInQueue(invalidationKeys: InvalidationKeys, priority: QueuePriority, newVersionEntry: VersionEntry) {
     const queue = await this.preAggregations.getQueue(this.preAggregation.dataSource);
     return queue.executeInQueue(
       'query',

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
@@ -12,7 +12,7 @@ import {
   parseUtcIntoLocalDate,
   LoggerFn,
 } from '@cubejs-backend/shared';
-import { InlineTable, TableStructure } from '@cubejs-backend/base-driver';
+import { InlineTable, QueuePriority, TableStructure } from '@cubejs-backend/base-driver';
 import { DriverFactory } from './DriverFactory';
 import { QueryCache, QueryWithParams } from './QueryCache';
 import {
@@ -104,7 +104,7 @@ export class PreAggregationPartitionRangeLoader {
         renewalThreshold: this.queryCache.options.refreshKeyRenewalThreshold
           || queryOptions?.renewalThreshold || 24 * 60 * 60,
         waitForRenew: this.waitForRenew,
-        priority: this.priority(10),
+        priority: this.priority(QueuePriority.Interactive),
         requestId: this.requestId,
         dataSource: this.dataSource,
         useInMemory: true,
@@ -122,7 +122,7 @@ export class PreAggregationPartitionRangeLoader {
       (this.preAggregation.invalidateKeyQueries || []).map(
         (sqlQuery) => (
           this.loadCache.keyQueryResult(
-            this.replacePartitionSqlAndParams(sqlQuery, range, partitionTableName), this.waitForRenew, this.priority(10)
+            this.replacePartitionSqlAndParams(sqlQuery, range, partitionTableName), this.waitForRenew, this.priority(QueuePriority.Interactive)
           )
         )
       )

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -17,6 +17,7 @@ import {
   CacheDriverInterface,
   TableStructure,
   DriverInterface, QueryKey,
+  QueuePriority,
 } from '@cubejs-backend/base-driver';
 
 import { QueryQueue, QueryQueueOptions } from './QueryQueue';
@@ -214,7 +215,7 @@ export class QueryCache {
       )
     );
 
-    let queuePriority = 10;
+    let queuePriority: QueuePriority = QueuePriority.Interactive;
 
     if (Number.isInteger(queryBody.queuePriority)) {
       queuePriority = queryBody.queuePriority;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -267,28 +267,11 @@ export class QueryQueue {
         if (jobExists) return null;
       }
 
-      const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
-
       options.orphanedTimeout = query.orphanedTimeout;
 
-      const orphanedTimeout = 'orphanedTimeout' in query ? query.orphanedTimeout : this.orphanedTimeout;
-      const orphanedTime = time + (orphanedTimeout * 1000);
-
-      const addArgs = [keyScore, queryKey, orphanedTime, queryHandler, query, priority, options] as const;
-
-      let added: number;
-      let queueId: QueueId | null;
-      let queueSize: number;
-      let addedToQueueTime: number;
-      let claim: RetrieveForProcessingSuccess | null = null;
-
-      // The env is read per call on purpose, a queue outlives changes of it
-      if (getEnv('queueFastTrack')) {
-        [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addAndRetrieve(...addArgs);
-      } else {
-        [added, queueId, queueSize, addedToQueueTime] = await queueConnection.addToQueue(...addArgs);
-      }
+      const [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addAndRetrieve(
+        queryKey, queryHandler, query, priority, options
+      );
 
       if (added > 0) {
         waitingContext = {
@@ -326,7 +309,7 @@ export class QueryQueue {
       }
 
       if (claim) {
-        // The item is active and owned by us already, there is nothing for reconcile to pick up
+        // The item is active already, there is nothing for reconcile to pick up
         await this.sendProcessMessageFn(this.claimedQuery(queryKeyHash, queueId, claim));
       } else {
         await this.reconcileQueue();
@@ -391,8 +374,7 @@ export class QueryQueue {
    */
   protected claimedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId | null, claim: RetrieveForProcessingSuccess): ClaimedQuery {
     const [, claimQueueId, , queueSize, query] = claim;
-    // A driver which claims an item reports the id of it, which is what identifies the
-    // processing lock for every command downstream
+    // The id identifies the processing lock for every command downstream
     const claimedQueueId = claimQueueId ?? queueId;
 
     if (claimedQueueId === null) {
@@ -409,9 +391,7 @@ export class QueryQueue {
   }
 
   /**
-   * Subscribes to the stream of the specified query, the returned promise resolves with the
-   * stream or with `null` on a timeout. `dispose` releases the listener and the timer, it's
-   * a no-op once the promise has been resolved.
+   * `dispose` releases the listener and the timer, it's a no-op once the promise resolved.
    */
   protected waitForQueryStream(queryKeyHash: QueryKeyHash): QueryStreamWait {
     let timeoutTimerId: ReturnType<typeof setTimeout> | null = null;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -26,7 +26,7 @@ export type QueryHandlerFn = (query: QueryDef, cancelHandler: CancelHandlerFn) =
 export type StreamHandlerFn = (query: QueryDef, stream: QueryStream) => Promise<unknown>;
 export type QueryHandlersMap = Record<string, QueryHandlerFn>;
 
-export type ClaimedQuery = {
+export type RetrievedQuery = {
   queryKeyHash: QueryKeyHash;
   queueId: QueueId | null;
   processingId: ProcessingId;
@@ -34,7 +34,7 @@ export type ClaimedQuery = {
   query: QueryDef;
 };
 
-export type SendProcessMessageFn = (claimed: ClaimedQuery) => Promise<void> | void;
+export type SendProcessMessageFn = (retrieved: RetrievedQuery) => Promise<void> | void;
 export type SendCancelMessageFn = (query: QueryDef, queueId: QueueId | null) => Promise<void> | void;
 
 export type ExecuteInQueueOptions = Omit<AddToQueueOptions, 'queueId'> & {
@@ -133,7 +133,7 @@ export class QueryQueue {
     this.orphanedTimeout = options.orphanedTimeout || 120;
     this.heartBeatInterval = options.heartBeatInterval || 30;
 
-    this.sendProcessMessageFn = options.sendProcessMessageFn || ((claimed) => { this.executeQuery(claimed); });
+    this.sendProcessMessageFn = options.sendProcessMessageFn || ((retrieved) => { this.executeQuery(retrieved); });
     this.sendCancelMessageFn = options.sendCancelMessageFn || ((query, queueId) => { this.processCancel(query, queueId); });
     this.queryHandlers = options.queryHandlers;
     this.streamHandler = options.streamHandler;
@@ -267,7 +267,7 @@ export class QueryQueue {
 
       options.orphanedTimeout = query.orphanedTimeout;
 
-      const [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addToQueue(
+      const [added, queueId, queueSize, addedToQueueTime, retrieved] = await queueConnection.addToQueue(
         queryKey, queryHandler, query, priority, options
       );
 
@@ -296,7 +296,7 @@ export class QueryQueue {
           preAggregation: query.preAggregation,
           addedToQueueTime,
           persistent: !!queryKey.persistent,
-          fastTrack: !!claim,
+          fastTrack: !!retrieved,
         });
       }
 
@@ -306,15 +306,15 @@ export class QueryQueue {
         streamWait = this.waitForQueryStream(queryKeyHash);
       }
 
-      if (claim) {
+      if (retrieved) {
         // The item is active already, there is nothing for reconcile to pick up
-        await this.sendProcessMessageFn(this.claimedQuery(queryKeyHash, queueId, claim));
+        await this.sendProcessMessageFn(this.retrievedQuery(queryKeyHash, queueId, retrieved));
       } else {
         await this.reconcileQueue();
       }
 
       if (!added) {
-        const queryDef = claim ? claim[4] : await queueConnection.getQueryDef(queryKeyHash, queueId);
+        const queryDef = retrieved ? retrieved[4] : await queueConnection.getQueryDef(queryKeyHash, queueId);
         if (queryDef) {
           waitingContext = {
             queueId,
@@ -327,9 +327,9 @@ export class QueryQueue {
         }
       }
 
-      // A claim carries the active keys of its prefix, and a claimed query is never pending,
+      // A retrieval carries the active keys of its prefix, and a retrieved query is never pending,
       // so it has no place in the queue to report
-      const [active, toProcess] = claim ? [claim[2], undefined] : await queueConnection.getQueryStageState(true);
+      const [active, toProcess] = retrieved ? [retrieved[2], undefined] : await queueConnection.getQueryStageState(true);
 
       this.logger('Waiting for query', {
         ...waitingContext,
@@ -338,7 +338,7 @@ export class QueryQueue {
         toProcessQueryKeys: toProcess,
         active: active.indexOf(queryKeyHash) !== -1,
         queueIndex: toProcess ? toProcess.indexOf(queryKeyHash) : -1,
-        fastTrack: !!claim,
+        fastTrack: !!retrieved,
       });
 
       if (streamWait) {
@@ -367,22 +367,22 @@ export class QueryQueue {
   }
 
   /**
-   * A claim from the queue driver is the same thing `claimQueryForProcessing` produces, it just
-   * came back with the insert instead of a separate retrieval.
+   * A retrieval from the queue driver is the same thing `retrieveQueryForProcessing` produces, it
+   * just came back with the insert instead of a separate retrieval.
    */
-  protected claimedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId | null, claim: RetrieveForProcessingSuccess): ClaimedQuery {
-    const [, claimQueueId, , queueSize, query] = claim;
+  protected retrievedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId | null, retrieved: RetrieveForProcessingSuccess): RetrievedQuery {
+    const [, retrievedQueueId, , queueSize, query] = retrieved;
     // The id identifies the processing lock for every command downstream
-    const claimedQueueId = claimQueueId ?? queueId;
+    const processingQueueId = retrievedQueueId ?? queueId;
 
-    if (claimedQueueId === null) {
-      throw new Error('Queue driver claimed a query without reporting its queue id');
+    if (processingQueueId === null) {
+      throw new Error('Queue driver retrieved a query without reporting its queue id');
     }
 
     return {
       queryKeyHash,
-      queueId: claimedQueueId,
-      processingId: claimedQueueId,
+      queueId: processingQueueId,
+      processingId: processingQueueId,
       queueSize,
       query,
     };
@@ -655,7 +655,7 @@ export class QueryQueue {
         .slice(0, toProcessLimit)
         .map(([queryKey, queueId]) => this.processQuery(queryKey, queueId));
 
-      // Awaits the claim of every picked query, not their execution.
+      // Awaits the retrieval of every picked query, not their execution.
       await Promise.all(tasks);
     } finally {
       this.queueDriver.release(queueConnection);
@@ -800,21 +800,21 @@ export class QueryQueue {
   }
 
   /**
-   * Claims the query specified by the `queryKeyHashed` and hands it over for execution.
+   * Retrieves the query specified by the `queryKeyHashed` and hands it over for execution.
    */
   protected async processQuery(queryKeyHashed: QueryKeyHash, queueId: QueueId | null): Promise<void> {
-    const claimed = await this.claimQueryForProcessing(queryKeyHashed, queueId);
-    if (!claimed) {
+    const retrieved = await this.retrieveQueryForProcessing(queryKeyHashed, queueId);
+    if (!retrieved) {
       return;
     }
 
     try {
-      await this.sendProcessMessageFn(claimed);
+      await this.sendProcessMessageFn(retrieved);
     } catch (e: any) {
       this.logger('Error while sending process message', {
-        queueId: claimed.queueId,
-        queryKey: claimed.query.queryKey,
-        requestId: claimed.query.requestId,
+        queueId: retrieved.queueId,
+        queryKey: retrieved.query.queryKey,
+        requestId: retrieved.query.requestId,
         error: (e.stack || e).toString(),
         queuePrefix: this.redisQueuePrefix
       });
@@ -823,10 +823,10 @@ export class QueryQueue {
 
   /**
    * Acquires the processing lock for the query specified by the `queryKeyHashed` and moves it to
-   * the active set. Returns `null` when the claim didn't succeed, which means another node is
+   * the active set. Returns `null` when the retrieval didn't succeed, which means another node is
    * already running the query or the concurrency budget is full.
    */
-  protected async claimQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId | null): Promise<ClaimedQuery | null> {
+  protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId | null): Promise<RetrievedQuery | null> {
     const queueConnection = await this.queueDriver.createConnection();
 
     let insertedCount;
@@ -906,12 +906,12 @@ export class QueryQueue {
   }
 
   /**
-   * Executes a claimed query: runs its handler while keeping the queue heartbeat alive, then acks
+   * Executes a retrieved query: runs its handler while keeping the queue heartbeat alive, then acks
    * the result. It's the counterpart of `sendProcessMessageFn` and the entry point for a custom
    * implementation which hands the query over to another process.
    */
-  public async executeQuery(claimed: ClaimedQuery): Promise<void> {
-    const { queryKeyHash: queryKeyHashed, queueId, processingId, queueSize, query } = claimed;
+  public async executeQuery(retrieved: RetrievedQuery): Promise<void> {
+    const { queryKeyHash: queryKeyHashed, queueId, processingId, queueSize, query } = retrieved;
 
     const queueConnection = await this.queueDriver.createConnection();
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -269,7 +269,7 @@ export class QueryQueue {
 
       options.orphanedTimeout = query.orphanedTimeout;
 
-      const [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addAndRetrieve(
+      const [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addToQueue(
         queryKey, queryHandler, query, priority, options
       );
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -308,7 +308,7 @@ export class QueryQueue {
 
       if (retrieved) {
         // The item is active already, there is nothing for reconcile to pick up
-        await this.sendProcessMessageFn(this.retrievedQuery(queryKeyHash, queueId, retrieved));
+        await this.dispatchQuery(this.retrievedQuery(queryKeyHash, queueId, retrieved));
       } else {
         await this.reconcileQueue();
       }
@@ -808,10 +808,14 @@ export class QueryQueue {
       return;
     }
 
+    await this.dispatchQuery(retrieved);
+  }
+
+  protected async dispatchQuery(retrieved: RetrievedQuery): Promise<void> {
     try {
       await this.sendProcessMessageFn(retrieved);
     } catch (e: any) {
-      this.logger('Error while sending process message', {
+      this.logger('Error while processing message', {
         queueId: retrieved.queueId,
         queryKey: retrieved.query.queryKey,
         requestId: retrieved.query.requestId,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -8,6 +8,7 @@ import {
   QueryDef,
   QueryStageStateResponse,
   AddToQueueOptions,
+  QueuePriority,
   ProcessingId,
   RetrieveForProcessingSuccess
 } from '@cubejs-backend/base-driver';
@@ -201,7 +202,7 @@ export class QueryQueue {
     queryHandler: string,
     queryKey: QueryKey,
     query: QueryDef,
-    priority?: number,
+    priority: QueuePriority = QueuePriority.Background,
     executeOptions?: ExecuteInQueueOptions,
   ) {
     const options: AddToQueueOptions = {
@@ -243,11 +244,8 @@ export class QueryQueue {
     const queueConnection = await this.queueDriver.createConnection();
     let waitingContext;
     let streamWait: QueryStreamWait | null = null;
-    try {
-      if (priority == null) {
-        priority = 0;
-      }
 
+    try {
       if (!(priority >= -10000 && priority <= 10000)) {
         throw new Error('Priority should be between -10000 and 10000');
       }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -28,7 +28,7 @@ export type QueryHandlersMap = Record<string, QueryHandlerFn>;
 
 export type RetrievedQuery = {
   queryKeyHash: QueryKeyHash;
-  queueId: QueueId | null;
+  queueId: QueueId;
   processingId: ProcessingId;
   queueSize: number;
   query: QueryDef;
@@ -366,23 +366,13 @@ export class QueryQueue {
     }
   }
 
-  /**
-   * A retrieval from the queue driver is the same thing `retrieveQueryForProcessing` produces, it
-   * just came back with the insert instead of a separate retrieval.
-   */
-  protected retrievedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId | null, retrieved: RetrieveForProcessingSuccess): RetrievedQuery {
-    const [, retrievedQueueId, , queueSize, query] = retrieved;
-    // The id identifies the processing lock for every command downstream
-    const processingQueueId = retrievedQueueId ?? queueId;
-
-    if (processingQueueId === null) {
-      throw new Error('Queue driver retrieved a query without reporting its queue id');
-    }
+  protected retrievedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId, retrieved: RetrieveForProcessingSuccess): RetrievedQuery {
+    const [, , , queueSize, query] = retrieved;
 
     return {
       queryKeyHash,
-      queueId: processingQueueId,
-      processingId: processingQueueId,
+      queueId,
+      processingId: queueId,
       queueSize,
       query,
     };

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -8,7 +8,8 @@ import {
   QueryDef,
   QueryStageStateResponse,
   AddToQueueOptions,
-  ProcessingId
+  ProcessingId,
+  RetrieveForProcessingSuccess
 } from '@cubejs-backend/base-driver';
 import { CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
 
@@ -37,6 +38,11 @@ export type SendCancelMessageFn = (query: QueryDef, queueId: QueueId | null) => 
 
 export type ExecuteInQueueOptions = Omit<AddToQueueOptions, 'queueId'> & {
   spanId?: string
+};
+
+export type QueryStreamWait = {
+  promise: Promise<QueryStream | null>,
+  dispose: () => void,
 };
 
 export type QueryQueueOptions = {
@@ -236,6 +242,7 @@ export class QueryQueue {
 
     const queueConnection = await this.queueDriver.createConnection();
     let waitingContext;
+    let streamWait: QueryStreamWait | null = null;
     try {
       if (priority == null) {
         priority = 0;
@@ -268,9 +275,20 @@ export class QueryQueue {
       const orphanedTimeout = 'orphanedTimeout' in query ? query.orphanedTimeout : this.orphanedTimeout;
       const orphanedTime = time + (orphanedTimeout * 1000);
 
-      const [added, queueId, queueSize, addedToQueueTime] = await queueConnection.addToQueue(
-        keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
-      );
+      const addArgs = [keyScore, queryKey, orphanedTime, queryHandler, query, priority, options] as const;
+
+      let added: number;
+      let queueId: QueueId | null;
+      let queueSize: number;
+      let addedToQueueTime: number;
+      let claim: RetrieveForProcessingSuccess | null = null;
+
+      // The env is read per call on purpose, a queue outlives changes of it
+      if (getEnv('queueFastTrack')) {
+        [added, queueId, queueSize, addedToQueueTime, claim] = await queueConnection.addAndRetrieve(...addArgs);
+      } else {
+        [added, queueId, queueSize, addedToQueueTime] = await queueConnection.addToQueue(...addArgs);
+      }
 
       if (added > 0) {
         waitingContext = {
@@ -297,13 +315,25 @@ export class QueryQueue {
           preAggregation: query.preAggregation,
           addedToQueueTime,
           persistent: !!queryKey.persistent,
+          fastTrack: !!claim,
         });
       }
 
-      await this.reconcileQueue();
+      // Subscribing after the dispatch would lose the `streamStarted` event of a handler
+      // which starts fast
+      if (queryHandler === 'stream') {
+        streamWait = this.waitForQueryStream(queryKeyHash);
+      }
+
+      if (claim) {
+        // The item is active and owned by us already, there is nothing for reconcile to pick up
+        await this.sendProcessMessageFn(this.claimedQuery(queryKeyHash, queueId, claim));
+      } else {
+        await this.reconcileQueue();
+      }
 
       if (!added) {
-        const queryDef = await queueConnection.getQueryDef(queryKeyHash, queueId);
+        const queryDef = claim ? claim[4] : await queueConnection.getQueryDef(queryKeyHash, queueId);
         if (queryDef) {
           waitingContext = {
             queueId,
@@ -316,7 +346,9 @@ export class QueryQueue {
         }
       }
 
-      const [active, toProcess] = await queueConnection.getQueryStageState(true);
+      // A claim carries the active keys of its prefix, and a claimed query is never pending,
+      // so it has no place in the queue to report
+      const [active, toProcess] = claim ? [claim[2], undefined] : await queueConnection.getQueryStageState(true);
 
       this.logger('Waiting for query', {
         ...waitingContext,
@@ -324,44 +356,12 @@ export class QueryQueue {
         activeQueryKeys: active,
         toProcessQueryKeys: toProcess,
         active: active.indexOf(queryKeyHash) !== -1,
-        queueIndex: toProcess.indexOf(queryKeyHash),
+        queueIndex: toProcess ? toProcess.indexOf(queryKeyHash) : -1,
+        fastTrack: !!claim,
       });
 
-      // Stream processing goes here under assumption there's no way of a stream close just after it was added to the `streams` map.
-      // Otherwise `streamStarted` event listener should go before the `reconcileQueue` call.
-      // TODO: Fix an issue with a fast execution of stream handler which caused by removal of QueryStream from streams,
-      // while EventListener doesnt start to listen for started stream event
-      if (queryHandler === 'stream') {
-        const self = this;
-        result = await new Promise((resolve) => {
-          let timeoutTimerId = null;
-
-          const onStreamStarted = (streamStartedHash) => {
-            if (streamStartedHash === queryKeyHash) {
-              if (timeoutTimerId) {
-                clearTimeout(timeoutTimerId);
-              }
-
-              resolve(self.getQueryStream(queryKeyHash));
-            }
-          };
-
-          self.streamEvents.addListener('streamStarted', onStreamStarted);
-
-          const stream = this.getQueryStream(queryKeyHash);
-          if (stream) {
-            self.streamEvents.removeListener('streamStarted', onStreamStarted);
-            resolve(stream);
-          } else {
-            timeoutTimerId = setTimeout(
-              () => {
-                self.streamEvents.removeListener('streamStarted', onStreamStarted);
-                resolve(null);
-              },
-              this.continueWaitTimeout * 10000
-            );
-          }
-        });
+      if (streamWait) {
+        result = await streamWait.promise;
       } else {
         // Result here won't be fetched for a jobed build query (initialized by
         // the /cubejs-system/v1/pre-aggregations/jobs endpoint).
@@ -380,8 +380,84 @@ export class QueryQueue {
       }
       throw error;
     } finally {
+      streamWait?.dispose();
       this.queueDriver.release(queueConnection);
     }
+  }
+
+  /**
+   * A claim from the queue driver is the same thing `claimQueryForProcessing` produces, it just
+   * came back with the insert instead of a separate retrieval.
+   */
+  protected claimedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId | null, claim: RetrieveForProcessingSuccess): ClaimedQuery {
+    const [, claimQueueId, , queueSize, query] = claim;
+    // A driver which claims an item reports the id of it, which is what identifies the
+    // processing lock for every command downstream
+    const claimedQueueId = claimQueueId ?? queueId;
+
+    if (claimedQueueId === null) {
+      throw new Error('Queue driver claimed a query without reporting its queue id');
+    }
+
+    return {
+      queryKeyHash,
+      queueId: claimedQueueId,
+      processingId: claimedQueueId,
+      queueSize,
+      query,
+    };
+  }
+
+  /**
+   * Subscribes to the stream of the specified query, the returned promise resolves with the
+   * stream or with `null` on a timeout. `dispose` releases the listener and the timer, it's
+   * a no-op once the promise has been resolved.
+   */
+  protected waitForQueryStream(queryKeyHash: QueryKeyHash): QueryStreamWait {
+    let timeoutTimerId: ReturnType<typeof setTimeout> | null = null;
+    let onStreamStarted: ((streamStartedHash: QueryKeyHash) => void) | null = null;
+
+    const dispose = () => {
+      if (timeoutTimerId) {
+        clearTimeout(timeoutTimerId);
+        timeoutTimerId = null;
+      }
+
+      if (onStreamStarted) {
+        this.streamEvents.removeListener('streamStarted', onStreamStarted);
+        onStreamStarted = null;
+      }
+    };
+
+    const promise = new Promise<QueryStream | null>((resolve) => {
+      onStreamStarted = (streamStartedHash) => {
+        if (streamStartedHash === queryKeyHash) {
+          dispose();
+
+          resolve(this.getQueryStream(queryKeyHash) ?? null);
+        }
+      };
+
+      this.streamEvents.addListener('streamStarted', onStreamStarted);
+
+      const stream = this.getQueryStream(queryKeyHash);
+      if (stream) {
+        dispose();
+
+        resolve(stream);
+      } else {
+        timeoutTimerId = setTimeout(
+          () => {
+            dispose();
+
+            resolve(null);
+          },
+          this.continueWaitTimeout * 10000
+        );
+      }
+    });
+
+    return { promise, dispose };
   }
 
   /**

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -73,7 +73,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       await options.beforeAll();
     }
 
-    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number }) => {
+    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number, priority: number }) => {
       const counters = {
         connections: 0,
         methods: {},
@@ -270,7 +270,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
                 large_str: 'a'.repeat(benchSettings.queuePayloadSize)
               },
               orphanedTimeout: 120
-            }, 1, {
+            }, benchSettings.priority, {
               stageQueryKey: 1,
               requestId: 'request-id',
               spanId: 'span-id'
@@ -326,6 +326,8 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       currency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
       totalQueries,
       pushIntervalMs: periodMs > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
+      // the fast track only takes queries at priority 10 and above
+      priority: parseInt(process.env.BENCH_PRIORITY || '10', 10),
       // eslint-disable-next-line no-bitwise
       queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
       queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import path from 'path';
 import { ChildProcess, fork } from 'child_process';
 import { createPromiseLock, MethodName, pausePromise } from '@cubejs-backend/shared';
-import { QueueDriverConnectionInterface, QueueDriverInterface, } from '@cubejs-backend/base-driver';
+import { QueueDriverConnectionInterface, QueueDriverInterface, QueuePriority } from '@cubejs-backend/base-driver';
 import { LocalQueueDriver, QueryQueue, QueryQueueOptions } from '../../src';
 
 export type QueryQueueTestOptions = Pick<QueryQueueOptions, 'cacheAndQueueDriver' | 'cubeStoreDriverFactory'> & {
@@ -73,7 +73,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       await options.beforeAll();
     }
 
-    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number, priority: number }) => {
+    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number, priority: QueuePriority }) => {
       const counters = {
         connections: 0,
         methods: {},
@@ -326,8 +326,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       currency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
       totalQueries,
       pushIntervalMs: periodMs > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
-      // the fast track only takes queries at priority 10 and above
-      priority: parseInt(process.env.BENCH_PRIORITY || '10', 10),
+      priority: parseInt(process.env.BENCH_PRIORITY || `${QueuePriority.Interactive}`, 10),
       // eslint-disable-next-line no-bitwise
       queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
       queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -318,11 +318,11 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
     };
 
     await createBenchmark({
-      currency: 50,
-      totalQueries: 1_000,
+      currency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
+      totalQueries: parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10),
       // eslint-disable-next-line no-bitwise
-      queueResponseSize: 5 << 20,
-      queuePayloadSize: 256 * 1024,
+      queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
+      queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),
     });
 
     if (options.afterAll) {

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -73,7 +73,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       await options.beforeAll();
     }
 
-    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number }) => {
+    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number }) => {
       const counters = {
         connections: 0,
         methods: {},
@@ -287,7 +287,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
 
         processingPromisses.push(running);
         await running;
-      }, 10);
+      }, benchSettings.pushIntervalMs);
 
       await lock.promise;
       await awaitProcessing();
@@ -317,9 +317,15 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       }, { depth: null });
     };
 
+    const totalQueries = parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10);
+    // BENCH_PERIOD_MS spreads the queries evenly over that window instead of pushing them
+    // as fast as the loop allows, which is what decides whether the queue ever backlogs
+    const periodMs = parseInt(process.env.BENCH_PERIOD_MS || '0', 10);
+
     await createBenchmark({
       currency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
-      totalQueries: parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10),
+      totalQueries,
+      pushIntervalMs: periodMs > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
       // eslint-disable-next-line no-bitwise
       queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
       queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -426,7 +426,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         // only the call order pins it down
         expect(streamCallOrder).toContain('subscribe');
         expect(streamCallOrder).toContain('dispatch');
-        expect(streamCallOrder.indexOf('subscribe')).toBeLessThan(streamCallOrder.indexOf('dispatch'));
+        expect(streamCallOrder).toEqual(['subscribe', 'dispatch']);
       } finally {
         spy.mockRestore();
       }

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream';
 import crypto from 'crypto';
 
 import type { QueryKey, QueueDriverInterface } from '@cubejs-backend/base-driver';
+import { QueuePriority } from '@cubejs-backend/base-driver';
 import { pausePromise } from '@cubejs-backend/shared';
 import { CubeStoreDriver, CubestoreQueueDriverConnection } from '@cubejs-backend/cubestore-driver';
 
@@ -142,9 +143,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
     test('priority', async () => {
       const result = await Promise.all([
-        queue.executeInQueue('delay', '11', { delay: 600, result: '1' }, 1),
-        queue.executeInQueue('delay', '12', { delay: 100, result: '2' }, 0),
-        queue.executeInQueue('delay', '13', { delay: 100, result: '3' }, 10)
+        queue.executeInQueue('delay', '11', { delay: 600, result: '1' }, QueuePriority.Warmup),
+        queue.executeInQueue('delay', '12', { delay: 100, result: '2' }, QueuePriority.Background),
+        queue.executeInQueue('delay', '13', { delay: 100, result: '3' }, QueuePriority.Interactive)
       ]);
       expect(parseInt(result.find(f => f[0] === '3'), 10) % 10).toBeLessThan(2);
     });
@@ -184,7 +185,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     });
 
     test('stage reporting', async () => {
-      const resultPromise = queue.executeInQueue('delay', '1', { delay: 200, result: '1' }, 0, {
+      const resultPromise = queue.executeInQueue('delay', '1', { delay: 200, result: '1' }, QueuePriority.Background, {
         stageQueryKey: '1',
         requestId: '9f056234-aa57-4702-ab30-145221da6a46-span-1',
         spanId: 'span-id'
@@ -196,13 +197,13 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     });
 
     test('priority stage reporting', async () => {
-      const resultPromise1 = queue.executeInQueue('delay', '31', { delay: 200, result: '1' }, 20, {
+      const resultPromise1 = queue.executeInQueue('delay', '31', { delay: 200, result: '1' }, QueuePriority.Interactive + 10, {
         stageQueryKey: '12',
         requestId: '4274691a-5f4c-480e-89c4-d2b9d989891c-span-1',
         spanId: 'span-id'
       });
       await delayFn(null, 50);
-      const resultPromise2 = queue.executeInQueue('delay', '32', { delay: 200, result: '1' }, 10, {
+      const resultPromise2 = queue.executeInQueue('delay', '32', { delay: 200, result: '1' }, QueuePriority.Interactive, {
         stageQueryKey: '12',
         requestId: '000bce99-b987-4649-ae5e-1178532929f5-span-1',
         spanId: 'span-id'
@@ -217,19 +218,21 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
     test('negative priority', async () => {
       const results = [];
+      // The open range between the named rungs, which is what a scheduled refresh computes
+      const priority = (value: number): QueuePriority => value;
 
-      queue.executeInQueue('delay', '31', { delay: 400, result: '4' }, -10);
+      queue.executeInQueue('delay', '31', { delay: 400, result: '4' }, priority(-10));
 
       await delayFn(null, 200);
 
       await Promise.all([
-        queue.executeInQueue('delay', '32', { delay: 100, result: '3' }, -9).then(r => {
+        queue.executeInQueue('delay', '32', { delay: 100, result: '3' }, priority(-9)).then(r => {
           results.push(['32', r]);
         }),
-        queue.executeInQueue('delay', '33', { delay: 100, result: '2' }, -8).then(r => {
+        queue.executeInQueue('delay', '33', { delay: 100, result: '2' }, priority(-8)).then(r => {
           results.push(['33', r]);
         }),
-        queue.executeInQueue('delay', '34', { delay: 100, result: '1' }, -7).then(r => {
+        queue.executeInQueue('delay', '34', { delay: 100, result: '1' }, priority(-7)).then(r => {
           results.push(['34', r]);
         })
       ]);
@@ -242,10 +245,10 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     });
 
     test('sequence', async () => {
-      const p1 = queue.executeInQueue('delay', '111', { delay: 50, result: '1' }, 0);
-      const p2 = delayFn(null, 50).then(() => queue.executeInQueue('delay', '112', { delay: 50, result: '2' }, 0));
-      const p3 = delayFn(null, 75).then(() => queue.executeInQueue('delay', '113', { delay: 50, result: '3' }, 0));
-      const p4 = delayFn(null, 100).then(() => queue.executeInQueue('delay', '114', { delay: 50, result: '4' }, 0));
+      const p1 = queue.executeInQueue('delay', '111', { delay: 50, result: '1' }, QueuePriority.Background);
+      const p2 = delayFn(null, 50).then(() => queue.executeInQueue('delay', '112', { delay: 50, result: '2' }, QueuePriority.Background));
+      const p3 = delayFn(null, 75).then(() => queue.executeInQueue('delay', '113', { delay: 50, result: '3' }, QueuePriority.Background));
+      const p4 = delayFn(null, 100).then(() => queue.executeInQueue('delay', '114', { delay: 50, result: '4' }, QueuePriority.Background));
 
       const result = await Promise.all([p1, p2, p3, p4]);
       expect(result).toEqual(['10', '21', '32', '43']);
@@ -260,14 +263,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       // orphaned set themselves: the memory driver reports active queries as orphaned once
       // their timeout passes, Cube Store does not.
       const pending = [
-        queue.executeInQueue('delay', '121', { delay: 1200, result: '1', orphanedTimeout: 60 }, 0).catch(e => e),
+        queue.executeInQueue('delay', '121', { delay: 1200, result: '1', orphanedTimeout: 60 }, QueuePriority.Background).catch(e => e),
       ];
       await delayFn(null, 50);
-      pending.push(queue.executeInQueue('delay', '122', { delay: 1200, result: '2', orphanedTimeout: 60 }, 0).catch(e => e));
+      pending.push(queue.executeInQueue('delay', '122', { delay: 1200, result: '2', orphanedTimeout: 60 }, QueuePriority.Background).catch(e => e));
       await delayFn(null, 50);
       // 121 and 122 keep the worker busy for ~2.4s, so this one is still queued when its
       // 1s orphaned timeout expires
-      pending.push(queue.executeInQueue('delay', '123', { delay: 50, result: '3', orphanedTimeout: 1 }, 0).catch(e => e));
+      pending.push(queue.executeInQueue('delay', '123', { delay: 50, result: '3', orphanedTimeout: 1 }, QueuePriority.Background).catch(e => e));
 
       // Reconciliation is what cancels orphaned queries and nothing else triggers it while
       // the worker is busy.
@@ -287,7 +290,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       // 123 was cancelled before the worker could pick it up
       expect(delayCount).toBe(2);
       // cancellation removed it from the queue, so the same key can be queued again
-      expect(await queue.executeInQueue('delay', '123', { delay: 50, result: '3' }, 0)).toBe('32');
+      expect(await queue.executeInQueue('delay', '123', { delay: 50, result: '3' }, QueuePriority.Background)).toBe('32');
     });
 
     test('orphaned with custom ttl', async () => {
@@ -531,12 +534,12 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         // Two clients execute the same query concurrently with different requestIds.
         // delay=1500ms > continueWaitTimeout=1s, so both will get ContinueWaitError.
         const clientA = queue
-          .executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+          .executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
             stageQueryKey: query, requestId: '70b0b0a6-60ff-43ee-95ca-b5a3d864879f-span-1', spanId: 'span-A'
           })
           .catch(e => e);
         const clientB = queue
-          .executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+          .executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
             stageQueryKey: query, requestId: '8030e1f2-5e14-4241-9481-46e34d478131-span-1', spanId: 'span-B'
           })
           .catch(e => e);
@@ -550,10 +553,10 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         // Both clients retry (with new span suffix, same UUID prefix).
         // Both should find the existing result without triggering re-execution.
         const [resultA, resultB] = await Promise.all([
-          queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+          queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
             stageQueryKey: query, requestId: '70b0b0a6-60ff-43ee-95ca-b5a3d864879f-span-2', spanId: 'span-A2'
           }),
-          queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+          queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
             stageQueryKey: query, requestId: '8030e1f2-5e14-4241-9481-46e34d478131-span-2', spanId: 'span-B2'
           }),
         ]);
@@ -582,7 +585,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         while (Date.now() < deadline) {
           try {
-            result = await queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+            result = await queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
               stageQueryKey: query,
               requestId: `${requestUuid}-span-${spanCounter++}`,
               spanId: `span-${spanCounter}`,
@@ -604,7 +607,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         // CubeStore supports read-many via external_id, so the result should
         // still be available. Local driver consumes the result on first read.
         if (options.cacheAndQueueDriver === 'cubestore') {
-          const secondResult = await queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, 0, {
+          const secondResult = await queue.executeInQueue('delay', query, { delay: 1500, result: '1' }, QueuePriority.Background, {
             stageQueryKey: query,
             requestId: `${requestUuid}-span-${spanCounter++}`,
             spanId: `span-${spanCounter}`,
@@ -633,7 +636,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         try {
           const query: QueryKey = ['select * from fast_track', []];
-          const result = await queue.executeInQueue('foo', query, query, 10);
+          const result = await queue.executeInQueue('foo', query, query, QueuePriority.Interactive);
 
           expect(result).toBe('select * from fast_track bar');
           expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(true);
@@ -649,8 +652,8 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       test('concurrent clients execute the query once', async () => {
         const results = await Promise.all([
-          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, 10),
-          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, 10)
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, QueuePriority.Interactive),
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, QueuePriority.Interactive)
         ]);
 
         expect(results).toStrictEqual(['20', '20']);
@@ -662,7 +665,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         try {
           const query: QueryKey = ['select * from slow_track', []];
-          const result = await queue.executeInQueue('foo', query, query, 9);
+          const result = await queue.executeInQueue('foo', query, query, QueuePriority.Interactive - 1);
 
           expect(result).toBe('select * from slow_track bar');
           expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(false);
@@ -680,7 +683,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           queryKey,
           'delay',
           { isJob: true, orphanedTimeout: undefined },
-          10,
+          QueuePriority.Interactive,
           { queueId, stageQueryKey: `${queueId}`, requestId: `${queueId}` }
         );
 

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -753,6 +753,30 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           queue.queueDriver.release(connection);
         }
       });
+
+      test('a failing dispatch does not surface to the client', async () => {
+        const query: QueryKey = ['select * from dispatch_failure', []];
+        const connection = await queue.queueDriver.createConnection();
+        // The retrieval already made the item active, so a throwing dispatch must be logged and
+        // left to the heartbeat reclaim rather than failing the request the way `processQuery`
+        // would never fail it
+        const sendProcessMessage = jest.spyOn(queue as any, 'sendProcessMessageFn')
+          .mockRejectedValueOnce(new Error('the worker is gone'));
+
+        try {
+          await expect(
+            queue.executeInQueue('foo', query, query, QueuePriority.Interactive)
+          ).rejects.toBeInstanceOf(ContinueWaitError);
+
+          expect(logger.mock.calls.map(([message]) => message)).toContain('Error while processing message');
+        } finally {
+          sendProcessMessage.mockRestore();
+          // The reclaim only comes after heartBeatTimeout, too late for the suite to wait for
+          await connection.getQueryAndRemove(connection.redisHash(query), null);
+
+          queue.queueDriver.release(connection);
+        }
+      });
     });
   });
 };

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -296,12 +296,11 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       try {
         const priority = 10;
         const time = new Date().getTime();
-        const keyScore = time + (10000 - priority) * 1E14;
 
         expect(await connection.getOrphanedQueries()).toEqual([]);
 
         let orphanedTimeout = 2;
-        await connection.addToQueue(keyScore, ['1', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['1', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 1,
           stageQueryKey: '1',
           requestId: '1',
@@ -312,7 +311,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         orphanedTimeout = 60;
 
-        await connection.addToQueue(keyScore, ['2', []], time + (orphanedTimeout * 1000), 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
+        await connection.addToQueue(['2', []], 'delay', { isJob: true, orphanedTimeout: time, }, priority, {
           queueId: 2,
           stageQueryKey: '2',
           requestId: '2',
@@ -408,21 +407,16 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const query: QueryKey = ['select * from add_and_retrieve', []];
 
       try {
-        const priority = 10;
-        const time = new Date().getTime();
         const [added, , , , claim] = await connection.addAndRetrieve(
-          time + (10000 - priority) * 1E14,
           query,
-          time + 2000,
           'delay',
           { isJob: true, orphanedTimeout: undefined },
-          priority,
+          10,
           { queueId: 1, stageQueryKey: '1', requestId: '1' }
         );
 
         expect(added).toBe(1);
         expect(claim).toBeNull();
-        // Nothing was claimed, so the item is left for reconcile to pick up
         expect(await connection.getToProcessQueries()).toStrictEqual([
           [connection.redisHash(query), expect.any(Number)]
         ]);
@@ -437,17 +431,15 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const connection: any = await queue.queueDriver.createConnection();
       const connection2: any = await queue.queueDriver.createConnection();
       const priority = 10;
-      const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
 
       await queue.reconcileQueue();
 
       await connection.addToQueue(
-        keyScore, 'race', time, 'handler', ['select'], priority, { stageQueryKey: 'race' }
+        'race', 'handler', ['select'], priority, { stageQueryKey: 'race' }
       );
 
       await connection.addToQueue(
-        keyScore + 100, 'race2', time + 100, 'handler2', ['select2'], priority, { stageQueryKey: 'race2' }
+        'race2', 'handler2', ['select2'], priority, { stageQueryKey: 'race2' }
       );
 
       const processingId1 = await connection.getNextProcessingId();
@@ -474,17 +466,15 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const connection = await queue.queueDriver.createConnection();
       const connection2 = await queue.queueDriver.createConnection();
       const priority = 10;
-      const time = new Date().getTime();
-      const keyScore = time + (10000 - priority) * 1E14;
 
       await queue.reconcileQueue();
 
       await connection.addToQueue(
-        keyScore, 'activated1', time, 'handler', <any>['select'], priority, { stageQueryKey: 'race', requestId: '1' }
+        'activated1', 'handler', <any>['select'], priority, { stageQueryKey: 'race', requestId: '1' }
       );
 
       await connection.addToQueue(
-        keyScore + 100, 'activated2', time + 100, 'handler2', <any>['select2'], priority, { stageQueryKey: 'race2', requestId: '1' }
+        'activated2', 'handler2', <any>['select2'], priority, { stageQueryKey: 'race2', requestId: '1' }
       );
 
       const processingId1 = await connection.getNextProcessingId();
@@ -647,8 +637,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
           expect(result).toBe('select * from fast_track bar');
           expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(true);
-          // The claim came with the response of QUEUE ADD_AND_RETRIEVE, so there was
-          // nothing left to retrieve
+          // The claim came with the insert, there was nothing left to retrieve
           expect(retrieveForProcessing).not.toHaveBeenCalled();
           // The claim carries the processing identity, the acknowledgement must be accepted
           expect(logger.mock.calls.map(([message]) => message)).not.toContain('Orphaned execution result');
@@ -672,20 +661,13 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         const connection = await queue.queueDriver.createConnection();
         const first: QueryKey = ['select * from budget_1', []];
         const second: QueryKey = ['select * from budget_2', []];
-        const addAndRetrieve = (queryKey: QueryKey, queueId: number) => {
-          const priority = 10;
-          const time = new Date().getTime();
-
-          return connection.addAndRetrieve(
-            time + (10000 - priority) * 1E14,
-            queryKey,
-            time + 2000,
-            'delay',
-            { isJob: true, orphanedTimeout: undefined },
-            priority,
-            { queueId, stageQueryKey: `${queueId}`, requestId: `${queueId}` }
-          );
-        };
+        const addAndRetrieve = (queryKey: QueryKey, queueId: number) => connection.addAndRetrieve(
+          queryKey,
+          'delay',
+          { isJob: true, orphanedTimeout: undefined },
+          10,
+          { queueId, stageQueryKey: `${queueId}`, requestId: `${queueId}` }
+        );
 
         try {
           // concurrency is 1, the first query takes the only slot

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -42,6 +42,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     const processMessagePromises: Promise<any>[] = [];
     const processCancelPromises: Promise<any>[] = [];
     let cancelledQuery;
+    let streamCallOrder: string[] = [];
 
     const tenantPrefix = crypto.randomBytes(6).toString('hex');
 
@@ -71,6 +72,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         });
       },
       sendProcessMessageFn: async (retrieved) => {
+        streamCallOrder.push('dispatch');
         processMessagePromises.push(queue.executeQuery(retrieved));
       },
       sendCancelMessageFn: async (query) => {
@@ -108,6 +110,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       delayCount = 0;
       streamCount = 0;
       streamHandlerDelay = 250;
+      streamCallOrder = [];
     });
 
     afterAll(async () => {
@@ -386,15 +389,47 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       const stream = await queue.executeInQueue('stream', key, { aliasNameToMember: {} }, 0);
       await awaitProcessing();
 
-      // The handler can emit `streamStarted` and finish before executeInQueue awaits for
-      // it, which is safe only because the listener is subscribed before the dispatch
-      expect(stream).toBeDefined();
-
+      // A stream which never arrived surfaces as a ContinueWaitError out of executeInQueue,
+      // so reaching this line is already the assertion
       for await (const chunk of stream) {
         console.log('streaming chunk: ', chunk);
       }
 
       expect(streamCount).toEqual(1);
+    });
+
+    test('the stream listener is subscribed before the dispatch', async () => {
+      streamHandlerDelay = 0;
+
+      const proto = QueryQueue.prototype as any;
+      const { waitForQueryStream } = proto;
+      const spy = jest.spyOn(proto, 'waitForQueryStream').mockImplementation(
+        function subscribeAndRecord(this: unknown, ...args: unknown[]) {
+          streamCallOrder.push('subscribe');
+
+          return waitForQueryStream.apply(this, args);
+        }
+      );
+
+      try {
+        const key: QueryKey = ['select * from table_ordering', []];
+        key.persistent = true;
+        const stream = await queue.executeInQueue('stream', key, { aliasNameToMember: {} }, QueuePriority.Background);
+        await awaitProcessing();
+
+        for await (const chunk of stream) {
+          console.log('streaming chunk: ', chunk);
+        }
+
+        // Subscribing after the dispatch loses the `streamStarted` event of a handler which
+        // starts fast. It is masked by the `streams` map fallback in waitForQueryStream, so
+        // only the call order pins it down
+        expect(streamCallOrder).toContain('subscribe');
+        expect(streamCallOrder).toContain('dispatch');
+        expect(streamCallOrder.indexOf('subscribe')).toBeLessThan(streamCallOrder.indexOf('dispatch'));
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     test('removed before reconciled', async () => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 
 import type { QueryKey, QueueDriverInterface } from '@cubejs-backend/base-driver';
 import { pausePromise } from '@cubejs-backend/shared';
-import { CubestoreQueueDriverConnection } from '@cubejs-backend/cubestore-driver';
+import { CubeStoreDriver, CubestoreQueueDriverConnection } from '@cubejs-backend/cubestore-driver';
 
 import { QueryQueue, QueryQueueOptions } from '../../src';
 import { ContinueWaitError } from '../../src/orchestrator/ContinueWaitError';
@@ -35,6 +35,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
     let delayCount = 0;
     let streamCount = 0;
+    // A cushion which keeps the order of the log calls deterministic for the tests which
+    // assert on it, a handler without it completes while executeInQueue is still logging
+    let streamHandlerDelay = 250;
     const processMessagePromises: Promise<any>[] = [];
     const processCancelPromises: Promise<any>[] = [];
     let cancelledQuery;
@@ -54,9 +57,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       streamHandler: async (query, stream) => {
         streamCount++;
 
-        // TODO: Fix an issue with a fast execution of stream handler which caused by removal of QueryStream from streams,
-        // while EventListener doesnt start to listen for started stream event
-        await pausePromise(250);
+        if (streamHandlerDelay) {
+          await pausePromise(streamHandlerDelay);
+        }
 
         return new Promise((resolve, reject) => {
           const readable = Readable.from([]);
@@ -103,6 +106,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       logger.mockClear();
       delayCount = 0;
       streamCount = 0;
+      streamHandlerDelay = 250;
     });
 
     afterAll(async () => {
@@ -372,12 +376,61 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(logger.mock.calls[logger.mock.calls.length - 1][0]).toEqual('Performing query completed');
     });
 
+    test('stream handler which starts immediately', async () => {
+      streamHandlerDelay = 0;
+
+      const key: QueryKey = ['select * from table_no_delay', []];
+      key.persistent = true;
+      const stream = await queue.executeInQueue('stream', key, { aliasNameToMember: {} }, 0);
+      await awaitProcessing();
+
+      // The handler can emit `streamStarted` and finish before executeInQueue awaits for
+      // it, which is safe only because the listener is subscribed before the dispatch
+      expect(stream).toBeDefined();
+
+      for await (const chunk of stream) {
+        console.log('streaming chunk: ', chunk);
+      }
+
+      expect(streamCount).toEqual(1);
+    });
+
     test('removed before reconciled', async () => {
       const query: QueryKey = ['select * from', []];
       const key = queue.redisHash(query);
       await queue.processQuery(key, null);
       const result = await queue.executeInQueue('foo', key, query);
       expect(result).toBe('select * from bar');
+    });
+
+    onlyLocalTest('addAndRetrieve never claims in memory', async () => {
+      const connection = await queue.queueDriver.createConnection();
+      const query: QueryKey = ['select * from add_and_retrieve', []];
+
+      try {
+        const priority = 10;
+        const time = new Date().getTime();
+        const [added, , , , claim] = await connection.addAndRetrieve(
+          time + (10000 - priority) * 1E14,
+          query,
+          time + 2000,
+          'delay',
+          { isJob: true, orphanedTimeout: undefined },
+          priority,
+          { queueId: 1, stageQueryKey: '1', requestId: '1' }
+        );
+
+        expect(added).toBe(1);
+        expect(claim).toBeNull();
+        // Nothing was claimed, so the item is left for reconcile to pick up
+        expect(await connection.getToProcessQueries()).toStrictEqual([
+          [connection.redisHash(query), expect.any(Number)]
+        ]);
+      } finally {
+        await connection.getQueryAndRemove(connection.redisHash(query), null);
+
+        queue.queueDriver.release(connection);
+      }
     });
 
     onlyLocalTest('queue driver lock obtain race condition', async () => {
@@ -570,6 +623,101 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           expect(delayCount).toBe(1);
         }
       }, 30000);
+    });
+
+    // eslint-disable-next-line no-unused-expressions
+    options.cacheAndQueueDriver === 'cubestore' && describe('with CUBEJS_QUEUE_FAST_TRACK enabled', () => {
+      jest.setTimeout(10 * 1000);
+
+      beforeAll(() => {
+        process.env.CUBEJS_QUEUE_FAST_TRACK = 'true';
+      });
+
+      afterAll(() => {
+        delete process.env.CUBEJS_QUEUE_FAST_TRACK;
+      });
+
+      test('an idle queue claims the query on add', async () => {
+        const retrieveForProcessing = jest.spyOn(CubestoreQueueDriverConnection.prototype, 'retrieveForProcessing');
+        const driverQuery = jest.spyOn(CubeStoreDriver.prototype, 'query');
+
+        try {
+          const query: QueryKey = ['select * from fast_track', []];
+          const result = await queue.executeInQueue('foo', query, query);
+
+          expect(result).toBe('select * from fast_track bar');
+          expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(true);
+          // The claim came with the response of QUEUE ADD_AND_RETRIEVE, so there was
+          // nothing left to retrieve
+          expect(retrieveForProcessing).not.toHaveBeenCalled();
+          // The claim carries the processing identity, the acknowledgement must be accepted
+          expect(logger.mock.calls.map(([message]) => message)).not.toContain('Orphaned execution result');
+        } finally {
+          retrieveForProcessing.mockRestore();
+          driverQuery.mockRestore();
+        }
+      });
+
+      test('concurrent clients execute the query once', async () => {
+        const results = await Promise.all([
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }),
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' })
+        ]);
+
+        expect(results).toStrictEqual(['20', '20']);
+        expect(delayCount).toBe(1);
+      });
+
+      test('a claim is not given out while the concurrency budget is taken', async () => {
+        const connection = await queue.queueDriver.createConnection();
+        const first: QueryKey = ['select * from budget_1', []];
+        const second: QueryKey = ['select * from budget_2', []];
+        const addAndRetrieve = (queryKey: QueryKey, queueId: number) => {
+          const priority = 10;
+          const time = new Date().getTime();
+
+          return connection.addAndRetrieve(
+            time + (10000 - priority) * 1E14,
+            queryKey,
+            time + 2000,
+            'delay',
+            { isJob: true, orphanedTimeout: undefined },
+            priority,
+            { queueId, stageQueryKey: `${queueId}`, requestId: `${queueId}` }
+          );
+        };
+
+        try {
+          // concurrency is 1, the first query takes the only slot
+          const [added1, , , , claim1] = await addAndRetrieve(first, 1);
+          expect(added1).toBe(1);
+          expect(claim1?.[5]).toBe(true);
+          expect(claim1?.[4].queryKey).toStrictEqual(first);
+
+          // an active item is never claimed twice
+          const [added1again, , , , claim1again] = await addAndRetrieve(first, 1);
+          expect(added1again).toBe(0);
+          expect(claim1again).toBeNull();
+
+          const [added2, , , , claim2] = await addAndRetrieve(second, 2);
+          expect(added2).toBe(1);
+          expect(claim2).toBeNull();
+
+          // A claimed item goes straight to active and never becomes pending, the one
+          // which was not claimed is left for reconcile to pick up by priority
+          expect(await connection.getActiveQueries()).toStrictEqual([
+            [connection.redisHash(first), expect.any(Number)]
+          ]);
+          expect(await connection.getToProcessQueries()).toStrictEqual([
+            [connection.redisHash(second), expect.any(Number)]
+          ]);
+        } finally {
+          await connection.getQueryAndRemove(connection.redisHash(first), null);
+          await connection.getQueryAndRemove(connection.redisHash(second), null);
+
+          queue.queueDriver.release(connection);
+        }
+      });
     });
   });
 };

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -633,7 +633,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         try {
           const query: QueryKey = ['select * from fast_track', []];
-          const result = await queue.executeInQueue('foo', query, query);
+          const result = await queue.executeInQueue('foo', query, query, 10);
 
           expect(result).toBe('select * from fast_track bar');
           expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(true);
@@ -649,12 +649,27 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       test('concurrent clients execute the query once', async () => {
         const results = await Promise.all([
-          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }),
-          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' })
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, 10),
+          queue.executeInQueue('delay', 'fast_track_concurrent', { delay: 400, result: '2' }, 10)
         ]);
 
         expect(results).toStrictEqual(['20', '20']);
         expect(delayCount).toBe(1);
+      });
+
+      test('a background priority query takes the normal path', async () => {
+        const driverQuery = jest.spyOn(CubeStoreDriver.prototype, 'query');
+
+        try {
+          const query: QueryKey = ['select * from slow_track', []];
+          const result = await queue.executeInQueue('foo', query, query, 9);
+
+          expect(result).toBe('select * from slow_track bar');
+          expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(false);
+          expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD PRIORITY'))).toBe(true);
+        } finally {
+          driverQuery.mockRestore();
+        }
       });
 
       test('a claim is not given out while the concurrency budget is taken', async () => {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -70,8 +70,8 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           readable.pipe(stream);
         });
       },
-      sendProcessMessageFn: async (claimed) => {
-        processMessagePromises.push(queue.executeQuery(claimed));
+      sendProcessMessageFn: async (retrieved) => {
+        processMessagePromises.push(queue.executeQuery(retrieved));
       },
       sendCancelMessageFn: async (query) => {
         processCancelPromises.push(queue.processCancel.bind(queue)(query));
@@ -405,12 +405,12 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(result).toBe('select * from bar');
     });
 
-    onlyLocalTest('addToQueue never claims in memory', async () => {
+    onlyLocalTest('addToQueue never retrieves in memory', async () => {
       const connection = await queue.queueDriver.createConnection();
       const query: QueryKey = ['select * from add_and_retrieve', []];
 
       try {
-        const [added, , , , claim] = await connection.addToQueue(
+        const [added, , , , retrieved] = await connection.addToQueue(
           query,
           'delay',
           { isJob: true, orphanedTimeout: undefined },
@@ -419,7 +419,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         );
 
         expect(added).toBe(1);
-        expect(claim).toBeNull();
+        expect(retrieved).toBeNull();
         expect(await connection.getToProcessQueries()).toStrictEqual([
           [connection.redisHash(query), expect.any(Number)]
         ]);
@@ -630,7 +630,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         delete process.env.CUBEJS_QUEUE_FAST_TRACK;
       });
 
-      test('an idle queue claims the query on add', async () => {
+      test('an idle queue retrieves the query on add', async () => {
         const retrieveForProcessing = jest.spyOn(CubestoreQueueDriverConnection.prototype, 'retrieveForProcessing');
         const driverQuery = jest.spyOn(CubeStoreDriver.prototype, 'query');
 
@@ -640,9 +640,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
           expect(result).toBe('select * from fast_track bar');
           expect(driverQuery.mock.calls.some(([sql]) => sql.startsWith('QUEUE ADD_AND_RETRIEVE'))).toBe(true);
-          // The claim came with the insert, there was nothing left to retrieve
+          // The retrieval came with the insert, there was nothing left to retrieve
           expect(retrieveForProcessing).not.toHaveBeenCalled();
-          // The claim carries the processing identity, the acknowledgement must be accepted
+          // The retrieval carries the processing identity, the acknowledgement must be accepted
           expect(logger.mock.calls.map(([message]) => message)).not.toContain('Orphaned execution result');
         } finally {
           retrieveForProcessing.mockRestore();
@@ -675,7 +675,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         }
       });
 
-      test('a claim is not given out while the concurrency budget is taken', async () => {
+      test('a query is not retrieved while the concurrency budget is taken', async () => {
         const connection = await queue.queueDriver.createConnection();
         const first: QueryKey = ['select * from budget_1', []];
         const second: QueryKey = ['select * from budget_2', []];
@@ -689,22 +689,22 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         try {
           // concurrency is 1, the first query takes the only slot
-          const [added1, , , , claim1] = await addToQueue(first, 1);
+          const [added1, , , , retrieved1] = await addToQueue(first, 1);
           expect(added1).toBe(1);
-          expect(claim1?.[5]).toBe(true);
-          expect(claim1?.[4].queryKey).toStrictEqual(first);
+          expect(retrieved1?.[5]).toBe(true);
+          expect(retrieved1?.[4].queryKey).toStrictEqual(first);
 
-          // an active item is never claimed twice
-          const [added1again, , , , claim1again] = await addToQueue(first, 1);
+          // an active item is never retrieved twice
+          const [added1again, , , , retrieved1again] = await addToQueue(first, 1);
           expect(added1again).toBe(0);
-          expect(claim1again).toBeNull();
+          expect(retrieved1again).toBeNull();
 
-          const [added2, , , , claim2] = await addToQueue(second, 2);
+          const [added2, , , , retrieved2] = await addToQueue(second, 2);
           expect(added2).toBe(1);
-          expect(claim2).toBeNull();
+          expect(retrieved2).toBeNull();
 
-          // A claimed item goes straight to active and never becomes pending, the one
-          // which was not claimed is left for reconcile to pick up by priority
+          // A retrieved item goes straight to active and never becomes pending, the one
+          // which was not retrieved is left for reconcile to pick up by priority
           expect(await connection.getActiveQueries()).toStrictEqual([
             [connection.redisHash(first), expect.any(Number)]
           ]);

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -402,12 +402,12 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       expect(result).toBe('select * from bar');
     });
 
-    onlyLocalTest('addAndRetrieve never claims in memory', async () => {
+    onlyLocalTest('addToQueue never claims in memory', async () => {
       const connection = await queue.queueDriver.createConnection();
       const query: QueryKey = ['select * from add_and_retrieve', []];
 
       try {
-        const [added, , , , claim] = await connection.addAndRetrieve(
+        const [added, , , , claim] = await connection.addToQueue(
           query,
           'delay',
           { isJob: true, orphanedTimeout: undefined },
@@ -661,7 +661,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         const connection = await queue.queueDriver.createConnection();
         const first: QueryKey = ['select * from budget_1', []];
         const second: QueryKey = ['select * from budget_2', []];
-        const addAndRetrieve = (queryKey: QueryKey, queueId: number) => connection.addAndRetrieve(
+        const addToQueue = (queryKey: QueryKey, queueId: number) => connection.addToQueue(
           queryKey,
           'delay',
           { isJob: true, orphanedTimeout: undefined },
@@ -671,17 +671,17 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
         try {
           // concurrency is 1, the first query takes the only slot
-          const [added1, , , , claim1] = await addAndRetrieve(first, 1);
+          const [added1, , , , claim1] = await addToQueue(first, 1);
           expect(added1).toBe(1);
           expect(claim1?.[5]).toBe(true);
           expect(claim1?.[4].queryKey).toStrictEqual(first);
 
           // an active item is never claimed twice
-          const [added1again, , , , claim1again] = await addAndRetrieve(first, 1);
+          const [added1again, , , , claim1again] = await addToQueue(first, 1);
           expect(added1again).toBe(0);
           expect(claim1again).toBeNull();
 
-          const [added2, , , , claim2] = await addAndRetrieve(second, 2);
+          const [added2, , , , claim2] = await addToQueue(second, 2);
           expect(added2).toBe(1);
           expect(claim2).toBeNull();
 

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -5,7 +5,8 @@ import crypto from 'crypto';
 import { Required } from '@cubejs-backend/shared';
 import {
   PreAggregationDescription,
-  PreAggregationPartitionRangeLoader
+  PreAggregationPartitionRangeLoader,
+  QueuePriority
 } from '@cubejs-backend/query-orchestrator';
 
 import { CubejsServerCore } from './server';
@@ -576,7 +577,9 @@ export class RefreshScheduler {
           return {
             preAggregations: partitions.map(partition => ({
               ...partition,
-              priority: preAggregationsWarmup ? 1 : queryCursor - queries.length
+              priority: preAggregationsWarmup
+                ? QueuePriority.Warmup
+                : QueuePriority.Scheduled - (queries.length - 1 - queryCursor)
             })),
             cacheMode: 'must-revalidate',
             requestId: context.requestId,


### PR DESCRIPTION
`QUEUE ADD_AND_RETRIEVE` inserts and claims a queue item in one atomic operation, but nothing on the JS side used it. Enqueueing a query cost five Cube Store round-trips before it could start executing, and between `QUEUE ADD` and `QUEUE RETRIEVE` another node could take the concurrency slot, so the enqueueing node often paid for the retrieval and got nothing back.