### PR TITLE
docs: add the funnel chart type page

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -71,6 +71,7 @@
                       "docs/explore-analyze/charts/chart-types/area",
                       "docs/explore-analyze/charts/chart-types/scatter",
                       "docs/explore-analyze/charts/chart-types/pie",
+                      "docs/explore-analyze/charts/chart-types/funnel",
                       "docs/explore-analyze/charts/chart-types/sankey",
                       "docs/explore-analyze/charts/chart-types/heatmap",
                       "docs/explore-analyze/charts/chart-types/boxplot",

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
@@ -24,12 +24,12 @@ A stage whose value is zero still draws, as a thin line in its stage color, so a
 
 The **Direction** row at the top of the Style tab decides which way the stages progress:
 
-- **Vertical** — stages run top to bottom, each bar spanning the width. The default, and the shape every funnel saved before this setting still has.
+- **Vertical** — stages run top to bottom, each bar spanning the width. The default.
 - **Horizontal** — stages run left to right, each bar spanning the height. Useful when stage names are long, or alongside other left-to-right charts.
 
 The taper, the connectors and every label carry over unchanged; only the axes swap.
 
-Direction is greyed out until the chart has both of its fields. Hovering it explains why: *"Add a stage field and a value field to rotate the funnel."*
+Direction is greyed out until the chart has both a stage field and a value field.
 
 {/* Screenshot: a horizontal funnel beside the Style tab's Direction row, with Horizontal selected. Place directly below this paragraph, full width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
@@ -14,6 +14,8 @@ A funnel needs exactly two fields, picked on the Fields tab:
 - **Stage** — a dimension (a time dimension works too, bucketed by its grain). Each distinct value becomes one stage.
 - **Value** — a measure. It is rolled up per stage, so a result with extra columns still draws one bar per stage.
 
+{/* Screenshot: Fields tab with the Stage and Value selectors bound. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
 Stages keep the order your query returned them in. To reorder stages, adjust the sort in the results table — a stage that grows partway down is real data (re-entry, late-arriving events), so the chart never sorts it away for you.
 
 A stage whose value is zero still draws, as a thin line in its stage color, so a gap in the data reads as a zero rather than as a missing stage.
@@ -27,6 +29,8 @@ The connectors between stages carry the funnel's percentages. Two independent to
 
 Turning both on stacks the two lines on each connector; turning both off leaves the connectors unlabeled. Whichever you select also appears in the tooltip, alongside the stage and value.
 
+{/* Screenshot: Style tab Data labels section with the First and Prev toggles. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
 ## Data labels
 
 Each bar carries its stage name and value, both on by default and toggled in the **Data labels** section of the Style tab. The value's number format has its own picker, and one font size governs every label the funnel draws — the bar labels and the connector percentages alike.
@@ -35,4 +39,10 @@ Labels always sit at the bar's center. When a bar is too narrow to hold its labe
 
 ## Color
 
-Each stage takes its own color from the palette selected in the **Palette** dropdown on the Style tab, in palette order.
+Each stage takes its own color from the palette selected in the **Palette** dropdown on the Style tab, in palette order. See [Palettes](/docs/explore-analyze/charts/configuration/color-and-stacking#palettes) for the built-in palettes and how to define a custom one.
+
+{/* Screenshot: Style tab with the Palette dropdown open, showing the built-in discrete palettes. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Legend
+
+A legend naming each stage in its palette color is available in the **Legend** section of the Style tab, along with its placement.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
@@ -1,0 +1,38 @@
+---
+title: Funnel
+description: Show how a value narrows from stage to stage, such as signup → activation → purchase.
+---
+
+Funnel charts draw one bar per stage, centered on a shared midline, with a connector between each adjacent pair of stages. Each bar's width is proportional to its stage's value, so the figure narrows wherever values drop. Best for stage-to-stage conversion: how many users, orders, or events survive each step of a process.
+
+{/* Screenshot: funnel chart — order counts across four statuses, with stage names and values on the bars and conversion percentages on the connectors. Place directly below this paragraph, full width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Fields
+
+A funnel needs exactly two fields, picked on the Fields tab:
+
+- **Stage** — a dimension (a time dimension works too, bucketed by its grain). Each distinct value becomes one stage.
+- **Value** — a measure. It is rolled up per stage, so a result with extra columns still draws one bar per stage.
+
+Stages keep the order your query returned them in. To reorder stages, adjust the sort in the results table — a stage that grows partway down is real data (re-entry, late-arriving events), so the chart never sorts it away for you.
+
+A stage whose value is zero still draws, as a thin line in its stage color, so a gap in the data reads as a zero rather than as a missing stage.
+
+## Conversion percentages
+
+The connectors between stages carry the funnel's percentages. Two independent toggles in the **Data labels** section of the Style tab control them:
+
+- **First** — each stage as a share of the first stage, drawn as `36% of first`. On by default.
+- **Prev** — each stage as a share of the stage before it, drawn as `20% of previous`.
+
+Turning both on stacks the two lines on each connector; turning both off leaves the connectors unlabeled. Whichever you select also appears in the tooltip, alongside the stage and value.
+
+## Data labels
+
+Each bar carries its stage name and value, both on by default and toggled in the **Data labels** section of the Style tab. The value's number format has its own picker, and one font size governs every label the funnel draws — the bar labels and the connector percentages alike.
+
+Labels always sit at the bar's center. When a bar is too narrow to hold its label, the text switches from white to a dark color so it stays readable against the page background.
+
+## Color
+
+Each stage takes its own color from the palette selected in the **Palette** dropdown on the Style tab, in palette order.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
@@ -58,4 +58,4 @@ Each stage takes its own color from the palette selected in the **Palette** drop
 
 ## Legend
 
-A funnel draws no legend by default — every bar already carries its stage name, so a legend would repeat it. Turn one on in the **Legend** section of the Style tab, which also sets its placement. It names each stage in its palette color.
+A funnel draws no legend by default — every bar already carries its stage name, so a legend would repeat it. Turn one on in the [**Legend**](/docs/explore-analyze/charts/configuration/color-and-stacking#legend) section of the Style tab, which also sets its placement. It names each stage in its palette color.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/funnel.mdx
@@ -20,6 +20,19 @@ Stages keep the order your query returned them in. To reorder stages, adjust the
 
 A stage whose value is zero still draws, as a thin line in its stage color, so a gap in the data reads as a zero rather than as a missing stage.
 
+## Direction
+
+The **Direction** row at the top of the Style tab decides which way the stages progress:
+
+- **Vertical** — stages run top to bottom, each bar spanning the width. The default, and the shape every funnel saved before this setting still has.
+- **Horizontal** — stages run left to right, each bar spanning the height. Useful when stage names are long, or alongside other left-to-right charts.
+
+The taper, the connectors and every label carry over unchanged; only the axes swap.
+
+Direction is greyed out until the chart has both of its fields. Hovering it explains why: *"Add a stage field and a value field to rotate the funnel."*
+
+{/* Screenshot: a horizontal funnel beside the Style tab's Direction row, with Horizontal selected. Place directly below this paragraph, full width. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
 ## Conversion percentages
 
 The connectors between stages carry the funnel's percentages. Two independent toggles in the **Data labels** section of the Style tab control them:
@@ -45,4 +58,4 @@ Each stage takes its own color from the palette selected in the **Palette** drop
 
 ## Legend
 
-A legend naming each stage in its palette color is available in the **Legend** section of the Style tab, along with its placement.
+A funnel draws no legend by default — every bar already carries its stage name, so a legend would repeat it. Turn one on in the **Legend** section of the Style tab, which also sets its placement. It names each stage in its palette color.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
@@ -10,6 +10,7 @@ Cube includes a library of built-in chart types covering the most common visuali
 - [Area](/docs/explore-analyze/charts/chart-types/area)
 - [Scatter](/docs/explore-analyze/charts/chart-types/scatter)
 - [Pie & donut](/docs/explore-analyze/charts/chart-types/pie)
+- [Funnel](/docs/explore-analyze/charts/chart-types/funnel)
 - [Sankey](/docs/explore-analyze/charts/chart-types/sankey)
 - [Heatmap](/docs/explore-analyze/charts/chart-types/heatmap)
 - [Boxplot](/docs/explore-analyze/charts/chart-types/boxplot)
@@ -80,9 +81,9 @@ Otherwise Cube checks these in order and takes the first that matches:
 The two [bar](/docs/explore-analyze/charts/chart-types/bar) rows are variants of the same chart
 type, not separate ones.
 
-Pie, sankey, area, boxplot and HTML are never recommended — pick them yourself. Pie's shape, one measure
-across a few categories, is the one Bar already answers, and a bar chart compares those values more
-accurately. All five stay available in the picker like any other chart type.
+Pie, funnel, sankey, area, boxplot and HTML are never recommended — pick them yourself. Pie's shape,
+one measure across a few categories, is the one Bar already answers, and a bar chart compares those
+values more accurately. All six stay available in the picker like any other chart type.
 
 ### When nothing is recommended
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/index.mdx
@@ -83,7 +83,9 @@ type, not separate ones.
 
 Pie, funnel, sankey, area, boxplot and HTML are never recommended — pick them yourself. Pie's shape,
 one measure across a few categories, is the one Bar already answers, and a bar chart compares those
-values more accurately. All six stay available in the picker like any other chart type.
+values more accurately. A funnel additionally asserts that its stages are sequential steps of one
+process, which the shape of a query does not reveal. All six stay available in the picker like any
+other chart type.
 
 ### When nothing is recommended
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -31,4 +31,6 @@ The total uses the font size set in the Data labels section, the same as the sli
 
 ## Color and slice ordering
 
-Slices are colored using the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking) in palette order, matched to the sort order of your query results. To change which slice appears first, adjust the sort in the results table.
+Slices take their colors from the palette selected in the **Palette** dropdown on the Style tab, in palette order, matched to the sort order of your query results. See [Palettes](/docs/explore-analyze/charts/configuration/color-and-stacking#palettes) for the built-in palettes and how to define a custom one. To change which slice appears first, adjust the sort in the results table.
+
+A pie draws a legend naming each slice. Hide it or move it in the [**Legend**](/docs/explore-analyze/charts/configuration/color-and-stacking#legend) section of the Style tab.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
@@ -64,6 +64,8 @@ The **Flows** control sets where a ribbon takes its color from:
 - **Neutral** — one muted color for every ribbon, leaving the nodes to carry the palette.
 - **Target** — the color of the node the ribbon enters.
 
+A sankey draws no legend, and has no setting for one: every node is labeled in the diagram itself.
+
 {/* Screenshot: Style tab Color section with the Palette dropdown and the Flows buttons. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Tooltips

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
@@ -64,9 +64,9 @@ The **Flows** control sets where a ribbon takes its color from:
 - **Neutral** — one muted color for every ribbon, leaving the nodes to carry the palette.
 - **Target** — the color of the node the ribbon enters.
 
-A sankey draws no legend, and has no setting for one: every node is labeled in the diagram itself.
-
 {/* Screenshot: Style tab Color section with the Palette dropdown and the Flows buttons. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+A sankey draws no legend, and has no setting for one: every node is labeled in the diagram itself.
 
 ## Tooltips
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
@@ -3,7 +3,7 @@ title: Color & stacking
 description: Configure color palettes, stacking behavior, stacked segment sorting, and legend placement for charts.
 ---
 
-The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply across bar, line, area, scatter, and heatmap charts. Pie and funnel charts have no Color section — they pick their palette in their own **Palette** dropdown — but the [palettes](#palettes) below are the same ones they offer.
+The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply to charts that color by a Color channel: bar, line, area, scatter, and heatmap. Other chart types pick their palette from a **Palette** dropdown of their own, on their own Style tab — but the [palettes](#palettes) below are the same ones they offer.
 
 {/* TODO screenshot: color and stacking section of the Style tab (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -86,7 +86,7 @@ The **Value** sorting option is only available for bar and column charts. For ar
 
 ## Legend
 
-The legend appears when a Color channel is assigned. Pie and funnel charts have no Color channel — a pie carries a legend regardless, a funnel starts without one — but both configure it in the same **Legend** section:
+The legend appears when a Color channel is assigned. A chart type without a Color channel decides for itself: a pie carries a legend regardless, a funnel starts without one, and a sankey has none to configure. Where a legend is offered, it uses the same **Legend** section:
 
 | Option | Description |
 |---|---|

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
@@ -86,7 +86,7 @@ The **Value** sorting option is only available for bar and column charts. For ar
 
 ## Legend
 
-The legend appears when a Color channel is assigned. Configure it in the **Legend** section:
+The legend appears when a Color channel is assigned. Pie and funnel charts have no Color channel — a pie carries a legend regardless, a funnel starts without one — but both configure it in the same **Legend** section:
 
 | Option | Description |
 |---|---|

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
@@ -3,7 +3,7 @@ title: Color & stacking
 description: Configure color palettes, stacking behavior, stacked segment sorting, and legend placement for charts.
 ---
 
-The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply across bar, line, area, scatter, and heatmap charts.
+The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply across bar, line, area, scatter, and heatmap charts. Pie and funnel charts have no Color section — they pick their palette in their own **Palette** dropdown — but the [palettes](#palettes) below are the same ones they offer.
 
 {/* TODO screenshot: color and stacking section of the Style tab (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
@@ -3,7 +3,7 @@ title: Color & stacking
 description: Configure color palettes, stacking behavior, stacked segment sorting, and legend placement for charts.
 ---
 
-The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply to charts that color by a Color channel: bar, line, area, scatter, and heatmap. Other chart types pick their palette from a **Palette** dropdown of their own, on their own Style tab — but the [palettes](#palettes) below are the same ones they offer.
+The **Color** section in the Style tab controls two related things: how series are colored, and how they are stacked or grouped relative to each other. These settings apply to charts that color by a Color channel: bar, line, area, scatter, and heatmap. Chart types that color some other way, such as pie, funnel and sankey, pick their palette from a **Palette** dropdown of their own — but the [palettes](#palettes) below are the same ones they offer.
 
 {/* TODO screenshot: color and stacking section of the Style tab (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 


### PR DESCRIPTION
Adds the Funnel page to the workbook chart-types docs — fields, direction, conversion percentages on the connectors, data labels, color and legend — and lists it in the chart-types index. Also updates the recommendation section's never-recommended list to include the funnel.

Two smaller corrections to `color-and-stacking.mdx`, both reached from the new page's links: its intro claimed the Color-section settings apply to five chart types, and its Legend section claimed a legend appears when a Color channel is assigned. Neither described pie or funnel, which have no Color section and no Color channel — a pie carries a legend regardless, a funnel starts without one.

Screenshots are still placeholder comments. Every chart-type page on master ships them that way, so real images are a directory-wide job rather than this page's debt.
