### PR TITLE
docs: document PNG/PDF embed export and add an Alerts page

### DIFF
--- a/docs-mintlify/admin/monitoring/alerts.mdx
+++ b/docs-mintlify/admin/monitoring/alerts.mdx
@@ -1,0 +1,43 @@
+---
+title: Alerts
+description: Get email notifications about API outages, database timeouts, and pre-aggregation build failures across your deployments.
+---
+
+Alerts send email notifications when a deployment has an API outage, a database
+response timeout, or a pre-aggregation build fails or completes. Manage them from
+**Alerts** in the account-level Admin panel.
+
+<Note>
+
+Available on the [Starter plan and above](https://cube.dev/pricing).
+
+</Note>
+
+## Configuration
+
+Click **New alert** and choose:
+
+- **Event type** — one of the [event types](#event-types) below, or **All** to
+  match every type.
+- **For deployments** — **All** deployments on the account, or specific ones.
+- **Send alerts to** — **All users on this account** or **Specific users**; you
+  can also add **Custom email** addresses that aren't Cube Cloud users.
+
+Existing alerts are listed in a table with their event type, deployments, and
+recipients, and can be edited or deleted (individually or in bulk).
+
+## Event types
+
+| Event type | Triggered when |
+| --- | --- |
+| API outages | A deployment's API becomes unreachable. |
+| Database response timeouts | A query to the connected data source times out. |
+| Pre-aggregation build failures | A [pre-aggregation build](/admin/monitoring/pre-aggregations) fails. |
+| Build completed | A deployment build finishes. |
+
+A pre-aggregation build failure notification links back to the pre-aggregation
+and suggests [partitioning it][ref-partition-granularity] or configuring an
+[export bucket][ref-export-bucket] if it's large.
+
+[ref-partition-granularity]: /reference/data-modeling/pre-aggregations#partition_granularity
+[ref-export-bucket]: /docs/pre-aggregations/using-pre-aggregations#export-bucket

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -370,6 +370,7 @@
               "admin/monitoring/query-history",
               "admin/monitoring/pre-aggregations",
               "admin/monitoring/performance",
+              "admin/monitoring/alerts",
               "admin/monitoring/audit-log",
               "admin/monitoring/chats-history",
               "admin/monitoring/query-history-export",

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,20 +77,22 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow CSV export
+## Allow CSV, PNG, and PDF export
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget's data as a CSV file, add the
-`allowExport=true` query parameter to the embed URL:
+widgets. To let viewers download a chart widget as a CSV, PNG, or PDF file, add
+the `allowExport=true` query parameter to the embed URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
-When enabled, each chart widget's ⋮ menu shows a **Download as CSV** action. The
-CSV is generated client-side from the data already loaded into the widget, so no
-additional query is issued. The parameter is opt-in — omit it (the default) to
-keep the download action hidden.
+When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
+as PNG**, and **Download as PDF** actions. The CSV is generated client-side from
+the data already loaded into the widget, so no additional query is issued. The
+PNG and PDF exports are rendered server-side and reflect the viewer's theme and
+locale. The parameter is opt-in — omit it (the default) to keep the download
+actions hidden.
 
 ## Show or hide the AI chat
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Two undocumented customer-facing changes found via a routine audit cross-checking recent `cubejs-enterprise` changes against docs-mintlify coverage:

1. **Embedded dashboard export.** `allowExport=true` on embedded dashboards previously gated only a **Download as CSV** action. As of CUB-4065 (cubejs-enterprise #14290), it also gates **Download as PNG** and **Download as PDF**. Updated the "Allow CSV export" section of the embedding docs accordingly.
2. **Alerts.** Alerts (email notifications for API outages, database response timeouts, and pre-aggregation build failures/completions) is a real, shipped, paid-plan feature that had no docs page at all. It just gained a permanent home in the account-level Admin panel (CUB-3926, cubejs-enterprise #14222), which is a good prompt to finally document it — added a new page under Admin → Monitoring covering configuration and event types.