### PR TITLE
docs: document the SQL fallback editor and embedded PNG/PDF export

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -149,3 +149,10 @@ not.
 
 Select a calculated field in the sidebar to open the editor. You can change its
 **name** and **SQL expression**, then choose **Update** to apply.
+
+Fields generated from a column header menu—aggregations, **Calculations**
+(**% of total**, **Running total**, etc.), and filtered measures—are edited
+through a SQL-only editor instead: it shows just the Semantic SQL expression,
+with no name field, since renaming isn't supported for these. Bucketed fields
+(**Edit bins…**, **Edit groups…**) keep their own structured editor, described
+above.

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,20 +77,24 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow CSV export
+## Allow chart export
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget's data as a CSV file, add the
+widgets. To let viewers download a chart widget's data, add the
 `allowExport=true` query parameter to the embed URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
-When enabled, each chart widget's ⋮ menu shows a **Download as CSV** action. The
-CSV is generated client-side from the data already loaded into the widget, so no
-additional query is issued. The parameter is opt-in — omit it (the default) to
-keep the download action hidden.
+When enabled, each chart widget's ⋮ menu shows **Download as PNG**, **Download
+as PDF**, and **Download as CSV** actions. CSV is generated client-side from
+the data already loaded into the widget, so no additional query is issued. PNG
+and PDF are server-rendered snapshots, the same mechanism used for
+[dashboard export](/docs/explore-analyze/dashboards#download-as-png-or-pdf) in
+the main app, and only one export can run at a time per dashboard. The
+parameter is opt-in — omit it (the default) to keep the download action
+hidden.
 
 ## Show or hide the AI chat
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,7 +77,7 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow chart export
+## Allow chart export {#allow-csv-export}
 
 By default, embedded dashboards do not expose a download action on individual
 widgets. To let viewers download a chart widget's data, add the

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -90,11 +90,14 @@ https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?sessi
 When enabled, each chart widget's ⋮ menu shows **Download as PNG**, **Download
 as PDF**, and **Download as CSV** actions. CSV is generated client-side from
 the data already loaded into the widget, so no additional query is issued. PNG
-and PDF are server-rendered snapshots, the same mechanism used for
+and PDF are server-rendered snapshots — the same mechanism used for
 [dashboard export](/docs/explore-analyze/dashboards#download-as-png-or-pdf) in
-the main app, and only one export can run at a time per dashboard. The
+the main app — so they can take up to a couple of minutes for large widgets,
+and only one export can run at a time per dashboard (a second attempt is
+rejected as "another export still running" rather than failing outright). The
 parameter is opt-in — omit it (the default) to keep the download action
-hidden.
+hidden; it is also hidden entirely when an admin turns off the account-wide
+[data download controls](/admin/users-and-permissions/roles-and-permissions#restricting-data-downloads).
 
 ## Show or hide the AI chat
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -209,9 +209,9 @@ exported rows themselves.
 ```
 
 <Note>
-  The CSV download action on a dashboard widget only appears when the embed URL
-  includes `allowExport=true` (see [Dashboards → Allow CSV
-  export](/embedding/iframe/dashboards#allow-csv-export)). The event fires when a
+  The download action on a dashboard widget only appears when the embed URL
+  includes `allowExport=true` (see [Dashboards → Allow chart
+  export](/embedding/iframe/dashboards#allow-chart-export)). The event fires when a
   viewer uses it.
 </Note>
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -211,7 +211,7 @@ exported rows themselves.
 <Note>
   The download action on a dashboard widget only appears when the embed URL
   includes `allowExport=true` (see [Dashboards → Allow chart
-  export](/embedding/iframe/dashboards#allow-chart-export)). The event fires when a
+  export](/embedding/iframe/dashboards#allow-csv-export)). The event fires when a
   viewer uses it.
 </Note>
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (not applicable — docs only)
- [ ] Linter has been run for changed code (not applicable — docs only)
- [ ] Tests for the changes have been added if not covered yet (not applicable — docs only)

**Description of Changes Made**

Routine documentation audit: cross-checked recent merges in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify` and found two small, genuinely undocumented customer-facing changes shipped since the previous audit (#11611).

- **Calculated field SQL fallback editor** (cubejs-enterprise #14322) — fields generated from a column-header menu (aggregations, `% of total`/`Running total` calculations, filtered measures) previously had no edit path at all; they now open a SQL-only editor (no rename, since renaming isn't supported for these). Documented in `docs/explore-analyze/workbooks/calculated-fields.mdx`, "Editing a calculated field".
- **PNG/PDF export in embedded dashboards** (cubejs-enterprise #14290) — the existing `allowExport=true` embed param previously enabled only CSV download; it now also exposes server-rendered PNG/PDF export on embedded dashboard widgets, matching the main-app feature. Updated `embedding/iframe/dashboards.mdx` ("Allow CSV export" → "Allow chart export") and fixed the now-stale cross-reference + anchor in `embedding/iframe/events.mdx`.

Two other undocumented items from this window are large enough to need their own new docs page rather than a small edit, so they're being tracked separately instead of bundled into this PR:
- A new **funnel chart type** in workbooks (cubejs-enterprise #13506) — fully shipped, has its own fields/style config comparable to the existing chart-type pages, entirely undocumented.
- **Dashboard apps** (agent-generated custom dashboards) gaining report filtering controls (cubejs-enterprise #14259) and file-editing tools (#14325) — the "dashboard app" concept itself has no docs yet at all, only a changelog mention of its GraphQL schema.

A third candidate — the recent Billing page split into Overview/Cost and Usage (cubejs-enterprise #14241) — was investigated but left out: it's gated behind a newly-introduced per-tenant flag combination with unclear rollout, so per the customer-facing criteria (wait until on by default) it's not yet safe to document as the new default navigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZXRxKcT3Rt5J4NKAPAeD3)_