### PR TITLE
docs: document undocumented customer-facing changes from the last few days

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -97,19 +97,25 @@ and an already derived field cannot be bucketed again.
   />
 </Frame>
 
-**Bins** take their boundaries either as a list (**Custom ranges**) or from a
-**Start**, **Width**, and number of **Ranges** (**Equal width**). Each boundary
-opens a bucket that includes its lower bound and excludes the upper one, and two
-open-ended buckets are added at the edges—so `0, 18, 25` yields `< 0`, `[0, 18)`,
-`[18, 25)`, `>= 25`, and no row is dropped. **Label style** renders a bucket as
-`[10, 20)`, `>= 10 and < 20`, or `10 to 19`; the last is offered only while every
-boundary is a whole number. Rows where the dimension is `NULL` are reported as
-`Unknown`.
+**Bins** take their boundaries either as a typed list (**Boundaries**) or generated
+over a range (**Equal intervals**, from a **Range start** and **Range end**, driven
+by either a **Number of bins** or a fixed **Bin size**—up to 100 generated bins).
+Each boundary opens a bucket that includes its lower bound and excludes the upper
+one, and two open-ended buckets are added at the edges—so `0, 18, 25` yields `< 0`,
+`[0, 18)`, `[18, 25)`, `>= 25`, and no row is dropped. **Label style** renders a
+bucket as `[10, 20)`, `>= 10 and < 20`, or `10 to 19`—the last is offered only while
+every boundary is a whole number—or lets you type a **Custom** label per bucket.
+
+By default, rows where the dimension is `NULL` fall into the last bucket. Turn on
+**Label empty values separately** to give them their own bucket, labeled `Unknown`
+by default (also editable).
 
 **Value groups** collect the dimension's values into named sets: pick values, name
-the group, and choose **Add group**. A value belongs to one group at a time.
-Whatever you did not pick—including empty values—falls under **Everything else**,
-which defaults to `Other`.
+the group, and choose **Add group**; the pencil icon on an existing group lets you
+edit its picked values and name. A value belongs to one group at a time. By
+default, whatever you did not pick—including empty values—falls under **Everything
+else**, which defaults to `Other`; turn off **Group remaining values** to return
+`NULL` for them instead.
 
 Bucket labels carry their position as a prefix (`1.`, `2.`, zero-padded past nine
 buckets) so that sorting the column sorts it by value rather than alphabetically,
@@ -134,7 +140,7 @@ CASE WHEN orders_view.age IS NULL THEN 'Unknown'
 
 <Info>
 
-**Equal width** ranges are resolved into boundaries when the field is created, not
+**Equal intervals** are resolved into boundaries when the field is created, not
 recomputed from the data. Values arriving later outside the range join the first
 and last buckets instead of extending them.
 
@@ -147,5 +153,9 @@ not.
 
 ### Editing a calculated field
 
-Select a calculated field in the sidebar to open the editor. You can change its
-**name** and **SQL expression**, then choose **Update** to apply.
+Open a calculated field's menu—in the **Query fields** sidebar list, or from its
+column header in the results—and choose **Edit**. A field created by the bins or
+value groups panel reopens that panel; every other calculated field opens a SQL
+editor showing its expression. Either way, only the expression can be changed—
+naming happens when the field is created, not afterward. Choose **Update** (or
+**Save**, for a bins/groups field) to apply.

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -659,6 +659,20 @@ hosts, a prefilled compare link to open it yourself.
 
 </Steps>
 
+### Push a cube from Analytics Chat
+
+Ask [the agent](/docs/explore-analyze/analytics-chat) to promote a cube to dbt, or to
+edit an existing dbt model, instead of opening the push dialog yourself—for example,
+"push the orders cube to dbt" or "add a total_amount column to the stg_orders dbt
+model." The agent opens a live sandboxed clone of your dbt repository, reads
+`dbt_project.yml` and neighboring models to match your project's conventions, then
+drafts and writes the model's `.sql` and `.yml` files and runs `dbt parse`/`dbt
+compile` in the sandbox—iterating until the change is valid—before handing it back to
+you to actually deliver via the push flow above.
+
+This requires [push](#enable-push) to be enabled on the deployment; it inherits dbt
+push's preview status.
+
 ### What gets pushed
 
 Each push creates exactly two new files:

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,20 +77,28 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow CSV export
+## Allow widget export {#allow-csv-export}
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget's data as a CSV file, add the
-`allowExport=true` query parameter to the embed URL:
+widgets. To let viewers download a chart widget, add the `allowExport=true`
+query parameter to the embed URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
-When enabled, each chart widget's ⋮ menu shows a **Download as CSV** action. The
-CSV is generated client-side from the data already loaded into the widget, so no
-additional query is issued. The parameter is opt-in — omit it (the default) to
-keep the download action hidden.
+When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
+as PNG**, and **Download as PDF**. The CSV is generated client-side from the
+data already loaded into the widget; PNG and PDF are rendered server-side, so
+they work even before the widget has finished loading in the browser. The
+parameter is opt-in — omit it (the default) to keep the download actions
+hidden. A tenant's **Restrict data downloads** admin lock, if enabled,
+overrides `allowExport` and hides all three actions regardless of the URL
+parameter.
+
+Only one export can run at a time per dashboard. Starting a second export
+while one is still in progress shows **"Another export is still running. Wait
+for it to finish and try again."**
 
 ## Show or hide the AI chat
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -186,9 +186,9 @@ painted" signal (distinct from `ready`, which fires at mount, before data loads)
 
 #### `cube:event:download` {#cube-event-download}
 
-Emitted when a viewer exports something — a widget's data as CSV, or (in future)
-a dashboard image. Reports _that_ an export happened and its shape — never the
-exported rows themselves.
+Emitted when a viewer exports something — a widget's data as CSV, or a chart
+widget as a PNG or PDF image. Reports _that_ an export happened and its shape
+— never the exported rows themselves.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -209,10 +209,10 @@ exported rows themselves.
 ```
 
 <Note>
-  The CSV download action on a dashboard widget only appears when the embed URL
-  includes `allowExport=true` (see [Dashboards → Allow CSV
-  export](/embedding/iframe/dashboards#allow-csv-export)). The event fires when a
-  viewer uses it.
+  The CSV, PNG, and PDF download actions on a dashboard widget only appear
+  when the embed URL includes `allowExport=true` (see [Dashboards → Allow
+  widget export](/embedding/iframe/dashboards#allow-csv-export)). The event
+  fires when a viewer uses one of them.
 </Note>
 
 #### `cube:event:drilldown` {#cube-event-drilldown}


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change)
- [ ] Linter has been run for changed code (docs-only change)
- [ ] Tests for the changes have been added if not covered yet (docs-only change)

**Description of Changes Made**

Routine audit of recent `cubejs-enterprise` changes cross-checked against `docs-mintlify`, filtered through the customer-facing criteria. Four undocumented customer-facing changes, all fitting as edits to existing pages:

- **Embedding → Dashboards / Events**: `allowExport=true` now gates PNG and PDF widget export in addition to CSV (previously CSV-only), plus the new "one export in flight per dashboard" toast (CUB-4065, cubejs-enterprise#14290).
- **Workbooks → Calculated fields**: the bins/value-groups panel gained custom per-bucket labels, renamed Boundaries/Equal intervals tabs with a Number-of-bins-vs-Bin-size choice, optional separate handling of empty values, an edit action on existing value groups, and an opt-out of the `Other` bucket in favor of `NULL` (cubejs-enterprise#14324).
- **Workbooks → Calculated fields**: editing a calculated field now opens from a row-menu **Edit** action (not just the sidebar), reopens the bins/groups panel for a generated field, and no longer offers renaming an existing field (cubejs-enterprise#14322).
- **Integrations → dbt**: the agent can now author and validate a dbt model from Analytics Chat (open a live sandbox, read project conventions, draft/write/`dbt parse`+`compile` a model) before handing it back for you to push — beyond the existing sync-only chat trigger (CUB-3964, cubejs-enterprise#14298).

One change was scoped down to a **big** item needing its own new docs page rather than a page edit — a new Funnel chart type (cubejs-enterprise#13506) — and is being tracked separately rather than included here. Two other candidate changes were investigated and skipped as not customer-facing: an internal Support MCP OAuth change (staff-only tool, no customer surface) and an ai-engineer "dashboard app file tools" refactor (no new customer-visible capability, per the design doc it replaces an existing whole-file tool with a more granular one).


---
_Generated by [Claude Code](https://claude.ai/code/session_013WDi4ZgWJgBpzAYk7skChN)_