### PR TITLE
fix(cubestore): transmit the router's planning flags with the query

### DIFF
--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -235,7 +235,7 @@ crate::di_service!(ClusterImpl, [Cluster]);
 /// must reproduce. Each of these shapes both the worker subtree and the node that combines it, so a
 /// receiver planning its half from a different value returns wrong rows instead of failing. They
 /// travel with the query so that the sender's configuration decides for the whole plan.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlanningFlags {
     pub group_by_limit_factor: usize,
     pub topk_strategy: TopKAggregateStrategy,
@@ -2397,17 +2397,39 @@ mod tests {
                 flags: Some(flags),
             }));
         assert_eq!(params.worker_partition_count, 7);
-        let flags = params.flags.unwrap();
-        assert_eq!(flags.group_by_limit_factor, 5);
-        assert_eq!(
-            flags.topk_strategy,
-            TopKAggregateStrategy::VectorizedStreaming
-        );
+        assert_eq!(params.flags, Some(flags));
     }
 
     #[test]
-    fn planning_flags_fall_back_to_the_receiver_configuration() {
-        let config = Config::test("planning_flags_fall_back_to_the_receiver_configuration")
+    fn planning_flags_strategy_wire_names() {
+        // The names are the cross-node contract, so a renamed variant must not change them.
+        #[derive(Serialize)]
+        struct FlagsWithStrategyAsString {
+            group_by_limit_factor: usize,
+            topk_strategy: &'static str,
+        }
+
+        for (name, strategy) in [
+            ("streaming", TopKAggregateStrategy::Streaming),
+            (
+                "vectorized_streaming",
+                TopKAggregateStrategy::VectorizedStreaming,
+            ),
+            ("full_merge", TopKAggregateStrategy::FullMerge),
+        ] {
+            let buffer = to_flexbuffers(&FlagsWithStrategyAsString {
+                group_by_limit_factor: 1,
+                topk_strategy: name,
+            });
+            let flags: PlanningFlags = from_flexbuffers(&buffer);
+            assert_eq!(flags.topk_strategy, strategy, "wire name {}", name);
+        }
+    }
+
+    /// The values a receiver falls back to when the sender sends no flags.
+    #[test]
+    fn planning_flags_from_config() {
+        let config = Config::test("planning_flags_from_config")
             .update_config(|mut c| {
                 c.group_by_limit_factor = 4;
                 c.topk_aggregate_strategy = TopKAggregateStrategy::FullMerge;

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -26,7 +26,7 @@ use crate::cluster::transport::{ClusterTransport, MetaStoreTransport, WorkerConn
 use crate::config::injection::{DIService, Injector};
 use crate::config::is_router;
 #[allow(unused_imports)]
-use crate::config::{Config, ConfigObj, RepartitionStrategy};
+use crate::config::{Config, ConfigObj, RepartitionStrategy, TopKAggregateStrategy};
 use crate::metastore::chunks::chunk_file_name;
 use crate::metastore::job::{Job, JobRunnerPool, JobStatus, JobType};
 use crate::metastore::{
@@ -231,12 +231,36 @@ pub struct ClusterImpl {
 
 crate::di_service!(ClusterImpl, [Cluster]);
 
+/// Planning decisions the sending node takes from its own configuration and that the receiving node
+/// must reproduce. Each of these shapes both the worker subtree and the node that combines it, so a
+/// receiver planning its half from a different value returns wrong rows instead of failing. They
+/// travel with the query so that the sender's configuration decides for the whole plan.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct PlanningFlags {
+    pub group_by_limit_factor: usize,
+    pub topk_strategy: TopKAggregateStrategy,
+}
+
+impl PlanningFlags {
+    pub fn from_config(config: &dyn ConfigObj) -> PlanningFlags {
+        PlanningFlags {
+            group_by_limit_factor: config.group_by_limit_factor(),
+            topk_strategy: config.topk_aggregate_strategy(),
+        }
+    }
+}
+
 /// Parameters that the worker node uses to plan queries.  Generally, it needs to construct the same
 /// query plans as the router node (or if there are multiple levels of cluster send, the node from
 /// which it received the query).  We include the necessary information here.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct WorkerPlanningParams {
     pub worker_partition_count: usize,
+    /// Absent from a sender that predates the flags. Such a sender planned its half from its own
+    /// configuration, so the receiver falls back to its own -- the same value, as long as the two
+    /// binaries still agree on the defaults.
+    #[serde(default)]
+    pub flags: Option<PlanningFlags>,
 }
 
 impl WorkerPlanningParams {
@@ -244,6 +268,7 @@ impl WorkerPlanningParams {
     pub fn no_worker() -> WorkerPlanningParams {
         WorkerPlanningParams {
             worker_partition_count: 1,
+            flags: None,
         }
     }
 }
@@ -2315,6 +2340,84 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use std::fs;
+
+    /// The wire shape a node that predates the planning flags writes.
+    #[derive(Serialize, Deserialize)]
+    struct WorkerPlanningParamsWithoutFlags {
+        worker_partition_count: usize,
+    }
+
+    fn to_flexbuffers<T: Serialize>(value: &T) -> Vec<u8> {
+        let mut ser = flexbuffers::FlexbufferSerializer::new();
+        value.serialize(&mut ser).unwrap();
+        ser.take_buffer()
+    }
+
+    fn from_flexbuffers<'de, T: Deserialize<'de>>(buffer: &'de [u8]) -> T {
+        T::deserialize(flexbuffers::Reader::get_root(buffer).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn planning_flags_absent_from_a_sender_that_omits_them() {
+        // A message from a node that predates the flags must still be read, and must leave the
+        // flags absent so that the receiver falls back to its own configuration -- which is what
+        // that sender planned its half from.
+        let buffer = to_flexbuffers(&WorkerPlanningParamsWithoutFlags {
+            worker_partition_count: 3,
+        });
+        let params: WorkerPlanningParams = from_flexbuffers(&buffer);
+        assert_eq!(params.worker_partition_count, 3);
+        assert!(params.flags.is_none());
+    }
+
+    #[test]
+    fn planning_flags_are_ignored_by_a_receiver_that_does_not_know_them() {
+        // The reverse direction: a peer that predates the flags must still read the rest of the
+        // message rather than fail on the field it does not know.
+        let buffer = to_flexbuffers(&WorkerPlanningParams {
+            worker_partition_count: 3,
+            flags: Some(PlanningFlags {
+                group_by_limit_factor: 2,
+                topk_strategy: TopKAggregateStrategy::FullMerge,
+            }),
+        });
+        let params: WorkerPlanningParamsWithoutFlags = from_flexbuffers(&buffer);
+        assert_eq!(params.worker_partition_count, 3);
+    }
+
+    #[test]
+    fn planning_flags_round_trip() {
+        let flags = PlanningFlags {
+            group_by_limit_factor: 5,
+            topk_strategy: TopKAggregateStrategy::VectorizedStreaming,
+        };
+        let params: WorkerPlanningParams =
+            from_flexbuffers(&to_flexbuffers(&WorkerPlanningParams {
+                worker_partition_count: 7,
+                flags: Some(flags),
+            }));
+        assert_eq!(params.worker_partition_count, 7);
+        let flags = params.flags.unwrap();
+        assert_eq!(flags.group_by_limit_factor, 5);
+        assert_eq!(
+            flags.topk_strategy,
+            TopKAggregateStrategy::VectorizedStreaming
+        );
+    }
+
+    #[test]
+    fn planning_flags_fall_back_to_the_receiver_configuration() {
+        let config = Config::test("planning_flags_fall_back_to_the_receiver_configuration")
+            .update_config(|mut c| {
+                c.group_by_limit_factor = 4;
+                c.topk_aggregate_strategy = TopKAggregateStrategy::FullMerge;
+                c
+            })
+            .config_obj();
+        let flags = PlanningFlags::from_config(config.as_ref());
+        assert_eq!(flags.group_by_limit_factor, 4);
+        assert_eq!(flags.topk_strategy, TopKAggregateStrategy::FullMerge);
+    }
 
     fn config_with_workers(name: &str, workers: Vec<String>) -> Arc<dyn ConfigObj> {
         Config::test(name)

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -596,6 +596,10 @@ pub trait ConfigObj: DIService {
     /// lives: `false` (default) coalesces the partial aggregate's input to one partition (one hash
     /// table per worker, "over merge"); `true` keeps the raw multi-partition input so it runs per
     /// partition ("under merge").
+    ///
+    /// Unlike [`ConfigObj::group_by_limit_factor`], this one stays node-local and is not part of
+    /// [`PlanningFlags`]: it only moves a partition coalesce below the partial aggregate, leaving
+    /// the subtree's schema and the partition count the router sees the same either way.
     fn group_by_limit_per_partition(&self) -> bool;
 
     /// Replace the sort-preserving merge feeding a grouped Linear (hash) aggregate with a plain
@@ -1320,17 +1324,22 @@ pub async fn init_test_logger() {
 /// A worker reads its own value only for a query whose sender did not send any flags, i.e. one
 /// from a node that predates them and therefore planned from its own configuration.
 ///
-/// Serialized as part of those flags, deliberately without a catch-all variant: a strategy this
-/// binary does not know about must fail the query loudly rather than fall back to a value the
-/// sender did not plan with.
+/// Serialized as part of those flags under the same names `CUBESTORE_TOPK_STRATEGY` accepts, which
+/// are therefore part of the cross-node contract: renaming a variant must not change them.
+/// Deliberately without a catch-all variant: a strategy this binary does not know about must fail
+/// the query rather than fall back to a value the sender did not plan with. The receiving node fails to deserialize the message and drops the connection, so
+/// the reason is in its own log while the sender reports a connection error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopKAggregateStrategy {
     /// Original streaming NRA merge with per-row state (default).
+    #[serde(rename = "streaming")]
     Streaming,
     /// Same streaming NRA merge (keeps early termination, bounded router memory), but vectorized.
+    #[serde(rename = "vectorized_streaming")]
     VectorizedStreaming,
     /// ClickHouse-style full re-aggregation on the router + fetch-limited sort. Drops early
     /// termination, so the router materializes every distinct group.
+    #[serde(rename = "full_merge")]
     FullMerge,
 }
 

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -55,6 +55,7 @@ use futures::future::join_all;
 use log::Level;
 use log::{debug, error};
 use mockall::automock;
+use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 use std::fmt::Display;
 use std::future::Future;
@@ -585,7 +586,10 @@ pub trait ConfigObj: DIService {
     fn repartition_check_overlapping_children(&self) -> bool;
     /// Factor `f` controlling when the worker-side partial hash aggregate trims its output to the
     /// top-k groups. Trimming happens only when the number of local groups exceeds `f * k`, where
-    /// `k = limit + offset`. `0` disables the optimization.
+    /// `k = limit + offset`. `0` disables the optimization. Whether the trim runs at all decides
+    /// the shape of both halves of a split plan, so the router's value governs the whole query: it
+    /// travels in [`PlanningFlags`] and a select worker reads its own value only for a query whose
+    /// sender did not send any flags.
     fn group_by_limit_factor(&self) -> usize;
 
     /// When the worker group-by-limit hash trim is active, controls where the worker's hash table
@@ -598,7 +602,8 @@ pub trait ConfigObj: DIService {
     /// partition coalesce (the hash aggregate ignores input order, so the per-row merge is wasted).
     fn coalesce_under_hash_aggregate(&self) -> bool;
 
-    /// Router-side merge strategy for distributed value-ordered top-k.
+    /// Router-side merge strategy for distributed value-ordered top-k. The router's value governs
+    /// the whole query; see [`TopKAggregateStrategy`].
     fn topk_aggregate_strategy(&self) -> TopKAggregateStrategy;
 
     fn allow_decimal128(&self) -> bool;
@@ -1304,7 +1309,21 @@ pub async fn init_test_logger() {
 
 /// Router-side merge strategy for distributed value-ordered top-k (`SELECT ... GROUP BY x ORDER BY
 /// agg(...) LIMIT k`). Selected by `CUBESTORE_TOPK_STRATEGY`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// The strategy shapes both the worker subtree and the router node that combines it, and the two
+/// only fit together when both halves were planned from the same value -- otherwise the router
+/// combines a worker stream whose ordering guarantee it does not have and returns wrong rows
+/// instead of failing. So the router's value travels with the query in [`PlanningFlags`] and the
+/// worker plans from that rather than from its own configuration; setting `CUBESTORE_TOPK_STRATEGY`
+/// on a select worker alone has no effect.
+///
+/// A worker reads its own value only for a query whose sender did not send any flags, i.e. one
+/// from a node that predates them and therefore planned from its own configuration.
+///
+/// Serialized as part of those flags, deliberately without a catch-all variant: a strategy this
+/// binary does not know about must fail the query loudly rather than fall back to a value the
+/// sender did not plan with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopKAggregateStrategy {
     /// Original streaming NRA merge with per-row state (default).
     Streaming,

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -586,10 +586,9 @@ pub trait ConfigObj: DIService {
     fn repartition_check_overlapping_children(&self) -> bool;
     /// Factor `f` controlling when the worker-side partial hash aggregate trims its output to the
     /// top-k groups. Trimming happens only when the number of local groups exceeds `f * k`, where
-    /// `k = limit + offset`. `0` disables the optimization. Whether the trim runs at all decides
-    /// the shape of both halves of a split plan, so the router's value governs the whole query: it
-    /// travels in [`PlanningFlags`] and a select worker reads its own value only for a query whose
-    /// sender did not send any flags.
+    /// `k = limit + offset`. `0` disables the optimization. Whether the trim runs decides the shape
+    /// of both halves of a split plan, so it rides in [`PlanningFlags`]; a worker uses its own value
+    /// only when the sender sent no flags.
     fn group_by_limit_factor(&self) -> usize;
 
     /// When the worker group-by-limit hash trim is active, controls where the worker's hash table
@@ -1314,21 +1313,13 @@ pub async fn init_test_logger() {
 /// Router-side merge strategy for distributed value-ordered top-k (`SELECT ... GROUP BY x ORDER BY
 /// agg(...) LIMIT k`). Selected by `CUBESTORE_TOPK_STRATEGY`.
 ///
-/// The strategy shapes both the worker subtree and the router node that combines it, and the two
-/// only fit together when both halves were planned from the same value -- otherwise the router
-/// combines a worker stream whose ordering guarantee it does not have and returns wrong rows
-/// instead of failing. So the router's value travels with the query in [`PlanningFlags`] and the
-/// worker plans from that rather than from its own configuration; setting `CUBESTORE_TOPK_STRATEGY`
-/// on a select worker alone has no effect.
+/// Both halves of a split plan must be planned from the same value, or the router combines a worker
+/// stream whose ordering it does not have and returns wrong rows instead of failing. So it rides in
+/// [`PlanningFlags`], and a worker uses its own value only when the sender sent no flags.
 ///
-/// A worker reads its own value only for a query whose sender did not send any flags, i.e. one
-/// from a node that predates them and therefore planned from its own configuration.
-///
-/// Serialized as part of those flags under the same names `CUBESTORE_TOPK_STRATEGY` accepts, which
-/// are therefore part of the cross-node contract: renaming a variant must not change them.
-/// Deliberately without a catch-all variant: a strategy this binary does not know about must fail
-/// the query rather than fall back to a value the sender did not plan with. The receiving node fails to deserialize the message and drops the connection, so
-/// the reason is in its own log while the sender reports a connection error.
+/// The wire names are the env names and must survive a variant rename. No catch-all variant: an
+/// unknown strategy fails the message deserialize, which the receiver logs and the sender sees as a
+/// dropped connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TopKAggregateStrategy {
     /// Original streaming NRA merge with per-row state (default).

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/distributed_partial_aggregate.rs
@@ -1,4 +1,3 @@
-use crate::cluster::WorkerPlanningParams;
 use crate::queryplanner::check_memory::CheckMemoryExec;
 use crate::queryplanner::group_by_limit_aggregate::GroupByLimitAggregateExec;
 use crate::queryplanner::inline_aggregate::{InlineAggregateExec, InlineAggregateMode};
@@ -106,9 +105,7 @@ pub fn push_aggregate_to_workers(
                     .next()
                     .unwrap(),
                 w.worker_sort_and_limit.clone(),
-                WorkerPlanningParams {
-                    worker_partition_count: w.properties().output_partitioning().partition_count(),
-                },
+                w.properties().output_partitioning().partition_count(),
             ))
         } else {
             return Ok(p_final);
@@ -314,9 +311,7 @@ pub fn push_worker_sort_and_limit(
             w.limit_and_reverse.clone(),
             w.required_input_ordering.clone(),
             w.worker_sort_and_limit.clone(),
-            WorkerPlanningParams {
-                worker_partition_count: w.properties().output_partitioning().partition_count(),
-            },
+            w.properties().output_partitioning().partition_count(),
         )));
     }
 
@@ -1260,9 +1255,7 @@ mod tests {
             limit_and_reverse,
             None,
             None,
-            WorkerPlanningParams {
-                worker_partition_count: 1,
-            },
+            1,
         ))
     }
 

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
@@ -7,8 +7,7 @@ pub mod rolling_optimizer;
 mod trace_data_loaded;
 
 use super::serialized_plan::PreSerializedPlan;
-use crate::cluster::{Cluster, WorkerPlanningParams};
-use crate::config::TopKAggregateStrategy;
+use crate::cluster::{Cluster, PlanningFlags};
 use crate::queryplanner::optimizations::distributed_partial_aggregate::{
     add_limit_to_workers, drop_sort_merge_under_global_aggregate, ensure_partition_merge,
     push_aggregate_to_workers, push_sorted_partial_aggregate_below_merge,
@@ -40,13 +39,13 @@ pub struct CubeQueryPlanner {
     /// Set on the router
     cluster: Option<Arc<dyn Cluster>>,
     /// Set on the worker
-    worker_partition_count: Option<WorkerPlanningParams>,
+    worker_partition_count: Option<usize>,
     serialized_plan: Arc<PreSerializedPlan>,
     memory_handler: Arc<dyn MemoryHandler>,
     data_loaded_size: Option<Arc<DataLoadedSize>>,
-    group_by_limit_factor: usize,
+    /// On the router, this node's own configuration; on a worker, what the router sent.
+    planning_flags: PlanningFlags,
     group_by_limit_per_partition: bool,
-    topk_strategy: TopKAggregateStrategy,
 }
 
 impl CubeQueryPlanner {
@@ -54,9 +53,8 @@ impl CubeQueryPlanner {
         cluster: Arc<dyn Cluster>,
         serialized_plan: Arc<PreSerializedPlan>,
         memory_handler: Arc<dyn MemoryHandler>,
-        group_by_limit_factor: usize,
+        planning_flags: PlanningFlags,
         group_by_limit_per_partition: bool,
-        topk_strategy: TopKAggregateStrategy,
     ) -> CubeQueryPlanner {
         CubeQueryPlanner {
             cluster: Some(cluster),
@@ -64,30 +62,29 @@ impl CubeQueryPlanner {
             serialized_plan,
             memory_handler,
             data_loaded_size: None,
-            group_by_limit_factor,
+            planning_flags,
             group_by_limit_per_partition,
-            topk_strategy,
         }
     }
 
+    /// The worker plans from the flags the router sent, not from its own configuration: the two
+    /// halves of a split plan only fit together when both were planned from the same values.
     pub fn new_on_worker(
         serialized_plan: Arc<PreSerializedPlan>,
-        worker_planning_params: WorkerPlanningParams,
+        worker_partition_count: usize,
         memory_handler: Arc<dyn MemoryHandler>,
         data_loaded_size: Option<Arc<DataLoadedSize>>,
-        group_by_limit_factor: usize,
+        planning_flags: PlanningFlags,
         group_by_limit_per_partition: bool,
-        topk_strategy: TopKAggregateStrategy,
     ) -> CubeQueryPlanner {
         CubeQueryPlanner {
             serialized_plan,
             cluster: None,
-            worker_partition_count: Some(worker_planning_params),
+            worker_partition_count: Some(worker_partition_count),
             memory_handler,
             data_loaded_size,
-            group_by_limit_factor,
+            planning_flags,
             group_by_limit_per_partition,
-            topk_strategy,
         }
     }
 }
@@ -108,9 +105,9 @@ impl QueryPlanner for CubeQueryPlanner {
         let p = DefaultPhysicalPlanner::with_extension_planners(vec![
             Arc::new(CubeExtensionPlanner {
                 cluster: self.cluster.clone(),
-                worker_planning_params: self.worker_partition_count,
+                worker_partition_count: self.worker_partition_count,
                 serialized_plan: self.serialized_plan.clone(),
-                topk_strategy: self.topk_strategy,
+                planning_flags: self.planning_flags,
             }),
             Arc::new(RollingWindowPlanner {}),
         ])
@@ -121,7 +118,7 @@ impl QueryPlanner for CubeQueryPlanner {
             self.memory_handler.clone(),
             self.data_loaded_size.clone(),
             ctx_state.config().options(),
-            self.group_by_limit_factor,
+            self.planning_flags.group_by_limit_factor,
             self.group_by_limit_per_partition,
         );
         result

--- a/rust/cubestore/cubestore/src/queryplanner/panic.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/panic.rs
@@ -1,4 +1,3 @@
-use crate::cluster::WorkerPlanningParams;
 use crate::queryplanner::planning::WorkerExec;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::Schema;
@@ -184,8 +183,7 @@ pub fn plan_panic_worker() -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         // a WorkerExec for some reason. (Also, it's important that DF optimizations run identically
         // when it comes to aggregates pushed down through ClusterSend and the like -- it's actually
         // NOT important for panic worker planning.)
-        WorkerPlanningParams {
-            worker_partition_count: 1,
-        },
+        /* worker_partition_count */
+        1,
     )))
 }

--- a/rust/cubestore/cubestore/src/queryplanner/planning.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/planning.rs
@@ -32,8 +32,7 @@ use itertools::{EitherOrBoth, Itertools};
 use std::any::Any;
 use std::fmt::Formatter;
 
-use crate::cluster::{Cluster, WorkerPlanningParams};
-use crate::config::TopKAggregateStrategy;
+use crate::cluster::{Cluster, PlanningFlags};
 use crate::metastore::multi_index::MultiPartition;
 use crate::metastore::table::{Table, TablePath};
 use crate::metastore::{
@@ -1969,9 +1968,10 @@ fn pull_up_cluster_send(mut p: LogicalPlan) -> Result<LogicalPlan, DataFusionErr
 pub struct CubeExtensionPlanner {
     pub cluster: Option<Arc<dyn Cluster>>,
     // Set on the workers.
-    pub worker_planning_params: Option<WorkerPlanningParams>,
+    pub worker_partition_count: Option<usize>,
     pub serialized_plan: Arc<PreSerializedPlan>,
-    pub topk_strategy: TopKAggregateStrategy,
+    /// On the router, this node's own configuration; on a worker, what the router sent.
+    pub planning_flags: PlanningFlags,
 }
 
 #[async_trait]
@@ -2116,16 +2116,19 @@ impl CubeExtensionPlanner {
                 limit_and_reverse,
                 worker_sort_and_limit,
                 required_input_ordering,
+                self.planning_flags,
             )?))
         } else {
-            let worker_planning_params = self.worker_planning_params.expect("cluster_send_partition_count must be set when CubeExtensionPlanner::cluster is None");
+            let worker_partition_count = self.worker_partition_count.expect(
+                "worker_partition_count must be set when CubeExtensionPlanner::cluster is None",
+            );
             Ok(Arc::new(WorkerExec::new(
                 input,
                 max_batch_rows,
                 limit_and_reverse,
                 required_input_ordering,
                 worker_sort_and_limit,
-                worker_planning_params,
+                worker_partition_count,
             )))
         }
     }
@@ -2150,13 +2153,11 @@ impl WorkerExec {
         limit_and_reverse: Option<(usize, bool)>,
         required_input_ordering: Option<LexRequirement>,
         worker_sort_and_limit: Option<WorkerSortAndLimit>,
-        worker_planning_params: WorkerPlanningParams,
+        worker_partition_count: usize,
     ) -> WorkerExec {
         // This, importantly, gives us the same PlanProperties as ClusterSendExec.
-        let properties = ClusterSendExec::compute_properties(
-            input.properties(),
-            worker_planning_params.worker_partition_count,
-        );
+        let properties =
+            ClusterSendExec::compute_properties(input.properties(), worker_partition_count);
         WorkerExec {
             input,
             max_batch_rows,

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -1,5 +1,5 @@
 use crate::cluster::{
-    pick_worker_by_ids, pick_worker_by_partitions, Cluster, WorkerPlanningParams,
+    pick_worker_by_ids, pick_worker_by_partitions, Cluster, PlanningFlags, WorkerPlanningParams,
 };
 use crate::config::injection::DIService;
 use crate::config::ConfigObj;
@@ -567,9 +567,8 @@ impl QueryExecutorImpl {
             cluster,
             serialized_plan,
             self.memory_handler.clone(),
-            self.config.group_by_limit_factor(),
+            PlanningFlags::from_config(self.config.as_ref()),
             self.config.group_by_limit_per_partition(),
-            self.config.topk_aggregate_strategy(),
         ))
     }
 
@@ -580,14 +579,19 @@ impl QueryExecutorImpl {
         worker_planning_params: WorkerPlanningParams,
         data_loaded_size: Option<Arc<DataLoadedSize>>,
     ) -> Result<Arc<SessionContext>, CubeError> {
+        // A sender that does not send the flags planned from its own configuration, which this
+        // node's configuration reproduces: an explicitly set value is set on every node of a
+        // cluster, and an unset one still defaults to the same value in both binaries.
+        let planning_flags = worker_planning_params
+            .flags
+            .unwrap_or_else(|| PlanningFlags::from_config(self.config.as_ref()));
         self.make_context(CubeQueryPlanner::new_on_worker(
             serialized_plan,
-            worker_planning_params,
+            worker_planning_params.worker_partition_count,
             self.memory_handler.clone(),
             data_loaded_size.clone(),
-            self.config.group_by_limit_factor(),
+            planning_flags,
             self.config.group_by_limit_per_partition(),
-            self.config.topk_aggregate_strategy(),
         ))
     }
 
@@ -1482,6 +1486,8 @@ pub struct ClusterSendExec {
     pub required_input_ordering: Option<LexRequirement>,
     /// Not used in execution, only stored to allow consistent optimization on router and worker.
     pub worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
+    /// The flags this node planned with, sent to the worker so it plans its half the same way.
+    pub planning_flags: PlanningFlags,
 }
 
 pub type PartitionWithFilters = (u64, RowRange);
@@ -1506,6 +1512,7 @@ impl ClusterSendExec {
         limit_and_reverse: Option<(usize, bool)>,
         worker_sort_and_limit: Option<(Vec<(usize, bool, bool)>, usize)>,
         required_input_ordering: Option<LexRequirement>,
+        planning_flags: PlanningFlags,
     ) -> Result<Self, CubeError> {
         let partitions = Self::distribute_to_workers(
             cluster.config().as_ref(),
@@ -1525,6 +1532,7 @@ impl ClusterSendExec {
             limit_and_reverse,
             required_input_ordering,
             worker_sort_and_limit,
+            planning_flags,
         })
     }
 
@@ -1551,6 +1559,7 @@ impl ClusterSendExec {
         WorkerPlanningParams {
             // Or, self.partitions.len().
             worker_partition_count: self.properties().output_partitioning().partition_count(),
+            flags: Some(self.planning_flags),
         }
     }
 
@@ -1847,6 +1856,7 @@ impl ClusterSendExec {
             limit_and_reverse: self.limit_and_reverse,
             worker_sort_and_limit: self.worker_sort_and_limit.clone(),
             required_input_ordering: new_required_input_ordering,
+            planning_flags: self.planning_flags,
         }
     }
 
@@ -1915,6 +1925,7 @@ impl ExecutionPlan for ClusterSendExec {
             limit_and_reverse: self.limit_and_reverse,
             worker_sort_and_limit: self.worker_sort_and_limit.clone(),
             required_input_ordering: self.required_input_ordering.clone(),
+            planning_flags: self.planning_flags,
         }))
     }
 

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -579,9 +579,10 @@ impl QueryExecutorImpl {
         worker_planning_params: WorkerPlanningParams,
         data_loaded_size: Option<Arc<DataLoadedSize>>,
     ) -> Result<Arc<SessionContext>, CubeError> {
-        // A sender that does not send the flags planned from its own configuration, which this
-        // node's configuration reproduces: an explicitly set value is set on every node of a
-        // cluster, and an unset one still defaults to the same value in both binaries.
+        // A sender that does not send the flags planned from its own configuration, and this
+        // node's configuration reproduces it as long as the value is unset (both binaries default
+        // to the same one) or set on every node. A value set on the router alone is the one case
+        // it cannot reproduce, so keep such a value set cluster-wide until every node sends flags.
         let planning_flags = worker_planning_params
             .flags
             .unwrap_or_else(|| PlanningFlags::from_config(self.config.as_ref()));
@@ -2541,7 +2542,53 @@ fn slice_copy(a: &dyn Array, start: usize, len: usize) -> ArrayRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cluster::MockCluster;
+    use crate::config::TopKAggregateStrategy;
+    use crate::queryplanner::planning::PlanningMeta;
     use datafusion::arrow::datatypes::Field;
+    use datafusion::common::DFSchema;
+    use datafusion::logical_expr::EmptyRelation;
+    use std::collections::HashMap;
+
+    /// The flags the router stamped must reach the worker, not silently decay to the absent case
+    /// that makes the worker plan from its own configuration.
+    #[test]
+    fn cluster_send_exec_sends_its_planning_flags() -> Result<(), CubeError> {
+        let flags = PlanningFlags {
+            group_by_limit_factor: 3,
+            topk_strategy: TopKAggregateStrategy::FullMerge,
+        };
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
+        let plan = PreSerializedPlan::try_new(
+            LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(DFSchema::empty()),
+            }),
+            PlanningMeta {
+                indices: Vec::new(),
+                multi_part_subtree: HashMap::new(),
+                pushable_chunk_filters: Vec::new(),
+            },
+            None,
+        )?;
+        let exec = ClusterSendExec {
+            properties: ClusterSendExec::compute_properties(input.properties(), 2),
+            partitions: Vec::new(),
+            cluster: Arc::new(MockCluster::new()),
+            serialized_plan: Arc::new(plan),
+            input_for_optimizations: input,
+            use_streaming: false,
+            limit_and_reverse: None,
+            required_input_ordering: None,
+            worker_sort_and_limit: None,
+            planning_flags: flags,
+        };
+
+        let params = exec.worker_planning_params();
+        assert_eq!(params.worker_partition_count, 2);
+        assert_eq!(params.flags, Some(flags));
+        Ok(())
+    }
 
     #[test]
     fn test_batch_to_dataframe() -> Result<(), CubeError> {

--- a/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/topk/plan.rs
@@ -616,7 +616,7 @@ pub fn plan_topk(
     // Full-merge strategy: workers send their groups unsorted, the router re-aggregates with one
     // vectorized hash aggregate and takes the top-k with a fetch-limited sort. Drops early
     // termination (so the router materializes every distinct group), so it is opt-in and skips HLL.
-    if ext_planner.topk_strategy == TopKAggregateStrategy::FullMerge
+    if ext_planner.planning_flags.topk_strategy == TopKAggregateStrategy::FullMerge
         && agg_fun
             .iter()
             .all(|(f, _)| *f != TopKAggregateFunction::Merge)
@@ -679,7 +679,8 @@ pub fn plan_topk(
         None
     };
 
-    let merge_version = if ext_planner.topk_strategy == TopKAggregateStrategy::VectorizedStreaming
+    let merge_version = if ext_planner.planning_flags.topk_strategy
+        == TopKAggregateStrategy::VectorizedStreaming
         && topk_v2_supported(lower_node, group_expr_len, agg_fun.as_slice())
     {
         TopKMergeVersion::V2

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -856,13 +856,7 @@ impl SqlService for SqlServiceImpl {
                     } else {
                         let worker = &workers[0];
                         cluster
-                            .run_select(
-                                worker,
-                                plan,
-                                WorkerPlanningParams {
-                                    worker_partition_count: 1,
-                                },
-                            )
+                            .run_select(worker, plan, WorkerPlanningParams::no_worker())
                             .await?;
                     }
                     panic!("worker did not panic")


### PR DESCRIPTION
A select worker does not execute the physical plan the router sends it -- it plans its own
half from the logical plan it receives (`worker_plan` -> `worker_context` ->
`CubeQueryPlanner::new_on_worker`), and it read the planning flags from its own
configuration. Two hops are involved: router -> worker (`NetworkMessage::Select`) and
worker -> select subprocess (`WorkerMessage::Select`, where the subprocess is respawned with
`Config::default()`, i.e. from env).

When the values at the two ends disagree, the two halves of a split plan do not fit
together and the query returns **silently wrong rows** rather than failing. Measured by
skewing the router and the select subprocess:

| Skew (router / select subprocess) | Result |
|---|---|
| `topk_strategy`: FullMerge / Streaming | 4 cluster top-k tests, wrong order (`url10` instead of `url2`) |
| `group_by_limit_factor`: 0 / 2 | `limit_pushdown_group_nonprefix_order`: sum `100` instead of `1110` |
| `group_by_limit_factor`: 2 / 0 | harmless |
| `coalesce_under_hash_aggregate`, `push_partial_aggregate_below_merge` | harmless both ways |

So the bundle holds exactly `topk_strategy` and `group_by_limit_factor`.
`group_by_limit_per_partition` is deliberately left out: it only changes the layout inside
the worker (both `resort_worker_subtree` paths end in a `CoalescePartitionsExec`, so the
schema and partition count the router sees are the same either way).

## What this does

- `PlanningFlags { group_by_limit_factor, topk_strategy }`, carried as a field of
  `WorkerPlanningParams` -- a struct that already travelled on both hops.
- The router stamps its own values into `ClusterSendExec`; the worker plans from what it
  received.
- The field is `Option<PlanningFlags>` with `#[serde(default)]`. A sender that does not send
  it is an older binary, which planned its half from its own configuration -- so the
  receiver falls back to *its own* configuration (`worker_context`), not to a hardcoded
  default. Since this branch does not change any default, that fallback is exact in both
  cases: the value is set explicitly on every node of a cluster, or it is unset and both
  binaries default to the same thing.
- `WorkerExec::new` takes `worker_partition_count: usize` instead of the whole
  `WorkerPlanningParams` -- it only ever read that field, and this way the struct can grow
  without touching plan construction.
- `TopKAggregateStrategy` gets serde derives deliberately **without** `#[serde(other)]`: a
  strategy from a newer node that this binary does not know must fail the query loudly.
- Three tests in `cluster::tests` pin the wire contract (message without the flags, older
  receiver, round trip) and one pins the configuration fallback. flexbuffers+serde
  compatibility was checked empirically in both directions.

## Release ordering -- important

This must ship **before** the default flip (`cubestore-change-perf-defaults`, #11600). The
flags only help when both nodes are new: an older worker does not know the field and plans
from its own configuration. If the default flip lands at the same time or earlier, there is
a "new router + old worker" window with silently wrong results that no fallback can close.

## Testing

`cargo test --no-fail-fast` in `rust/cubestore` -- lib, cluster, in-process, migration and
multi-process suites green.

Counter-examples that pass because of this branch (the subprocess with a skewed env now
obeys the router):

```
CUBESTORE_GROUP_BY_LIMIT_FACTOR=0 CUBESTORE_TOPK_STRATEGY=streaming \
  cargo test -p cubestore-sql-tests --test cluster -- limit_pushdown topk
```

and the reverse skew (`group_by_limit_factor: 0` in `Config::test`, run with
`CUBESTORE_GROUP_BY_LIMIT_FACTOR=2`): `limit_pushdown_group_nonprefix_order` passes, where
without the branch it returned 100 instead of 1110.
