### PR TITLE
fix(query-orchestrator): don't report failed pre-agg build jobs as done

### DIFF
--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -544,14 +544,14 @@ To trigger pre-aggregation builds, send a `POST` request with a payload
 including `post` as the `action` and `selector` properties. The response will
 contain an array of `tokens` (identifiers) of triggered jobs.
 
-<Warning>
+<Note>
 
-Jobs run on the instance that receives the request. If that instance isn't set
-up to build pre-aggregations, the request fails. Send jobs to an instance that
-runs a [refresh worker][ref-refresh-worker], or set
-[`CUBEJS_PRE_AGGREGATIONS_BUILDER`][ref-preaggs-builder] to `true` for it.
+Builds run in the process that receives the request, even on an instance that
+never builds pre-aggregations while serving queries. Restarting that instance
+interrupts any build it is running; such a build is reported as `failure`, so
+re-trigger the job for those partitions.
 
-</Warning>
+</Note>
 
 Example request triggering builds of all pre-aggregations defined in all cubes
 using an empty security context and a `UTC` timezone:
@@ -659,9 +659,9 @@ In the `status` property of the payload, you can get the following statuses:
 | `scheduled` | The job hasn't run yet |
 | `processing` | The job is currently running |
 | `done` | The build has completed and its data has landed in the pre-aggregation storage |
-| `failure: <error>` | The build has failed; the error message is appended to the status |
-| `missing_partition` | No build outcome is known for this partition. Either the job was never picked up, or its record has expired (job records are kept for 24 hours). Trigger the job again |
-| `not_found` | The token is unknown or has expired |
+| `failure: <error>` | The build has failed; the error message is appended to the status. `failure: the build has not completed` means the instance running the build stopped before it finished, for example because it was restarted mid-build |
+| `missing_partition` | No table exists for this partition and no build outcome is recorded for it. Trigger the job again |
+| `not_found` | The token is unknown, or the job record has expired. Job records are kept for 24 hours |
 | `pre_agg_not_found` | The pre-aggregation the job was triggered for is no longer defined in the data model |
 
 <Note>
@@ -1199,6 +1199,4 @@ Keep-Alive: timeout=5
 [ref-time-zone]: /reference/core-data-apis/queries#time-zone
 [link-tzdb]: https://en.wikipedia.org/wiki/Tz_database
 [ref-control-plane-api]: /reference/control-plane-api
-[ref-refresh-worker]: /reference/configuration/environment-variables#cubejs_refresh_worker
-[ref-preaggs-builder]: /reference/configuration/environment-variables#cubejs_pre_aggregations_builder
 [self-metadata-api]: #metadata-api

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -544,6 +544,15 @@ To trigger pre-aggregation builds, send a `POST` request with a payload
 including `post` as the `action` and `selector` properties. The response will
 contain an array of `tokens` (identifiers) of triggered jobs.
 
+<Warning>
+
+Jobs run on the instance that receives the request. If that instance isn't set
+up to build pre-aggregations, the request fails. Send jobs to an instance that
+runs a [refresh worker][ref-refresh-worker], or set
+[`CUBEJS_PRE_AGGREGATIONS_BUILDER`][ref-preaggs-builder] to `true` for it.
+
+</Warning>
+
 Example request triggering builds of all pre-aggregations defined in all cubes
 using an empty security context and a `UTC` timezone:
 
@@ -649,8 +658,19 @@ In the `status` property of the payload, you can get the following statuses:
 | --- | --- |
 | `scheduled` | The job hasn't run yet |
 | `processing` | The job is currently running |
-| `missing_partition` | The job has failed |
-| `done` | The job has successfully completed |
+| `done` | The build has completed and its data has landed in the pre-aggregation storage |
+| `failure: <error>` | The build has failed; the error message is appended to the status |
+| `missing_partition` | No build outcome is known for this partition. Either the job was never picked up, or its record has expired (job records are kept for 24 hours). Trigger the job again |
+| `not_found` | The token is unknown or has expired |
+| `pre_agg_not_found` | The pre-aggregation the job was triggered for is no longer defined in the data model |
+
+<Note>
+
+`done` means the build itself has finished successfully. It doesn't mean the
+partition has any rows: a partition with no matching source data is built and
+reported as `done` with zero rows.
+
+</Note>
 
 Example request:
 
@@ -1179,4 +1199,6 @@ Keep-Alive: timeout=5
 [ref-time-zone]: /reference/core-data-apis/queries#time-zone
 [link-tzdb]: https://en.wikipedia.org/wiki/Tz_database
 [ref-control-plane-api]: /reference/control-plane-api
+[ref-refresh-worker]: /reference/configuration/environment-variables#cubejs_refresh_worker
+[ref-preaggs-builder]: /reference/configuration/environment-variables#cubejs_pre_aggregations_builder
 [self-metadata-api]: #metadata-api

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -101,6 +101,8 @@ export class PreAggregationLoader {
 
   private readonly externalRefresh: boolean;
 
+  private buildLanded: boolean = false;
+
   public constructor(
     private readonly driverFactory: DriverFactory,
     private readonly logger: LoggerFn,
@@ -493,19 +495,22 @@ export class PreAggregationLoader {
         });
 
         try {
-          const result = await refreshStrategy.bind(this)(
+          return await refreshStrategy.bind(this)(
             client,
             newVersionEntry,
             saveCancelFn,
             invalidationKeys
           );
-          await this.reportBuildStatus(targetTableName, { status: 'done' });
-          return result;
         } catch (e: any) {
-          await this.reportBuildStatus(targetTableName, {
-            status: 'failure',
-            error: (e.message || e).toString(),
-          });
+          // Post-build cleanup runs after the rows have landed and can fail on
+          // its own. The partition is complete either way, so it keeps the
+          // outcome the strategy already reported.
+          if (!this.buildLanded) {
+            await this.reportBuildStatus(targetTableName, {
+              status: 'failure',
+              error: (e.message || e).toString(),
+            });
+          }
 
           // It's required to remove touch keys, because they are unique per run/table, and it causes
           // a large number of touch keys in the cache store
@@ -534,10 +539,28 @@ export class PreAggregationLoader {
   }
 
   /**
-   * Persists the build outcome so the jobs API can tell a finished build from a
-   * versioned table that merely exists. Recorded for every build, not just for
-   * the ones a job started: the queue de-duplicates on the query key, so a job
-   * regularly ends up waiting on a build some other request enqueued.
+   * Marks the rows as landed in the partition table. From here on the table
+   * speaks for itself, so the record that a build is in flight goes away and
+   * nothing but a live build is left behind in the cache store.
+   */
+  protected async reportBuildLanded(targetTableName: string): Promise<void> {
+    this.buildLanded = true;
+
+    try {
+      await this.preAggregations.removePreAggregationBuildStatus(targetTableName);
+    } catch (e: any) {
+      this.logger('Error on dropping pre-aggregation build status', {
+        error: (e.stack || e), preAggregation: this.preAggregation, requestId: this.requestId,
+      });
+    }
+  }
+
+  /**
+   * Persists that a build is running or has failed, so the jobs API can tell an
+   * unfinished build from a versioned table that merely exists. Recorded for
+   * every build, not just for the ones a job started: the queue de-duplicates
+   * on the query key, so a job regularly ends up waiting on a build some other
+   * request enqueued.
    */
   private async reportBuildStatus(targetTableName: string, status: PreAggregationBuildStatus): Promise<void> {
     try {
@@ -602,6 +625,7 @@ export class PreAggregationLoader {
       ));
 
       await this.createIndexes(client, newVersionEntry, saveCancelFn, queryOptions);
+      await this.reportBuildLanded(targetTableName);
       await this.loadCache.fetchTables(this.preAggregation);
     } finally {
       // We must clean orphaned in any cases: success or exception
@@ -997,6 +1021,7 @@ export class PreAggregationLoader {
       throw error;
     });
     this.logger('Uploading external pre-aggregation completed', queryOptions);
+    await this.reportBuildLanded(table);
 
     await this.loadCache.fetchTables(this.preAggregation);
     await this.dropOrphanedTables(externalDriver, table, saveCancelFn, true, queryOptions);

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -20,6 +20,7 @@ import {
   getStructureVersion,
   InvalidationKeys,
   LoadPreAggregationResult,
+  PreAggregationBuildStatus,
   PreAggregations,
   PreAggregationTableToTempTable,
   tablesToVersionEntries,
@@ -131,6 +132,11 @@ export class PreAggregationLoader {
   public async loadPreAggregation(
     throwOnMissingPartition: boolean,
   ): Promise<null | LoadPreAggregationResult> {
+    if (this.isJob && this.externalRefresh) {
+      // eslint-disable-next-line no-use-before-define
+      throw new Error(PreAggregations.buildJobsNotAllowedMessage());
+    }
+
     const notLoadedKey = (this.preAggregation.invalidateKeyQueries || [])
       .find(keyQuery => !this.loadCache.hasKeyQueryResult(keyQuery));
 
@@ -486,14 +492,26 @@ export class PreAggregationLoader {
 
     return cancelCombinator(
       async saveCancelFn => {
+        await this.reportBuildStatus(targetTableName, {
+          status: 'building',
+          startedAt: new Date().getTime(),
+        });
+
         try {
-          return await refreshStrategy.bind(this)(
+          const result = await refreshStrategy.bind(this)(
             client,
             newVersionEntry,
             saveCancelFn,
             invalidationKeys
           );
-        } catch (e) {
+          await this.reportBuildStatus(targetTableName, { status: 'done' });
+          return result;
+        } catch (e: any) {
+          await this.reportBuildStatus(targetTableName, {
+            status: 'failure',
+            error: (e.message || e).toString(),
+          });
+
           // It's required to remove touch keys, because they are unique per run/table, and it causes
           // a large number of touch keys in the cache store
           try {
@@ -518,6 +536,26 @@ export class PreAggregationLoader {
         }
       }
     );
+  }
+
+  /**
+   * Persists the build outcome so the jobs API can tell a finished build from a
+   * versioned table that merely exists. Only build jobs are tracked: nothing
+   * else reads these records and every build would otherwise write to the cache
+   * store on every refresh.
+   */
+  private async reportBuildStatus(targetTableName: string, status: PreAggregationBuildStatus): Promise<void> {
+    if (!this.isJob) {
+      return;
+    }
+
+    try {
+      await this.preAggregations.setPreAggregationBuildStatus(targetTableName, status);
+    } catch (e: any) {
+      this.logger('Error on saving pre-aggregation build status', {
+        error: (e.stack || e), preAggregation: this.preAggregation, requestId: this.requestId,
+      });
+    }
   }
 
   protected logExecutingSql(payload) {
@@ -941,6 +979,9 @@ export class PreAggregationLoader {
   ) {
     const externalDriver: DriverInterface = await this.externalDriverFactory();
     const table = this.targetTableName(newVersionEntry);
+    // A table that is already there was built by someone else, so a failure
+    // here says nothing about it and it must be left alone
+    const preExistingTable = await this.externalTableExists(externalDriver, table);
 
     this.logger('Uploading external pre-aggregation', queryOptions);
     await saveCancelFn(
@@ -957,17 +998,45 @@ export class PreAggregationLoader {
           sealAt: this.preAggregation.sealAt
         }
       )
-    ).catch((error: any) => {
+    ).catch(async (error: any) => {
       this.logger('Uploading external pre-aggregation error', {
         ...queryOptions,
         error: error?.stack || error?.message
       });
+      // A half-built table is the newest version of the partition, so it shadows
+      // the previous correct one and orphaned tables cleanup always keeps it.
+      if (!preExistingTable) {
+        await this.dropPartiallyBuiltTable(externalDriver, table, queryOptions);
+      }
       throw error;
     });
     this.logger('Uploading external pre-aggregation completed', queryOptions);
 
     await this.loadCache.fetchTables(this.preAggregation);
     await this.dropOrphanedTables(externalDriver, table, saveCancelFn, true, queryOptions);
+  }
+
+  private async externalTableExists(driver: DriverInterface, table: string): Promise<boolean> {
+    const actualTables = await driver.getTablesQuery(this.preAggregation.preAggregationsSchema);
+
+    return actualTables
+      .map(t => `${this.preAggregation.preAggregationsSchema}.${t.table_name || t.TABLE_NAME}`)
+      .includes(table);
+  }
+
+  private async dropPartiallyBuiltTable(driver: DriverInterface, table: string, queryOptions: QueryOptions) {
+    this.logger('Dropping partially built external pre-aggregation', queryOptions);
+
+    try {
+      // Dropped without looking it up first: a table listing can be stale, and
+      // losing the drop is much worse than dropping a table that was never created
+      await driver.dropTable(table);
+    } catch (e: any) {
+      this.logger('Dropping partially built external pre-aggregation error', {
+        ...queryOptions,
+        error: e?.stack || e?.message
+      });
+    }
   }
 
   protected async createIndexes(driver: DriverInterface, newVersionEntry: VersionEntry, saveCancelFn: SaveCancelFn, queryOptions: QueryOptions) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -132,11 +132,6 @@ export class PreAggregationLoader {
   public async loadPreAggregation(
     throwOnMissingPartition: boolean,
   ): Promise<null | LoadPreAggregationResult> {
-    if (this.isJob && this.externalRefresh) {
-      // eslint-disable-next-line no-use-before-define
-      throw new Error(PreAggregations.buildJobsNotAllowedMessage());
-    }
-
     const notLoadedKey = (this.preAggregation.invalidateKeyQueries || [])
       .find(keyQuery => !this.loadCache.hasKeyQueryResult(keyQuery));
 
@@ -540,15 +535,11 @@ export class PreAggregationLoader {
 
   /**
    * Persists the build outcome so the jobs API can tell a finished build from a
-   * versioned table that merely exists. Only build jobs are tracked: nothing
-   * else reads these records and every build would otherwise write to the cache
-   * store on every refresh.
+   * versioned table that merely exists. Recorded for every build, not just for
+   * the ones a job started: the queue de-duplicates on the query key, so a job
+   * regularly ends up waiting on a build some other request enqueued.
    */
   private async reportBuildStatus(targetTableName: string, status: PreAggregationBuildStatus): Promise<void> {
-    if (!this.isJob) {
-      return;
-    }
-
     try {
       await this.preAggregations.setPreAggregationBuildStatus(targetTableName, status);
     } catch (e: any) {
@@ -979,9 +970,6 @@ export class PreAggregationLoader {
   ) {
     const externalDriver: DriverInterface = await this.externalDriverFactory();
     const table = this.targetTableName(newVersionEntry);
-    // A table that is already there was built by someone else, so a failure
-    // here says nothing about it and it must be left alone
-    const preExistingTable = await this.externalTableExists(externalDriver, table);
 
     this.logger('Uploading external pre-aggregation', queryOptions);
     await saveCancelFn(
@@ -1005,9 +993,7 @@ export class PreAggregationLoader {
       });
       // A half-built table is the newest version of the partition, so it shadows
       // the previous correct one and orphaned tables cleanup always keeps it.
-      if (!preExistingTable) {
-        await this.dropPartiallyBuiltTable(externalDriver, table, queryOptions);
-      }
+      await this.dropPartiallyBuiltTable(externalDriver, table, queryOptions);
       throw error;
     });
     this.logger('Uploading external pre-aggregation completed', queryOptions);
@@ -1016,20 +1002,13 @@ export class PreAggregationLoader {
     await this.dropOrphanedTables(externalDriver, table, saveCancelFn, true, queryOptions);
   }
 
-  private async externalTableExists(driver: DriverInterface, table: string): Promise<boolean> {
-    const actualTables = await driver.getTablesQuery(this.preAggregation.preAggregationsSchema);
-
-    return actualTables
-      .map(t => `${this.preAggregation.preAggregationsSchema}.${t.table_name || t.TABLE_NAME}`)
-      .includes(table);
-  }
-
   private async dropPartiallyBuiltTable(driver: DriverInterface, table: string, queryOptions: QueryOptions) {
     this.logger('Dropping partially built external pre-aggregation', queryOptions);
 
     try {
-      // Dropped without looking it up first: a table listing can be stale, and
-      // losing the drop is much worse than dropping a table that was never created
+      // Dropped without checking that it is there: `CREATE TABLE` carries no
+      // `IF NOT EXISTS`, so a leftover table fails every later attempt at this
+      // version until it is gone
       await driver.dropTable(table);
     } catch (e: any) {
       this.logger('Dropping partially built external pre-aggregation error', {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -385,7 +385,7 @@ export class PreAggregations {
       return false;
     }
 
-    const { executionTimeout } = await this.options.queueOptions(dataSource);
+    const { executionTimeout } = await this.options.queueOptions?.(dataSource) || {};
     const limit = (executionTimeout || getEnv('dbQueryTimeout')) * 1000 * ABANDONED_BUILD_TIMEOUT_FACTOR;
 
     return new Date().getTime() - buildStatus.startedAt > limit;
@@ -538,14 +538,14 @@ export class PreAggregations {
     let status: string;
     if (buildStatus?.status === 'failure') {
       status = `failure: ${buildStatus.error}`;
-    } else if (result?.error) {
-      status = `failure: ${result.error}`;
     } else if (buildStatus?.status === 'building') {
       status = await this.isBuildAbandoned(dataSource, buildStatus)
         ? 'failure: the build has not completed'
         : 'processing';
     } else if (tables.length === 1) {
       status = 'done';
+    } else if (result?.error) {
+      status = `failure: ${result.error}`;
     } else {
       status = 'missing_partition';
     }
@@ -556,7 +556,9 @@ export class PreAggregations {
       .getCacheDriver()
       .get(`PRE_AGG_JOB_${token}`);
 
-    if (preAggJob) {
+    // clients poll in a loop, so rewriting an unchanged status would both add a
+    // write per token per poll and keep pushing the record's expiry forward
+    if (preAggJob && preAggJob.status !== status) {
       await this
         .queryCache
         .getCacheDriver()
@@ -774,7 +776,7 @@ export class PreAggregations {
           () => this.driverFactory(dataSource, true),
           (client, q) => {
             const {
-              preAggregation, preAggregationsTablesToTempTables, newVersionEntry, requestId, invalidationKeys, buildRangeEnd, isJob
+              preAggregation, preAggregationsTablesToTempTables, newVersionEntry, requestId, invalidationKeys, buildRangeEnd
             } = q;
             const loader = new PreAggregationLoader(
               () => this.driverFactory(dataSource, true),
@@ -792,7 +794,7 @@ export class PreAggregations {
                   dataSource,
                 },
               ),
-              { requestId, externalRefresh: this.externalRefresh, buildRangeEnd, isJob }
+              { requestId, externalRefresh: this.externalRefresh, buildRangeEnd }
             );
             return loader.refresh(newVersionEntry, invalidationKeys, client);
           },
@@ -877,12 +879,6 @@ export class PreAggregations {
       'Please make sure your refresh worker is configured correctly, running, pre-aggregation tables are built and ' +
       'all pre-aggregation refresh settings like timezone match. ' +
       `Expected table name patterns: ${expectedTableNames.join(', ')}`;
-  }
-
-  public static buildJobsNotAllowedMessage(): string {
-    return 'This instance isn\'t set up to build pre-aggregations, so it can\'t run a pre-aggregation build job. ' +
-      'Please post build jobs to an instance running a refresh worker, or set ' +
-      'CUBEJS_PRE_AGGREGATIONS_BUILDER=true for this instance.';
   }
 
   public static structureVersion(preAggregation) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -139,6 +139,26 @@ type PreAggJob = {
   dataSource: string,
 };
 
+/**
+ * Outcome of a build for a particular versioned partition table. Tracked
+ * separately from the table itself: the versioned table becomes visible to
+ * `getTablesQuery` as soon as it is created, which is long before the rows
+ * are imported into it.
+ */
+export type PreAggregationBuildStatus = {
+  status: 'building' | 'done' | 'failure',
+  error?: string,
+  startedAt?: number,
+};
+
+const PRE_AGG_BUILD_STATUS_PERSIST_TIME = 86400;
+
+/**
+ * How much longer than the queue execution timeout a build is still believed
+ * to be running. The slack covers the queue writing the timeout failure down.
+ */
+const ABANDONED_BUILD_TIMEOUT_FACTOR = 2;
+
 export type LoadPreAggregationResult = {
   targetTableName: string;
   refreshKeyValues: any[];
@@ -338,6 +358,39 @@ export class PreAggregations {
     return this.queryCache.getKey('SQL_PRE_AGGREGATIONS_REFRESH_END_REACHED', '');
   }
 
+  protected preAggBuildStatusRedisKey(tableName: string): string {
+    // TODO add dataSource?
+    return this.queryCache.getKey('SQL_PRE_AGGREGATIONS_BUILD_STATUS', tableName);
+  }
+
+  public async setPreAggregationBuildStatus(tableName: string, status: PreAggregationBuildStatus): Promise<void> {
+    await this.queryCache.getCacheDriver().set(
+      this.preAggBuildStatusRedisKey(tableName),
+      status,
+      PRE_AGG_BUILD_STATUS_PERSIST_TIME
+    );
+  }
+
+  public async getPreAggregationBuildStatus(tableName: string): Promise<PreAggregationBuildStatus | null> {
+    return await this.queryCache.getCacheDriver().get(this.preAggBuildStatusRedisKey(tableName)) || null;
+  }
+
+  /**
+   * The queue times a build out on its own and records the failure, so a build
+   * that is still marked as running long past that timeout is one whose process
+   * is gone and will never report an outcome.
+   */
+  private async isBuildAbandoned(dataSource: string, buildStatus: PreAggregationBuildStatus): Promise<boolean> {
+    if (!buildStatus.startedAt) {
+      return false;
+    }
+
+    const { executionTimeout } = await this.options.queueOptions(dataSource);
+    const limit = (executionTimeout || getEnv('dbQueryTimeout')) * 1000 * ABANDONED_BUILD_TIMEOUT_FACTOR;
+
+    return new Date().getTime() - buildStatus.startedAt > limit;
+  }
+
   public async addTableUsed(tableName: string): Promise<void> {
     if (this.usedCache.has(tableName)) {
       return;
@@ -472,23 +525,38 @@ export class PreAggregations {
     const result = await conn.getResult(key);
     this.queue[dataSource].getQueueDriver().release(conn);
 
-    // calculating status
+    // fetching the build outcome. The queue result is readable only once, so
+    // the persisted build status is the durable source of truth here.
+    const buildStatus = await this.getPreAggregationBuildStatus(table);
+
+    // calculating status. A build that is known to be running or to have failed
+    // wins over the existence of the versioned table: the table is created
+    // before the rows are imported into it and it is left behind when the
+    // import fails or is killed. Without such a record the table is all we
+    // have, which is also the only thing to go by when the partition was
+    // already up to date and no build was run for it at all.
     let status: string;
-    if (tables.length === 1) {
+    if (buildStatus?.status === 'failure') {
+      status = `failure: ${buildStatus.error}`;
+    } else if (result?.error) {
+      status = `failure: ${result.error}`;
+    } else if (buildStatus?.status === 'building') {
+      status = await this.isBuildAbandoned(dataSource, buildStatus)
+        ? 'failure: the build has not completed'
+        : 'processing';
+    } else if (tables.length === 1) {
       status = 'done';
     } else {
-      status = result?.error
-        ? `failure: ${result.error}`
-        : 'missing_partition';
+      status = 'missing_partition';
     }
 
     // updating jobs cache if needed
-    if (result) {
-      const preAggJob: PreAggJob = await this
-        .queryCache
-        .getCacheDriver()
-        .get(`PRE_AGG_JOB_${token}`);
+    const preAggJob: PreAggJob = await this
+      .queryCache
+      .getCacheDriver()
+      .get(`PRE_AGG_JOB_${token}`);
 
+    if (preAggJob) {
       await this
         .queryCache
         .getCacheDriver()
@@ -706,7 +774,7 @@ export class PreAggregations {
           () => this.driverFactory(dataSource, true),
           (client, q) => {
             const {
-              preAggregation, preAggregationsTablesToTempTables, newVersionEntry, requestId, invalidationKeys, buildRangeEnd
+              preAggregation, preAggregationsTablesToTempTables, newVersionEntry, requestId, invalidationKeys, buildRangeEnd, isJob
             } = q;
             const loader = new PreAggregationLoader(
               () => this.driverFactory(dataSource, true),
@@ -724,7 +792,7 @@ export class PreAggregations {
                   dataSource,
                 },
               ),
-              { requestId, externalRefresh: this.externalRefresh, buildRangeEnd }
+              { requestId, externalRefresh: this.externalRefresh, buildRangeEnd, isJob }
             );
             return loader.refresh(newVersionEntry, invalidationKeys, client);
           },
@@ -809,6 +877,12 @@ export class PreAggregations {
       'Please make sure your refresh worker is configured correctly, running, pre-aggregation tables are built and ' +
       'all pre-aggregation refresh settings like timezone match. ' +
       `Expected table name patterns: ${expectedTableNames.join(', ')}`;
+  }
+
+  public static buildJobsNotAllowedMessage(): string {
+    return 'This instance isn\'t set up to build pre-aggregations, so it can\'t run a pre-aggregation build job. ' +
+      'Please post build jobs to an instance running a refresh worker, or set ' +
+      'CUBEJS_PRE_AGGREGATIONS_BUILDER=true for this instance.';
   }
 
   public static structureVersion(preAggregation) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -140,13 +140,18 @@ type PreAggJob = {
 };
 
 /**
- * Outcome of a build for a particular versioned partition table. Tracked
+ * State of a build for a particular versioned partition table, tracked
  * separately from the table itself: the versioned table becomes visible to
- * `getTablesQuery` as soon as it is created, which is long before the rows
- * are imported into it.
+ * `getTablesQuery` as soon as it is created, which is long before the rows are
+ * imported into it. A finished build has no record — the complete table speaks
+ * for itself — so only builds in flight and failures are kept.
+ *
+ * `startedAt` is stamped by whichever instance runs the build and read by
+ * whichever instance serves the status request, so it is compared against a
+ * different machine's clock.
  */
 export type PreAggregationBuildStatus = {
-  status: 'building' | 'done' | 'failure',
+  status: 'building' | 'failure',
   error?: string,
   startedAt?: number,
 };
@@ -155,7 +160,9 @@ const PRE_AGG_BUILD_STATUS_PERSIST_TIME = 86400;
 
 /**
  * How much longer than the queue execution timeout a build is still believed
- * to be running. The slack covers the queue writing the timeout failure down.
+ * to be running. The slack covers the queue writing the timeout failure down,
+ * and the clock difference between the instance that started the build and the
+ * one reading its status.
  */
 const ABANDONED_BUILD_TIMEOUT_FACTOR = 2;
 
@@ -375,6 +382,10 @@ export class PreAggregations {
     return await this.queryCache.getCacheDriver().get(this.preAggBuildStatusRedisKey(tableName)) || null;
   }
 
+  public async removePreAggregationBuildStatus(tableName: string): Promise<void> {
+    await this.queryCache.getCacheDriver().remove(this.preAggBuildStatusRedisKey(tableName));
+  }
+
   /**
    * The queue times a build out on its own and records the failure, so a build
    * that is still marked as running long past that timeout is one whose process
@@ -525,16 +536,16 @@ export class PreAggregations {
     const result = await conn.getResult(key);
     this.queue[dataSource].getQueueDriver().release(conn);
 
-    // fetching the build outcome. The queue result is readable only once, so
-    // the persisted build status is the durable source of truth here.
+    // fetching the state of the build. The queue result is readable only once,
+    // so this record is the durable source of truth here.
     const buildStatus = await this.getPreAggregationBuildStatus(table);
 
     // calculating status. A build that is known to be running or to have failed
     // wins over the existence of the versioned table: the table is created
     // before the rows are imported into it and it is left behind when the
-    // import fails or is killed. Without such a record the table is all we
-    // have, which is also the only thing to go by when the partition was
-    // already up to date and no build was run for it at all.
+    // import fails or is killed. A finished build leaves no record, and neither
+    // does a partition that was already up to date and never rebuilt, so in
+    // both of those the table is what the answer rests on.
     let status: string;
     if (buildStatus?.status === 'failure') {
       status = `failure: ${buildStatus.error}`;

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
@@ -1,0 +1,403 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { QueryOrchestrator } from '../../src/orchestrator/QueryOrchestrator';
+
+class MockDriver {
+  public tablesObj: any[] = [];
+
+  public executedQueries: any[] = [];
+
+  public droppedTables: string[] = [];
+
+  public now: number = Date.now();
+
+  public schema: string | undefined;
+
+  public get tables(): string[] {
+    return this.tablesObj.map(t => t.tableName || t);
+  }
+
+  public query(query: any, _params?: any): any {
+    this.executedQueries.push(query);
+
+    if (typeof query !== 'string') {
+      return Promise.resolve([]);
+    }
+
+    let promise: any = Promise.resolve([query]);
+
+    if (query.match(/^SELECT NOW\(\)$/)) {
+      promise = promise.then(() => [{ now: new Date().toJSON() }]);
+    }
+
+    promise.cancel = () => undefined;
+    return promise;
+  }
+
+  public async getTablesQuery(schema: string) {
+    return this.tablesObj
+      .filter(t => (t.tableName || t).split('.')[0] === schema)
+      .map(t => ({ table_name: (t.tableName || t).replace(`${schema}.`, '') }));
+  }
+
+  public async createSchemaIfNotExists(schema: string) {
+    this.schema = schema;
+    return null;
+  }
+
+  public loadPreAggregationIntoTable(preAggregationTableName: string, loadSql: string) {
+    this.tablesObj.push({ tableName: preAggregationTableName.substring(0, 100) });
+    return this.query(loadSql);
+  }
+
+  public async dropTable(tableName: string) {
+    this.droppedTables.push(tableName);
+    this.tablesObj = this.tablesObj.filter(t => (t.tableName || t) !== tableName);
+  }
+
+  public async downloadTable(table: string) {
+    return { rows: await this.query(`SELECT * FROM ${table}`) };
+  }
+
+  public async tableColumnTypes() {
+    return [{ name: 'foo', type: 'int' }];
+  }
+
+  public nowTimestamp() {
+    return this.now;
+  }
+
+  public capabilities() {
+    return {};
+  }
+}
+
+type ImportBehavior = 'ok' | 'fail' | 'hang';
+
+/**
+ * Emulates Cube Store. `importBehavior` reproduces the shape from the incident:
+ * `CREATE TABLE` lands (the versioned table becomes visible to `getTablesQuery`)
+ * and only then rows are imported, so there is a window where an unfinished
+ * build already looks like a complete one from the outside.
+ */
+class ExternalMockDriver extends MockDriver {
+  public indexes: any[] = [];
+
+  public importBehavior: ImportBehavior = 'ok';
+
+  public importStarted: Promise<void> = Promise.resolve();
+
+  private importStartedResolve: () => void = () => undefined;
+
+  public constructor() {
+    super();
+    this.importStarted = new Promise(resolve => {
+      this.importStartedResolve = resolve as () => void;
+    });
+  }
+
+  public async uploadTableWithIndexes(table: string, columns: any, tableData: any, indexesSql: any[]) {
+    // CREATE TABLE: the versioned table is registered and queryable from now on
+    this.tablesObj.push({ tableName: table.substring(0, 100) });
+    this.importStartedResolve();
+
+    if (this.importBehavior === 'fail') {
+      // INSERTs never land and the table is left behind as a `ready` 0-row ghost
+      throw new Error('Import into Cube Store failed after CREATE TABLE');
+    }
+
+    if (this.importBehavior === 'hang') {
+      // The import is still running: the process may be killed at any moment here
+      await new Promise(() => undefined);
+    }
+
+    for (let i = 0; i < indexesSql.length; i++) {
+      const [query, params] = indexesSql[i].sql;
+      await this.query(query, params);
+    }
+    this.indexes = this.indexes.concat(indexesSql);
+  }
+}
+
+const PRE_AGGREGATION = {
+  preAggregationsSchema: 'stb_pre_aggregations',
+  tableName: 'stb_pre_aggregations.orders_month',
+  preAggregationId: 'orders.month',
+  loadSql: [
+    'CREATE TABLE stb_pre_aggregations.orders_month AS SELECT * FROM public.orders',
+    [],
+  ],
+  sql: ['SELECT * FROM public.orders', []],
+  invalidateKeyQueries: [['SELECT NOW()', [], { renewalThreshold: 21600 }]],
+  indexesSql: [{
+    sql: ['CREATE INDEX orders_month_main ON stb_pre_aggregations.orders_month ("orders__created_at")', []],
+    indexName: 'orders_month_main',
+  }],
+  external: true,
+  dataSource: 'default',
+  timezone: 'UTC',
+};
+
+const jobQuery = (requestId: string) => ({
+  // The jobs API posts a build query without `query`
+  values: [],
+  cacheKeyQueries: { queries: [] },
+  preAggregations: [PRE_AGGREGATION],
+  continueWait: true,
+  renewQuery: true,
+  requestId,
+  isJob: true,
+  forceBuildPreAggregations: true,
+  external: true,
+});
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const waitFor = async (predicate: () => boolean | Promise<boolean>, timeout = 10000) => {
+  const started = Date.now();
+  // eslint-disable-next-line no-await-in-loop
+  while (!(await predicate())) {
+    if (Date.now() - started > timeout) {
+      throw new Error('Timeout while waiting for a condition');
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await delay(20);
+  }
+};
+
+describe('pre-aggregation build jobs', () => {
+  jest.setTimeout(20000);
+
+  let mockDriver: MockDriver;
+  let externalMockDriver: ExternalMockDriver;
+  let orchestrator: QueryOrchestrator;
+  let orchestratorExternalRefresh: QueryOrchestrator;
+  let testCount = 1;
+
+  beforeEach(() => {
+    mockDriver = new MockDriver();
+    externalMockDriver = new ExternalMockDriver();
+
+    const prefix = `PRE_AGG_JOBS_TEST_${testCount++}`;
+    const driverFactory = () => mockDriver;
+    const logger = () => undefined;
+
+    const options = {
+      externalDriverFactory: () => externalMockDriver,
+      queryCacheOptions: {
+        queueOptions: () => ({ concurrency: 2, processUid: 'p1' }),
+      },
+      preAggregationsOptions: {
+        maxPartitions: 100,
+        queueOptions: () => ({ executionTimeout: 2, concurrency: 2, processUid: 'p1' }),
+        usedTablePersistTime: 1,
+      },
+    };
+
+    orchestrator = new QueryOrchestrator(prefix, driverFactory as any, logger, options as any);
+    orchestratorExternalRefresh = new QueryOrchestrator(prefix, driverFactory as any, logger, {
+      ...options,
+      preAggregationsOptions: {
+        ...options.preAggregationsOptions,
+        externalRefresh: true,
+      },
+    } as any);
+  });
+
+  afterEach(async () => {
+    await orchestrator.cleanup();
+    await orchestratorExternalRefresh.cleanup();
+  });
+
+  const pollUntilSettled = async (requestId: string, targetTableName: string, queryKey: any) => {
+    let status = 'processing';
+
+    await waitFor(async () => {
+      [, status] = await orchestrator.isPartitionExist(
+        requestId,
+        true,
+        'default',
+        'stb_pre_aggregations',
+        targetTableName,
+        queryKey,
+        'test-token',
+      );
+      return status !== 'processing';
+    });
+
+    return status;
+  };
+
+  // An instance that is configured to never build pre-aggregations must not run
+  // jobs-API builds in-process either.
+  test('jobs-API build honours the externalRefresh guard', async () => {
+    // Sanity check: a regular query on an externalRefresh instance refuses to build.
+    await expect(
+      orchestratorExternalRefresh.fetchQuery({
+        query: 'SELECT * FROM stb_pre_aggregations.orders_month',
+        values: [],
+        cacheKeyQueries: { queries: [] },
+        preAggregations: [PRE_AGGREGATION],
+        requestId: 'externalRefresh regular query',
+        external: true,
+      } as any)
+    ).rejects.toThrow(/refresh worker/);
+
+    expect(externalMockDriver.tables.length).toEqual(0);
+
+    // The very same instance must refuse a jobs-API build as well.
+    await expect(
+      orchestratorExternalRefresh.fetchQuery(jobQuery('externalRefresh job query') as any)
+    ).rejects.toThrow(/build pre-aggregations/);
+
+    await delay(500);
+
+    expect(externalMockDriver.tables.length).toEqual(0);
+  });
+
+  test('completed jobs-API build is reported as done', async () => {
+    const result = await orchestrator.fetchQuery(jobQuery('successful job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    await waitFor(() => externalMockDriver.indexes.length > 0);
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'successful job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).toEqual('done');
+  });
+
+  // A build that is still importing rows must not be reported as `done` just
+  // because the versioned table is already visible.
+  test('in-flight jobs-API build is not reported as done', async () => {
+    externalMockDriver.importBehavior = 'hang';
+
+    const result = await orchestrator.fetchQuery(jobQuery('in-flight job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    await externalMockDriver.importStarted;
+
+    // The table is registered in Cube Store while the import is still running.
+    expect(externalMockDriver.tables).toContain(targetTableName);
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'in-flight job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).not.toEqual('done');
+  });
+
+  // A failed jobs-API build must surface as `failure`, not as `done`.
+  test('failed jobs-API build is reported as failure', async () => {
+    externalMockDriver.importBehavior = 'fail';
+
+    const result = await orchestrator.fetchQuery(jobQuery('failing job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    await externalMockDriver.importStarted;
+    const status = await pollUntilSettled('failing job query', targetTableName, queryKey);
+
+    expect(status).toMatch(/^failure/);
+  });
+
+  // A build error must win over the table existence even when the queue result
+  // has already been consumed by an earlier status poll.
+  test('failure status survives repeated status polls', async () => {
+    externalMockDriver.importBehavior = 'fail';
+
+    const result = await orchestrator.fetchQuery(jobQuery('repeated poll job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    await externalMockDriver.importStarted;
+    await pollUntilSettled('repeated poll job query', targetTableName, queryKey);
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'repeated poll job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).toMatch(/^failure/);
+  });
+
+  // A build whose process is gone never reports an outcome of its own, and the
+  // job must not be left waiting on it until the record expires.
+  test('abandoned build is reported as failure', async () => {
+    const result = await orchestrator.fetchQuery(jobQuery('abandoned job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    await waitFor(() => externalMockDriver.indexes.length > 0);
+
+    // executionTimeout is 2s for this orchestrator, so this build can't still be running
+    await orchestrator.getPreAggregations().setPreAggregationBuildStatus(targetTableName, {
+      status: 'building',
+      startedAt: new Date().getTime() - 60000,
+    });
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'abandoned job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).toMatch(/^failure/);
+  });
+
+  // Only the last pre-aggregation of a job build query is force built, so a
+  // dependency that is already up to date never runs a build and never records
+  // an outcome. Its job still has to report the partition as built.
+  test('partition that exists without a recorded build is reported as done', async () => {
+    const result = await orchestrator.fetchQuery(jobQuery('dependency job query') as any);
+    const [{ queryKey }] = result;
+
+    await waitFor(() => externalMockDriver.indexes.length > 0);
+
+    const dependencyTableName = 'stb_pre_aggregations.orders_day_wd2ap0ny_i2isylsi_1jr2sxb';
+    externalMockDriver.tablesObj.push({ tableName: dependencyTableName });
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'dependency job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      dependencyTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).toEqual('done');
+  });
+
+  // A partially built external table must not be left behind: it is the newest
+  // version of the partition and would shadow the previous correct table forever.
+  test('failed external import drops the partially built table', async () => {
+    externalMockDriver.importBehavior = 'fail';
+
+    const result = await orchestrator.fetchQuery(jobQuery('dropping job query') as any);
+    const [{ targetTableName }] = result;
+
+    await waitFor(() => externalMockDriver.droppedTables.includes(targetTableName));
+
+    expect(externalMockDriver.tables).not.toContain(targetTableName);
+  });
+});

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
@@ -227,10 +227,10 @@ describe('pre-aggregation build jobs', () => {
     return status;
   };
 
-  // An instance that is configured to never build pre-aggregations must not run
-  // jobs-API builds in-process either.
-  test('jobs-API build honours the externalRefresh guard', async () => {
-    // Sanity check: a regular query on an externalRefresh instance refuses to build.
+  // `externalRefresh` stops a query from building a pre-aggregation as a side
+  // effect. A build job is an explicit request to build, so it runs anyway —
+  // posting jobs to an instance that serves queries only is a supported setup.
+  test('jobs-API build runs on an externalRefresh instance', async () => {
     await expect(
       orchestratorExternalRefresh.fetchQuery({
         query: 'SELECT * FROM stb_pre_aggregations.orders_month',
@@ -244,14 +244,9 @@ describe('pre-aggregation build jobs', () => {
 
     expect(externalMockDriver.tables.length).toEqual(0);
 
-    // The very same instance must refuse a jobs-API build as well.
-    await expect(
-      orchestratorExternalRefresh.fetchQuery(jobQuery('externalRefresh job query') as any)
-    ).rejects.toThrow(/build pre-aggregations/);
+    await orchestratorExternalRefresh.fetchQuery(jobQuery('externalRefresh job query') as any);
 
-    await delay(500);
-
-    expect(externalMockDriver.tables.length).toEqual(0);
+    await waitFor(() => externalMockDriver.indexes.length > 0);
   });
 
   test('completed jobs-API build is reported as done', async () => {
@@ -271,6 +266,37 @@ describe('pre-aggregation build jobs', () => {
     );
 
     expect(status).toEqual('done');
+  });
+
+  // The queue de-duplicates on the query key, so a job regularly ends up
+  // waiting on a build some other request enqueued. That build has to record
+  // its outcome as well, or the job falls back to the bare table again.
+  test('build started by a regular query records its outcome', async () => {
+    externalMockDriver.importBehavior = 'hang';
+
+    orchestrator.fetchQuery({
+      query: 'SELECT * FROM stb_pre_aggregations.orders_month',
+      values: [],
+      cacheKeyQueries: { queries: [] },
+      preAggregations: [PRE_AGGREGATION],
+      requestId: 'regular query build',
+      external: true,
+    } as any).catch(() => undefined);
+
+    await externalMockDriver.importStarted;
+    const [targetTableName] = externalMockDriver.tables;
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'regular query build',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      ['some key'],
+      'test-token',
+    );
+
+    expect(status).toEqual('processing');
   });
 
   // A build that is still importing rows must not be reported as `done` just

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts
@@ -71,7 +71,7 @@ class MockDriver {
   }
 }
 
-type ImportBehavior = 'ok' | 'fail' | 'hang';
+type ImportBehavior = 'ok' | 'fail' | 'hang' | 'fail-cleanup';
 
 /**
  * Emulates Cube Store. `importBehavior` reproduces the shape from the incident:
@@ -83,6 +83,8 @@ class ExternalMockDriver extends MockDriver {
   public indexes: any[] = [];
 
   public importBehavior: ImportBehavior = 'ok';
+
+  public failTableListingOnce: boolean = false;
 
   public importStarted: Promise<void> = Promise.resolve();
 
@@ -115,6 +117,19 @@ class ExternalMockDriver extends MockDriver {
       await this.query(query, params);
     }
     this.indexes = this.indexes.concat(indexesSql);
+
+    if (this.importBehavior === 'fail-cleanup') {
+      this.failTableListingOnce = true;
+    }
+  }
+
+  public async getTablesQuery(schema: string) {
+    if (this.failTableListingOnce) {
+      this.failTableListingOnce = false;
+      throw new Error('Transient error while listing tables');
+    }
+
+    return super.getTablesQuery(schema);
   }
 }
 
@@ -323,6 +338,30 @@ describe('pre-aggregation build jobs', () => {
     );
 
     expect(status).not.toEqual('done');
+  });
+
+  // Orphaned tables cleanup runs once the rows are already in place. It can
+  // fail on its own, and that says nothing about the partition it just built.
+  test('cleanup failure after the rows landed is not reported as failure', async () => {
+    externalMockDriver.importBehavior = 'fail-cleanup';
+
+    const result = await orchestrator.fetchQuery(jobQuery('cleanup failure job query') as any);
+    const [{ targetTableName, queryKey }] = result;
+
+    // The listing that orphaned tables cleanup runs right after the upload fails
+    await waitFor(() => externalMockDriver.indexes.length > 0 && !externalMockDriver.failTableListingOnce);
+
+    const [, status] = await orchestrator.isPartitionExist(
+      'cleanup failure job query',
+      true,
+      'default',
+      'stb_pre_aggregations',
+      targetTableName,
+      queryKey,
+      'test-token',
+    );
+
+    expect(status).toEqual('done');
   });
 
   // A failed jobs-API build must surface as `failure`, not as `done`.

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -2574,6 +2574,104 @@ mod tests {
         Ok(())
     }
 
+    /// A table imported from a location is published only after the import
+    /// succeeds, so a failed import can't leave a queryable empty table behind
+    /// that would shadow the previous version of a pre-aggregation partition.
+    #[tokio::test]
+    async fn failed_location_import_leaves_no_table() -> Result<(), CubeError> {
+        Config::test("failed_location_import_leaves_no_table")
+            .start_test(async move |services| {
+                let service = services.sql_service;
+
+                let path = env::temp_dir().join("failed_location_import.csv.gz");
+                // Not a gzip stream, so the import job fails while reading it
+                fs::write(&path, b"this is not a gzip stream").unwrap();
+
+                service
+                    .exec_query("CREATE SCHEMA foo")
+                    .await?
+                    .collect()
+                    .await?;
+
+                let res = service
+                    .exec_query(&format!(
+                        "CREATE TABLE foo.orders (id int, amount int) LOCATION '{}'",
+                        path.to_string_lossy()
+                    ))
+                    .await;
+                assert!(res.is_err(), "Expected import to fail, got {:?}", res.err());
+
+                let tables = service
+                    .exec_query(
+                        "SELECT table_name FROM information_schema.tables \
+                         WHERE table_schema = 'foo'",
+                    )
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(tables.get_rows(), &Vec::<Row>::new());
+
+                // Not published and not left behind in any state
+                let all_tables = services.meta_store.get_tables_with_path(true).await?;
+                assert!(
+                    all_tables.is_empty(),
+                    "Expected no tables left after a failed import, got {:?}",
+                    all_tables
+                );
+
+                fs::remove_file(&path).unwrap();
+                Ok::<(), CubeError>(())
+            })
+            .await;
+        Ok(())
+    }
+
+    /// A table created without a location becomes queryable right away, before
+    /// any rows are inserted into it. Anything that treats table existence as
+    /// proof of a finished import has to account for this window.
+    #[tokio::test]
+    async fn table_without_location_is_visible_while_empty() -> Result<(), CubeError> {
+        Config::test("table_without_location_is_visible_while_empty")
+            .start_test(async move |services| {
+                let service = services.sql_service;
+
+                service
+                    .exec_query("CREATE SCHEMA foo")
+                    .await?
+                    .collect()
+                    .await?;
+                service
+                    .exec_query("CREATE TABLE foo.orders (id int, amount int)")
+                    .await?
+                    .collect()
+                    .await?;
+
+                let tables = service
+                    .exec_query(
+                        "SELECT table_name FROM information_schema.tables \
+                         WHERE table_schema = 'foo'",
+                    )
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(
+                    tables.get_rows(),
+                    &vec![Row::new(vec![TableValue::String("orders".to_string())])]
+                );
+
+                let count = service
+                    .exec_query("SELECT count(*) FROM foo.orders")
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(count.get_rows(), &vec![Row::new(vec![TableValue::Int(0)])]);
+
+                Ok::<(), CubeError>(())
+            })
+            .await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn decimal() -> Result<(), CubeError> {
         Config::test("decimal").update_config(|mut c| {


### PR DESCRIPTION
## Summary

A pre-aggregation build triggered through the jobs API whose client-side import failed was indistinguishable from a successful one. The empty versioned table stayed in Cube Store as the newest version of the partition, shadowing the previous correct one, while the job reported `done` and nothing signalled an error — dashboards silently returned zero rows and the planner never rebuilt the partition.

Fixes [CORE-811](https://linear.app/cube-d3/issue/CORE-811) / #11609. In the reporter's incident 3 of 4 monthly partitions became `ready` and empty while Databricks showed all 4 source `SELECT`s as `FINISHED` with full row counts — the jobs API had reported them `done` ~17 minutes *before* those queries finished.

## Changes

- **The build outcome, not the table, decides the job status.** `isPartitionExist` derived `done` from the existence of the target table, which is created *before* the rows are imported into it and is left behind when the import fails or the process is killed. The outcome of each build is now recorded per versioned table and wins over the table being there. It is tracked for build jobs only, and its absence still falls back to the table, so a partition that was already up to date and never built keeps reporting `done`.
- **A build whose process is gone is reported as `failure`.** Such a build never records an outcome of its own. Since the queue times a build out on its own and records that, a build still marked as running long past that timeout is reported as failed rather than leaving the job polling forever.
- **A failed external upload drops the table it was creating** — unless that table was already there before the upload started and therefore belongs to another build. Orphaned-table cleanup always keeps the newest version per table name, so without this the half-built table lives forever.
- **Build jobs honour the `externalRefresh` guard.** `isJob` short-circuited `loadPreAggregation` ahead of the guard, so an API instance configured to never build pre-aggregations still ran jobs-API builds in-process. Those instances restart often (deploys, config rollouts, autoscaling), which is what makes a build killed mid-import likely in the first place. Such an instance now refuses the job and says so.
- **Docs**: the job status table only documented `scheduled` / `processing` / `missing_partition` / `done`, described `done` as "successfully completed" without saying the build might merely have been dispatched, and presented `missing_partition` as *the* error signal while `failure` was undocumented. The table is now complete, and a warning covers which instance a job may be posted to.

### Notes

- `CubeStoreDriver.importRows` (`CREATE TABLE` + `INSERT`s) still has a window where the table is visible while empty. The csv and stream import paths both go through `CREATE TABLE ... LOCATION`, which Cube Store already publishes atomically. That window is now covered from the orchestrator side rather than by changing Cube Store.
- A `done` partition can still legitimately have zero rows when no source data matches; this is called out in the docs rather than treated as an error.

## Testing

New `packages/cubejs-query-orchestrator/test/unit/PreAggregationJobs.test.ts` (8 tests). 6 of them fail on `master`; the other 2 are deliberate regression guards for the fallback behaviour above.

- `jobs-API build honours the externalRefresh guard`
- `completed jobs-API build is reported as done` *(guard)*
- `in-flight jobs-API build is not reported as done`
- `failed jobs-API build is reported as failure`
- `failure status survives repeated status polls` — the queue result is readable only once, so the recorded outcome has to be durable
- `abandoned build is reported as failure`
- `partition that exists without a recorded build is reported as done` *(guard)*
- `failed external import drops the partially built table`

Two Cube Store tests pin down the invariants the orchestrator relies on: a table imported from a location is published only after the import succeeds and is dropped when it fails, while a table created without a location is queryable straight away, before any rows are inserted.

Also run: `cubejs-query-orchestrator` unit suite (76 passed), `cubejs-api-gateway` (271 passed), `RefreshScheduler` (13 passed, including the `postBuildJobs` cases), `cargo fmt --check`.

> `RefreshScheduler` › `Exponential backoff` is flaky — it failed 1 of 3 runs on unmodified `master` as well, and this change doesn't touch the path it exercises.

[CORE-811]: https://cubedevinc.atlassian.net/browse/CORE-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ