### PR TITLE
refactor(query-orchestrator): Queue - require queueId, drop getNextProcessingId

### DIFF
--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -1,14 +1,14 @@
 export type QueryDef = any;
 // Primary key of Queue item
 export type QueueId = string | number | bigint;
-// This was used as a lock for Redis, deprecated.
+// The lock token of a retrieval, always the item's queueId. Only the memory driver compares it.
 export type ProcessingId = string | number | bigint;
 export type QueryKey = (string | [string, any[]]) & {
   persistent?: true,
 };
 export type QueryKeyHash = string & { __type: 'QueryKeyHash' };
 
-export type QueryKeysTuple = [keyHash: QueryKeyHash, queueId: QueueId | null /** Supported by new Cube Store and Memory */];
+export type QueryKeysTuple = [keyHash: QueryKeyHash, queueId: QueueId];
 export type GetActiveAndToProcessResponse = [active: QueryKeysTuple[], toProcess: QueryKeysTuple[]];
 export type QueryStageStateResponse = [active: string[], toProcess: string[]] | [active: string[], toProcess: string[], defs: Record<string, QueryDef>];
 export type RetrieveForProcessingSuccess = [
@@ -106,7 +106,6 @@ export interface QueueDriverConnectionInterface {
   getStalledQueries(): Promise<QueryKeysTuple[]>;
   getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse>;
   updateHeartBeat(hash: QueryKeyHash, queueId: QueueId | null): Promise<void>;
-  getNextProcessingId(): Promise<ProcessingId>;
   // Trying to acquire a lock for processing a queue item, this method can return null when
   // multiple nodes tries to process the same query
   retrieveForProcessing(hash: QueryKeyHash, processingId: ProcessingId): Promise<RetrieveForProcessingResponse>;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -35,8 +35,9 @@ function hashQueryKey(queryKey: QueryKey, processUid?: string): QueryKeyHash {
 
 type CubeStoreListResponse = {
   id: unknown,
+  // Returned by every LIST-shaped queue command since Cube Store v0.34.11
   // eslint-disable-next-line camelcase
-  queue_id?: string
+  queue_id: string
   status: string
 };
 
@@ -191,7 +192,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ]);
     return rows.map((row) => [
       row.id as QueryKeyHash,
-      row.queue_id ? parseInt(row.queue_id, 10) : null,
+      parseInt(row.queue_id, 10),
     ]);
   }
 
@@ -201,7 +202,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ]);
     return rows.map((row) => [
       row.id as QueryKeyHash,
-      row.queue_id ? parseInt(row.queue_id, 10) : null,
+      parseInt(row.queue_id, 10),
     ]);
   }
 
@@ -217,12 +218,12 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
         if (row.status === 'active') {
           active.push([
             row.id as QueryKeyHash,
-            row.queue_id ? parseInt(row.queue_id, 10) : null,
+            parseInt(row.queue_id, 10),
           ]);
         } else {
           toProcess.push([
             row.id as QueryKeyHash,
-            row.queue_id ? parseInt(row.queue_id, 10) : null,
+            parseInt(row.queue_id, 10),
           ]);
         }
       }
@@ -232,17 +233,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
       active,
       toProcess,
     ];
-  }
-
-  public async getNextProcessingId(): Promise<number | string> {
-    const rows = await this.driver.query('CACHE INCR ?', [
-      `${this.options.redisQueuePrefix}:PROCESSING_COUNTER`
-    ]);
-    if (rows && rows.length) {
-      return rows[0].value;
-    }
-
-    throw new Error('Unable to get next processing id');
   }
 
   public async getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse> {
@@ -294,7 +284,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ]);
     return rows.map((row) => [
       row.id as QueryKeyHash,
-      row.queue_id ? parseInt(row.queue_id, 10) : null,
+      parseInt(row.queue_id, 10),
     ]);
   }
 
@@ -305,7 +295,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ]);
     return rows.map((row) => [
       row.id as QueryKeyHash,
-      row.queue_id ? parseInt(row.queue_id, 10) : null,
+      parseInt(row.queue_id, 10),
     ]);
   }
 
@@ -317,7 +307,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ]);
     return rows.map((row) => [
       row.id as QueryKeyHash,
-      row.queue_id ? parseInt(row.queue_id, 10) : null,
+      parseInt(row.queue_id, 10),
     ]);
   }
 

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -186,6 +186,9 @@ sequenceDiagram
 purpose, so a custom implementation can serialize it and let another process run
 `executeQuery`. The default implementation calls `executeQuery` in-process.
 
+`processingId` is the lock token of the retrieval and always carries the `queueId`. Only the
+memory driver compares it, Cube Store ignores it and keys every command off the `queueId`.
+
 `sendProcessMessageFn` must resolve once the hand-off is done, **not** once the query is
 executed: reconcile awaits it, and `executeQuery` ends with `reconcileQueue`, which is
 single-flight — awaiting the execution from inside reconcile deadlocks.

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -42,10 +42,6 @@ export interface PromiseWithResolve<T = any> extends Promise<T> {
   resolved?: boolean;
 }
 
-export interface ProcessingCounter {
-  counter: number;
-}
-
 export class LocalQueueDriverConnectionState {
   public resultPromises: Record<QueryKeyHash, PromiseWithResolve> = {};
 
@@ -58,8 +54,6 @@ export class LocalQueueDriverConnectionState {
   public active: Record<QueryKeyHash, QueueItem> = {};
 
   public heartBeat: Record<QueryKeyHash, QueueItem> = {};
-
-  public processingCounter: ProcessingCounter = { counter: 1 };
 
   public processingLocks: Record<QueryKeyHash, any> = {};
 }
@@ -261,11 +255,6 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return true;
   }
 
-  public async getNextProcessingId(): Promise<ProcessingId> {
-    this.state.processingCounter.counter += 1;
-    return this.state.processingCounter.counter;
-  }
-
   public async getOrphanedQueries(): Promise<QueryKeysTuple[]> {
     return this.queueArrayAsTuple(this.state.recent, new Date().getTime());
   }
@@ -301,17 +290,17 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     let added = 0;
 
     if (Object.keys(this.state.active).length < this.concurrency && !this.state.active[queryKeyHash]) {
-      this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(processingId), queueId: Number(processingId) };
+      this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(processingId), queueId: processingId };
       delete this.state.toProcess[queryKeyHash];
 
       added = 1;
     }
 
-    this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId: Number(processingId) };
+    this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId: processingId };
 
     return [
       added,
-      this.state.queryDef[queryKeyHash]?.queueId || null,
+      this.state.queryDef[queryKeyHash]?.queueId ?? null,
       this.queueArray(this.state.active) as QueryKeyHash[],
       Object.keys(this.state.toProcess).length,
       this.state.queryDef[queryKeyHash],

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -185,7 +185,8 @@ export class QueryQueue {
     return stream;
   }
 
-  protected counter = 0;
+  // Zero is falsy, and a queueId is still checked for truthiness in a few places
+  protected counter = 1;
 
   public generateQueueId() {
     return this.counter++;
@@ -602,7 +603,7 @@ export class QueryQueue {
         const [queryDef] = await queueConnection.getQueryAndRemove(queryKey, queueId);
         if (queryDef) {
           this.logger('Removing orphaned query', {
-            queueId: queueId || queryDef.queueId /** Special handling for Redis */,
+            queueId,
             queryKey: queryDef.queryKey,
             queuePrefix: this.redisQueuePrefix,
             requestId: queryDef.requestId,
@@ -792,7 +793,7 @@ export class QueryQueue {
   /**
    * Retrieves the query specified by the `queryKeyHashed` and hands it over for execution.
    */
-  protected async processQuery(queryKeyHashed: QueryKeyHash, queueId: QueueId | null): Promise<void> {
+  protected async processQuery(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<void> {
     const retrieved = await this.retrieveQueryForProcessing(queryKeyHashed, queueId);
     if (!retrieved) {
       return;
@@ -820,7 +821,7 @@ export class QueryQueue {
    * the active set. Returns `null` when the retrieval didn't succeed, which means another node is
    * already running the query or the concurrency budget is full.
    */
-  protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId | null): Promise<RetrievedQuery | null> {
+  protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<RetrievedQuery | null> {
     const queueConnection = await this.queueDriver.createConnection();
 
     let insertedCount;
@@ -830,7 +831,9 @@ export class QueryQueue {
     let processingLockAcquired;
 
     try {
-      const processingId = queueId || /** for Redis only */ await queueConnection.getNextProcessingId();
+      // The lock token, taken before the retrieval can replace queueId below. Every call that
+      // releases the lock has to be handed the same value retrieveForProcessing got.
+      const processingId = queueId;
       const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, processingId);
 
       if (retrieveResult) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -831,20 +831,13 @@ export class QueryQueue {
     let processingLockAcquired;
 
     try {
-      // The lock token, taken before the retrieval can replace queueId below. Every call that
-      // releases the lock has to be handed the same value retrieveForProcessing got.
+      // The lock token is the queueId, every call which releases the lock has to be handed
+      // the same value retrieveForProcessing got
       const processingId = queueId;
+
       const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, processingId);
-
       if (retrieveResult) {
-        let retrieveQueueId;
-
-        [insertedCount, retrieveQueueId, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
-
-        // Backward compatibility for old Cube Store, Redis and Memory
-        if (retrieveQueueId) {
-          queueId = retrieveQueueId;
-        }
+        [insertedCount, , activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
       }
 
       const activated = activeKeys && activeKeys.indexOf(queryKeyHashed) !== -1;

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -45,7 +45,6 @@ function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInt
     freeProcessingLock: wrapAsyncMethod('freeProcessingLock'),
     optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
     getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
-    getNextProcessingId: wrapAsyncMethod('getNextProcessingId'),
     release: connection.release,
   };
 }

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -435,7 +435,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
     test('removed before reconciled', async () => {
       const query: QueryKey = ['select * from', []];
       const key = queue.redisHash(query);
-      await queue.processQuery(key, null);
+      await queue.processQuery(key, queue.generateQueueId());
       const result = await queue.executeInQueue('foo', key, query);
       expect(result).toBe('select * from bar');
     });
@@ -472,24 +472,21 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       await queue.reconcileQueue();
 
-      await connection.addToQueue(
-        'race', 'handler', ['select'], priority, { stageQueryKey: 'race' }
+      const [, raceQueueId] = await connection.addToQueue(
+        'race', 'handler', ['select'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race' }
       );
 
-      await connection.addToQueue(
-        'race2', 'handler2', ['select2'], priority, { stageQueryKey: 'race2' }
+      const [, race2QueueId] = await connection.addToQueue(
+        'race2', 'handler2', ['select2'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race2' }
       );
 
-      const processingId1 = await connection.getNextProcessingId();
-      const processingId4 = await connection.getNextProcessingId();
+      // Neither is locked yet, so both releases are no-ops
+      await connection.freeProcessingLock('race', raceQueueId, true);
+      await connection.freeProcessingLock('race2', race2QueueId, true);
 
-      await connection.freeProcessingLock('race', processingId1, true);
-      await connection.freeProcessingLock('race2', processingId4, true);
+      await connection2.retrieveForProcessing('race2', race2QueueId);
 
-      await connection2.retrieveForProcessing('race2', await connection.getNextProcessingId());
-
-      const processingId = await connection.getNextProcessingId();
-      const retrieve6 = await connection.retrieveForProcessing('race', processingId);
+      const retrieve6 = await connection.retrieveForProcessing('race', raceQueueId);
       console.log(retrieve6);
       expect(!!retrieve6[5]).toBe(true);
 
@@ -507,30 +504,28 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
 
       await queue.reconcileQueue();
 
-      await connection.addToQueue(
-        'activated1', 'handler', <any>['select'], priority, { stageQueryKey: 'race', requestId: '1' }
+      const [, activated1QueueId] = await connection.addToQueue(
+        'activated1', 'handler', <any>['select'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race', requestId: '1' }
       );
 
-      await connection.addToQueue(
-        'activated2', 'handler2', <any>['select2'], priority, { stageQueryKey: 'race2', requestId: '1' }
+      const [, activated2QueueId] = await connection.addToQueue(
+        'activated2', 'handler2', <any>['select2'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race2', requestId: '1' }
       );
 
-      const processingId1 = await connection.getNextProcessingId();
-      const processingId2 = await connection.getNextProcessingId();
-      const processingId3 = await connection.getNextProcessingId();
-
-      const retrieve1 = await connection.retrieveForProcessing('activated1' as any, processingId1);
+      const retrieve1 = await connection.retrieveForProcessing('activated1' as any, activated1QueueId);
       console.log(retrieve1);
-      const retrieve2 = await connection2.retrieveForProcessing('activated2' as any, processingId2);
+      const retrieve2 = await connection2.retrieveForProcessing('activated2' as any, activated2QueueId);
       console.log(retrieve2);
-      console.log(await connection.freeProcessingLock('activated1' as any, processingId1, retrieve1 && retrieve1[2].indexOf('activated1' as any) !== -1));
-      const retrieve3 = await connection.retrieveForProcessing('activated2' as any, processingId3);
-      console.log(retrieve3);
-      console.log(await connection.freeProcessingLock('activated2' as any, processingId3, retrieve3 && retrieve3[2].indexOf('activated2' as any) !== -1));
-      console.log(retrieve2[2].indexOf('activated2' as any) !== -1);
-      console.log(await connection2.freeProcessingLock('activated2' as any, processingId2, retrieve2 && retrieve2[2].indexOf('activated2' as any) !== -1));
+      console.log(await connection.freeProcessingLock('activated1' as any, activated1QueueId, retrieve1 && retrieve1[2].indexOf('activated1' as any) !== -1));
 
-      const retrieve4 = await connection.retrieveForProcessing('activated2' as any, await connection.getNextProcessingId());
+      // Another node reaches the same item, so it comes with the same lock token and loses
+      const retrieve3 = await connection.retrieveForProcessing('activated2' as any, activated2QueueId);
+      expect(retrieve3).toBeNull();
+
+      console.log(retrieve2[2].indexOf('activated2' as any) !== -1);
+      console.log(await connection2.freeProcessingLock('activated2' as any, activated2QueueId, retrieve2 && retrieve2[2].indexOf('activated2' as any) !== -1));
+
+      const retrieve4 = await connection.retrieveForProcessing('activated2' as any, activated2QueueId);
       console.log(retrieve4);
       expect(retrieve4[0]).toBe(1);
       expect(!!retrieve4[5]).toBe(true);


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`processQuery` / `retrieveQueryForProcessing` took `queueId: QueueId | null` and compensated with `queueId || await queueConnection.getNextProcessingId()`, but there is no Redis queue driver left and Cube Store has returned `queue_id` from every LIST-shaped queue command since v0.34.11 (`7b1a0c0534`, Oct 2023) — far below the oldest capability floor the driver already requires — so `getNextProcessingId` was dead weight in both drivers: Cube Store spent a `CACHE INCR <prefix>:PROCESSING_COUNTER` round-trip on a value every consumer then ignored, and the memory driver just bumped an in-process counter. `queueId` is now required and non-null on the retrieval path and `processingId` always carries it, which is what the fast-track path already did in `retrievedQuery()`.

The nullable signature was also masking a live bug: `generateQueueId()` started at `0`, which is falsy, so the first query of every process took the `getNextProcessingId()` branch and ran with `processingId !== queueId`; starting the counter at 1 also fixes the same truthiness misread at `if (retrieveQueueId)` and in the driver's `queueId || prefixKey(hash)`. As a side effect the memory driver's `active` / `heartBeat` entries now report the real queueId instead of a processing counter.

**Breaking change:** `getNextProcessingId` is removed from `QueueDriverConnectionInterface`, `QueryKeysTuple[1]` is no longer nullable, and `ProcessingCounter` is no longer exported from `@cubejs-backend/query-orchestrator`. `AddToQueueOptions.queueId`, `AddToQueueResponse[1]`, `RetrieveForProcessing*[1]` and the per-item `queueId: QueueId | null` params stay optional/nullable — skip-queue tasks rely on the former, and `cancelQueryByRequestId` and `PreAggregations` pass an explicit `null` by design.

**Verification:** `yarn tsc` and `yarn lint` clean in `cubejs-base-driver`, `cubejs-cubestore-driver` and `cubejs-query-orchestrator`; `yarn unit` 71/71; `QueryQueueCubestore.test.ts` 24 passed / 3 skipped (memory-only) against an auto-provisioned Cube Store, including the `CUBEJS_QUEUE_FAST_TRACK` and `CUBEJS_QUEUE_EXTERNAL_ID` blocks. `QueryCacheCubestore.test.ts` fails 12/12 with `Unable to start Cube Store, timeout after 4s` — verified identical on clean `master`, so it is environmental and not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)