### PR TITLE
fix(cubestore): inline aggregate dropped rows past the first partition

### DIFF
--- a/rust/cubestore/cubestore/src/queryplanner/group_by_limit_aggregate/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/group_by_limit_aggregate/mod.rs
@@ -4,7 +4,7 @@ use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::stats::Precision;
 use datafusion::common::Statistics;
-use datafusion::error::Result as DFResult;
+use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion::physical_expr::{Distribution, LexRequirement};
@@ -16,7 +16,7 @@ use datafusion::physical_plan::{
     PlanProperties, SendableRecordBatchStream,
 };
 use std::any::Any;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 /// Worker-side partial hash aggregate that trims its output to the top-k groups by a total order,
@@ -32,7 +32,7 @@ use std::sync::Arc;
 /// columns), expressed as `(partial-output column index, sort options)`. A total order is required
 /// for correctness: the same group key can live on multiple workers, and a consistent cut across
 /// workers guarantees every partial state the router selects reaches it.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GroupByLimitAggregateExec {
     group_by: PhysicalGroupBy,
     aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
@@ -48,6 +48,28 @@ pub struct GroupByLimitAggregateExec {
     factor: usize,
     /// Total order over the partial output columns.
     order: Vec<(usize, SortOptions)>,
+    /// The aggregate this node replaced. Kept so that swapping the input can be delegated to it:
+    /// DataFusion recomputes the plan properties there and preserves the output schema.
+    source: Arc<AggregateExec>,
+}
+
+/// Skips [GroupByLimitAggregateExec::source]: it carries a copy of the same input subtree the node
+/// already prints, so deriving would double the output of every nested aggregate.
+impl Debug for GroupByLimitAggregateExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GroupByLimitAggregateExec")
+            .field("group_by", &self.group_by)
+            .field("aggr_expr", &self.aggr_expr)
+            .field("filter_expr", &self.filter_expr)
+            .field("input", &self.input)
+            .field("schema", &self.schema)
+            .field("input_schema", &self.input_schema)
+            .field("cache", &self.cache)
+            .field("k", &self.k)
+            .field("factor", &self.factor)
+            .field("order", &self.order)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GroupByLimitAggregateExec {
@@ -97,6 +119,7 @@ impl GroupByLimitAggregateExec {
             k,
             factor,
             order,
+            source: Arc::new(aggregate.clone()),
         })
     }
 
@@ -177,24 +200,23 @@ impl ExecutionPlan for GroupByLimitAggregateExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let input = children[0].clone();
-        // Track the (possibly changed) input's partitioning; a partial aggregate preserves it.
-        let cache = self
-            .cache
-            .clone()
-            .with_partitioning(input.output_partitioning().clone());
-        Ok(Arc::new(Self {
-            group_by: self.group_by.clone(),
-            aggr_expr: self.aggr_expr.clone(),
-            filter_expr: self.filter_expr.clone(),
-            input,
-            schema: self.schema.clone(),
-            input_schema: self.input_schema.clone(),
-            cache,
-            k: self.k,
-            factor: self.factor,
-            order: self.order.clone(),
-        }))
+        // Swapping the input is delegated to the aggregate this node was built from, so that
+        // DataFusion recomputes the whole of the plan properties -- output partitioning above all,
+        // a stale count there makes the parent read only some of the input's partitions and
+        // silently drop the rest -- and preserves the output schema.
+        let rebuilt = Arc::clone(&self.source).with_new_children(children)?;
+        let Some(aggregate) = rebuilt.as_any().downcast_ref::<AggregateExec>() else {
+            return Err(DataFusionError::Internal(format!(
+                "AggregateExec::with_new_children returned {}",
+                rebuilt.name()
+            )));
+        };
+        Ok(
+            match Self::try_new_from_partial(aggregate, self.k, self.factor, self.order.clone()) {
+                Some(trimmed) => Arc::new(trimmed),
+                None => rebuilt,
+            },
+        )
     }
 
     fn execute(

--- a/rust/cubestore/cubestore/src/queryplanner/group_by_limit_aggregate/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/group_by_limit_aggregate/mod.rs
@@ -99,10 +99,8 @@ impl GroupByLimitAggregateExec {
             return None;
         }
         let input = aggregate.input().clone();
-        // A partial aggregate preserves its input's partitioning (it runs once per input partition).
-        // Derive the output partitioning from the input rather than copying the wrapped aggregate's
-        // cached value, which can be stale: a later pass may swap our input for one with a different
-        // partition count via `with_new_children` without the cache following, and a too-low count
+        // A partial aggregate runs once per input partition and so preserves its partitioning.
+        // `aggregate.cache()` already says that; spell it out anyway, since a wrong count here
         // makes the parent coalesce read only some partitions and silently drop the rest.
         let cache = aggregate
             .cache()
@@ -214,7 +212,23 @@ impl ExecutionPlan for GroupByLimitAggregateExec {
         Ok(
             match Self::try_new_from_partial(aggregate, self.k, self.factor, self.order.clone()) {
                 Some(trimmed) => Arc::new(trimmed),
-                None => rebuilt,
+                None => {
+                    // Correct but a perf cliff: the worker goes from `factor * k` rows per
+                    // partition to the full group cardinality. Say it out loud so the loss of the
+                    // trim is diagnosable instead of showing up only as a slow query.
+                    log::warn!(
+                        "Rebuilt aggregate no longer fits the group-by-limit trim (input order \
+                         mode {:?}), dropping it for group by [{}]",
+                        aggregate.input_order_mode(),
+                        self.group_by
+                            .expr()
+                            .iter()
+                            .map(|(_, name)| name.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                    rebuilt
+                }
             },
         )
     }
@@ -475,6 +489,10 @@ mod tests {
         let three = MemorySourceConfig::try_new(&three_parts, input_schema(), None).unwrap();
         let three_input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(three)));
         let exec3 = exec.with_new_children(vec![three_input]).unwrap();
+        assert!(
+            exec3.as_any().is::<GroupByLimitAggregateExec>(),
+            "re-childing must keep the trimming exec, otherwise this test no longer pins it"
+        );
         assert_eq!(
             exec3.output_partitioning().partition_count(),
             3,

--- a/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
@@ -9,7 +9,7 @@ pub use sorted_group_values_rows::SortedGroupValuesRows;
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::common::stats::Precision;
 use datafusion::common::Statistics;
-use datafusion::error::Result as DFResult;
+use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr::aggregate::AggregateFunctionExpr;
 use datafusion::physical_expr::{Distribution, LexRequirement};
@@ -22,7 +22,7 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream,
 };
 use std::any::Any;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -31,7 +31,7 @@ pub enum InlineAggregateMode {
     Final,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct InlineAggregateExec {
     mode: InlineAggregateMode,
     /// Group by expressions
@@ -55,6 +55,29 @@ pub struct InlineAggregateExec {
     pub input_schema: SchemaRef,
     cache: PlanProperties,
     required_input_ordering: Vec<Option<LexRequirement>>,
+    /// The aggregate this node replaced. Kept so that swapping the input can be delegated to it:
+    /// DataFusion recomputes the plan properties there and preserves the output schema, which it
+    /// derives from aggregate expression names that its own rules are free to rewrite.
+    source: Arc<AggregateExec>,
+}
+
+/// Skips [InlineAggregateExec::source]: it carries a copy of the same input subtree the node
+/// already prints, so deriving would double the output of every nested aggregate.
+impl Debug for InlineAggregateExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InlineAggregateExec")
+            .field("mode", &self.mode)
+            .field("group_by", &self.group_by)
+            .field("aggr_expr", &self.aggr_expr)
+            .field("filter_expr", &self.filter_expr)
+            .field("limit", &self.limit)
+            .field("input", &self.input)
+            .field("schema", &self.schema)
+            .field("input_schema", &self.input_schema)
+            .field("cache", &self.cache)
+            .field("required_input_ordering", &self.required_input_ordering)
+            .finish_non_exhaustive()
+    }
 }
 
 impl InlineAggregateExec {
@@ -101,6 +124,7 @@ impl InlineAggregateExec {
             input_schema,
             cache,
             required_input_ordering,
+            source: Arc::new(aggregate.clone()),
         })
     }
 
@@ -192,19 +216,37 @@ impl ExecutionPlan for InlineAggregateExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let result = Self {
-            mode: self.mode,
-            group_by: self.group_by.clone(),
-            aggr_expr: self.aggr_expr.clone(),
-            filter_expr: self.filter_expr.clone(),
-            limit: self.limit.clone(),
-            input: children[0].clone(),
-            schema: self.schema.clone(),
-            input_schema: self.input_schema.clone(),
-            cache: self.cache.clone(),
-            required_input_ordering: self.required_input_ordering.clone(),
+        // Swapping the input is delegated to the aggregate this node was built from, so that
+        // DataFusion recomputes the plan properties -- output partitioning above all. Carrying
+        // them over leaves a stale partition count, and the parent then executes only that many
+        // of the input's partitions and silently drops the rows of the rest.
+        let rebuilt = Arc::clone(&self.source).with_new_children(children)?;
+        let Some(aggregate) = rebuilt.as_any().downcast_ref::<AggregateExec>() else {
+            return Err(DataFusionError::Internal(format!(
+                "AggregateExec::with_new_children returned {}",
+                rebuilt.name()
+            )));
         };
-        Ok(Arc::new(result))
+
+        // The streaming implementation is only valid while the new input stays sorted on the
+        // group keys; if it no longer is, keep the plain hash aggregate. The limit stays behind
+        // with it: here it counts complete groups off a sorted input, while a hash aggregate
+        // reads it as a cap on distinct groups and would stop mid-way through arbitrary ones.
+        // Dropping it only costs the early exit.
+        Ok(match Self::try_new_from_aggregate(aggregate) {
+            Some(inline) => Arc::new(inline.with_limit(self.limit)),
+            None => {
+                // No pass in the pipeline is known to de-sort an inline aggregate's input, and a
+                // parent merge built around the old ordering would not notice the switch, so say
+                // it out loud rather than degrade quietly.
+                log::warn!(
+                    "Input of an inline {:?} aggregate is no longer sorted on the group keys, \
+                     falling back to a hash aggregate",
+                    self.mode
+                );
+                Arc::new(aggregate.clone().with_limit(None))
+            }
+        })
     }
 
     fn execute(

--- a/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/inline_aggregate/mod.rs
@@ -241,8 +241,17 @@ impl ExecutionPlan for InlineAggregateExec {
                 // it out loud rather than degrade quietly.
                 log::warn!(
                     "Input of an inline {:?} aggregate is no longer sorted on the group keys, \
-                     falling back to a hash aggregate",
-                    self.mode
+                     falling back to a hash aggregate. Group by [{}], new input order mode {:?}, \
+                     new input ordering {:?}",
+                    self.mode,
+                    self.group_by
+                        .expr()
+                        .iter()
+                        .map(|(_, name)| name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    aggregate.input_order_mode(),
+                    aggregate.input().properties().output_ordering()
                 );
                 Arc::new(aggregate.clone().with_limit(None))
             }
@@ -450,6 +459,41 @@ mod tests {
     }
 
     /// A group continuing in the next input batch must not be emitted early with a partial sum.
+    /// A partial aggregate runs once per input partition, so its reported partitioning must
+    /// follow a re-childed input. A stale single-partition count makes the parent coalesce
+    /// execute only partition 0 and silently drop the rows of the rest -- the row loss this node
+    /// was fixed for. Built over a 1-partition input so its cache says 1, then re-childed onto 3.
+    #[test]
+    fn output_partitioning_follows_rechilded_input() {
+        let schema = test_schema();
+        let one = sorted_source(
+            &schema,
+            vec![vec![make_batch(&schema, &[(1, 10), (2, 20)])]],
+        );
+        let exec = partial_sum_inline_aggregate(one, None);
+        assert_eq!(exec.properties().output_partitioning().partition_count(), 1);
+
+        let three: Vec<Vec<RecordBatch>> = (0..3)
+            .map(|i| vec![make_batch(&schema, &[(i, 10), (i + 10, 20)])])
+            .collect();
+        let rechilded = exec
+            .with_new_children(vec![sorted_source(&schema, three)])
+            .unwrap();
+
+        assert!(
+            rechilded.as_any().is::<InlineAggregateExec>(),
+            "re-childing a still-sorted input must keep the streaming exec"
+        );
+        assert_eq!(
+            rechilded
+                .properties()
+                .output_partitioning()
+                .partition_count(),
+            3,
+            "exec must report its re-childed input's partition count, not a stale 1"
+        );
+    }
+
     #[test]
     fn limit_emits_only_closed_groups() {
         let schema = test_schema();

--- a/rust/cubestore/cubestore/src/queryplanner/partition_filter.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/partition_filter.rs
@@ -1531,6 +1531,131 @@ mod tests {
             Vec::new()
         }
     }
+
+    /// Exhaustive check that [MinMaxCondition] never prunes a range that holds a matching row.
+    ///
+    /// Enumerates every per-column bound combination over a small integer domain against every
+    /// ordered pair of min/max rows, and compares the verdict with a direct search for a tuple
+    /// that both satisfies the bounds and lies inside the range. A false negative here means a
+    /// query silently returning fewer rows than it should.
+    fn assert_no_false_negatives(n: usize, d: i64) {
+        // Rows and bounds use 0..d; candidate tuples reach one step further on both sides to
+        // stand in for the unbounded parts of the domain.
+        let rows = cross(n, &(0..d).collect::<Vec<_>>());
+        let candidates = cross(n, &(-1..=d).collect::<Vec<_>>());
+
+        for cond in column_bounds(n, d) {
+            let min_max = MinMaxCondition {
+                min: cond.iter().map(|(mn, _)| mn.map(TableValue::Int)).collect(),
+                max: cond.iter().map(|(_, mx)| mx.map(TableValue::Int)).collect(),
+            };
+            let matching = candidates
+                .iter()
+                .filter(|t| satisfies(&cond, t))
+                .collect::<Vec<_>>();
+
+            for mn in &rows {
+                for mx in &rows {
+                    if mn > mx {
+                        continue;
+                    }
+                    let min_row = mn.iter().cloned().map(TableValue::Int).collect::<Vec<_>>();
+                    let max_row = mx.iter().cloned().map(TableValue::Int).collect::<Vec<_>>();
+
+                    if matching.iter().any(|t| *t >= mn && *t <= mx) {
+                        assert!(
+                            min_max.can_match(&min_row, &max_row),
+                            "pruned a matching range: cond {:?}, min_row {:?}, max_row {:?}",
+                            cond,
+                            mn,
+                            mx
+                        );
+                    }
+                    if matching.iter().any(|t| *t >= mn) {
+                        assert!(
+                            min_max.can_match_min(&min_row),
+                            "pruned a matching range with unbounded max: cond {:?}, min_row {:?}",
+                            cond,
+                            mn
+                        );
+                    }
+                    if matching.iter().any(|t| *t <= mx) {
+                        assert!(
+                            min_max.can_match_max(&max_row),
+                            "pruned a matching range with unbounded min: cond {:?}, max_row {:?}",
+                            cond,
+                            mx
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// All tuples of length `n` over `vals`.
+    fn cross(n: usize, vals: &[i64]) -> Vec<Vec<i64>> {
+        let mut r = vec![vec![]];
+        for _ in 0..n {
+            r = r
+                .iter()
+                .flat_map(|t| {
+                    vals.iter().map(move |v| {
+                        let mut t = t.clone();
+                        t.push(*v);
+                        t
+                    })
+                })
+                .collect();
+        }
+        r
+    }
+
+    /// All per-column `(min, max)` bound combinations over `0..d`, `None` meaning unbounded.
+    fn column_bounds(n: usize, d: i64) -> Vec<Vec<(Option<i64>, Option<i64>)>> {
+        let mut per_col = Vec::new();
+        for mn in 0..=d {
+            for mx in 0..=d {
+                let mn = (mn != d).then_some(mn);
+                let mx = (mx != d).then_some(mx);
+                if let (Some(mn), Some(mx)) = (mn, mx) {
+                    if mn > mx {
+                        continue;
+                    }
+                }
+                per_col.push((mn, mx));
+            }
+        }
+        let mut r = vec![vec![]];
+        for _ in 0..n {
+            r = r
+                .iter()
+                .flat_map(|t| {
+                    per_col.iter().map(move |c| {
+                        let mut t = t.clone();
+                        t.push(*c);
+                        t
+                    })
+                })
+                .collect();
+        }
+        r
+    }
+
+    fn satisfies(cond: &[(Option<i64>, Option<i64>)], t: &[i64]) -> bool {
+        cond.iter()
+            .zip(t)
+            .all(|((mn, mx), v)| mn.map_or(true, |mn| mn <= *v) && mx.map_or(true, |mx| *v <= mx))
+    }
+
+    #[test]
+    fn no_false_negatives_two_columns() {
+        assert_no_false_negatives(2, 3);
+    }
+
+    #[test]
+    fn no_false_negatives_three_columns() {
+        assert_no_false_negatives(3, 3);
+    }
 }
 
 struct ColumnStat {

--- a/rust/cubestore/cubestore/src/queryplanner/rolling.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/rolling.rs
@@ -709,6 +709,9 @@ impl ExecutionPlan for RollingWindowAggExec {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         assert_eq!(children.len(), 1);
         Ok(Arc::new(RollingWindowAggExec {
+            // Safe to carry over: these are built from this node's own output schema plus
+            // constants, nothing in them is derived from the input. A node whose properties do
+            // follow the input -- output partitioning above all -- must recompute them here.
             properties: self.properties.clone(),
             sorted_input: children.remove(0),
             group_key: self.group_key.clone(),

--- a/rust/cubestore/cubestore/src/queryplanner/topk/execute.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/topk/execute.rs
@@ -190,6 +190,9 @@ impl ExecutionPlan for AggregateTopKExec {
             having: self.having.clone(),
             cluster,
             schema: self.schema.clone(),
+            // Safe to carry over: built from this node's own output schema plus constants, and
+            // the input's partition count is read live in `execute`. A node whose properties do
+            // follow the input -- output partitioning above all -- must recompute them here.
             cache: self.cache.clone(),
             sort_requirement: self.sort_requirement.clone(),
             merge_version: self.merge_version,

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -6832,6 +6832,109 @@ mod tests {
             .await;
         Ok(())
     }
+    /// A grouped aggregate over an index whose sort key does not start with the filtered
+    /// columns: every group column is pinned to a single value by the filter, which makes the
+    /// aggregate sorted and hands it to the streaming implementation. Its output partitioning
+    /// must follow the scan's, otherwise only the first partition is read and the rows living
+    /// in the others are silently dropped.
+    #[tokio::test]
+    async fn single_value_equals_scans_every_partition() -> Result<(), CubeError> {
+        Config::test("single_value_equals_scans_every_partition")
+            .update_config(|mut c| {
+                c.compaction_chunks_count_threshold = 0;
+                c.partition_split_threshold = 400;
+                c.max_partition_split_threshold = 400;
+                c
+            })
+            .start_test(async move |services| {
+                let service = services.sql_service;
+                service.exec_query("CREATE SCHEMA pa").await?.collect().await?;
+                // The time dimension leads the sort key, so the equality-filtered columns are
+                // not an index prefix -- the shape of a partitioned rollup.
+                service
+                    .exec_query(
+                        "CREATE TABLE pa.rollup (date_code timestamp, equipment_type text, \
+                         month_code text, site_id text, hours int)",
+                    )
+                    .await?
+                    .collect()
+                    .await?;
+
+                let mut rows = Vec::new();
+                for month in 1..=12 {
+                    for day in 1..=8 {
+                        for equipment_type in &["QC", "RTG", "STS"] {
+                            for site_id in &["ABC", "PSE", "XYZ"] {
+                                rows.push(format!(
+                                    "('2026-{:02}-{:02}T00:00:00.000', '{}', '2026{:02}', '{}', {})",
+                                    month, day, equipment_type, month, site_id, 10
+                                ));
+                            }
+                        }
+                    }
+                }
+                for chunk in rows.chunks(300) {
+                    service
+                        .exec_query(&format!(
+                            "INSERT INTO pa.rollup (date_code, equipment_type, month_code, \
+                             site_id, hours) VALUES {}",
+                            chunk.join(", ")
+                        ))
+                        .await?
+                        .collect()
+                        .await?;
+                }
+                // Rows reachable only through the first of several scanned partitions is what
+                // the regression is about, so wait for the data to be split across partitions
+                // and fail loudly rather than silently testing a single-partition scan.
+                let mut scanned_partitions = TableValue::Int(0);
+                for _ in 0..1200 {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    let partitions = service
+                        .exec_query(
+                            "SELECT count(*) FROM system.partitions \
+                             WHERE active = true AND main_table_row_count > 0",
+                        )
+                        .await?
+                        .collect()
+                        .await?;
+                    scanned_partitions = partitions.get_rows()[0].values()[0].clone();
+                    if scanned_partitions > TableValue::Int(1) {
+                        break;
+                    }
+                }
+                assert!(
+                    scanned_partitions > TableValue::Int(1),
+                    "the scan must span several partitions, got {:?}",
+                    scanned_partitions
+                );
+
+                // The last month of the range, so the matching rows sit in the last partition
+                // the scan visits and never in the first one -- reading only the first partition
+                // has to show up as a missing row rather than by chance returning the right one.
+                let single_value = service
+                    .exec_query(
+                        "SELECT site_id, CAST(month_code AS INT) mc, sum(hours) v FROM pa.rollup \
+                         WHERE (equipment_type = 'QC') AND (CAST(month_code AS INT) = '202612') \
+                         AND (site_id = 'PSE') GROUP BY 1, 2",
+                    )
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(
+                    single_value.get_rows(),
+                    &vec![Row::new(vec![
+                        TableValue::String("PSE".to_string()),
+                        TableValue::Int(202612),
+                        TableValue::Int(80)
+                    ])]
+                );
+
+                Ok::<(), CubeError>(())
+            })
+            .await;
+        Ok(())
+    }
 }
 
 impl SqlServiceImpl {

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -6887,6 +6887,7 @@ mod tests {
                 // Rows reachable only through the first of several scanned partitions is what
                 // the regression is about, so wait for the data to be split across partitions
                 // and fail loudly rather than silently testing a single-partition scan.
+                // Compaction settles in a few iterations; the bound is a ceiling, not a wait.
                 let mut scanned_partitions = TableValue::Int(0);
                 for _ in 0..1200 {
                     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -6912,15 +6913,24 @@ mod tests {
                 // The last month of the range, so the matching rows sit in the last partition
                 // the scan visits and never in the first one -- reading only the first partition
                 // has to show up as a missing row rather than by chance returning the right one.
-                let single_value = service
-                    .exec_query(
-                        "SELECT site_id, CAST(month_code AS INT) mc, sum(hours) v FROM pa.rollup \
-                         WHERE (equipment_type = 'QC') AND (CAST(month_code AS INT) = '202612') \
-                         AND (site_id = 'PSE') GROUP BY 1, 2",
-                    )
-                    .await?
-                    .collect()
-                    .await?;
+                let query = "SELECT site_id, CAST(month_code AS INT) mc, sum(hours) v \
+                             FROM pa.rollup \
+                             WHERE (equipment_type = 'QC') \
+                             AND (CAST(month_code AS INT) = '202612') \
+                             AND (site_id = 'PSE') GROUP BY 1, 2";
+
+                // Pinning every group column to a single value is what hands the aggregate to
+                // the streaming implementation, and only that one carried a stale partition
+                // count. Without this the test would keep passing on a plan that never exercises
+                // the fix.
+                let worker_plan = pp_phys_plan(service.plan_query(query).await?.worker.as_ref());
+                assert!(
+                    worker_plan.contains("InlinePartialAggregate"),
+                    "expected a streaming partial aggregate, got:\n{}",
+                    worker_plan
+                );
+
+                let single_value = service.exec_query(query).await?.collect().await?;
                 assert_eq!(
                     single_value.get_rows(),
                     &vec![Row::new(vec![


### PR DESCRIPTION
## Summary

A grouped query over a rollup could silently return no rows — or an undercount — when every group-by dimension was pinned to a single value by a filter. `InlineAggregateExec` carried its `PlanProperties` over to a new child instead of recomputing them, so it kept reporting one output partition while its input had several; the parent then executed only partition 0 and dropped every row living in the rest, with no error anywhere. Fixes CORE-778 (reported by Maersk on `assetmgmt-prod`).

## Changes

- `InlineAggregateExec::with_new_children` delegates the input swap to the `AggregateExec` the node was converted from, then re-converts. DataFusion recomputes the properties there and preserves the output schema, which it derives from aggregate expression names its own rules may rewrite (`try_new` would regenerate them and can trip `schema_check`). If the new input is no longer sorted on the group keys, the plain hash aggregate is kept — without the limit, which means "stop after N complete groups" on the streaming path but "cap on distinct groups" for a hash aggregate.
- `GroupByLimitAggregateExec` refreshed only the output partitioning and kept orderings and constants projected from the previous input; it now uses the same delegation.
- `RollingWindowAggExec` and `AggregateTopKExec` also carry their properties over, but build them from their own output schema plus constants and read the input's partition count live, so nothing can go stale. Both sites now say so, since the same pattern loses rows in a node whose partitioning follows the input.

## How it fired

All of these had to hold at once, which is why it looked intermittent:

- every group-by column pinned to a single value by the filter — that is what makes the aggregate `Sorted` and hands it to the streaming implementation. With `IN (a, b)` there is no constant, the plan stays `PartiallySorted*` and is correct, which is the whole `=` vs `IN` asymmetry in the report;
- the leading sort key column outside the filter set, so partition pruning cannot collapse the scan — a rollup partitioned by a time dimension the query does not filter is exactly that shape;
- the matching rows outside the first scanned partition. Rebuilding a pre-aggregation moves the split points, so the same query can start or stop reproducing.

Sequence inside a single physical-optimizer run, no router/worker boundary involved: `ensure_partition_merge` puts a `CoalescePartitionsExec` under the aggregate, the node is converted with a cached partition count of 1, and DataFusion's `EnforceSorting::remove_bottleneck_in_subplan` then strips that coalesce and reattaches the multi-partition subtree.

Present since the DataFusion 46 upgrade (`4ef3442827`), which introduced the node.

## Testing

- `sql::tests::single_value_equals_scans_every_partition` — end-to-end regression test on the reported shape: a rollup-like table whose sort key leads with a time dimension, several partitions, both group columns pinned. Fails on the old `with_new_children` (returns no rows), passes with the fix. It probes the last month of the range on purpose: a probe near the start of the sort key can land in partition 0 and go green with the bug present.
- The existing `group_by_limit_aggregate::tests::output_partitioning_follows_rechilded_input` covers the same class for the second node and still passes.
- `partition_filter::tests::no_false_negatives_{two,three}_columns` — exhaustive check that `MinMaxCondition` never prunes a range holding a matching row. Partition pruning was the first suspect and is clean; this pins that.
- `cargo test -p cubestore --lib` green (317 tests), several consecutive runs.
