### PR TITLE
docs: document undocumented customer-facing changes from the last week

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -103,13 +103,18 @@ opens a bucket that includes its lower bound and excludes the upper one, and two
 open-ended buckets are added at the edges—so `0, 18, 25` yields `< 0`, `[0, 18)`,
 `[18, 25)`, `>= 25`, and no row is dropped. **Label style** renders a bucket as
 `[10, 20)`, `>= 10 and < 20`, or `10 to 19`; the last is offered only while every
-boundary is a whole number. Rows where the dimension is `NULL` are reported as
-`Unknown`.
+boundary is a whole number. Choose **Custom** to type your own label for each
+bucket instead.
+
+By default, rows where the dimension is `NULL` get their own label (**Unknown**,
+editable). Turn off **Label empty values separately** to fold them into the last
+bucket instead.
 
 **Value groups** collect the dimension's values into named sets: pick values, name
 the group, and choose **Add group**. A value belongs to one group at a time.
 Whatever you did not pick—including empty values—falls under **Everything else**,
-which defaults to `Other`.
+which defaults to `Other`. Turn off **Group remaining values** to return `NULL`
+for unpicked and empty values instead.
 
 Bucket labels carry their position as a prefix (`1.`, `2.`, zero-padded past nine
 buckets) so that sorting the column sorts it by value rather than alphabetically,

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -672,6 +672,27 @@ Each push creates exactly two new files:
   from the cube's joins (only to targets that originated in dbt), and the cube's measures
   preserved under `meta.cube.measures` for context.
 
+## Author dbt models from Analytics Chat
+
+<Warning>
+
+Authoring dbt models from Analytics Chat is currently in preview, and its behavior may
+still change. Reach out to the [Cube support team](/admin/account-billing/support) to
+activate this feature for your account.
+
+</Warning>
+
+Ask [the agent](/docs/explore-analyze/analytics-chat) to create or update a dbt
+model — for example, "turn this cube into a dbt model" or "add a `region` column to the
+`orders` dbt model." The agent opens a private **dbt workspace**: a live sandbox scoped
+to that model, where it reads the existing model and YAML files, drafts or edits the
+SQL, runs `dbt` to validate the change, and iterates until it compiles. Once you
+confirm, it publishes the result — a pull request or a direct commit, per your
+[delivery mode](#enable-push) — back to your dbt repository.
+
+This shares its enablement with [dbt push](#push-cubes-to-dbt): activating one activates
+the other, and a model authored from chat is delivered the same way a pushed cube is.
+
 ## Limitations
 
 - **Supported warehouses:** Snowflake, Amazon Redshift, PostgreSQL, Google

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -80,7 +80,11 @@ Google Cloud for Sheets works only with [views][ref-views], not cubes.
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
 the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+remove members from a query. Drag measures within the **Measures** pane to
+reorder them in the output. When the pivot has column dimensions, a
+**Measure position** setting controls whether measures nest **After columns**
+(the default — each column value gets its own set of measures) or
+**Before columns** (each measure spans every column value).
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -244,6 +244,14 @@ work together.
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
 guessing them.
 
+Pass an optional `branchName` to `runQuery` to query a dev branch's model — the one
+returned by `startDataModelEdit` — instead of the deployed model, so you can verify an
+edit before it's committed. The response reports the branch it actually queried
+(`null` for the deployed model), which never just echoes the argument back. Keep
+`branchName` identical across paginated calls: `runQuery` re-issues the whole query for
+each page, so dropping it on a later page silently switches that page to the deployed
+model.
+
 ### Dashboard authoring
 
 These tools build [workbooks][ref-workbooks] and [dashboards][ref-dashboards]

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -88,7 +88,11 @@ Cube Cloud for Excel works only with [views][ref-views], not cubes.
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
 the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+remove members from a query. Drag measures within the **Measures** pane to
+reorder them in the output. When the pivot has column dimensions, a
+**Measure position** setting controls whether measures nest **After columns**
+(the default — each column value gets its own set of measures) or
+**Before columns** (each measure spans every column value).
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,20 +77,22 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow CSV export
+## Allow chart export
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget's data as a CSV file, add the
-`allowExport=true` query parameter to the embed URL:
+widgets. To let viewers export a chart widget, add the `allowExport=true` query
+parameter to the embed URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
-When enabled, each chart widget's ⋮ menu shows a **Download as CSV** action. The
-CSV is generated client-side from the data already loaded into the widget, so no
-additional query is issued. The parameter is opt-in — omit it (the default) to
-keep the download action hidden.
+When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download as
+PNG**, and **Download as PDF** actions. CSV is generated client-side from the data
+already loaded into the widget; PNG and PDF are [server-rendered
+snapshots](/docs/explore-analyze/dashboards#download-as-png-or-pdf), the same as
+on a non-embedded dashboard. The parameter is opt-in — omit it (the default) to
+keep the download actions hidden.
 
 ## Show or hide the AI chat
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (not applicable — docs only)
- [ ] Linter has been run for changed code (not applicable — docs only)
- [ ] Tests for the changes have been added if not covered yet (not applicable — docs only)

**Description of Changes Made**

Routine documentation audit: cross-checked recent merges in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify` and found five small, genuinely undocumented customer-facing changes. Each gets its own commit:

- **Author dbt models from Analytics Chat** (cubejs-enterprise CUB-3964) — the agent can open a live dbt workspace to draft or edit a model, validate it with `dbt`, and publish the result as a PR or commit. Shares its preview enablement with dbt push. Added a new section to `docs/integrations/dbt.mdx`.
- **PNG/PDF export in embedded dashboards** (cubejs-enterprise CUB-4065) — `allowExport=true` now also unlocks **Download as PNG** and **Download as PDF** on embedded chart widgets, not just CSV. Updated `embedding/iframe/dashboards.mdx`.
- **Bin/group editor: custom labels and NULL handling** (cubejs-enterprise #14324) — bins can take a custom label per bucket and a separate label for empty values; value groups can return `NULL` for unpicked/empty values instead of folding them into **Everything else**. Updated the "Bins and value groups" section in `docs/explore-analyze/workbooks/calculated-fields.mdx`.
- **Measure reordering and position in pivot reports** (cubejs-enterprise CUB-2405) — measures in the Excel/Sheets pivot builder can now be dragged to reorder, and a **Measure position** setting nests them before or after column dimensions. Updated `docs/integrations/microsoft-excel.mdx` and `docs/integrations/google-sheets.mdx`.
- **`branchName` on the MCP `runQuery` tool** (cubejs-enterprise CUB-3732) — `runQuery` can now query a dev branch's model to verify an edit before it's committed, and reports which branch it actually queried. Updated `docs/integrations/mcp-server.mdx`.

Also investigated and intentionally skipped: dashboard apps (still behind an off-by-default flag, pre-GA per its own design doc), tenant-facing dedicated regions (same — off-by-default flag), the notification inbox's mark-unread/delete (self-explanatory UI polish, not a new concept), the calculated-field SQL fallback editor (already covered by the existing "Editing a calculated field" section), and a superadmin CLI JWT (internal Cube-employee tooling, not customer-facing). No large/new-page-worthy gap was found in this window.

---
_Generated by [Claude Code](https://claude.ai/code/session_0147wCkQyR3LJ67FZgUN8jz5)_