### PR TITLE
refactor(query-orchestrator): Queue - remove processingId locks

### DIFF
--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -1,8 +1,6 @@
 export type QueryDef = any;
 // Primary key of Queue item
 export type QueueId = string | number | bigint;
-// The lock token of a retrieval, always the item's queueId. Only the memory driver compares it.
-export type ProcessingId = string | number | bigint;
 export type QueryKey = (string | [string, any[]]) & {
   persistent?: true,
 };
@@ -13,21 +11,21 @@ export type GetActiveAndToProcessResponse = [active: QueryKeysTuple[], toProcess
 export type QueryStageStateResponse = [active: string[], toProcess: string[]] | [active: string[], toProcess: string[], defs: Record<string, QueryDef>];
 export type RetrieveForProcessingSuccess = [
   added: unknown,
-  // QueueId is required for Cube Store, other providers don't support it
+  // Identifies the retrieved generation of the queue item.
   queueId: QueueId | null,
   active: QueryKeyHash[],
   pending: number,
   def: QueryDef,
-  lockAquired: true
+  retrieved: true
 ];
 export type RetrieveForProcessingFail = [
   added: unknown,
-  // QueueId is required for Cube Store, other providers don't support it
+  // Null when no queue item was retrieved.
   queueId: QueueId | null,
   active: QueryKeyHash[],
   pending: number,
   def: null,
-  lockAquired: false
+  retrieved: false
 ];
 export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | RetrieveForProcessingFail | null;
 export type AddToQueueResponse = [
@@ -106,14 +104,13 @@ export interface QueueDriverConnectionInterface {
   getStalledQueries(): Promise<QueryKeysTuple[]>;
   getQueryStageState(onlyKeys: boolean): Promise<QueryStageStateResponse>;
   updateHeartBeat(hash: QueryKeyHash, queueId: QueueId | null): Promise<void>;
-  // Trying to acquire a lock for processing a queue item, this method can return null when
-  // multiple nodes tries to process the same query
-  retrieveForProcessing(hash: QueryKeyHash, processingId: ProcessingId): Promise<RetrieveForProcessingResponse>;
-  freeProcessingLock(hash: QueryKeyHash, processingId: ProcessingId, activated: unknown): Promise<void>;
-  optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, processingId: ProcessingId, queueId: QueueId | null): Promise<boolean>;
+  // Atomically moves a queue item to active. Returns null when another node is already
+  // processing the query or the concurrency budget is full.
+  retrieveForProcessing(hash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingResponse>;
+  optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, queueId: QueueId): Promise<boolean>;
   cancelQuery(queryKey: QueryKey, queueId: QueueId | null): Promise<QueryDef | null>;
   getQueryAndRemove(hash: QueryKeyHash, queueId: QueueId | null): Promise<[QueryDef]>;
-  setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: any, processingId: ProcessingId, queueId: QueueId | null): Promise<unknown>;
+  setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: any, queueId: QueueId): Promise<unknown>;
   release(): void;
   //
   getQueriesToCancel(): Promise<QueryKeysTuple[]>

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -12,7 +12,6 @@ import {
   AddToQueueResponse,
   QueryKey,
   QueryKeyHash,
-  ProcessingId,
   QueueId,
   GetActiveAndToProcessResponse,
   QueryKeysTuple,
@@ -182,10 +181,6 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async freeProcessingLock(_hash: QueryKeyHash, _processingId: string, _activated: unknown): Promise<void> {
-    // nothing to do
-  }
-
   public async getActiveQueries(): Promise<QueryKeysTuple[]> {
     const rows = await this.driver.query<CubeStoreListResponse>('QUEUE ACTIVE ?', [
       this.options.redisQueuePrefix
@@ -336,7 +331,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, _processingId: ProcessingId, queueId: QueueId): Promise<boolean> {
+  public async optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, queueId: QueueId): Promise<boolean> {
     await this.driver.query('QUEUE MERGE_EXTRA ? ?', [
       // queryKeyHash as compatibility fallback
       queueId || this.prefixKey(hash),
@@ -372,7 +367,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     ];
   }
 
-  public async retrieveForProcessing(hash: QueryKeyHash, _processingId: string): Promise<RetrieveForProcessingResponse> {
+  public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingResponse> {
     const rows = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
@@ -404,7 +399,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     return null;
   }
 
-  public async setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: unknown, _processingId: ProcessingId, queueId: QueueId): Promise<boolean> {
+  public async setResultAndRemoveQuery(hash: QueryKeyHash, executionResult: unknown, queueId: QueueId): Promise<boolean> {
     const rows = await this.driver.query('QUEUE ACK ? ?', [
       // queryKeyHash as compatibility fallback
       queueId || this.prefixKey(hash),

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -182,12 +182,13 @@ sequenceDiagram
 ## Background execution: `processQuery` → `executeQuery`
 
 `processQuery` retrieves the item and nothing else. What it hands to `sendProcessMessageFn` is a
-`RetrievedQuery` — `{ queryKeyHash, queueId, processingId, queueSize, query }`, plain data on
+`RetrievedQuery` — `{ queryKeyHash, queueId, queueSize, query }`, plain data on
 purpose, so a custom implementation can serialize it and let another process run
 `executeQuery`. The default implementation calls `executeQuery` in-process.
 
-`processingId` is the lock token of the retrieval and always carries the `queueId`. Only the
-memory driver compares it, Cube Store ignores it and keys every command off the `queueId`.
+`queueId` identifies the specific generation of a queue item. The memory driver compares it
+with the active entry before updating or acknowledging a query, while Cube Store keys those
+commands directly off the `queueId`.
 
 `sendProcessMessageFn` must resolve once the hand-off is done, **not** once the query is
 executed: reconcile awaits it, and `executeQuery` ends with `reconcileQueue`, which is
@@ -200,8 +201,8 @@ Two consequences of retrieving before the hand-off:
   `@<processUid>` suffix matches, so `sendProcessMessageFn` is always called on the owning
   process for them — it just must not route them elsewhere.
 - A retrieved item is already active. If a custom hand-off loses the message, the item is only
-  recovered by the stalled-heartbeat / `TO_CANCEL` path; `freeProcessingLock` is a no-op on
-  Cube Store, so the retrieval cannot be cheaply undone.
+  recovered by the stalled-heartbeat / `TO_CANCEL` path; a successful retrieval is not undone
+  when the hand-off fails.
 
 A stream query is dispatched while `executeInQueue` is still running, so `waitForQueryStream`
 subscribes to `streamStarted` *before* the dispatch — a handler which starts fast would
@@ -222,10 +223,10 @@ sequenceDiagram
     QueryQueue->>QueueDriver: retrieveForProcessing
     QueueDriver->>CubeStore: QUEUE RETRIEVE EXTENDED CONCURRENCY ?n ?path
     CubeStore-->>QueueDriver: RetrieveResponse
-    QueueDriver-->>QueryQueue: [added, queueId, activeKeys, queueSize, def, lockAcquired]
+    QueueDriver-->>QueryQueue: [added, queueId, activeKeys, queueSize, def, retrieved]
     Note over QueueDriver,CubeStore: The retrieval is atomic in Cube Store:<br/>only one node moves the item to active
 
-    alt def && added && activeKeys includes our key && lockAcquired
+    alt def && added && activeKeys includes our key && retrieved
         QueryQueue-)Background: sendProcessMessageFn(RetrievedQuery)
         Note over QueryQueue,Background: Detached from here on: the hand-off returns,<br/>the execution keeps running
 
@@ -254,8 +255,7 @@ sequenceDiagram
         Background->>Background: reconcileQueue
         Note over Background: The freed concurrency slot is<br/>immediately given to the next query
     else the retrieval did not succeed
-        QueryQueue->>QueueDriver: freeProcessingLock
-        Note over QueryQueue,QueueDriver: Another node is running it, or the<br/>concurrency budget is full. No-op for Cube Store
+        Note over QueryQueue,QueueDriver: Another node is running it, or the<br/>concurrency budget is full. Queue state is unchanged
     end
 ```
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -4,7 +4,6 @@ import {
   QueryKey,
   QueryKeyHash,
   QueueId,
-  ProcessingId,
   QueryDef,
   AddToQueueQuery,
   AddToQueueOptions,
@@ -54,8 +53,6 @@ export class LocalQueueDriverConnectionState {
   public active: Record<QueryKeyHash, QueueItem> = {};
 
   public heartBeat: Record<QueryKeyHash, QueueItem> = {};
-
-  public processingLocks: Record<QueryKeyHash, any> = {};
 }
 
 export class LocalQueueDriverConnection implements QueueDriverConnectionInterface {
@@ -223,7 +220,6 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     delete this.state.toProcess[queryKeyHash];
     delete this.state.recent[queryKeyHash];
     delete this.state.queryDef[queryKeyHash];
-    delete this.state.processingLocks[queryKeyHash];
 
     return [query];
   }
@@ -233,8 +229,8 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     return query;
   }
 
-  public async setResultAndRemoveQuery(queryKeyHash: QueryKeyHash, executionResult: any, processingId: ProcessingId, _queueId?: QueueId | null): Promise<boolean> {
-    if (this.state.processingLocks[queryKeyHash] !== processingId) {
+  public async setResultAndRemoveQuery(queryKeyHash: QueryKeyHash, executionResult: any, queueId: QueueId): Promise<boolean> {
+    if (this.state.active[queryKeyHash]?.queueId !== queueId) {
       return false;
     }
 
@@ -245,7 +241,6 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     delete this.state.toProcess[queryKeyHash];
     delete this.state.recent[queryKeyHash];
     delete this.state.queryDef[queryKeyHash];
-    delete this.state.processingLocks[queryKeyHash];
 
     promise.resolved = true;
     if (promise.resolve) {
@@ -277,48 +272,44 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     }
   }
 
-  public async retrieveForProcessing(queryKeyHash: QueryKeyHash, processingId: ProcessingId): Promise<RetrieveForProcessingResponse> {
-    let lockAcquired = false;
+  public async retrieveForProcessing(queryKeyHash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingResponse> {
+    const query = this.state.queryDef[queryKeyHash];
+    const activeKeys = this.queueArray(this.state.active) as QueryKeyHash[];
 
-    if (!this.state.processingLocks[queryKeyHash]) {
-      this.state.processingLocks[queryKeyHash] = processingId;
-      lockAcquired = true;
-    } else {
-      return null;
+    if (
+      !query ||
+      query.queueId !== queueId ||
+      this.state.toProcess[queryKeyHash]?.queueId !== queueId ||
+      this.state.active[queryKeyHash] ||
+      activeKeys.length >= this.concurrency
+    ) {
+      return [
+        0,
+        null,
+        activeKeys,
+        Object.keys(this.state.toProcess).length,
+        null,
+        false
+      ];
     }
 
-    let added = 0;
+    this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(queueId), queueId };
+    delete this.state.toProcess[queryKeyHash];
 
-    if (Object.keys(this.state.active).length < this.concurrency && !this.state.active[queryKeyHash]) {
-      this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(processingId), queueId: processingId };
-      delete this.state.toProcess[queryKeyHash];
-
-      added = 1;
-    }
-
-    this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId: processingId };
+    this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId };
 
     return [
-      added,
-      this.state.queryDef[queryKeyHash]?.queueId ?? null,
+      1,
+      query.queueId,
       this.queueArray(this.state.active) as QueryKeyHash[],
       Object.keys(this.state.toProcess).length,
-      this.state.queryDef[queryKeyHash],
-      lockAcquired
+      query,
+      true
     ];
   }
 
-  public async freeProcessingLock(queryKeyHash: QueryKeyHash, processingId: ProcessingId, activated: any): Promise<void> {
-    if (this.state.processingLocks[queryKeyHash] === processingId) {
-      delete this.state.processingLocks[queryKeyHash];
-      if (activated) {
-        delete this.state.active[queryKeyHash];
-      }
-    }
-  }
-
-  public async optimisticQueryUpdate(queryKeyHash: QueryKeyHash, toUpdate: any, processingId: ProcessingId, _queueId?: QueueId | null): Promise<boolean> {
-    if (this.state.processingLocks[queryKeyHash] !== processingId) {
+  public async optimisticQueryUpdate(queryKeyHash: QueryKeyHash, toUpdate: any, queueId: QueueId): Promise<boolean> {
+    if (this.state.active[queryKeyHash]?.queueId !== queueId || !this.state.queryDef[queryKeyHash]) {
       return false;
     }
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -9,7 +9,6 @@ import {
   QueryStageStateResponse,
   AddToQueueOptions,
   QueuePriority,
-  ProcessingId,
   RetrieveForProcessingSuccess
 } from '@cubejs-backend/base-driver';
 import { CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
@@ -29,7 +28,6 @@ export type QueryHandlersMap = Record<string, QueryHandlerFn>;
 export type RetrievedQuery = {
   queryKeyHash: QueryKeyHash;
   queueId: QueueId;
-  processingId: ProcessingId;
   queueSize: number;
   query: QueryDef;
 };
@@ -373,7 +371,6 @@ export class QueryQueue {
     return {
       queryKeyHash,
       queueId,
-      processingId: queueId,
       queueSize,
       query,
     };
@@ -817,9 +814,8 @@ export class QueryQueue {
   }
 
   /**
-   * Acquires the processing lock for the query specified by the `queryKeyHashed` and moves it to
-   * the active set. Returns `null` when the retrieval didn't succeed, which means another node is
-   * already running the query or the concurrency budget is full.
+   * Atomically moves the query specified by `queryKeyHashed` to the active set. Returns `null`
+   * when another node is already running the query or the concurrency budget is full.
    */
   protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<RetrievedQuery | null> {
     const queueConnection = await this.queueDriver.createConnection();
@@ -828,16 +824,12 @@ export class QueryQueue {
     let activeKeys;
     let queueSize;
     let query;
-    let processingLockAcquired;
+    let retrievalSucceeded;
 
     try {
-      // The lock token is the queueId, every call which releases the lock has to be handed
-      // the same value retrieveForProcessing got
-      const processingId = queueId;
-
-      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, processingId);
+      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, queueId);
       if (retrieveResult) {
-        [insertedCount, , activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
+        [insertedCount, , activeKeys, queueSize, query, retrievalSucceeded] = retrieveResult;
       }
 
       const activated = activeKeys && activeKeys.indexOf(queryKeyHashed) !== -1;
@@ -845,7 +837,7 @@ export class QueryQueue {
         query = await queueConnection.getQueryDef(queryKeyHashed, null);
       }
 
-      if (!query || !insertedCount || !activated || !processingLockAcquired) {
+      if (!query || !insertedCount || !activated || !retrievalSucceeded) {
         // TODO Ideally streaming queries should reconcile queue here after waiting on open slot however in practice continue wait timeout reconciles faster CPU-wise
         // if (query?.queryHandler === 'stream') {
         //   const [active] = await queueConnection.getQueryStageState(true);
@@ -857,26 +849,22 @@ export class QueryQueue {
 
         this.logger('Skip processing', {
           queueId,
-          processingId,
           queryKey: query && query.queryKey || queryKeyHashed,
           requestId: query && query.requestId,
           queuePrefix: this.redisQueuePrefix,
-          processingLockAcquired,
+          retrievalSucceeded,
           query,
           insertedCount,
           activeKeys,
           activated,
           queryExists: !!query
         });
-        await queueConnection.freeProcessingLock(queryKeyHashed, processingId, activated);
-
         return null;
       }
 
       return {
         queryKeyHash: queryKeyHashed,
         queueId,
-        processingId,
         queueSize,
         query,
       };
@@ -901,7 +889,7 @@ export class QueryQueue {
    * implementation which hands the query over to another process.
    */
   public async executeQuery(retrieved: RetrievedQuery): Promise<void> {
-    const { queryKeyHash: queryKeyHashed, queueId, processingId, queueSize, query } = retrieved;
+    const { queryKeyHash: queryKeyHashed, queueId, queueSize, query } = retrieved;
 
     const queueConnection = await this.queueDriver.createConnection();
 
@@ -915,7 +903,6 @@ export class QueryQueue {
       const timeInQueue = (new Date()).getTime() - query.addedToQueueTime;
       this.logger('Performing query', {
         queueId,
-        processingId,
         queueSize,
         queryKey: query.queryKey,
         queuePrefix: this.redisQueuePrefix,
@@ -927,7 +914,7 @@ export class QueryQueue {
         preAggregation: query.query?.preAggregation,
         addedToQueueTime: query.addedToQueueTime,
       });
-      await queueConnection.optimisticQueryUpdate(queryKeyHashed, { startQueryTime }, processingId, queueId);
+      await queueConnection.optimisticQueryUpdate(queryKeyHashed, { startQueryTime }, queueId);
 
       let queryProcessHeartbeat = Date.now();
       const heartBeatTimer = setInterval(
@@ -1011,7 +998,7 @@ export class QueryQueue {
                   async (cancelHandler) => {
                     localCancelHandler = cancelHandler;
                     try {
-                      await queueConnection.optimisticQueryUpdate(queryKeyHashed, { cancelHandler }, processingId, queueId);
+                      await queueConnection.optimisticQueryUpdate(queryKeyHashed, { cancelHandler }, queueId);
                     } catch (e: any) {
                       this.logger('Error while query update', {
                         queueId,
@@ -1035,7 +1022,6 @@ export class QueryQueue {
 
         this.logger('Performing query completed', {
           queueId,
-          processingId,
           queueSize,
           duration: ((new Date()).getTime() - startQueryTime),
           queryKey: query.queryKey,
@@ -1054,7 +1040,6 @@ export class QueryQueue {
         };
         this.logger('Error while querying', {
           queueId,
-          processingId,
           queueSize,
           duration: ((new Date()).getTime() - startQueryTime),
           queryKey: query.queryKey,
@@ -1073,7 +1058,6 @@ export class QueryQueue {
           if (queryWithCancelHandle) {
             this.logger('Cancelling query due to timeout', {
               queueId,
-              processingId,
               queryKey: queryWithCancelHandle.queryKey,
               queuePrefix: this.redisQueuePrefix,
               requestId: queryWithCancelHandle.requestId,
@@ -1092,11 +1076,10 @@ export class QueryQueue {
         clearInterval(heartBeatTimer);
       }
 
-      if (!(await queueConnection.setResultAndRemoveQuery(queryKeyHashed, executionResult, processingId, queueId))) {
+      if (!(await queueConnection.setResultAndRemoveQuery(queryKeyHashed, executionResult, queueId))) {
         this.logger('Orphaned execution result', {
           queueId,
-          processingId,
-          warn: 'Result for query was not set due to processing lock wasn\'t acquired',
+          warn: 'Result for query was not set because the queue item is no longer active',
           queryKey: query.queryKey,
           queuePrefix: this.redisQueuePrefix,
           requestId: query.requestId,

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -42,7 +42,6 @@ function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInt
     setResultAndRemoveQuery: wrapAsyncMethod('setResultAndRemoveQuery'),
     getQueryStageState: wrapAsyncMethod('getQueryStageState'),
     getResultBlocking: wrapAsyncMethod('getResultBlocking'),
-    freeProcessingLock: wrapAsyncMethod('freeProcessingLock'),
     optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
     getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
     release: connection.release,

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -465,76 +465,111 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       }
     });
 
-    onlyLocalTest('queue driver lock obtain race condition', async () => {
-      const connection: any = await queue.queueDriver.createConnection();
-      const connection2: any = await queue.queueDriver.createConnection();
-      const priority = 10;
-
-      await queue.reconcileQueue();
-
-      const [, raceQueueId] = await connection.addToQueue(
-        'race', 'handler', ['select'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race' }
-      );
-
-      const [, race2QueueId] = await connection.addToQueue(
-        'race2', 'handler2', ['select2'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race2' }
-      );
-
-      // Neither is locked yet, so both releases are no-ops
-      await connection.freeProcessingLock('race', raceQueueId, true);
-      await connection.freeProcessingLock('race2', race2QueueId, true);
-
-      await connection2.retrieveForProcessing('race2', race2QueueId);
-
-      const retrieve6 = await connection.retrieveForProcessing('race', raceQueueId);
-      console.log(retrieve6);
-      expect(!!retrieve6[5]).toBe(true);
-
-      console.log(await connection.getQueryAndRemove('race'));
-      console.log(await connection.getQueryAndRemove('race2'));
-
-      await queue.queueDriver.release(connection);
-      await queue.queueDriver.release(connection2);
-    });
-
-    onlyLocalTest('activated but lock is not acquired', async () => {
+    onlyLocalTest('an active query cannot be retrieved twice', async () => {
       const connection = await queue.queueDriver.createConnection();
       const connection2 = await queue.queueDriver.createConnection();
       const priority = 10;
+      const key = 'active-retrieval' as any;
 
-      await queue.reconcileQueue();
+      try {
+        const [, queueId] = await connection.addToQueue(
+          key, 'handler', <any>['select'], priority, {
+            queueId: queue.generateQueueId(), stageQueryKey: key, requestId: '1'
+          }
+        );
 
-      const [, activated1QueueId] = await connection.addToQueue(
-        'activated1', 'handler', <any>['select'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race', requestId: '1' }
-      );
+        const firstRetrieval = await connection.retrieveForProcessing(key, queueId);
+        expect(firstRetrieval?.[5]).toBe(true);
 
-      const [, activated2QueueId] = await connection.addToQueue(
-        'activated2', 'handler2', <any>['select2'], priority, { queueId: queue.generateQueueId(), stageQueryKey: 'race2', requestId: '1' }
-      );
+        const secondRetrieval = await connection2.retrieveForProcessing(key, queueId);
+        expect(secondRetrieval).toStrictEqual([0, null, [key], 0, null, false]);
+      } finally {
+        await connection.getQueryAndRemove(key, null);
+        queue.queueDriver.release(connection);
+        queue.queueDriver.release(connection2);
+      }
+    });
 
-      const retrieve1 = await connection.retrieveForProcessing('activated1' as any, activated1QueueId);
-      console.log(retrieve1);
-      const retrieve2 = await connection2.retrieveForProcessing('activated2' as any, activated2QueueId);
-      console.log(retrieve2);
-      console.log(await connection.freeProcessingLock('activated1' as any, activated1QueueId, retrieve1 && retrieve1[2].indexOf('activated1' as any) !== -1));
+    onlyLocalTest('a failed retrieval does not reserve a pending query', async () => {
+      const connection = await queue.queueDriver.createConnection();
+      const connection2 = await queue.queueDriver.createConnection();
+      const priority = 10;
+      const firstKey = 'concurrency-first' as any;
+      const secondKey = 'concurrency-second' as any;
 
-      // Another node reaches the same item, so it comes with the same lock token and loses
-      const retrieve3 = await connection.retrieveForProcessing('activated2' as any, activated2QueueId);
-      expect(retrieve3).toBeNull();
+      try {
+        const [, firstQueueId] = await connection.addToQueue(
+          firstKey, 'handler', <any>['select'], priority, {
+            queueId: queue.generateQueueId(), stageQueryKey: firstKey, requestId: '1'
+          }
+        );
+        const [, secondQueueId] = await connection.addToQueue(
+          secondKey, 'handler2', <any>['select2'], priority, {
+            queueId: queue.generateQueueId(), stageQueryKey: secondKey, requestId: '1'
+          }
+        );
 
-      console.log(retrieve2[2].indexOf('activated2' as any) !== -1);
-      console.log(await connection2.freeProcessingLock('activated2' as any, activated2QueueId, retrieve2 && retrieve2[2].indexOf('activated2' as any) !== -1));
+        expect((await connection.retrieveForProcessing(firstKey, firstQueueId))?.[5]).toBe(true);
+        expect(await connection2.retrieveForProcessing(secondKey, secondQueueId)).toStrictEqual([
+          0, null, [firstKey], 1, null, false
+        ]);
+        expect(await connection.getToProcessQueries()).toStrictEqual([[secondKey, secondQueueId]]);
 
-      const retrieve4 = await connection.retrieveForProcessing('activated2' as any, activated2QueueId);
-      console.log(retrieve4);
-      expect(retrieve4[0]).toBe(1);
-      expect(!!retrieve4[5]).toBe(true);
+        await connection.getQueryAndRemove(firstKey, firstQueueId);
 
-      console.log(await connection.getQueryAndRemove('activated1' as any, null));
-      console.log(await connection.getQueryAndRemove('activated2' as any, null));
+        const secondRetrieval = await connection2.retrieveForProcessing(secondKey, secondQueueId);
+        expect(secondRetrieval?.[0]).toBe(1);
+        expect(secondRetrieval?.[5]).toBe(true);
+      } finally {
+        await connection.getQueryAndRemove(firstKey, null);
+        await connection.getQueryAndRemove(secondKey, null);
+        queue.queueDriver.release(connection);
+        queue.queueDriver.release(connection2);
+      }
+    });
 
-      await queue.queueDriver.release(connection);
-      await queue.queueDriver.release(connection2);
+    test('stale queueId cannot update or acknowledge a requeued query', async () => {
+      const connection = await queue.queueDriver.createConnection();
+      const queryKey = 'requeued-query' as QueryKey;
+      const key = connection.redisHash(queryKey);
+      const priority = 10;
+
+      try {
+        const [, staleQueueId] = await connection.addToQueue(
+          queryKey, 'handler', <any>['old'], priority, {
+            queueId: queue.generateQueueId(), stageQueryKey: key, requestId: '1'
+          }
+        );
+        expect((await connection.retrieveForProcessing(key, staleQueueId))?.[5]).toBe(true);
+        await connection.getQueryAndRemove(key, staleQueueId);
+
+        const [, currentQueueId] = await connection.addToQueue(
+          queryKey, 'handler', <any>['new'], priority, {
+            queueId: queue.generateQueueId(), stageQueryKey: key, requestId: '2'
+          }
+        );
+
+        if (options.cacheAndQueueDriver !== 'cubestore') {
+          expect(await connection.retrieveForProcessing(key, staleQueueId)).toStrictEqual([
+            0, null, [], 1, null, false
+          ]);
+          expect(await connection.getToProcessQueries()).toStrictEqual([[key, currentQueueId]]);
+        }
+        expect((await connection.retrieveForProcessing(key, currentQueueId))?.[5]).toBe(true);
+
+        const staleUpdateResult = await connection.optimisticQueryUpdate(key, { stale: true }, staleQueueId);
+        if (options.cacheAndQueueDriver !== 'cubestore') {
+          expect(staleUpdateResult).toBe(false);
+        }
+        expect(await connection.setResultAndRemoveQuery(key, { result: 'stale' }, staleQueueId)).toBe(false);
+        const currentQuery = await connection.getQueryDef(key, currentQueueId);
+        expect(currentQuery).toMatchObject({ query: ['new'] });
+        expect(currentQuery).not.toHaveProperty('stale');
+        expect(await connection.getActiveQueries()).toStrictEqual([[key, currentQueueId]]);
+      } finally {
+        await connection.getQueryAndRemove(key, null);
+        queue.queueDriver.release(connection);
+      }
     });
 
     // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Removes `processingId` and `freeProcessingLock` from the queue-driver API and serialized `RetrievedQuery` payload. Local queue retrieval now atomically moves the matching `queueId` from pending to active, while update and acknowledgement reject stale queue generations. CubeStore signatures, queue documentation, benchmarks, and race/regression tests are updated to match the new contract.