### PR TITLE
fix(tesseract): compose grain.include with rolling_window

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-grain-rolling-window.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-grain-rolling-window.test.ts
@@ -1,0 +1,170 @@
+import { getEnv } from '@cubejs-backend/shared';
+import { prepareYamlCompiler } from '../../unit/PrepareCompiler';
+import { dbRunner } from './PostgresDBRunner';
+
+// A multi-stage measure that declares both `grain` and `rolling_window`.
+// The grain says at what grain the value inside a bucket is computed; the
+// window says which rows land in the bucket. Both have to hold at once.
+//
+// Inline data: two equally weighted rows per day, so the weighted daily
+// factor equals the row factor — 1.10, 1.20, 0.50. Linked over the three
+// days that is exactly -0.34, and every window below is wide enough to
+// cover all three, so at any grain coarser than a day the windowed measure
+// has to agree with the plain one.
+//
+// The measures round to six digits so the assertions compare exact strings
+// rather than IEEE noise from EXP/LN.
+describe('Multi-Stage grain with rolling window', () => {
+  jest.setTimeout(200000);
+
+  const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(`
+cubes:
+  - name: returns
+    sql: >
+      SELECT '2024-01-01'::date as DAY, 'A' as SECURITY, 10.0 as IRR, 100.0 as WEIGHT
+      union all
+      SELECT '2024-01-01'::date, 'B', 10.0, 100.0
+      union all
+      SELECT '2024-01-02'::date, 'A', 20.0, 100.0
+      union all
+      SELECT '2024-01-02'::date, 'B', 20.0, 100.0
+      union all
+      SELECT '2024-01-03'::date, 'A', -50.0, 100.0
+      union all
+      SELECT '2024-01-03'::date, 'B', -50.0, 100.0
+
+    dimensions:
+      - name: day
+        sql: DAY
+        type: time
+
+      - name: security
+        sql: SECURITY
+        type: string
+
+      - name: irr
+        sql: IRR
+        type: number
+
+      - name: weight
+        sql: WEIGHT
+        type: number
+
+    measures:
+      - name: weight_sum
+        sql: "{CUBE.weight}"
+        type: sum
+
+      - name: irr_weight_sum
+        sql: "{CUBE.irr} * {CUBE.weight}"
+        type: sum
+
+      - name: daily_irr_weight
+        multi_stage: true
+        sql: "{CUBE.irr_weight_sum}"
+        type: number
+
+      - name: daily_weight
+        multi_stage: true
+        sql: "{CUBE.weight_sum}"
+        type: number
+
+      - name: log_return_sum
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+
+      - name: twr
+        multi_stage: true
+        sql: "ROUND((EXP({CUBE.log_return_sum}) - 1)::numeric, 6)"
+        type: number
+
+      - name: log_return_sum_ytd
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+        rolling_window:
+          type: to_date
+          granularity: year
+
+      - name: twr_ytd
+        multi_stage: true
+        sql: "ROUND((EXP({CUBE.log_return_sum_ytd}) - 1)::numeric, 6)"
+        type: number
+
+      - name: log_return_sum_1y
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+        rolling_window:
+          trailing: 1 year
+          offset: end
+
+      - name: twr_1y
+        multi_stage: true
+        sql: "ROUND((EXP({CUBE.log_return_sum_1y}) - 1)::numeric, 6)"
+        type: number
+    `);
+
+  if (getEnv('nativeSqlPlanner')) {
+    it('day granularity: the window accumulates over the declared grain', async () => dbRunner.runQueryTest({
+      measures: ['returns.twr', 'returns.twr_ytd', 'returns.twr_1y'],
+      timeDimensions: [{
+        dimension: 'returns.day',
+        granularity: 'day',
+        dateRange: ['2024-01-01', '2024-01-03'],
+      }],
+      order: [{ id: 'returns.day' }],
+      timezone: 'UTC',
+    }, [
+      // Per-day factors 1.10 / 1.20 / 0.50; the windows link them up.
+      { returns__day_day: '2024-01-01T00:00:00.000Z', returns__twr: '0.100000', returns__twr_ytd: '0.100000', returns__twr_1y: '0.100000' },
+      { returns__day_day: '2024-01-02T00:00:00.000Z', returns__twr: '0.200000', returns__twr_ytd: '0.320000', returns__twr_1y: '0.320000' },
+      { returns__day_day: '2024-01-03T00:00:00.000Z', returns__twr: '-0.500000', returns__twr_ytd: '-0.340000', returns__twr_1y: '-0.340000' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+
+    it('month granularity: query grain does not replace the declared grain', async () => dbRunner.runQueryTest({
+      measures: ['returns.twr', 'returns.twr_ytd', 'returns.twr_1y'],
+      timeDimensions: [{
+        dimension: 'returns.day',
+        granularity: 'month',
+        dateRange: ['2024-01-01', '2024-01-31'],
+      }],
+      order: [{ id: 'returns.day' }],
+      timezone: 'UTC',
+    }, [
+      { returns__day_month: '2024-01-01T00:00:00.000Z', returns__twr: '-0.340000', returns__twr_ytd: '-0.340000', returns__twr_1y: '-0.340000' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+
+    it('no time dimension: the window is one bucket over the whole range', async () => dbRunner.runQueryTest({
+      measures: ['returns.twr', 'returns.twr_ytd', 'returns.twr_1y'],
+      timezone: 'UTC',
+    }, [
+      { returns__twr: '-0.340000', returns__twr_ytd: '-0.340000', returns__twr_1y: '-0.340000' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+
+    it('non-time dimension: the grain survives a plain group by', async () => dbRunner.runQueryTest({
+      measures: ['returns.twr', 'returns.twr_ytd', 'returns.twr_1y'],
+      dimensions: ['returns.security'],
+      order: [{ id: 'returns.security' }],
+      timezone: 'UTC',
+    }, [
+      { returns__security: 'A', returns__twr: '-0.340000', returns__twr_ytd: '-0.340000', returns__twr_1y: '-0.340000' },
+      { returns__security: 'B', returns__twr: '-0.340000', returns__twr_ytd: '-0.340000', returns__twr_1y: '-0.340000' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+  } else {
+    test.skip('day granularity: the window accumulates over the declared grain', () => { expect(1).toBe(1); });
+    test.skip('month granularity: query grain does not replace the declared grain', () => { expect(1).toBe(1); });
+    test.skip('no time dimension: the window is one bucket over the whole range', () => { expect(1).toBe(1); });
+    test.skip('non-time dimension: the grain survives a plain group by', () => { expect(1).toBe(1); });
+  }
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -807,6 +807,10 @@ impl MultiStageQueryPlanner {
                 // the rolling window node has no side enumerating that grid, so
                 // there is nothing to broadcast from. Reject them instead of
                 // computing at the unnarrowed grain and calling it the answer.
+                //
+                // `reduce_by` and `group_by` compile into the same two lists, so
+                // the message names both spellings — the model may contain
+                // neither of the words the grain keys are called by here.
                 let grain = measure
                     .multi_stage()
                     .map(|ms| ms.grain.clone())
@@ -815,9 +819,10 @@ impl MultiStageQueryPlanner {
                     |g: &Option<Vec<Rc<MemberSymbol>>>| g.as_ref().is_some_and(|v| !v.is_empty());
                 if has_partition_grain(&grain.exclude) || has_partition_grain(&grain.keep_only) {
                     return Err(CubeError::user(format!(
-                        "Measure {} declares `rolling_window` together with `grain.exclude` or \
-                         `grain.keep_only`, which is not supported. Only `grain.include` can be \
-                         combined with a rolling window.",
+                        "Measure {} declares `rolling_window` together with `grain.exclude` / \
+                         `reduce_by` or `grain.keep_only` / `group_by`, which is not supported. \
+                         Only `grain.include` (`add_group_by`) can be combined with a rolling \
+                         window.",
                         member.full_name(),
                     )));
                 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -815,9 +815,12 @@ impl MultiStageQueryPlanner {
                     .multi_stage()
                     .map(|ms| ms.grain.clone())
                     .unwrap_or_default();
-                let has_partition_grain =
-                    |g: &Option<Vec<Rc<MemberSymbol>>>| g.as_ref().is_some_and(|v| !v.is_empty());
-                if has_partition_grain(&grain.exclude) || has_partition_grain(&grain.keep_only) {
+                // `keep_only` is an intersection, so declaring it empty narrows
+                // the grain to nothing rather than meaning "no key given";
+                // `exclude` subtracts, so an empty list really does nothing.
+                let narrows_grain = grain.exclude.as_ref().is_some_and(|v| !v.is_empty())
+                    || grain.keep_only.is_some();
+                if narrows_grain {
                     return Err(CubeError::user(format!(
                         "Measure {} declares `rolling_window` together with `grain.exclude` / \
                          `reduce_by` or `grain.keep_only` / `group_by`, which is not supported. \
@@ -857,12 +860,12 @@ impl MultiStageQueryPlanner {
                             scope,
                         )?
                     } else {
-                        // Without a time dimension the window collapses to a
-                        // single bucket over the whole date range, so there is
-                        // no frame to build and no outer stage to carry the
-                        // aggregation. What the query asks for is the measure's
-                        // own multi-stage definition — aggregation and grain
-                        // included — over the window's range.
+                        // Without a time dimension there is no series to walk,
+                        // so the window collapses to a single bucket: no frame
+                        // to build, and no outer stage to carry the aggregation.
+                        // What is left is the measure's own multi-stage
+                        // definition — aggregation and grain included — over the
+                        // base state prepared above.
                         self.make_queries_descriptions(
                             MemberSymbol::new_measure(transforms::strip_rolling_window(&measure)),
                             base_state,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -799,6 +799,30 @@ impl MultiStageQueryPlanner {
                     }
                 }
 
+                // Of the grain keys only `include` reaches the rolling
+                // assembly. It extends the grain the values inside a bucket are
+                // computed at, which the base CTE carries anyway. `exclude` and
+                // `keep_only` narrow the grain the value is *reported* at, and a
+                // narrowed value has to be broadcast back onto the query grid;
+                // the rolling window node has no side enumerating that grid, so
+                // there is nothing to broadcast from. Reject them instead of
+                // computing at the unnarrowed grain and calling it the answer.
+                let grain = measure
+                    .multi_stage()
+                    .map(|ms| ms.grain.clone())
+                    .unwrap_or_default();
+                let has_partition_grain =
+                    |g: &Option<Vec<Rc<MemberSymbol>>>| g.as_ref().is_some_and(|v| !v.is_empty());
+                if has_partition_grain(&grain.exclude) || has_partition_grain(&grain.keep_only) {
+                    return Err(CubeError::user(format!(
+                        "Measure {} declares `rolling_window` together with `grain.exclude` or \
+                         `grain.keep_only`, which is not supported. Only `grain.include` can be \
+                         combined with a rolling window.",
+                        member.full_name(),
+                    )));
+                }
+                let grain_include = grain.include.clone().unwrap_or_default();
+
                 let ungrouped = measure.is_rolling_window() && !measure.is_additive();
 
                 let mut time_dimensions = self
@@ -828,8 +852,14 @@ impl MultiStageQueryPlanner {
                             scope,
                         )?
                     } else {
+                        // Without a time dimension the window collapses to a
+                        // single bucket over the whole date range, so there is
+                        // no frame to build and no outer stage to carry the
+                        // aggregation. What the query asks for is the measure's
+                        // own multi-stage definition — aggregation and grain
+                        // included — over the window's range.
                         self.make_queries_descriptions(
-                            base_member,
+                            MemberSymbol::new_measure(transforms::strip_rolling_window(&measure)),
                             base_state,
                             descriptions,
                             resolved_multi_stage_dimensions,
@@ -858,6 +888,18 @@ impl MultiStageQueryPlanner {
                     &rolling_window,
                     state.clone(),
                 )?;
+
+                // `grain.include` extends the grain the values inside the window
+                // are computed at. The frame still keys off the base time
+                // dimension, so the extension only splits rows the outer
+                // aggregation merges back together.
+                let base_rolling_state = if grain_include.is_empty() {
+                    base_rolling_state
+                } else {
+                    let mut extended = base_rolling_state.as_ref().clone();
+                    extended.add_dimensions(grain_include);
+                    Rc::new(extended)
+                };
 
                 let time_series =
                     self.add_time_series(time_dimension.clone(), state.clone(), descriptions)?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -799,36 +799,10 @@ impl MultiStageQueryPlanner {
                     }
                 }
 
-                // Of the grain keys only `include` reaches the rolling
-                // assembly. It extends the grain the values inside a bucket are
-                // computed at, which the base CTE carries anyway. `exclude` and
-                // `keep_only` narrow the grain the value is *reported* at, and a
-                // narrowed value has to be broadcast back onto the query grid;
-                // the rolling window node has no side enumerating that grid, so
-                // there is nothing to broadcast from. Reject them instead of
-                // computing at the unnarrowed grain and calling it the answer.
-                //
-                // `reduce_by` and `group_by` compile into the same two lists, so
-                // the message names both spellings — the model may contain
-                // neither of the words the grain keys are called by here.
                 let grain = measure
                     .multi_stage()
                     .map(|ms| ms.grain.clone())
                     .unwrap_or_default();
-                // `keep_only` is an intersection, so declaring it empty narrows
-                // the grain to nothing rather than meaning "no key given";
-                // `exclude` subtracts, so an empty list really does nothing.
-                let narrows_grain = grain.exclude.as_ref().is_some_and(|v| !v.is_empty())
-                    || grain.keep_only.is_some();
-                if narrows_grain {
-                    return Err(CubeError::user(format!(
-                        "Measure {} declares `rolling_window` together with `grain.exclude` / \
-                         `reduce_by` or `grain.keep_only` / `group_by`, which is not supported. \
-                         Only `grain.include` (`add_group_by`) can be combined with a rolling \
-                         window.",
-                        member.full_name(),
-                    )));
-                }
                 let grain_include = grain.include.clone().unwrap_or_default();
 
                 let ungrouped = measure.is_rolling_window() && !measure.is_additive();
@@ -890,6 +864,41 @@ impl MultiStageQueryPlanner {
                 let time_dimension =
                     GranularityHelper::find_dimension_with_min_granularity(&time_dimensions)?;
                 let time_dimension = MemberSymbol::new_time_dimension(time_dimension);
+
+                // Of the grain keys only `include` reaches the window assembly.
+                // It extends the grain the values inside a bucket are computed
+                // at, which the base CTE carries anyway. `exclude` and
+                // `keep_only` narrow the grain the value is *reported* at, and a
+                // narrowed value has to be broadcast back onto the query grid;
+                // the rolling window node has no side enumerating that grid, so
+                // there is nothing to broadcast from.
+                //
+                // What is rejected is the narrowing actually happening, not the
+                // keys being declared: `exclude` of a member this grain does not
+                // carry subtracts nothing, and `keep_only` listing everything the
+                // query groups by intersects to the same list. Such a key costs
+                // the query nothing, and the value is the one the measure would
+                // have without it. `partition_filter` only ever removes, so a
+                // shorter list is exactly the case that has no answer here.
+                //
+                // The check sits below the branch above on purpose. Without a
+                // time dimension the window has no frame and the measure is
+                // planned through the ordinary multi-stage path, which narrows
+                // the grain and broadcasts it back the usual way.
+                let narrows = Self::partition_filter(state.dimensions(), &grain).len()
+                    != state.dimensions().len()
+                    || Self::partition_filter(state.time_dimensions(), &grain).len()
+                        != state.time_dimensions().len();
+                if narrows {
+                    return Err(CubeError::user(format!(
+                        "Measure {} narrows the grain of this query through `grain.exclude` / \
+                         `reduce_by` or `grain.keep_only` / `group_by` while also declaring a \
+                         `rolling_window` over {}, which is not supported. Drop the narrowing \
+                         keys, drop the window, or query the measure without a time dimension.",
+                        member.full_name(),
+                        time_dimension.full_name(),
+                    )));
+                }
 
                 let (base_rolling_state, base_time_dimension) = self.make_rolling_base_state(
                     time_dimension.clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -711,13 +711,24 @@ impl QueryProperties {
     }
 
     /// Append `dimensions` to the existing list, deduplicating by
-    /// reference-chain-resolved full name.
+    /// reference-chain-resolved full name. A dimension the grain already
+    /// carries as a time dimension is dropped rather than appended: a time
+    /// dimension's full name pins its granularity, so an entry that matches
+    /// one would render the very same column under the very same alias.
     pub fn add_dimensions(&mut self, dimensions: Vec<Rc<MemberSymbol>>) {
+        let time_dimension_names = self
+            .time_dimensions
+            .iter()
+            .map(|d| d.clone().resolve_reference_chain().full_name())
+            .collect::<HashSet<_>>();
+        let added = dimensions.into_iter().filter(|d| {
+            !time_dimension_names.contains(&d.clone().resolve_reference_chain().full_name())
+        });
         self.dimensions = self
             .dimensions
             .iter()
             .cloned()
-            .chain(dimensions.into_iter())
+            .chain(added)
             .unique_by(|d| d.clone().resolve_reference_chain().full_name())
             .collect_vec();
         self.invalidate_join_groups_cache();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/unroll_rolling.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/unroll_rolling.rs
@@ -44,3 +44,17 @@ pub fn unroll_rolling(measure: &MeasureSymbol) -> Rc<MeasureSymbol> {
         render_modifier: None,
     })
 }
+
+/// Returns a copy of the measure with the rolling window dropped and
+/// the rest of its definition — aggregation kind, multi-stage grain —
+/// left in place. What remains is the measure as it would have been
+/// declared without a window, which is what a window that resolves to
+/// a single bucket computes.
+pub fn strip_rolling_window(measure: &MeasureSymbol) -> Rc<MeasureSymbol> {
+    let mut result = measure.clone();
+    result.rolling_window = None;
+    // The render modifier is stamped against the rolling form and has
+    // nothing to modify once the window is gone.
+    result.render_modifier = None;
+    Rc::new(result)
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
@@ -1,0 +1,134 @@
+cubes:
+  - name: returns
+    sql_table: grain_returns
+
+    dimensions:
+      - name: day
+        sql: day
+        type: time
+
+      - name: security
+        sql: security
+        type: string
+
+      - name: irr
+        sql: irr
+        type: number
+
+      - name: weight
+        sql: weight
+        type: number
+
+    measures:
+      - name: weight_sum
+        sql: "{CUBE.weight}"
+        type: sum
+
+      - name: irr_weight_sum
+        sql: "{CUBE.irr} * {CUBE.weight}"
+        type: sum
+
+      - name: daily_irr_weight
+        multi_stage: true
+        sql: "{CUBE.irr_weight_sum}"
+        type: number
+
+      - name: daily_weight
+        multi_stage: true
+        sql: "{CUBE.weight_sum}"
+        type: number
+
+      # Reference point: the same log-return sum with `grain.include` alone.
+      - name: log_return_sum
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+
+      - name: twr
+        multi_stage: true
+        sql: "EXP({CUBE.log_return_sum}) - 1"
+        type: number
+
+      # Same declaration plus a year-to-date window. The window has to compose
+      # with the grain: the log return is still summed per day, the window only
+      # decides which days fall into each bucket.
+      - name: log_return_sum_ytd
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+        rolling_window:
+          type: to_date
+          granularity: year
+
+      - name: twr_ytd
+        multi_stage: true
+        sql: "EXP({CUBE.log_return_sum_ytd}) - 1"
+        type: number
+
+      # Trailing variant of the same window, wide enough to cover every day.
+      - name: log_return_sum_1y
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day
+        rolling_window:
+          trailing: 1 year
+          offset: end
+
+      - name: twr_1y
+        multi_stage: true
+        sql: "EXP({CUBE.log_return_sum_1y}) - 1"
+        type: number
+
+      # Same composition with the grain written as an explicit granularity of
+      # the rolling time dimension rather than the raw dimension.
+      - name: log_return_sum_ytd_day_granularity
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day.day
+        rolling_window:
+          type: to_date
+          granularity: year
+
+      - name: twr_ytd_day_granularity
+        multi_stage: true
+        sql: "EXP({CUBE.log_return_sum_ytd_day_granularity}) - 1"
+        type: number
+
+      # Control for the same grain form without a window.
+      - name: log_return_sum_day_granularity
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          include:
+            - returns.day.day
+
+      - name: twr_day_granularity
+        multi_stage: true
+        sql: "EXP({CUBE.log_return_sum_day_granularity}) - 1"
+        type: number
+
+      # Partition-shaping grain keys have no meaning next to a window frame;
+      # the planner must say so instead of quietly ignoring them.
+      - name: log_return_sum_ytd_keep_only
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        grain:
+          keep_only:
+            - returns.security
+        rolling_window:
+          type: to_date
+          granularity: year

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
@@ -159,3 +159,39 @@ cubes:
         rolling_window:
           type: to_date
           granularity: year
+
+      # Baseline for the inert-grain pair below: the same rolling sum with no
+      # grain keys at all.
+      - name: weight_ytd
+        multi_stage: true
+        sql: "{CUBE.daily_weight}"
+        type: sum
+        rolling_window:
+          type: to_date
+          granularity: year
+
+      # Whether this narrows anything depends on the query: against a grain
+      # without `security` it subtracts nothing and has to answer as
+      # `weight_ytd` does; against one carrying `security` it pools the two.
+      - name: weight_ytd_reduce_security
+        multi_stage: true
+        sql: "{CUBE.daily_weight}"
+        type: sum
+        reduce_by:
+          - returns.security
+        rolling_window:
+          type: to_date
+          granularity: year
+
+      # `group_by` listing exactly what the query groups by. The intersection is
+      # the identity, so this too has to answer as `weight_ytd` does.
+      - name: weight_ytd_group_by_query_grain
+        multi_stage: true
+        sql: "{CUBE.daily_weight}"
+        type: sum
+        group_by:
+          - returns.security
+          - returns.day
+        rolling_window:
+          type: to_date
+          granularity: year

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
@@ -146,3 +146,16 @@ cubes:
         rolling_window:
           type: to_date
           granularity: year
+
+      # An empty `keep_only` intersects the grain down to nothing, so it narrows
+      # just as a populated one does and must be rejected the same way.
+      - name: log_return_sum_ytd_empty_keep_only
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        add_group_by:
+          - returns.day
+        group_by: []
+        rolling_window:
+          type: to_date
+          granularity: year

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage_grain_rolling.yaml
@@ -132,3 +132,17 @@ cubes:
         rolling_window:
           type: to_date
           granularity: year
+
+      # `reduce_by` compiles into the same list as `grain.exclude`, so the same
+      # rejection has to reach a model written in the older spelling.
+      - name: log_return_sum_ytd_reduce_by
+        multi_stage: true
+        sql: "LN(1.0 + ({CUBE.daily_irr_weight} / NULLIF({CUBE.daily_weight}, 0)) / 100.0)"
+        type: sum
+        add_group_by:
+          - returns.day
+        reduce_by:
+          - returns.security
+        rolling_window:
+          type: to_date
+          granularity: year

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/integration_multi_stage_grain_rolling_tables.sql
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/integration_multi_stage_grain_rolling_tables.sql
@@ -1,0 +1,16 @@
+CREATE TABLE grain_returns (
+    day DATE NOT NULL,
+    security VARCHAR(16) NOT NULL,
+    irr NUMERIC NOT NULL,
+    weight NUMERIC NOT NULL
+);
+
+-- Two equally weighted rows per day, so the weighted daily factor is the row
+-- factor: 1.10, 1.20, 0.50. Linked over the three days that is exactly -0.34.
+INSERT INTO grain_returns (day, security, irr, weight) VALUES
+    ('2024-01-01', 'A',  10.0, 100.0),
+    ('2024-01-01', 'B',  10.0, 100.0),
+    ('2024-01-02', 'A',  20.0, 100.0),
+    ('2024-01-02', 'B',  20.0, 100.0),
+    ('2024-01-03', 'A', -50.0, 100.0),
+    ('2024-01-03', 'B', -50.0, 100.0);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
@@ -17,6 +17,7 @@ mod order_limit;
 mod plan_optimizers;
 mod rank;
 mod reduce_by;
+mod rolling_window_grain;
 mod time_shift_basic;
 mod time_shift_mixed;
 mod timezone;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
@@ -224,6 +224,12 @@ async fn test_rolling_grain_keep_only_is_rejected() {
           - returns.log_return_sum_ytd_keep_only
         dimensions:
           - returns.security
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
     "#};
 
     let err = ctx
@@ -248,6 +254,12 @@ async fn test_rolling_grain_reduce_by_is_rejected() {
           - returns.log_return_sum_ytd_reduce_by
         dimensions:
           - returns.security
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
     "#};
 
     let err = ctx
@@ -269,6 +281,12 @@ async fn test_rolling_grain_empty_keep_only_is_rejected() {
           - returns.log_return_sum_ytd_empty_keep_only
         dimensions:
           - returns.security
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
     "#};
 
     let err = ctx
@@ -279,4 +297,107 @@ async fn test_rolling_grain_empty_keep_only_is_rejected() {
         "unexpected error: {}",
         err.message
     );
+}
+
+// A narrowing grain key can be inert for a given query: `exclude` of a member
+// the grain does not carry subtracts nothing, and `keep_only` listing exactly
+// what the query groups by intersects to the same list. Such a measure answers
+// like one that declares no grain at all, and that answer is correct.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_inert_reduce_by_answers_as_plain() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.weight_ytd
+          - returns.weight_ytd_reduce_security
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
+        order:
+          - id: returns.day
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__weight_ytd", vec![600.0]),
+                ("returns__weight_ytd_reduce_security", vec![600.0]),
+            ],
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_inert_group_by_answers_as_plain() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.weight_ytd
+          - returns.weight_ytd_group_by_query_grain
+        dimensions:
+          - returns.security
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
+        order:
+          - id: returns.security
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__weight_ytd", vec![300.0, 300.0]),
+                (
+                    "returns__weight_ytd_group_by_query_grain",
+                    vec![300.0, 300.0],
+                ),
+            ],
+        );
+    }
+}
+
+// The same narrowing key, on a query with no time dimension: no frame is built,
+// the measure goes through the ordinary multi-stage path, and the narrowing is
+// honoured — the value is pooled over both securities while the rows stay per
+// security.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_narrowing_without_time_dimension() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.weight_ytd
+          - returns.weight_ytd_reduce_security
+        dimensions:
+          - returns.security
+        order:
+          - id: returns.security
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__weight_ytd", vec![300.0, 300.0]),
+                ("returns__weight_ytd_reduce_security", vec![600.0, 600.0]),
+            ],
+        );
+    }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
@@ -1,0 +1,237 @@
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_multi_stage_grain_rolling.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+const SEED: &str = "integration_multi_stage_grain_rolling_tables.sql";
+
+/// Splits the pipe-separated result table into header + rows of trimmed cells.
+fn parse_table(result: &str) -> (Vec<String>, Vec<Vec<String>>) {
+    let mut lines = result.lines();
+    let header = lines
+        .next()
+        .expect("result has no header")
+        .split('|')
+        .map(|c| c.trim().to_string())
+        .collect::<Vec<_>>();
+    lines.next();
+    let rows = lines
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.split('|').map(|c| c.trim().to_string()).collect())
+        .collect();
+    (header, rows)
+}
+
+fn assert_measures(result: &str, expected: &[(&str, Vec<f64>)]) {
+    let (header, rows) = parse_table(result);
+    for (column, values) in expected {
+        let idx = header
+            .iter()
+            .position(|h| h == column)
+            .unwrap_or_else(|| panic!("column `{column}` not found in:\n{result}"));
+        assert_eq!(
+            rows.len(),
+            values.len(),
+            "unexpected row count for `{column}` in:\n{result}"
+        );
+        for (row_index, expected_value) in values.iter().enumerate() {
+            let actual: f64 = rows[row_index][idx].parse().unwrap_or_else(|_| {
+                panic!(
+                    "`{column}` row {row_index} is not a number: `{}`\n{result}",
+                    rows[row_index][idx]
+                )
+            });
+            assert!(
+                (actual - expected_value).abs() < 1e-9,
+                "`{column}` row {row_index}: expected {expected_value}, got {actual}\n{result}"
+            );
+        }
+    }
+}
+
+// The rolling measures declare `grain.include: [returns.day]`, so their inner
+// stage is summed per day whatever grain the query asks for. Each window is
+// wide enough to cover all three days, so at any grain coarser than a day both
+// windows have to agree with the plain `twr`.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_include_day_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.twr
+          - returns.twr_ytd
+          - returns.twr_1y
+          - returns.twr_ytd_day_granularity
+        time_dimensions:
+          - dimension: returns.day
+            granularity: day
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-03"
+        order:
+          - id: returns.day
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__twr", vec![0.1, 0.2, -0.5]),
+                ("returns__twr_ytd", vec![0.1, 0.32, -0.34]),
+                ("returns__twr_1y", vec![0.1, 0.32, -0.34]),
+                ("returns__twr_ytd_day_granularity", vec![0.1, 0.32, -0.34]),
+            ],
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_include_month_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.twr
+          - returns.twr_ytd
+          - returns.twr_1y
+          - returns.twr_ytd_day_granularity
+        time_dimensions:
+          - dimension: returns.day
+            granularity: month
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
+        order:
+          - id: returns.day
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__twr", vec![-0.34]),
+                ("returns__twr_ytd", vec![-0.34]),
+                ("returns__twr_1y", vec![-0.34]),
+                ("returns__twr_ytd_day_granularity", vec![-0.34]),
+            ],
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_include_no_time_dimension() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.twr
+          - returns.twr_ytd
+          - returns.twr_1y
+          - returns.twr_ytd_day_granularity
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__twr", vec![-0.34]),
+                ("returns__twr_ytd", vec![-0.34]),
+                ("returns__twr_1y", vec![-0.34]),
+                ("returns__twr_ytd_day_granularity", vec![-0.34]),
+            ],
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_include_non_time_dimension() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.twr
+          - returns.twr_ytd
+          - returns.twr_1y
+          - returns.twr_ytd_day_granularity
+        dimensions:
+          - returns.security
+        order:
+          - id: returns.security
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[
+                ("returns__twr", vec![-0.34, -0.34]),
+                ("returns__twr_ytd", vec![-0.34, -0.34]),
+                ("returns__twr_1y", vec![-0.34, -0.34]),
+                ("returns__twr_ytd_day_granularity", vec![-0.34, -0.34]),
+            ],
+        );
+    }
+}
+
+// A `grain.include` naming a granularity the query already groups by is a
+// no-op, not a second copy of the same column.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_grain_include_duplicates_query_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.twr_day_granularity
+        time_dimensions:
+          - dimension: returns.day
+            granularity: day
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-03"
+        order:
+          - id: returns.day
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        assert_measures(
+            &result,
+            &[("returns__twr_day_granularity", vec![0.1, 0.2, -0.5])],
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_keep_only_is_rejected() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.log_return_sum_ytd_keep_only
+        dimensions:
+          - returns.security
+    "#};
+
+    let err = ctx
+        .build_sql(query)
+        .expect_err("keep_only must be rejected");
+    assert!(
+        err.message.contains("grain.exclude") && err.message.contains("grain.keep_only"),
+        "unexpected error: {}",
+        err.message
+    );
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
@@ -235,3 +235,27 @@ async fn test_rolling_grain_keep_only_is_rejected() {
         err.message
     );
 }
+
+// The older `reduce_by` / `group_by` spellings compile into the same grain
+// lists, so a model that never writes the word `grain` must still be told
+// which of its own keys the message is about.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_reduce_by_is_rejected() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.log_return_sum_ytd_reduce_by
+        dimensions:
+          - returns.security
+    "#};
+
+    let err = ctx
+        .build_sql(query)
+        .expect_err("reduce_by must be rejected");
+    assert!(
+        err.message.contains("reduce_by") && err.message.contains("group_by"),
+        "unexpected error: {}",
+        err.message
+    );
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rolling_window_grain.rs
@@ -259,3 +259,24 @@ async fn test_rolling_grain_reduce_by_is_rejected() {
         err.message
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_grain_empty_keep_only_is_rejected() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - returns.log_return_sum_ytd_empty_keep_only
+        dimensions:
+          - returns.security
+    "#};
+
+    let err = ctx
+        .build_sql(query)
+        .expect_err("an empty keep_only must be rejected");
+    assert!(
+        err.message.contains("grain.keep_only"),
+        "unexpected error: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary

A multi-stage measure declaring both `grain` and `rolling_window` silently ignored the declared grain: the inner stage was grouped by the *query's* granularity instead, and with no time dimension in the query the outer aggregation was dropped entirely. Nothing failed — the model compiled, `/meta` was clean, and the query returned a plausible wrong number. Reported as CORE-789, reproduced standalone against Postgres.

The reported model computes a time-weighted return: a per-day log return summed into a year-to-date window. Only a query asking for the time dimension exactly at the declared grain was correct; `granularity: month`, a KPI tile with no time dimension, and a group-by on a non-time dimension all returned `-0.0667` instead of `-0.34` — a single factor over a fully collapsed aggregate, never linked by day.

## Changes

- **`grain.include` now reaches the rolling base.** The base member is built by unrolling the measure, which drops its multi-stage properties, so the recursion planning the base CTE never saw the grain. The base rolling state is extended with `grain.include` after `make_rolling_base_state`; the frame still keys off the base time dimension, so the extra grain only splits rows the outer aggregation merges back.
- **The no-time-dimension case keeps its aggregation.** That branch returns the rolling description directly — no `RollingWindow` node, hence no `RollingMerge` render modifier, hence no outer stage to carry the aggregation — while unrolling also collapses the aggregate kind to a calculated one, so `type: sum` vanished too. New `strip_rolling_window` transform drops only the window, and the measure is planned as its plain multi-stage self, which is what a window resolving to a single bucket computes.
- **`grain.exclude` / `grain.keep_only` are honoured where they can be and rejected where they cannot.** They were silently ignored next to a window. With no time dimension there is no frame to build, so the measure goes through the ordinary multi-stage path, which narrows the grain and broadcasts it back — that combination now works. With a time dimension the narrowed value would have to be broadcast onto the query grid and the rolling node has no side enumerating it, so the query is refused.

  The refusal is on the narrowing *happening*, not on the keys being declared: `exclude` of a member the grain does not carry subtracts nothing, and `keep_only` listing everything the query groups by intersects to the same list. Such queries answer exactly as a measure with no keys would, and are left alone. The message names the older `reduce_by` / `group_by` spellings too, since those compile into the same lists and a model may contain neither of the `grain.*` words. An empty `keep_only` does narrow — it is an intersection, so `group_by: []` collapses the grain to a grand total rather than meaning "no key given".
- **`QueryProperties::add_dimensions` deduplicates against time dimensions.** It deduplicated only within `dimensions`, so a `grain.include` naming a granularity the query already groups by rendered the same column twice and the query failed as ambiguous. This was broken on the non-rolling path too. A time dimension's `full_name` pins its granularity, so the check is exact — a bare `returns.day` and `returns.day.day` stay distinct grains.

## Testing

Both suites were shown failing on the pre-fix code before the fix was written.

**Rust** — `tests/integration/multi_stage/rolling_window_grain.rs`, 11 tests asserting **values against Postgres, not SQL shape**: all four query forms from the report (`granularity: day`, `granularity: month`, no time dimension, group-by on a non-time dimension), a granularity-qualified `grain.include`, the ambiguous-column regression, narrowing honoured without a time dimension, two inert narrowing keys answering as a keyless measure, and the three rejection paths (`keep_only`, `reduce_by`, empty `keep_only`). Before the fix, 3 of the 4 value tests failed with exactly the reported `-0.0667`. Full suite: 1283 passed, 0 failed.

**JS** — `packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-grain-rolling-window.test.ts`, the same four forms on the same model. Verified failing by rebuilding the native addon from the reverted Rust sources: 3 of 4 failed with `-0.066667`. Also ran `multi-stage*`, `postgres-cumulative-measures`, `rolling-window-offset-no-granularity`, `bucketing`, `calc-groups`, `calendars`, `custom-granularities`, `cube-views`, `member-expression`, `multiple-join-paths`, `pre-aggregations*`, `sql-generation` (135 tests), `sql-generation-logic` and `yaml-compiler` under `CUBEJS_TESSERACT_SQL_PLANNER=true` — all green.

**On the legacy planner as an oracle:** it is not one here. Under `CUBEJS_TESSERACT_SQL_PLANNER=false` all four forms are wrong *including the control measure that declares no window* (`-0.20` vs `-0.34`) — the v1 planner does not implement `grain:` at all, which is why the existing `multi-stage-grain.test.ts` skips every case on it. The new JS test follows that convention.

## Known gaps, deliberately not addressed here

- Supporting `grain.exclude` / `grain.keep_only` alongside a time dimension needs a broadcast side on `MultiStageRollingWindow` (the node has no `keys_input` field and its processor never reads one), or a window wrapper mirroring `MultiStageCalculationWindowFunction::Window`. A prototype got most of the way — narrowing the rolling description's state plus filtering the keys UNION to refs covering every key dim — but a narrowed measure queried *alone* still has no source for the grid. Left for a follow-up rather than shipped half-working.
- A `to_date` window with no time dimension never bounds the date range: `replace_date_range_for_rolling_window_without_granularity` returns early when both `trailing` and `leading` are `None`. A `dateRange` spanning two years is reported as year-to-date. Pre-existing and shared with plain non-multi-stage rolling measures — verified identical there — so changing it is its own decision.
