### PR TITLE
refactor(query-orchestrator): Queue - simplify retrieval result

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -195,11 +195,8 @@ and we don't recommend enabling it in production yet.
 
 Enables the preview fast-track path for Cube Store query queues. When enabled,
 Cube can atomically enqueue and retrieve a query when queue concurrency is
-available, reducing queue coordination round trips. It applies to queries at
-queue priority 10 and above, which is where user-facing queries and the
-pre-aggregation builds a request waits on are submitted; background refresh runs
-below that and keeps using the regular path. This requires Cube Store
-1.7.25 or newer; against an older version Cube keeps using the regular path.
+available, reducing queue coordination round trips. This requires Cube and Cube Store
+1.7.26 or newer; against an older version Cube keeps using the regular path.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -14,7 +14,6 @@ export type RetrieveForProcessingSuccess = {
   queueSize: number,
   def: QueryDef,
 };
-export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | null;
 export type AddToQueueResponse = [
   added: number,
   queueId: QueueId | null,
@@ -93,7 +92,7 @@ export interface QueueDriverConnectionInterface {
   updateHeartBeat(hash: QueryKeyHash, queueId: QueueId | null): Promise<void>;
   // Atomically moves a queue item to active. Returns null when another node is already
   // processing the query or the concurrency budget is full.
-  retrieveForProcessing(hash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingResponse>;
+  retrieveForProcessing(hash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingSuccess | null>;
   optimisticQueryUpdate(hash: QueryKeyHash, toUpdate: unknown, queueId: QueueId): Promise<boolean>;
   cancelQuery(queryKey: QueryKey, queueId: QueueId | null): Promise<QueryDef | null>;
   getQueryAndRemove(hash: QueryKeyHash, queueId: QueueId | null): Promise<[QueryDef]>;

--- a/packages/cubejs-base-driver/src/queue-driver.interface.ts
+++ b/packages/cubejs-base-driver/src/queue-driver.interface.ts
@@ -9,25 +9,12 @@ export type QueryKeyHash = string & { __type: 'QueryKeyHash' };
 export type QueryKeysTuple = [keyHash: QueryKeyHash, queueId: QueueId];
 export type GetActiveAndToProcessResponse = [active: QueryKeysTuple[], toProcess: QueryKeysTuple[]];
 export type QueryStageStateResponse = [active: string[], toProcess: string[]] | [active: string[], toProcess: string[], defs: Record<string, QueryDef>];
-export type RetrieveForProcessingSuccess = [
-  added: unknown,
-  // Identifies the retrieved generation of the queue item.
-  queueId: QueueId | null,
+export type RetrieveForProcessingSuccess = {
   active: QueryKeyHash[],
-  pending: number,
+  queueSize: number,
   def: QueryDef,
-  retrieved: true
-];
-export type RetrieveForProcessingFail = [
-  added: unknown,
-  // Null when no queue item was retrieved.
-  queueId: QueueId | null,
-  active: QueryKeyHash[],
-  pending: number,
-  def: null,
-  retrieved: false
-];
-export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | RetrieveForProcessingFail | null;
+};
+export type RetrieveForProcessingResponse = RetrieveForProcessingSuccess | null;
 export type AddToQueueResponse = [
   added: number,
   queueId: QueueId | null,

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -365,15 +365,11 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingResponse> {
-    const rows = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
+    const [row] = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
     ]);
-    if (rows && rows.length) {
-      return this.decodeRetrievedFromRow(rows[0], 'retrieveForProcessing');
-    }
-
-    return null;
+    return this.decodeRetrievedFromRow(row, 'retrieveForProcessing');
   }
 
   public async getResultBlocking(hash: QueryKeyHash, queueId: QueueId): Promise<QueryDef | null> {

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -364,11 +364,15 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
   }
 
   public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingSuccess | null> {
-    const [row] = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
+    const rows = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),
     ]);
-    return this.decodeRetrievedFromRow(row, 'retrieveForProcessing');
+    if (rows.length) {
+      return this.decodeRetrievedFromRow(rows[0], 'retrieveForProcessing');
+    }
+
+    return null;
   }
 
   public async getResultBlocking(hash: QueryKeyHash, queueId: QueueId): Promise<QueryDef | null> {

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -357,14 +357,11 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
       return null;
     }
 
-    return [
-      1,
-      row.id ? parseInt(row.id, 10) : null,
-      this.decodeActiveKeysFromRow(row.active),
-      parseInt(row.pending, 10),
-      this.decodeQueryDefFromRow(row as { payload: string, extra?: string | null }, method),
-      true
-    ];
+    return {
+      active: this.decodeActiveKeysFromRow(row.active),
+      queueSize: parseInt(row.pending, 10),
+      def: this.decodeQueryDefFromRow(row as { payload: string, extra?: string | null }, method),
+    };
   }
 
   public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingResponse> {
@@ -373,14 +370,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
       this.prefixKey(hash),
     ]);
     if (rows && rows.length) {
-      return this.decodeRetrievedFromRow(rows[0], 'retrieveForProcessing') || [
-        0,
-        null,
-        this.decodeActiveKeysFromRow(rows[0].active),
-        parseInt(rows[0].pending, 10),
-        null,
-        false
-      ];
+      return this.decodeRetrievedFromRow(rows[0], 'retrieveForProcessing');
     }
 
     return null;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQueueDriver.ts
@@ -4,7 +4,6 @@ import {
   QueueDriverConnectionInterface,
   QueryStageStateResponse,
   QueryDef,
-  RetrieveForProcessingResponse,
   RetrieveForProcessingSuccess,
   QueueDriverOptions,
   AddToQueueQuery,
@@ -364,7 +363,7 @@ export class CubestoreQueueDriverConnection implements QueueDriverConnectionInte
     };
   }
 
-  public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingResponse> {
+  public async retrieveForProcessing(hash: QueryKeyHash, _queueId: QueueId): Promise<RetrieveForProcessingSuccess | null> {
     const [row] = await this.driver.query<CubeStoreRetrieveResponse>('QUEUE RETRIEVE EXTENDED CONCURRENCY ? ?', [
       this.options.concurrency,
       this.prefixKey(hash),

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -79,7 +79,8 @@ enum ResultStatus {
 
 `EXTENDED` on `QUEUE RETRIEVE` changes only the failure shape: without it a failed retrieval
 returns zero rows, with it a single row where `payload` and `id` are `NULL` but `pending`
-and `active` are filled. The driver always sends `EXTENDED`.
+and `active` are filled. The driver uses the non-extended form and treats zero rows as a failed
+retrieval.
 
 ## Enqueue and wait: `executeInQueue`
 
@@ -221,13 +222,13 @@ sequenceDiagram
     participant QueryOrchestrator
 
     QueryQueue->>QueueDriver: retrieveForProcessing
-    QueueDriver->>CubeStore: QUEUE RETRIEVE EXTENDED CONCURRENCY ?n ?path
+    QueueDriver->>CubeStore: QUEUE RETRIEVE CONCURRENCY ?n ?path
     CubeStore-->>QueueDriver: RetrieveResponse
-    QueueDriver-->>QueryQueue: [added, queueId, activeKeys, queueSize, def, retrieved]
+    QueueDriver-->>QueryQueue: { active, queueSize, def } | null
     Note over QueueDriver,CubeStore: The retrieval is atomic in Cube Store:<br/>only one node moves the item to active
 
-    alt def && added && activeKeys includes our key && retrieved
-        QueryQueue-)Background: sendProcessMessageFn(RetrievedQuery)
+    alt retrieved
+        QueryQueue-)Background: sendProcessMessageFn(queryKeyHash, queueId, retrieved)
         Note over QueryQueue,Background: Detached from here on: the hand-off returns,<br/>the execution keeps running
 
         Background->>QueueDriver: optimisticQueryUpdate

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -283,14 +283,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
       this.state.active[queryKeyHash] ||
       activeKeys.length >= this.concurrency
     ) {
-      return [
-        0,
-        null,
-        activeKeys,
-        Object.keys(this.state.toProcess).length,
-        null,
-        false
-      ];
+      return null;
     }
 
     this.state.active[queryKeyHash] = { key: queryKeyHash, order: Number(queueId), queueId };
@@ -298,14 +291,11 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
 
     this.state.heartBeat[queryKeyHash] = { key: queryKeyHash, order: new Date().getTime(), queueId };
 
-    return [
-      1,
-      query.queueId,
-      this.queueArray(this.state.active) as QueryKeyHash[],
-      Object.keys(this.state.toProcess).length,
-      query,
-      true
-    ];
+    return {
+      active: this.queueArray(this.state.active) as QueryKeyHash[],
+      queueSize: Object.keys(this.state.toProcess).length,
+      def: query,
+    };
   }
 
   public async optimisticQueryUpdate(queryKeyHash: QueryKeyHash, toUpdate: any, queueId: QueueId): Promise<boolean> {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/LocalQueueDriverConnection.ts
@@ -11,7 +11,7 @@ import {
   QueryKeysTuple,
   GetActiveAndToProcessResponse,
   QueryStageStateResponse,
-  RetrieveForProcessingResponse,
+  RetrieveForProcessingSuccess,
   QueueDriverOptions,
   QueuePriority
 } from '@cubejs-backend/base-driver';
@@ -272,7 +272,7 @@ export class LocalQueueDriverConnection implements QueueDriverConnectionInterfac
     }
   }
 
-  public async retrieveForProcessing(queryKeyHash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingResponse> {
+  public async retrieveForProcessing(queryKeyHash: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingSuccess | null> {
     const query = this.state.queryDef[queryKeyHash];
     const activeKeys = this.queueArray(this.state.active) as QueryKeyHash[];
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -313,7 +313,7 @@ export class QueryQueue {
       }
 
       if (!added) {
-        const queryDef = retrieved ? retrieved[4] : await queueConnection.getQueryDef(queryKeyHash, queueId);
+        const queryDef = retrieved ? retrieved.def : await queueConnection.getQueryDef(queryKeyHash, queueId);
         if (queryDef) {
           waitingContext = {
             queueId,
@@ -328,7 +328,7 @@ export class QueryQueue {
 
       // A retrieval carries the active keys of its prefix, and a retrieved query is never pending,
       // so it has no place in the queue to report
-      const [active, toProcess] = retrieved ? [retrieved[2], undefined] : await queueConnection.getQueryStageState(true);
+      const [active, toProcess] = retrieved ? [retrieved.active, undefined] : await queueConnection.getQueryStageState(true);
 
       this.logger('Waiting for query', {
         ...waitingContext,
@@ -366,13 +366,11 @@ export class QueryQueue {
   }
 
   protected retrievedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId, retrieved: RetrieveForProcessingSuccess): RetrievedQuery {
-    const [, , , queueSize, query] = retrieved;
-
     return {
       queryKeyHash,
       queueId,
-      queueSize,
-      query,
+      queueSize: retrieved.queueSize,
+      query: retrieved.def,
     };
   }
 
@@ -820,24 +818,13 @@ export class QueryQueue {
   protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<RetrievedQuery | null> {
     const queueConnection = await this.queueDriver.createConnection();
 
-    let insertedCount;
-    let activeKeys;
-    let queueSize;
     let query;
-    let retrievalSucceeded;
 
     try {
-      const retrieveResult = await queueConnection.retrieveForProcessing(queryKeyHashed, queueId);
-      if (retrieveResult) {
-        [insertedCount, , activeKeys, queueSize, query, retrievalSucceeded] = retrieveResult;
-      }
-
-      const activated = activeKeys && activeKeys.indexOf(queryKeyHashed) !== -1;
-      if (!query) {
+      const retrieved = await queueConnection.retrieveForProcessing(queryKeyHashed, queueId);
+      if (!retrieved) {
         query = await queueConnection.getQueryDef(queryKeyHashed, null);
-      }
 
-      if (!query || !insertedCount || !activated || !retrievalSucceeded) {
         // TODO Ideally streaming queries should reconcile queue here after waiting on open slot however in practice continue wait timeout reconciles faster CPU-wise
         // if (query?.queryHandler === 'stream') {
         //   const [active] = await queueConnection.getQueryStageState(true);
@@ -852,22 +839,13 @@ export class QueryQueue {
           queryKey: query && query.queryKey || queryKeyHashed,
           requestId: query && query.requestId,
           queuePrefix: this.redisQueuePrefix,
-          retrievalSucceeded,
           query,
-          insertedCount,
-          activeKeys,
-          activated,
           queryExists: !!query
         });
         return null;
       }
 
-      return {
-        queryKeyHash: queryKeyHashed,
-        queueId,
-        queueSize,
-        query,
-      };
+      return this.retrievedQuery(queryKeyHashed, queueId, retrieved);
     } catch (e: any) {
       this.logger('Queue storage error', {
         queueId,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -25,14 +25,11 @@ export type QueryHandlerFn = (query: QueryDef, cancelHandler: CancelHandlerFn) =
 export type StreamHandlerFn = (query: QueryDef, stream: QueryStream) => Promise<unknown>;
 export type QueryHandlersMap = Record<string, QueryHandlerFn>;
 
-export type RetrievedQuery = {
-  queryKeyHash: QueryKeyHash;
-  queueId: QueueId;
-  queueSize: number;
-  query: QueryDef;
-};
-
-export type SendProcessMessageFn = (retrieved: RetrievedQuery) => Promise<void> | void;
+export type SendProcessMessageFn = (
+  queryKeyHash: QueryKeyHash,
+  queueId: QueueId,
+  retrieved: RetrieveForProcessingSuccess
+) => Promise<void> | void;
 export type SendCancelMessageFn = (query: QueryDef, queueId: QueueId | null) => Promise<void> | void;
 
 export type ExecuteInQueueOptions = Omit<AddToQueueOptions, 'queueId'> & {
@@ -131,7 +128,9 @@ export class QueryQueue {
     this.orphanedTimeout = options.orphanedTimeout || 120;
     this.heartBeatInterval = options.heartBeatInterval || 30;
 
-    this.sendProcessMessageFn = options.sendProcessMessageFn || ((retrieved) => { this.executeQuery(retrieved); });
+    this.sendProcessMessageFn = options.sendProcessMessageFn || (
+      (queryKeyHash, queueId, retrieved) => { this.executeQuery(queryKeyHash, queueId, retrieved); }
+    );
     this.sendCancelMessageFn = options.sendCancelMessageFn || ((query, queueId) => { this.processCancel(query, queueId); });
     this.queryHandlers = options.queryHandlers;
     this.streamHandler = options.streamHandler;
@@ -307,7 +306,7 @@ export class QueryQueue {
 
       if (retrieved) {
         // The item is active already, there is nothing for reconcile to pick up
-        await this.dispatchQuery(this.retrievedQuery(queryKeyHash, queueId, retrieved));
+        await this.dispatchQuery(queryKeyHash, queueId, retrieved);
       } else {
         await this.reconcileQueue();
       }
@@ -363,15 +362,6 @@ export class QueryQueue {
       streamWait?.dispose();
       this.queueDriver.release(queueConnection);
     }
-  }
-
-  protected retrievedQuery(queryKeyHash: QueryKeyHash, queueId: QueueId, retrieved: RetrieveForProcessingSuccess): RetrievedQuery {
-    return {
-      queryKeyHash,
-      queueId,
-      queueSize: retrieved.queueSize,
-      query: retrieved.def,
-    };
   }
 
   /**
@@ -794,17 +784,21 @@ export class QueryQueue {
       return;
     }
 
-    await this.dispatchQuery(retrieved);
+    await this.dispatchQuery(queryKeyHashed, queueId, retrieved);
   }
 
-  protected async dispatchQuery(retrieved: RetrievedQuery): Promise<void> {
+  protected async dispatchQuery(
+    queryKeyHash: QueryKeyHash,
+    queueId: QueueId,
+    retrieved: RetrieveForProcessingSuccess
+  ): Promise<void> {
     try {
-      await this.sendProcessMessageFn(retrieved);
+      await this.sendProcessMessageFn(queryKeyHash, queueId, retrieved);
     } catch (e: any) {
       this.logger('Error while processing message', {
-        queueId: retrieved.queueId,
-        queryKey: retrieved.query.queryKey,
-        requestId: retrieved.query.requestId,
+        queueId,
+        queryKey: retrieved.def.queryKey,
+        requestId: retrieved.def.requestId,
         error: (e.stack || e).toString(),
         queuePrefix: this.redisQueuePrefix
       });
@@ -815,7 +809,7 @@ export class QueryQueue {
    * Atomically moves the query specified by `queryKeyHashed` to the active set. Returns `null`
    * when another node is already running the query or the concurrency budget is full.
    */
-  protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<RetrievedQuery | null> {
+  protected async retrieveQueryForProcessing(queryKeyHashed: QueryKeyHash, queueId: QueueId): Promise<RetrieveForProcessingSuccess | null> {
     const queueConnection = await this.queueDriver.createConnection();
 
     let query;
@@ -845,7 +839,7 @@ export class QueryQueue {
         return null;
       }
 
-      return this.retrievedQuery(queryKeyHashed, queueId, retrieved);
+      return retrieved;
     } catch (e: any) {
       this.logger('Queue storage error', {
         queueId,
@@ -866,8 +860,12 @@ export class QueryQueue {
    * the result. It's the counterpart of `sendProcessMessageFn` and the entry point for a custom
    * implementation which hands the query over to another process.
    */
-  public async executeQuery(retrieved: RetrievedQuery): Promise<void> {
-    const { queryKeyHash: queryKeyHashed, queueId, queueSize, query } = retrieved;
+  public async executeQuery(
+    queryKeyHashed: QueryKeyHash,
+    queueId: QueueId,
+    retrieved: RetrieveForProcessingSuccess
+  ): Promise<void> {
+    const { queueSize, def: query } = retrieved;
 
     const queueConnection = await this.queueDriver.createConnection();
 

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -479,10 +479,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         );
 
         const firstRetrieval = await connection.retrieveForProcessing(key, queueId);
-        expect(firstRetrieval?.[5]).toBe(true);
+        expect(firstRetrieval).toMatchObject({
+          active: [key],
+          queueSize: 0,
+          def: { queryKey: key },
+        });
 
         const secondRetrieval = await connection2.retrieveForProcessing(key, queueId);
-        expect(secondRetrieval).toStrictEqual([0, null, [key], 0, null, false]);
+        expect(secondRetrieval).toBeNull();
       } finally {
         await connection.getQueryAndRemove(key, null);
         queue.queueDriver.release(connection);
@@ -509,17 +513,22 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           }
         );
 
-        expect((await connection.retrieveForProcessing(firstKey, firstQueueId))?.[5]).toBe(true);
-        expect(await connection2.retrieveForProcessing(secondKey, secondQueueId)).toStrictEqual([
-          0, null, [firstKey], 1, null, false
-        ]);
+        expect(await connection.retrieveForProcessing(firstKey, firstQueueId)).toMatchObject({
+          active: [firstKey],
+          queueSize: 1,
+          def: { queryKey: firstKey },
+        });
+        expect(await connection2.retrieveForProcessing(secondKey, secondQueueId)).toBeNull();
         expect(await connection.getToProcessQueries()).toStrictEqual([[secondKey, secondQueueId]]);
 
         await connection.getQueryAndRemove(firstKey, firstQueueId);
 
         const secondRetrieval = await connection2.retrieveForProcessing(secondKey, secondQueueId);
-        expect(secondRetrieval?.[0]).toBe(1);
-        expect(secondRetrieval?.[5]).toBe(true);
+        expect(secondRetrieval).toMatchObject({
+          active: [secondKey],
+          queueSize: 0,
+          def: { queryKey: secondKey },
+        });
       } finally {
         await connection.getQueryAndRemove(firstKey, null);
         await connection.getQueryAndRemove(secondKey, null);
@@ -540,7 +549,11 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
             queueId: queue.generateQueueId(), stageQueryKey: key, requestId: '1'
           }
         );
-        expect((await connection.retrieveForProcessing(key, staleQueueId))?.[5]).toBe(true);
+        expect(await connection.retrieveForProcessing(key, staleQueueId)).toMatchObject({
+          active: [key],
+          queueSize: 0,
+          def: { queryKey },
+        });
         await connection.getQueryAndRemove(key, staleQueueId);
 
         const [, currentQueueId] = await connection.addToQueue(
@@ -550,12 +563,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         );
 
         if (options.cacheAndQueueDriver !== 'cubestore') {
-          expect(await connection.retrieveForProcessing(key, staleQueueId)).toStrictEqual([
-            0, null, [], 1, null, false
-          ]);
+          expect(await connection.retrieveForProcessing(key, staleQueueId)).toBeNull();
           expect(await connection.getToProcessQueries()).toStrictEqual([[key, currentQueueId]]);
         }
-        expect((await connection.retrieveForProcessing(key, currentQueueId))?.[5]).toBe(true);
+        expect(await connection.retrieveForProcessing(key, currentQueueId)).toMatchObject({
+          active: [key],
+          queueSize: 0,
+          def: { queryKey },
+        });
 
         const staleUpdateResult = await connection.optimisticQueryUpdate(key, { stale: true }, staleQueueId);
         if (options.cacheAndQueueDriver !== 'cubestore') {
@@ -756,8 +771,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           // concurrency is 1, the first query takes the only slot
           const [added1, , , , retrieved1] = await addToQueue(first, 1);
           expect(added1).toBe(1);
-          expect(retrieved1?.[5]).toBe(true);
-          expect(retrieved1?.[4].queryKey).toStrictEqual(first);
+          expect(retrieved1?.def.queryKey).toStrictEqual(first);
 
           // an active item is never retrieved twice
           const [added1again, , , , retrieved1again] = await addToQueue(first, 1);

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -71,9 +71,9 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           readable.pipe(stream);
         });
       },
-      sendProcessMessageFn: async (retrieved) => {
+      sendProcessMessageFn: async (queryKeyHash, queueId, retrieved) => {
         streamCallOrder.push('dispatch');
-        processMessagePromises.push(queue.executeQuery(retrieved));
+        processMessagePromises.push(queue.executeQuery(queryKeyHash, queueId, retrieved));
       },
       sendCancelMessageFn: async (query) => {
         processCancelPromises.push(queue.processCancel.bind(queue)(query));

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -494,12 +494,14 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
       }
     });
 
-    onlyLocalTest('a failed retrieval does not reserve a pending query', async () => {
+    test('a failed retrieval does not reserve a pending query', async () => {
       const connection = await queue.queueDriver.createConnection();
       const connection2 = await queue.queueDriver.createConnection();
       const priority = 10;
-      const firstKey = 'concurrency-first' as any;
-      const secondKey = 'concurrency-second' as any;
+      const firstKey: QueryKey = 'concurrency-first';
+      const secondKey: QueryKey = 'concurrency-second';
+      const firstHash = connection.redisHash(firstKey);
+      const secondHash = connection.redisHash(secondKey);
 
       try {
         const [, firstQueueId] = await connection.addToQueue(
@@ -513,25 +515,25 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
           }
         );
 
-        expect(await connection.retrieveForProcessing(firstKey, firstQueueId)).toMatchObject({
-          active: [firstKey],
+        expect(await connection.retrieveForProcessing(firstHash, firstQueueId)).toMatchObject({
+          active: [firstHash],
           queueSize: 1,
           def: { queryKey: firstKey },
         });
-        expect(await connection2.retrieveForProcessing(secondKey, secondQueueId)).toBeNull();
-        expect(await connection.getToProcessQueries()).toStrictEqual([[secondKey, secondQueueId]]);
+        expect(await connection2.retrieveForProcessing(secondHash, secondQueueId)).toBeNull();
+        expect(await connection.getToProcessQueries()).toStrictEqual([[secondHash, secondQueueId]]);
 
-        await connection.getQueryAndRemove(firstKey, firstQueueId);
+        await connection.getQueryAndRemove(firstHash, firstQueueId);
 
-        const secondRetrieval = await connection2.retrieveForProcessing(secondKey, secondQueueId);
+        const secondRetrieval = await connection2.retrieveForProcessing(secondHash, secondQueueId);
         expect(secondRetrieval).toMatchObject({
-          active: [secondKey],
+          active: [secondHash],
           queueSize: 0,
           def: { queryKey: secondKey },
         });
       } finally {
-        await connection.getQueryAndRemove(firstKey, null);
-        await connection.getQueryAndRemove(secondKey, null);
+        await connection.getQueryAndRemove(firstHash, null);
+        await connection.getQueryAndRemove(secondHash, null);
         queue.queueDriver.release(connection);
         queue.queueDriver.release(connection2);
       }

--- a/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryQueue.abstract.ts
@@ -569,7 +569,7 @@ export const QueryQueueTest = (name: string, options: QueryQueueTestOptions) => 
         expect(await connection.retrieveForProcessing(key, currentQueueId)).toMatchObject({
           active: [key],
           queueSize: 0,
-          def: { queryKey },
+          def: { queryKey, query: ['new'] },
         });
 
         const staleUpdateResult = await connection.optimisticQueryUpdate(key, { stale: true }, staleQueueId);


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Replace the tuple-based successful retrieval response with an object containing active, queueSize, and def, while representing unsuccessful retrievals as null in both queue drivers. Remove the redundant RetrievedQuery wrapper and pass queryKeyHash, queueId, and RetrieveForProcessingSuccess directly through dispatch and execution callbacks. Update QueryQueue consumers and the local and Cube Store queue tests, including fast-track coverage, for the simplified contract. Clarify that queue fast-track requires Cube and Cube Store 1.7.26 or newer.