### PR TITLE
fix(schema-compiler): a cube that extends another broke the parent's multi-stage measures

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -299,6 +299,12 @@ export class CubeEvaluator extends CubeSymbols {
       return `${cube.name}.${match.name}`;
     };
 
+    // A view extending another one inherits its `default_filters` entries by
+    // reference, so the resolved references have to go into a copy owned by this
+    // view. Written in place they would resolve to whichever view is prepared
+    // last, pointing the other views' filters at members they do not include.
+    cube.defaultFilters = (cube.defaultFilters as ViewDefaultValueFilter[]).map(f => ({ ...f }));
+
     for (const filter of cube.defaultFilters as ViewDefaultValueFilter[]) {
       const rawMember = this.evaluateReferences(cube.name, filter.member);
       const resolved = resolveViewMember('member', rawMember);
@@ -641,24 +647,33 @@ export class CubeEvaluator extends CubeSymbols {
               : {}),
           }));
         }
+        // `filter` and `grain` are nested objects, and a cube extending another
+        // one inherits them by reference, so the resolved references have to go
+        // into a copy owned by this cube. Written in place they would resolve to
+        // whichever cube is prepared last, pointing every member of the other
+        // cubes at that cube's dimensions.
         if (member.filter) {
-          if (typeof member.filter.exclude === 'function') {
-            member.filter.excludeReferences = this.evaluateReferences(cubeName, member.filter.exclude);
+          const filter = { ...member.filter };
+          if (typeof filter.exclude === 'function') {
+            filter.excludeReferences = this.evaluateReferences(cubeName, filter.exclude);
           }
-          if (typeof member.filter.keepOnly === 'function') {
-            member.filter.keepOnlyReferences = this.evaluateReferences(cubeName, member.filter.keepOnly);
+          if (typeof filter.keepOnly === 'function') {
+            filter.keepOnlyReferences = this.evaluateReferences(cubeName, filter.keepOnly);
           }
+          member.filter = filter;
         }
         if (member.grain) {
-          if (typeof member.grain.exclude === 'function') {
-            member.grain.excludeReferences = this.evaluateReferences(cubeName, member.grain.exclude);
+          const grain = { ...member.grain };
+          if (typeof grain.exclude === 'function') {
+            grain.excludeReferences = this.evaluateReferences(cubeName, grain.exclude);
           }
-          if (typeof member.grain.keepOnly === 'function') {
-            member.grain.keepOnlyReferences = this.evaluateReferences(cubeName, member.grain.keepOnly);
+          if (typeof grain.keepOnly === 'function') {
+            grain.keepOnlyReferences = this.evaluateReferences(cubeName, grain.keepOnly);
           }
-          if (typeof member.grain.include === 'function') {
-            member.grain.includeReferences = this.evaluateReferences(cubeName, member.grain.include);
+          if (typeof grain.include === 'function') {
+            grain.includeReferences = this.evaluateReferences(cubeName, grain.include);
           }
+          member.grain = grain;
         }
       }
     }
@@ -711,7 +726,7 @@ export class CubeEvaluator extends CubeSymbols {
   protected preparePreAggregations(cube: any, errorReporter: ErrorReporter) {
     if (cube.preAggregations) {
       // eslint-disable-next-line no-restricted-syntax
-      for (const preAggregation of Object.values(cube.preAggregations) as any) {
+      for (const [preAggregationName, preAggregation] of Object.entries(cube.preAggregations) as any) {
         // preAggregation is actually (PreAggregationDefinitionRollup | PreAggregationDefinitionOriginalSql)
         if (preAggregation.timeDimension) {
           preAggregation.timeDimensionReference = preAggregation.timeDimension;
@@ -767,10 +782,17 @@ export class CubeEvaluator extends CubeSymbols {
           delete preAggregation.buildRangeEnd;
         }
 
+        // `outputColumnTypes` names are resolved against this cube, and a cube
+        // extending another one inherits the pre-aggregation by reference, so
+        // both the entry and its columns have to be copies owned by this cube.
         if (preAggregation.outputColumnTypes) {
-          preAggregation.outputColumnTypes.forEach(column => {
-            column.name = this.evaluateReferences(cube.name, column.member, { originalSorting: true });
-          });
+          cube.preAggregations[preAggregationName] = {
+            ...preAggregation,
+            outputColumnTypes: preAggregation.outputColumnTypes.map(column => ({
+              ...column,
+              name: this.evaluateReferences(cube.name, column.member, { originalSorting: true }),
+            })),
+          };
         }
       }
     }

--- a/packages/cubejs-schema-compiler/test/unit/extends-shared-definitions.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/extends-shared-definitions.test.ts
@@ -1,0 +1,255 @@
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+// `extends` hands the extending cube the very definitions of the cube it extends,
+// so every reference resolved per cube — a multi-stage `grain:`/`filter:`, a view
+// default filter, a pre-aggregation's output column names — has to be written into
+// an object owned by that cube. Written into the shared one it resolves to whichever
+// cube is prepared last, and the other cubes end up carrying member paths of a cube
+// that is not theirs.
+describe('Multi-stage members of a cube that another cube extends', () => {
+  const baseFact = `
+  - name: base_fact
+    sql: "SELECT 1 AS id, 1 AS dim_id, '2026-01-01'::date AS d, 10 AS v"
+    joins:
+      - name: dims
+        sql: "{CUBE}.dim_id = {dims}.id"
+        relationship: many_to_one
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: d
+        sql: "{CUBE}.d"
+        type: time
+      - name: v
+        sql: "{CUBE}.v"
+        type: number
+    measures:
+      - name: v_sum
+        sql: "{v}"
+        type: sum
+      - name: daily_v
+        multi_stage: true
+        sql: "{v_sum}"
+        type: number
+      - name: linked
+        multi_stage: true
+        sql: "{daily_v}"
+        type: sum
+        grain:
+          include:
+            - d
+      - name: combining
+        multi_stage: true
+        sql: "CASE WHEN {d} IS NOT NULL THEN {daily_v} ELSE 0 END"
+        type: max
+        grain:
+          include:
+            - d
+      - name: outer_combining
+        multi_stage: true
+        sql: "{combining}"
+        type: number
+      - name: v_sum_all_dates
+        multi_stage: true
+        sql: "{v_sum}"
+        type: number
+        filter:
+          exclude:
+            - d
+`;
+
+  const dims = `
+  - name: dims
+    sql: "SELECT 1 AS id, 'a' AS name"
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: name
+        sql: "{CUBE}.name"
+        type: string
+`;
+
+  const childFact = `
+  - name: child_fact
+    extends: base_fact
+    sql: "SELECT 1 AS id, 1 AS dim_id, '2026-01-01'::date AS d, 10 AS v, 'x' AS tag"
+    dimensions:
+      - name: tag
+        sql: "{CUBE}.tag"
+        type: string
+`;
+
+  const model = (withChild: boolean) => `cubes:${dims}${baseFact}${withChild ? childFact : ''}`;
+
+  const compile = async (withChild: boolean) => {
+    const compilers = prepareYamlCompiler(model(withChild));
+    await compilers.compiler.compile();
+    return compilers;
+  };
+
+  const buildSql = async (withChild: boolean, query: any, useNativeSqlPlanner: boolean) => {
+    const compilers = await compile(withChild);
+    return new PostgresQuery(compilers, {
+      timezone: 'UTC',
+      useNativeSqlPlanner,
+      ...query,
+    }).buildSqlAndParams();
+  };
+
+  it('resolves grain references against the cube that declares the member', async () => {
+    const { cubeEvaluator } = await compile(true);
+
+    expect(cubeEvaluator.evaluatedCubes.base_fact.measures.linked.grain?.includeReferences)
+      .toEqual(['base_fact.d']);
+    expect(cubeEvaluator.evaluatedCubes.child_fact.measures.linked.grain?.includeReferences)
+      .toEqual(['child_fact.d']);
+  });
+
+  it('resolves filter references against the cube that declares the member', async () => {
+    const { cubeEvaluator } = await compile(true);
+
+    expect(cubeEvaluator.evaluatedCubes.base_fact.measures.v_sum_all_dates.filter?.excludeReferences)
+      .toEqual(['base_fact.d']);
+    expect(cubeEvaluator.evaluatedCubes.child_fact.measures.v_sum_all_dates.filter?.excludeReferences)
+      .toEqual(['child_fact.d']);
+  });
+
+  describe.each([
+    ['native', true],
+    ['legacy', false],
+  ])('%s planner', (_name, useNativeSqlPlanner) => {
+    // Planning the parent's member must not depend on the extending cube being
+    // there at all, so the plan is compared against the same model without it.
+    const expectSamePlanWithAndWithoutChild = async (query: any) => {
+      const [withoutChild] = await buildSql(false, query, useNativeSqlPlanner);
+      const [withChild] = await buildSql(true, query, useNativeSqlPlanner);
+      expect(withChild).toEqual(withoutChild);
+    };
+
+    it('plans a multi-stage measure with an explicit grain', async () => {
+      await expectSamePlanWithAndWithoutChild({ measures: ['base_fact.linked'] });
+      await expect(buildSql(true, { measures: ['child_fact.linked'] }, useNativeSqlPlanner)).resolves.toBeDefined();
+    });
+
+    it('plans a chained multi-stage measure reading a grain dimension', async () => {
+      await expectSamePlanWithAndWithoutChild({ measures: ['base_fact.outer_combining'] });
+      await expectSamePlanWithAndWithoutChild({
+        measures: ['base_fact.outer_combining'],
+        dimensions: ['dims.name'],
+      });
+    });
+
+    it('plans a multi-stage measure with a filter directive', async () => {
+      await expectSamePlanWithAndWithoutChild({
+        measures: ['base_fact.v_sum_all_dates'],
+        timeDimensions: [{
+          dimension: 'base_fact.d',
+          granularity: 'month',
+          dateRange: ['2026-01-01', '2026-01-31'],
+        }],
+      });
+    });
+
+    it('plans a plain measure of a cube that another cube extends', async () => {
+      await expect(buildSql(true, { measures: ['base_fact.v_sum'] }, useNativeSqlPlanner)).resolves.toBeDefined();
+    });
+  });
+});
+
+describe('View default filters of a view that another view extends', () => {
+  const model = `
+cubes:
+  - name: orders
+    sql: "SELECT 1 AS id, 'usd' AS currency"
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: currency
+        sql: "{CUBE}.currency"
+        type: string
+    measures:
+      - name: count
+        type: count
+
+views:
+  - name: base_view
+    cubes:
+      - join_path: orders
+        includes:
+          - currency
+          - count
+    default_filters:
+      - member: currency
+        operator: equals
+        values: ["usd"]
+
+  - name: child_view
+    extends: base_view
+`;
+
+  it('resolves the filter member against the view that declares the filter', async () => {
+    const { compiler, cubeEvaluator } = prepareYamlCompiler(model);
+    await compiler.compile();
+
+    expect(cubeEvaluator.evaluatedCubes.base_view.defaultFilters?.map(f => f.memberReference))
+      .toEqual(['base_view.currency']);
+    expect(cubeEvaluator.evaluatedCubes.child_view.defaultFilters?.map(f => f.memberReference))
+      .toEqual(['child_view.currency']);
+  });
+});
+
+describe('Pre-aggregations of a cube that another cube extends', () => {
+  const model = `
+cubes:
+  - name: base
+    sql: "SELECT 1 AS id, '2026-01-01'::date AS d"
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: d
+        sql: "{CUBE}.d"
+        type: time
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: main
+        dimensions:
+          - id
+        measures:
+          - count
+        time_dimension: d
+        granularity: day
+        output_column_types:
+          - member: id
+            type: integer
+
+  - name: child
+    extends: base
+    sql: "SELECT 1 AS id, '2026-01-01'::date AS d, 'x' AS tag"
+    dimensions:
+      - name: tag
+        sql: "{CUBE}.tag"
+        type: string
+`;
+
+  it('resolves output column names against the cube that declares the pre-aggregation', async () => {
+    const { compiler, cubeEvaluator } = prepareYamlCompiler(model);
+    await compiler.compile();
+
+    const names = (cube: string) => (cubeEvaluator.evaluatedCubes[cube].preAggregations.main as any)
+      .outputColumnTypes.map((c: any) => c.name);
+
+    expect(names('base')).toEqual(['base.id']);
+    expect(names('child')).toEqual(['child.id']);
+  });
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -414,13 +414,98 @@ impl MultiStageQueryPlanner {
         }) {
             return Ok(());
         }
+        let grain = Self::grain_members(grain_state, parent_state);
+        // A granularity of the very dimension the sql reads looks like a match in
+        // the listing, so the one case where reading the grain is not enough to
+        // tell them apart is spelled out.
+        let target = dimension.clone().resolve_reference_chain().full_name();
+        let hint = if grain
+            .iter()
+            .any(|m| Self::granular_time_dimension_base(m).as_ref() == Some(&target))
+        {
+            format!(
+                " The grain carries {target} at a granularity, which is a value of its own and not \
+                 the dimension itself."
+            )
+        } else {
+            String::new()
+        };
+        let grain = if grain.is_empty() {
+            "no dimensions".to_string()
+        } else {
+            grain
+                .iter()
+                .map(Self::describe_grain_member)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
         Err(CubeError::user(format!(
             "Multi-stage member {member} reads dimension {dimension}, which is not part of the \
-             grain it is computed at. Add {dimension} to `grain.include` of {member}, or remove \
-             it from the member's sql.",
+             grain it is computed at ({grain}).{hint} Add {dimension} to `grain.include` of \
+             {member}, or remove it from the member's sql.",
             member = member.full_name(),
             dimension = dimension.full_name(),
         )))
+    }
+
+    // The grain the member is computed at: the stage's own dimensions and, when
+    // the assembly broadcasts back onto the query grid, the keys side.
+    fn grain_members(
+        grain_state: &QueryProperties,
+        parent_state: &QueryProperties,
+    ) -> Vec<Rc<MemberSymbol>> {
+        let mut members: Vec<Rc<MemberSymbol>> = Vec::new();
+        for state in [grain_state, parent_state] {
+            for dimension in state
+                .dimensions()
+                .iter()
+                .chain(state.time_dimensions().iter())
+            {
+                let resolved = dimension.clone().resolve_reference_chain();
+                if !members
+                    .iter()
+                    .any(|m| m.full_name() == resolved.full_name())
+                {
+                    members.push(resolved);
+                }
+            }
+        }
+        members
+    }
+
+    // A time dimension carries its granularity inside its name, which reads as a
+    // member of its own; the granularity is named separately instead.
+    fn describe_grain_member(member: &Rc<MemberSymbol>) -> String {
+        match member.as_ref() {
+            MemberSymbol::TimeDimension(time_dimension) => match time_dimension.granularity() {
+                Some(granularity) => format!(
+                    "{} ({})",
+                    time_dimension
+                        .base_symbol()
+                        .clone()
+                        .resolve_reference_chain()
+                        .full_name(),
+                    granularity
+                ),
+                None => member.full_name(),
+            },
+            _ => member.full_name(),
+        }
+    }
+
+    fn granular_time_dimension_base(member: &Rc<MemberSymbol>) -> Option<String> {
+        match member.as_ref() {
+            MemberSymbol::TimeDimension(time_dimension) => {
+                time_dimension.granularity().as_ref().map(|_| {
+                    time_dimension
+                        .base_symbol()
+                        .clone()
+                        .resolve_reference_chain()
+                        .full_name()
+                })
+            }
+            _ => None,
+        }
     }
 
     /// Plans CASE-SWITCH dependencies: collects, per dependency, the

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -414,6 +414,16 @@ cubes:
                 include:
                     - orders.created_at
 
+          # The declared grain is a dimension of another cube, so it does not
+          # supply the dimension the sql reads.
+          - name: amount_first_half_of_month_grain_of_other_cube
+            type: sum
+            sql: "CASE WHEN EXTRACT(DAY FROM {CUBE.created_at}) <= 15 THEN {CUBE.total_amount} ELSE 0 END"
+            multi_stage: true
+            grain:
+                include:
+                    - customers.city
+
           # Undeclared read one stage further out: the dimension is read by a
           # measure whose aggregated dependency is itself multi-stage.
           - name: amount_prev_month_first_half

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/dimension_deps.rs
@@ -58,6 +58,36 @@ async fn test_undeclared_time_dimension_read_is_reported() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_report_spells_out_the_grain_the_member_is_computed_at() {
+    let message = expect_error("amount_first_half_of_month");
+
+    assert!(
+        message.contains("orders.created_at (month)"),
+        "The error must spell out the grain the member is computed at:\n{}",
+        message
+    );
+    assert!(
+        message.contains("at a granularity"),
+        "A granularity of the dimension the sql reads must not read as a match:\n{}",
+        message
+    );
+}
+
+/// A grain declared at another cube's dimension: naming the read dimension
+/// alone would repeat what the model already says, so the grain the member is
+/// actually computed at is what tells the two apart.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_report_names_a_grain_declared_at_another_cube() {
+    let message = expect_error("amount_first_half_of_month_grain_of_other_cube");
+
+    assert!(
+        message.contains("orders.created_at") && message.contains("customers.city"),
+        "The error must name both the dimension the sql reads and the declared grain:\n{}",
+        message
+    );
+}
+
 /// The reading member consumes a time-shifted multi-stage measure, so its own
 /// grain is settled one stage above the leaf that would have to carry the
 /// dimension.


### PR DESCRIPTION
## Summary

A cube that `extends` another broke **all** multi-stage measures of the cube it extends — including queries that never mention the extending cube — with either `Can't find join path to join '<child>', '<parent>'` or `Multi-stage member … reads dimension …, which is not part of the grain it is computed at`, the latter naming a dimension the model already declares in `grain.include`. Both models compile cleanly and `/meta` is clean, so this only surfaces at query time. Reproduced on v1.7.5 and v1.7.19, so it is not a recent regression.

Root cause is in `CubeEvaluator`, not in the planner: `extends` hands the extending cube the very definitions of the cube it extends, and references resolved per cube were written into those shared objects, so the last cube prepared won.

## Changes

- `CubeEvaluator.evaluateMultiStageReferences`: copy a member's nested `grain` / `filter` before writing the resolved references. `prepareMembers` copies the member object itself, but not what hangs off it, so a parent's `grain.include: [d]` came out as `["child.d"]` — which pulls a cube into the query that is not part of it, hence either the missing join path or the unreachable grain dimension.
- `CubeEvaluator.prepareViewFilters`: same aliasing for a view extending another view — `default_filters` reach it through the prototype, so `base_view`'s own default filter resolved to `child_view.currency`, a member `base_view` does not include.
- `CubeEvaluator.preparePreAggregations`: same aliasing for `outputColumnTypes` — the base cube's rollup got column names scoped to the extending cube (`child.id`).
- Tesseract: the unreachable-dimension report now spells out the grain the member is computed at. It used to name only the member, the dimension and the declaration that fixes it — all of which the model already says — so a grain holding something else was indistinguishable from a grain the reader believed was right. Granularities are named separately (`orders.created_at (month)`) instead of being folded into the symbol name, and the one case a listing cannot disambiguate gets a sentence of its own:

```
Multi-stage member orders.amount_first_half_of_month reads dimension orders.created_at,
which is not part of the grain it is computed at (customers.city, orders.created_at (month)).
The grain carries orders.created_at at a granularity, which is a value of its own and not
the dimension itself. Add orders.created_at to `grain.include` of … .
```

The legacy planner is unaffected in effect: nothing outside the native planner reads `excludeReferences` / `keepOnlyReferences` / `includeReferences`, and legacy has no `grain:` at all.

## Testing

- New `packages/cubejs-schema-compiler/test/unit/extends-shared-definitions.test.ts`, which fails on the unfixed code with exactly the two reported messages. It asserts the resolved references per cube, and that the plan of the parent's multi-stage measure is **identical** with and without the extending cube — under both planners (`useNativeSqlPlanner: true` / `false`), plus the view-default-filter and pre-aggregation cases. Reverting each fix hunk was verified to fail the matching test.
- Two new `cubesqlplanner` integration tests in `multi_stage/dimension_deps.rs` for the report, including a grain declared at another cube's dimension.
- `cargo test --features integration-postgres` across the workspace: 1277 passed, 0 failed. `cargo fmt` clean.
- `jest dist/test/unit` in `cubejs-schema-compiler`: 782/784, the two failures are a pre-existing ANSI-colour snapshot in `error-reporter.test.ts` (passes under `FORCE_COLOR=1`).
- Docker-Postgres integration files, run individually and green: `extensions`, `multi-stage`, `multi-stage-grain`, `multi-stage-filter`, `multi-stage-member-to-alias`, `multi-stage-order-by-view`, `multi-stage-time-shift-filter-params`, `pre-aggregations-multi-stage`, `pre-aggregations`, `views`, `view-default-value-filters`.
