### PR TITLE
chore(query-orchestrator): Queue - improve benchmarks

### DIFF
--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -402,3 +402,7 @@ Two things about the numbers are artifacts of the harness rather than production
   and is the entire traffic of the idle-floor suite, which is why S5 measures two intervals.
 - Payload defaults are 5MB responses / 256KB query bodies, but the suites deliberately run at
   64KB / 16KB. S7 owns the payload axis.
+
+`driverCalls` is snapshotted after drain and before the idle tail, so on a suite with
+`BENCH_IDLE_TAIL_MS` the tail's polling lands in `idle.driverCalls` and nowhere else — and
+`main` plus `workers` add up to `total` exactly.

--- a/packages/cubejs-query-orchestrator/DEVELOPMENT.md
+++ b/packages/cubejs-query-orchestrator/DEVELOPMENT.md
@@ -356,7 +356,49 @@ returns items highest priority first (oldest first within a priority) and reconc
 The fast track selects itself, so it is priority blind with nothing to compensate. That is
 what the `active + pending < concurrency` condition rules out: retrieving leaves a free slot
 for every item already pending, so no item is jumped over, and once the budget gets tight
-the fast track steps aside and lets reconcile pick by priority. Note that a retrieved item
-goes straight to active and never becomes pending, so a burst onto an idle queue still
-fast-tracks every query — items only start accumulating in pending once the concurrency
-budget is exhausted, which is exactly when the condition should stop firing.
+the fast track steps aside and lets reconcile pick by priority. A retrieved item goes straight
+to active and never becomes pending, so a burst onto an idle queue fast-tracks exactly one
+concurrency budget's worth and no more: items start accumulating in pending the moment the
+budget is exhausted, which is when the condition stops firing. S3 measures this exactly —
+50 retrievals out of 1000 at concurrency 50, 200 out of 1000 at concurrency 200 — so on a
+burst the saving scales as `concurrency / burst size`, not with the size of the burst.
+
+## Benchmarks
+
+The harness lives in `test/benchmarks/` and is compiled by the ordinary `yarn tsc` — jest never
+picks it up (`testMatch` is `*.test.ts`). Runs go through the suite runner:
+
+```bash
+yarn tsc
+yarn bench:suite --list                  # what the suites are
+yarn bench:suite S1 --dry-run            # the matrix with computed ρ and wall clock, run this first
+yarn bench:suite S1                      # off and on, one pass each
+yarn bench:suite --report .context/bench-results/S1-….jsonl
+```
+
+Every run emits one `BENCH_RESULT {json}` line plus a `BENCH_TICK {json}` per second; the runner
+collects both into `.context/bench-results/<suites>-<stamp>.jsonl` and prints a markdown summary.
+A single run can also be driven straight from env vars against
+`dist/test/benchmarks/QueueCubestore.bench.js` (or `QueueMemory.bench.js`) — see `readSettings`
+in `QueueBench.abstract.ts` for the full list.
+
+The one axis that decides everything is the load factor:
+
+```
+ρ = arrival_rate / capacity,   capacity = concurrency / handler_latency
+```
+
+The fast track saves a round trip only while the concurrency budget has a free slot, so ρ is
+what the suites sweep. `driverCalls.fastTrack.missRate` is the direct measure of the cost side:
+an `ADD_AND_RETRIEVE` that comes back without a retrieval is a round trip spent for nothing.
+Eligibility is read off the connection's `useFastTrack`, so a driver that cannot fast track
+never registers an attempt.
+
+Two things about the numbers are artifacts of the harness rather than production behaviour:
+
+- Workers poll `reconcileQueue` on a timer (`BENCH_WORKER_RECONCILE_MS`, default 50ms) because a
+  worker never submits and so has no submit-time reconcile to bootstrap from. Production
+  reconcile is event-driven. This poll dominates `getQueriesToCancel` / `getActiveAndToProcess`
+  and is the entire traffic of the idle-floor suite, which is why S5 measures two intervals.
+- Payload defaults are 5MB responses / 256KB query bodies, but the suites deliberately run at
+  64KB / 16KB. S7 owns the payload axis.

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -21,6 +21,7 @@
     "unit": "jest --runInBand --forceExit --coverage --verbose test/unit",
     "integration": "jest --runInBand --verbose test/integration",
     "integration:cubestore": "jest --runInBand --verbose test/integration/cubestore",
+    "bench:suite": "node dist/test/benchmarks/run-suite.js",
     "lint": "eslint src/* test/* --ext .ts,.js",
     "lint:fix": "eslint --fix src/* test/* --ext .ts,.js"
   },
@@ -41,9 +42,11 @@
     "@types/jest": "^29",
     "@types/node": "^22",
     "@types/ramda": "^0.27.32",
+    "@types/yargs": "^17.0.31",
     "jest": "^29",
     "ts-jest": "^29",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "yargs": "^17.7.1"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -1,10 +1,20 @@
-import { CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
 import crypto from 'crypto';
 import path from 'path';
 import { ChildProcess, fork } from 'child_process';
-import { createPromiseLock, MethodName, pausePromise } from '@cubejs-backend/shared';
-import { QueueDriverConnectionInterface, QueueDriverInterface, QueuePriority } from '@cubejs-backend/base-driver';
-import { LocalQueueDriver, QueryQueue, QueryQueueOptions } from '../../src';
+import { createPromiseLock, pausePromise } from '@cubejs-backend/shared';
+import { QueuePriority } from '@cubejs-backend/base-driver';
+import { ContinueWaitError, QueryQueue, QueryQueueOptions, TimeoutError } from '../../src';
+import {
+  BenchCounters,
+  createCounters,
+  driverCallsTotal,
+  makeQueueDriverFactory,
+  MethodCounter,
+  mergeEvents,
+  mergeMethods,
+  percentiles,
+} from './instrument';
+import { ParentMessage, WorkerSnapshot } from './protocol';
 
 export type QueryQueueTestOptions = Pick<QueryQueueOptions, 'cacheAndQueueDriver' | 'cubeStoreDriverFactory'> & {
   beforeAll?: () => Promise<void>,
@@ -12,56 +22,159 @@ export type QueryQueueTestOptions = Pick<QueryQueueOptions, 'cacheAndQueueDriver
   workers?: number,
 };
 
-function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInterface, counters: any): QueueDriverConnectionInterface {
-  function wrapAsyncMethod<M extends MethodName<QueueDriverConnectionInterface>>(methodName: M): any {
-    return async (...args: Parameters<QueueDriverConnectionInterface[M]>) => {
-      if (!(methodName in counters.methods)) {
-        counters.methods[methodName] = {
-          started: 1,
-          finished: 0,
-        };
-      } else {
-        counters.methods[methodName].started++;
-      }
+type PriorityBucket = { priority: number, weight: number };
 
-      const result = await (connection[methodName] as any)(...args);
-      counters.methods[methodName].finished++;
+type BenchSettings = {
+  driver: string,
+  fastTrack: boolean,
+  workers: number,
+  concurrency: number,
+  totalQueries: number,
+  periodMs: number,
+  pushIntervalMs: number,
+  priority: QueuePriority,
+  priorityMix: PriorityBucket[] | null,
+  handlerLatencyMs: number,
+  queueResponseSize: number,
+  queuePayloadSize: number,
+  workerReconcileMs: number,
+  warmupQueries: number,
+  idleTailMs: number,
+  tickMs: number,
+};
 
-      return result;
-    };
-  }
+type Phase = 'warmup' | 'measure' | 'drain' | 'idle';
 
+type Aggregate = {
+  methods: Record<string, MethodCounter>,
+  events: Record<string, number>,
+  handlersStarted: number,
+  handlersFinished: number,
+  fastTrack: { attempts: number, hits: number },
+  driverCalls: number,
+};
+
+const EMPTY_AGGREGATE = (): Aggregate => ({
+  methods: {},
+  events: {},
+  handlersStarted: 0,
+  handlersFinished: 0,
+  fastTrack: { attempts: 0, hits: 0 },
+  driverCalls: 0,
+});
+
+function toAggregate(source: Pick<BenchCounters, 'methods' | 'events' | 'handlersStarted' | 'handlersFinished' | 'fastTrack'>): Aggregate {
   return {
-    ...connection,
-    addToQueue: wrapAsyncMethod('addToQueue'),
-    getResult: wrapAsyncMethod('getResult'),
-    getQueriesToCancel: wrapAsyncMethod('getQueriesToCancel'),
-    getActiveAndToProcess: wrapAsyncMethod('getActiveAndToProcess'),
-    retrieveForProcessing: wrapAsyncMethod('retrieveForProcessing'),
-    getQueryDef: wrapAsyncMethod('getQueryDef'),
-    setResultAndRemoveQuery: wrapAsyncMethod('setResultAndRemoveQuery'),
-    getQueryStageState: wrapAsyncMethod('getQueryStageState'),
-    getResultBlocking: wrapAsyncMethod('getResultBlocking'),
-    optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
-    getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
-    release: connection.release,
+    methods: JSON.parse(JSON.stringify(source.methods)),
+    events: { ...source.events },
+    handlersStarted: source.handlersStarted,
+    handlersFinished: source.handlersFinished,
+    fastTrack: { ...source.fastTrack },
+    driverCalls: driverCallsTotal(source),
   };
 }
 
-function patchQueueDriverForTrack(driver: QueueDriverInterface, counters: any): QueueDriverInterface {
+function addAggregate(into: Aggregate, from: Aggregate): Aggregate {
+  mergeMethods(into.methods, from.methods);
+  mergeEvents(into.events, from.events);
+  into.handlersStarted += from.handlersStarted;
+  into.handlersFinished += from.handlersFinished;
+  into.fastTrack.attempts += from.fastTrack.attempts;
+  into.fastTrack.hits += from.fastTrack.hits;
+  into.driverCalls += from.driverCalls;
+
+  return into;
+}
+
+/**
+ * Warmup is charged against a baseline instead of a counter reset, so the workers need no reset
+ * round trip and the subtraction is identical on every source
+ */
+function subAggregate(a: Aggregate, b: Aggregate): Aggregate {
+  const methods: Record<string, MethodCounter> = {};
+  for (const [name, m] of Object.entries(a.methods)) {
+    const base = b.methods[name] || { started: 0, finished: 0 };
+    methods[name] = { started: m.started - base.started, finished: m.finished - base.finished };
+  }
+
+  const events: Record<string, number> = {};
+  for (const [name, count] of Object.entries(a.events)) {
+    events[name] = count - (b.events[name] || 0);
+  }
+
   return {
-    ...driver,
-    createConnection: async () => {
-      counters.connections++;
-
-      return patchQueueDriverConnectionForTrack(await driver.createConnection(), counters);
+    methods,
+    events,
+    handlersStarted: a.handlersStarted - b.handlersStarted,
+    handlersFinished: a.handlersFinished - b.handlersFinished,
+    fastTrack: {
+      attempts: a.fastTrack.attempts - b.fastTrack.attempts,
+      hits: a.fastTrack.hits - b.fastTrack.hits,
     },
-    redisHash: (...args) => driver.redisHash(...args),
-    release: async (...args) => {
-      counters.connections--;
+    driverCalls: a.driverCalls - b.driverCalls,
+  };
+}
 
-      return driver.release(...args);
-    },
+function parsePriorityMix(raw: string | undefined): PriorityBucket[] | null {
+  if (!raw) {
+    return null;
+  }
+
+  const buckets = raw.split(',').map((part) => {
+    const [priority, weight] = part.split(':');
+    return { priority: parseInt(priority, 10), weight: parseInt(weight, 10) };
+  });
+
+  if (buckets.some((b) => Number.isNaN(b.priority) || Number.isNaN(b.weight) || b.weight <= 0)) {
+    throw new Error(`Malformed BENCH_PRIORITY_MIX: ${raw}, expected "10:50,0:50"`);
+  }
+
+  return buckets;
+}
+
+/**
+ * Largest-remainder apportionment, so an uneven mix still interleaves instead of arriving in blocks
+ */
+function pickBucket(buckets: PriorityBucket[], assigned: number[], index: number): number {
+  const total = buckets.reduce((acc, b) => acc + b.weight, 0);
+  let best = 0;
+  let bestScore = -Infinity;
+
+  for (let i = 0; i < buckets.length; i++) {
+    const score = (buckets[i].weight * (index + 1)) / total - assigned[i];
+    if (score > bestScore) {
+      bestScore = score;
+      best = i;
+    }
+  }
+
+  return best;
+}
+
+function readSettings(driver: string, workers: number): BenchSettings {
+  const totalQueries = parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10);
+  // BENCH_PERIOD_MS spreads the queries evenly over that window instead of pushing them
+  // as fast as the loop allows, which is what decides whether the queue ever backlogs
+  const periodMs = parseInt(process.env.BENCH_PERIOD_MS || '0', 10);
+
+  return {
+    driver,
+    fastTrack: process.env.CUBEJS_QUEUE_FAST_TRACK === 'true',
+    workers,
+    concurrency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
+    totalQueries,
+    periodMs,
+    pushIntervalMs: periodMs > 0 && totalQueries > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
+    priority: parseInt(process.env.BENCH_PRIORITY || `${QueuePriority.Interactive}`, 10),
+    priorityMix: parsePriorityMix(process.env.BENCH_PRIORITY_MIX),
+    handlerLatencyMs: parseInt(process.env.BENCH_HANDLER_LATENCY_MS || '1500', 10),
+    // eslint-disable-next-line no-bitwise
+    queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
+    queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),
+    workerReconcileMs: parseInt(process.env.BENCH_WORKER_RECONCILE_MS || '50', 10),
+    warmupQueries: parseInt(process.env.BENCH_WARMUP_QUERIES || '0', 10),
+    idleTailMs: parseInt(process.env.BENCH_IDLE_TAIL_MS || '0', 10),
+    tickMs: parseInt(process.env.BENCH_TICK_MS || '1000', 10),
   };
 }
 
@@ -71,46 +184,15 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       await options.beforeAll();
     }
 
-    const createBenchmark = async (benchSettings: { totalQueries: number, queueResponseSize: number, queuePayloadSize: number, currency: number, pushIntervalMs: number, priority: QueuePriority }) => {
-      const counters = {
-        connections: 0,
-        methods: {},
-        events: {},
-        queueStarted: 0,
-        queueResolved: 0,
-        handlersStarted: 0,
-        handlersFinished: 0,
-        queueDriverQueriesStarted: 0,
-      };
-
-      const queueDriverFactory = (driverType, queueDriverOptions) => {
-        switch (driverType) {
-          case 'memory':
-            return patchQueueDriverForTrack(
-              new LocalQueueDriver(
-                queueDriverOptions
-              ) as any,
-              counters
-            );
-          case 'cubestore':
-            return patchQueueDriverForTrack(
-              new CubeStoreQueueDriver(
-                async () => options.cubeStoreDriverFactory(),
-                queueDriverOptions
-              ),
-              counters
-            );
-          default:
-            throw new Error(`Unsupported driver: ${driverType}`);
-        }
-      };
+    const createBenchmark = async (benchSettings: BenchSettings) => {
+      const counters = createCounters();
 
       const tenantPrefix = crypto.randomBytes(6).toString('hex');
       const queue = new QueryQueue(`${tenantPrefix}#test_query_queue`, {
         queryHandlers: {
           query: async (_query) => {
             counters.handlersStarted++;
-            await pausePromise(1500);
+            await pausePromise(benchSettings.handlerLatencyMs);
             counters.handlersFinished++;
 
             return {
@@ -129,11 +211,8 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
         continueWaitTimeout: 60 * 2,
         executionTimeout: 20,
         orphanedTimeout: 60 * 5,
-        concurrency: benchSettings.currency,
+        concurrency: benchSettings.concurrency,
         logger: (event, _params) => {
-          // console.log(event, _params);
-          // console.log(event);
-
           if (event in counters.events) {
             counters.events[event]++;
           } else {
@@ -144,15 +223,29 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
             console.log(event, _params);
           }
         },
-        queueDriverFactory,
-        ...options
+        queueDriverFactory: makeQueueDriverFactory(counters, options.cubeStoreDriverFactory),
+        cacheAndQueueDriver: options.cacheAndQueueDriver,
+        cubeStoreDriverFactory: options.cubeStoreDriverFactory,
       });
 
-      // Spawn worker processes for multi-process simulation (CubeStore only)
-      type WorkerCounters = { handlersStarted: number; handlersFinished: number; events: Record<string, number> };
-      type WorkerState = { worker: ChildProcess; counters: WorkerCounters; prevFinished: number };
+      type WorkerState = {
+        worker: ChildProcess,
+        latest: WorkerSnapshot,
+        baseline: Aggregate,
+        awaiting: { seq: number, resolve: () => void } | null,
+        alive: boolean,
+      };
       const workerStates: WorkerState[] = [];
       const numWorkers = options.workers || 0;
+      const shutdown = { requested: false };
+
+      const emptySnapshot = (): WorkerSnapshot => ({
+        handlersStarted: 0,
+        handlersFinished: 0,
+        methods: {},
+        events: {},
+        fastTrack: { attempts: 0, hits: 0 },
+      });
 
       if (numWorkers > 0) {
         const workerPath = path.resolve(__dirname, 'QueueBenchWorker.js');
@@ -165,13 +258,20 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
 
           const state: WorkerState = {
             worker: w,
-            counters: { handlersStarted: 0, handlersFinished: 0, events: {} },
-            prevFinished: 0,
+            latest: emptySnapshot(),
+            baseline: EMPTY_AGGREGATE(),
+            awaiting: null,
+            alive: true,
           };
 
-          w.on('message', (msg: { type: string; data?: WorkerCounters }) => {
-            if (msg.type === 'counters' && msg.data) {
-              state.counters = msg.data;
+          w.on('message', (msg: ParentMessage) => {
+            if (msg.type === 'counters') {
+              state.latest = msg.data;
+
+              if (state.awaiting && (state.awaiting.seq === msg.seq || msg.seq === -1)) {
+                state.awaiting.resolve();
+                state.awaiting = null;
+              }
             }
           });
 
@@ -179,14 +279,27 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
             console.error(`[Worker ${i}] error:`, err);
           });
 
+          // Without this a dead worker keeps its last snapshot and every tick waits the full
+          // timeout for a reply that cannot come, while the run reports as if it were still there
+          w.on('exit', (code, signal) => {
+            if (!shutdown.requested) {
+              console.error(`[Worker ${i}] exited early with ${signal || `code ${code}`} — its counters stop here`);
+            }
+
+            state.alive = false;
+            state.awaiting?.resolve();
+            state.awaiting = null;
+          });
+
           w.send({
             type: 'start',
             tenantPrefix,
             benchSettings: {
               queueResponseSize: benchSettings.queueResponseSize,
-              currency: benchSettings.currency,
+              concurrency: benchSettings.concurrency,
+              handlerLatencyMs: benchSettings.handlerLatencyMs,
             },
-            reconcileInterval: 50,
+            reconcileIntervalMs: benchSettings.workerReconcileMs,
           });
 
           workerStates.push(state);
@@ -195,140 +308,378 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
         console.log(`Spawned ${numWorkers} worker processes`);
       }
 
-      const processingPromisses = [];
+      let tickSeq = 0;
 
-      async function awaitProcessing() {
-        // process query can call reconcileQueue
-        while (await queue.shutdown() || processingPromisses.length) {
-          console.log('awaitProcessing', {
-            counters,
-            processingPromisses: processingPromisses.length
+      async function collectWorkerSnapshots(timeoutMs = 200): Promise<number> {
+        if (workerStates.length === 0) {
+          return 0;
+        }
+
+        const seq = ++tickSeq;
+        const requestedAt = Date.now();
+
+        const waits = workerStates.filter((ws) => ws.alive).map((ws) => new Promise<void>((resolve) => {
+          if (ws.awaiting) {
+            ws.awaiting.resolve();
+          }
+
+          if (!ws.worker.connected) {
+            ws.alive = false;
+            resolve();
+
+            return;
+          }
+
+          ws.awaiting = { seq, resolve };
+          // Never reject: this promise loses the race below whenever a worker is slow, and a
+          // rejection settled after the loser is dropped would surface as an unhandled rejection
+          ws.worker.send({ type: 'tickRequest', seq }, (err) => {
+            if (err) {
+              ws.awaiting = null;
+              resolve();
+            }
           });
-          await Promise.all(processingPromisses.splice(0));
+        }));
+
+        if (waits.length === 0) {
+          return 0;
         }
 
-        // Shutdown worker processes
-        if (workerStates.length > 0) {
-          await Promise.all(workerStates.map((ws) => new Promise<void>((resolve) => {
-            const onMessage = (msg: { type: string; data?: WorkerCounters }) => {
-              if (msg.type === 'counters' && msg.data) {
-                ws.counters = msg.data;
-              }
-              if (msg.type === 'done') {
-                ws.worker.removeListener('message', onMessage);
-                resolve();
-              }
-            };
+        await Promise.race([Promise.all(waits), pausePromise(timeoutMs)]);
 
-            ws.worker.on('message', onMessage);
-            ws.worker.send({ type: 'shutdown' });
-          })));
-        }
+        return Date.now() - requestedAt;
       }
 
-      const progressIntervalId = setInterval(() => {
-        console.log('running', {
-          ...counters,
-          processingPromisses: processingPromisses.length,
-          benchSettings,
-          ...(workerStates.length > 0 ? {
-            workers: workerStates.map((ws, i) => {
-              const finishedSinceLastTick = ws.counters.handlersFinished - ws.prevFinished;
-              ws.prevFinished = ws.counters.handlersFinished;
-              return {
-                id: i,
-                handlersStarted: ws.counters.handlersStarted,
-                handlersFinished: ws.counters.handlersFinished,
-                processing: ws.counters.handlersStarted - ws.counters.handlersFinished,
-                processedFromLastEvent: finishedSinceLastTick,
-              };
-            }),
-          } : {}),
-        });
-      }, 1000);
-
-      const lock = createPromiseLock();
-
-      const pusherIntervalId = setInterval(async () => {
-        if (counters.queueStarted >= benchSettings.totalQueries) {
-          lock.resolve();
-          clearInterval(pusherIntervalId);
-
-          return;
+      function snapshotAggregate(): Aggregate {
+        const total = toAggregate(counters);
+        for (const ws of workerStates) {
+          addAggregate(total, toAggregate(ws.latest));
         }
 
-        counters.queueStarted++;
+        return total;
+      }
 
+      const runStartedAt = Date.now();
+      let phase: Phase = benchSettings.warmupQueries > 0 ? 'warmup' : 'measure';
+      let measureStartedAt = runStartedAt;
+      let baseline = EMPTY_AGGREGATE();
+      let baselineMain = EMPTY_AGGREGATE();
+
+      let pushed = 0;
+      let completed = 0;
+      const failed = { continueWait: 0, timeout: 0, other: 0 };
+      const errorSamples: string[] = [];
+      let latencies: number[] = [];
+      let latenciesByPriority: Record<number, number[]> = {};
+
+      const inFlight = () => pushed - completed - failed.continueWait - failed.timeout - failed.other;
+
+      const processingPromisses: Promise<null>[] = [];
+
+      const bucketAssigned = benchSettings.priorityMix ? benchSettings.priorityMix.map(() => 0) : [];
+
+      function priorityFor(index: number): QueuePriority {
+        if (!benchSettings.priorityMix) {
+          return benchSettings.priority;
+        }
+
+        const bucket = pickBucket(benchSettings.priorityMix, bucketAssigned, index);
+        bucketAssigned[bucket]++;
+
+        return benchSettings.priorityMix[bucket].priority;
+      }
+
+      function pushOne(index: number) {
+        pushed++;
+
+        const priority = priorityFor(index);
         const queueId = crypto.randomBytes(12).toString('hex');
+        const startedAt = process.hrtime.bigint();
+
         const running = (async () => {
           try {
             await queue.executeInQueue('query', queueId, {
-              // eslint-disable-next-line no-bitwise
               payload: {
                 large_str: 'a'.repeat(benchSettings.queuePayloadSize)
               },
               orphanedTimeout: 120
-            }, benchSettings.priority, {
+            }, priority, {
               stageQueryKey: 1,
               requestId: 'request-id',
               spanId: 'span-id'
             });
-          } catch (e) {
-            console.error(e);
+
+            completed++;
+
+            const latencyMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+            latencies.push(latencyMs);
+            (latenciesByPriority[priority] ||= []).push(latencyMs);
+          } catch (e: any) {
+            if (e instanceof ContinueWaitError) {
+              failed.continueWait++;
+            } else if (e instanceof TimeoutError) {
+              failed.timeout++;
+            } else {
+              failed.other++;
+            }
+
+            if (errorSamples.length < 3) {
+              errorSamples.push(`${e?.constructor?.name}: ${e?.message}`);
+            }
           }
 
-          counters.queueResolved++;
-
-          // losing memory for a result
+          // The result is dropped rather than returned, so 1000 payloads are not held alive
+          // by the promise array until the run ends
           return null;
         })();
 
         processingPromisses.push(running);
-        await running;
-      }, benchSettings.pushIntervalMs);
+      }
 
-      await lock.promise;
-      await awaitProcessing();
-      clearInterval(progressIntervalId);
+      function runPusher(count: number, intervalMs: number): Promise<void> {
+        if (count <= 0) {
+          return Promise.resolve();
+        }
 
-      const workerAgg = workerStates.reduce(
-        (acc, ws) => ({
-          handlersStarted: acc.handlersStarted + ws.counters.handlersStarted,
-          handlersFinished: acc.handlersFinished + ws.counters.handlersFinished,
-        }),
-        { handlersStarted: 0, handlersFinished: 0 }
-      );
+        const lock = createPromiseLock();
+        let index = 0;
 
-      console.dir({
-        message: 'Result',
-        benchSettings,
-        ...counters,
-        ...(workerStates.length > 0 ? {
-          workers: workerStates.map((ws, i) => ({
-            id: i,
-            ...ws.counters,
-            processing: ws.counters.handlersStarted - ws.counters.handlersFinished,
-          })),
-          totalHandlersStarted: counters.handlersStarted + workerAgg.handlersStarted,
-          totalHandlersFinished: counters.handlersFinished + workerAgg.handlersFinished,
-        } : {}),
-      }, { depth: null });
+        const pusherIntervalId = setInterval(() => {
+          if (index >= count) {
+            clearInterval(pusherIntervalId);
+            lock.resolve();
+
+            return;
+          }
+
+          pushOne(index);
+          index++;
+        }, intervalMs);
+
+        return lock.promise as Promise<void>;
+      }
+
+      async function drain() {
+        // process query can call reconcileQueue
+        while (await queue.shutdown() || processingPromisses.length) {
+          await Promise.all(processingPromisses.splice(0));
+        }
+      }
+
+      let prevDriverCalls = 0;
+      let prevHandlersFinished = 0;
+      let prevTickAt = runStartedAt;
+      let peakDriverCallsPerSec = 0;
+      let ticking = false;
+
+      const tickIntervalId = setInterval(async () => {
+        if (ticking) {
+          return;
+        }
+        ticking = true;
+
+        try {
+          const workerSnapshotAgeMs = await collectWorkerSnapshots();
+          const now = Date.now();
+          const agg = subAggregate(snapshotAggregate(), baseline);
+
+          const driverCallsDelta = agg.driverCalls - prevDriverCalls;
+          const elapsedSinceTick = Math.max(1, now - prevTickAt);
+          const perSec = (driverCallsDelta * 1000) / elapsedSinceTick;
+
+          if (phase === 'measure' || phase === 'drain') {
+            peakDriverCallsPerSec = Math.max(peakDriverCallsPerSec, perSec);
+          }
+
+          console.log(`BENCH_TICK ${JSON.stringify({
+            runId: process.env.BENCH_RUN_ID || null,
+            tMs: now - runStartedAt,
+            phase,
+            pushed,
+            inFlight: inFlight(),
+            completed,
+            failed: failed.continueWait + failed.timeout + failed.other,
+            driverCallsTotal: agg.driverCalls,
+            driverCallsDelta,
+            driverCallsPerSec: Math.round(perSec),
+            handlersFinished: agg.handlersFinished,
+            handlersFinishedDelta: agg.handlersFinished - prevHandlersFinished,
+            fastTrackAttempts: agg.fastTrack.attempts,
+            fastTrackHits: agg.fastTrack.hits,
+            workerSnapshotAgeMs,
+          })}`);
+
+          prevDriverCalls = agg.driverCalls;
+          prevHandlersFinished = agg.handlersFinished;
+          prevTickAt = now;
+        } finally {
+          ticking = false;
+        }
+      }, benchSettings.tickMs);
+
+      if (benchSettings.warmupQueries > 0) {
+        await runPusher(benchSettings.warmupQueries, Math.min(benchSettings.pushIntervalMs, 50));
+        await drain();
+
+        await collectWorkerSnapshots();
+        baseline = snapshotAggregate();
+        baselineMain = toAggregate(counters);
+        for (const ws of workerStates) {
+          ws.baseline = toAggregate(ws.latest);
+        }
+
+        pushed = 0;
+        completed = 0;
+        failed.continueWait = 0;
+        failed.timeout = 0;
+        failed.other = 0;
+        latencies = [];
+        latenciesByPriority = {};
+        errorSamples.splice(0);
+        prevDriverCalls = 0;
+        prevHandlersFinished = 0;
+      }
+
+      phase = 'measure';
+      measureStartedAt = Date.now();
+
+      await runPusher(benchSettings.totalQueries, benchSettings.pushIntervalMs);
+      const pushEndedAt = Date.now();
+
+      phase = 'drain';
+      await drain();
+      const drainEndedAt = Date.now();
+
+      // Without a fresh pull the idle delta absorbs up to a tick of worker polling that predates it
+      await collectWorkerSnapshots();
+      const aggBeforeIdle = subAggregate(snapshotAggregate(), baseline);
+
+      if (benchSettings.idleTailMs > 0) {
+        phase = 'idle';
+        await pausePromise(benchSettings.idleTailMs);
+      }
+
+      clearInterval(tickIntervalId);
+      await collectWorkerSnapshots();
+
+      const finalAgg = subAggregate(snapshotAggregate(), baseline);
+      const idleDriverCalls = benchSettings.idleTailMs > 0 ? finalAgg.driverCalls - aggBeforeIdle.driverCalls : 0;
+
+      shutdown.requested = true;
+
+      if (workerStates.length > 0) {
+        await Promise.all(workerStates.map((ws) => new Promise<void>((resolve) => {
+          if (!ws.alive || !ws.worker.connected) {
+            resolve();
+
+            return;
+          }
+
+          const onMessage = (msg: ParentMessage) => {
+            if (msg.type === 'counters') {
+              ws.latest = msg.data;
+            }
+            if (msg.type === 'done') {
+              ws.worker.removeListener('message', onMessage);
+              resolve();
+            }
+          };
+
+          ws.worker.on('message', onMessage);
+          // A worker that dies before answering would otherwise hold this promise open forever
+          ws.worker.once('exit', resolve);
+          ws.worker.send({ type: 'shutdown' }, (err) => {
+            if (err) {
+              resolve();
+            }
+          });
+        })));
+      }
+
+      const pushWindowMs = pushEndedAt - measureStartedAt;
+      const capacityQps = (benchSettings.concurrency * 1000) / benchSettings.handlerLatencyMs;
+      const targetRateQps = benchSettings.periodMs > 0
+        ? (benchSettings.totalQueries * 1000) / benchSettings.periodMs
+        : null;
+      const actualRateQps = pushWindowMs > 0 ? (pushed * 1000) / pushWindowMs : null;
+      const processes = benchSettings.workers + 1;
+
+      const round = (v: number | null, digits = 3) => (v === null ? null : Number(v.toFixed(digits)));
+
+      const result = {
+        runId: process.env.BENCH_RUN_ID || null,
+        suite: process.env.BENCH_SUITE || null,
+        label: process.env.BENCH_LABEL || null,
+        axis: process.env.BENCH_AXIS ? JSON.parse(process.env.BENCH_AXIS) : null,
+        settings: benchSettings,
+        derived: {
+          capacityQps: round(capacityQps),
+          targetRateQps: round(targetRateQps),
+          actualRateQps: round(actualRateQps),
+          targetRho: round(targetRateQps === null ? null : targetRateQps / capacityQps),
+          actualRho: round(actualRateQps === null ? null : actualRateQps / capacityQps),
+        },
+        timing: {
+          startedAt: new Date(runStartedAt).toISOString(),
+          measureStartedAtMs: measureStartedAt - runStartedAt,
+          pushWindowMs,
+          drainMs: drainEndedAt - pushEndedAt,
+          elapsedMs: drainEndedAt - measureStartedAt,
+          idleTailMs: benchSettings.idleTailMs,
+        },
+        outcome: {
+          pushed,
+          completed,
+          inFlightAtEnd: inFlight(),
+          failed: { ...failed, total: failed.continueWait + failed.timeout + failed.other },
+          errorSamples,
+        },
+        latencyMs: percentiles(latencies),
+        latencyMsByPriority: Object.fromEntries(
+          Object.entries(latenciesByPriority).map(([priority, samples]) => [priority, percentiles(samples)])
+        ),
+        driverCalls: {
+          total: finalAgg.driverCalls,
+          perQuery: completed > 0 ? round(finalAgg.driverCalls / completed) : null,
+          peakPerSec: Math.round(peakDriverCallsPerSec),
+          byMethod: finalAgg.methods,
+          main: subAggregate(toAggregate(counters), baselineMain).methods,
+          workers: workerStates.map((ws) => subAggregate(toAggregate(ws.latest), ws.baseline).methods),
+          fastTrack: {
+            ...finalAgg.fastTrack,
+            missRate: finalAgg.fastTrack.attempts > 0
+              ? round(1 - finalAgg.fastTrack.hits / finalAgg.fastTrack.attempts)
+              : null,
+          },
+        },
+        events: {
+          merged: finalAgg.events,
+          main: subAggregate(toAggregate(counters), baselineMain).events,
+          workers: workerStates.map((ws) => subAggregate(toAggregate(ws.latest), ws.baseline).events),
+        },
+        handlers: {
+          started: finalAgg.handlersStarted,
+          finished: finalAgg.handlersFinished,
+          main: counters.handlersFinished - baselineMain.handlersFinished,
+          workers: workerStates.map((ws) => ws.latest.handlersFinished - ws.baseline.handlersFinished),
+        },
+        idle: {
+          driverCalls: idleDriverCalls,
+          callsPerSecPerProcess: benchSettings.idleTailMs > 0
+            ? round((idleDriverCalls * 1000) / benchSettings.idleTailMs / processes)
+            : null,
+        },
+        connections: counters.connections,
+      };
+
+      console.log(`BENCH_RESULT ${JSON.stringify(result)}`);
+
+      if (!process.env.BENCH_RUN_ID) {
+        console.dir({ message: 'Result', ...result }, { depth: null });
+      }
     };
 
-    const totalQueries = parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10);
-    // BENCH_PERIOD_MS spreads the queries evenly over that window instead of pushing them
-    // as fast as the loop allows, which is what decides whether the queue ever backlogs
-    const periodMs = parseInt(process.env.BENCH_PERIOD_MS || '0', 10);
-
-    await createBenchmark({
-      currency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
-      totalQueries,
-      pushIntervalMs: periodMs > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
-      priority: parseInt(process.env.BENCH_PRIORITY || `${QueuePriority.Interactive}`, 10),
-      // eslint-disable-next-line no-bitwise
-      queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
-      queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),
-    });
+    await createBenchmark(readSettings(name, options.workers || 0));
 
     if (options.afterAll) {
       await options.afterAll();

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -152,30 +152,32 @@ function pickBucket(buckets: PriorityBucket[], assigned: number[], index: number
   return best;
 }
 
+const envInt = (name: string, fallback: number) => parseInt(process.env[name] || `${fallback}`, 10);
+
 function readSettings(driver: string, workers: number): BenchSettings {
-  const totalQueries = parseInt(process.env.BENCH_TOTAL_QUERIES || '1000', 10);
+  const totalQueries = envInt('BENCH_TOTAL_QUERIES', 1000);
   // BENCH_PERIOD_MS spreads the queries evenly over that window instead of pushing them
   // as fast as the loop allows, which is what decides whether the queue ever backlogs
-  const periodMs = parseInt(process.env.BENCH_PERIOD_MS || '0', 10);
+  const periodMs = envInt('BENCH_PERIOD_MS', 0);
 
   return {
     driver,
     fastTrack: process.env.CUBEJS_QUEUE_FAST_TRACK === 'true',
     workers,
-    concurrency: parseInt(process.env.BENCH_CONCURRENCY || '50', 10),
+    concurrency: envInt('BENCH_CONCURRENCY', 50),
     totalQueries,
     periodMs,
     pushIntervalMs: periodMs > 0 && totalQueries > 0 ? Math.max(1, Math.round(periodMs / totalQueries)) : 10,
-    priority: parseInt(process.env.BENCH_PRIORITY || `${QueuePriority.Interactive}`, 10),
+    priority: envInt('BENCH_PRIORITY', QueuePriority.Interactive),
     priorityMix: parsePriorityMix(process.env.BENCH_PRIORITY_MIX),
-    handlerLatencyMs: parseInt(process.env.BENCH_HANDLER_LATENCY_MS || '1500', 10),
+    handlerLatencyMs: envInt('BENCH_HANDLER_LATENCY_MS', 1500),
     // eslint-disable-next-line no-bitwise
-    queueResponseSize: parseInt(process.env.BENCH_RESPONSE_SIZE || `${5 << 20}`, 10),
-    queuePayloadSize: parseInt(process.env.BENCH_PAYLOAD_SIZE || `${256 * 1024}`, 10),
-    workerReconcileMs: parseInt(process.env.BENCH_WORKER_RECONCILE_MS || '50', 10),
-    warmupQueries: parseInt(process.env.BENCH_WARMUP_QUERIES || '0', 10),
-    idleTailMs: parseInt(process.env.BENCH_IDLE_TAIL_MS || '0', 10),
-    tickMs: parseInt(process.env.BENCH_TICK_MS || '1000', 10),
+    queueResponseSize: envInt('BENCH_RESPONSE_SIZE', 5 << 20),
+    queuePayloadSize: envInt('BENCH_PAYLOAD_SIZE', 256 * 1024),
+    workerReconcileMs: envInt('BENCH_WORKER_RECONCILE_MS', 50),
+    warmupQueries: envInt('BENCH_WARMUP_QUERIES', 0),
+    idleTailMs: envInt('BENCH_IDLE_TAIL_MS', 0),
+    tickMs: envInt('BENCH_TICK_MS', 1000),
   };
 }
 
@@ -189,47 +191,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       const counters = createCounters();
 
       const tenantPrefix = crypto.randomBytes(6).toString('hex');
-      const queue = new QueryQueue(`${tenantPrefix}#test_query_queue`, {
-        queryHandlers: {
-          query: async (_query) => {
-            counters.handlersStarted++;
-            await pausePromise(benchSettings.handlerLatencyMs);
-            counters.handlersFinished++;
-
-            return {
-              payload: 'a'.repeat(benchSettings.queueResponseSize),
-            };
-          },
-          stream: async (_query, _stream) => {
-            throw new Error('streaming handler is not supported for testing');
-          }
-        },
-        cancelHandlers: {
-          query: async (_query) => {
-            console.error('Cancel handler was called for query');
-          },
-        },
-        continueWaitTimeout: 60 * 2,
-        executionTimeout: 20,
-        orphanedTimeout: 60 * 5,
-        concurrency: benchSettings.concurrency,
-        logger: (event, _params) => {
-          if (event in counters.events) {
-            counters.events[event]++;
-          } else {
-            counters.events[event] = 1;
-          }
-
-          // stderr, not stdout: stdout carries the BENCH_RESULT/BENCH_TICK lines the suite
-          // runner parses, and it is shared with every worker
-          if (event.includes('error')) {
-            console.error(event, _params);
-          }
-        },
-        queueDriverFactory: makeQueueDriverFactory(counters, options.cubeStoreDriverFactory),
-        cacheAndQueueDriver: options.cacheAndQueueDriver,
-        cubeStoreDriverFactory: options.cubeStoreDriverFactory,
-      });
+      const queue = createBenchQueue(`${tenantPrefix}#test_query_queue`, counters, benchSettings, options);
 
       type WorkerState = {
         worker: ChildProcess,
@@ -243,14 +205,6 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       const shutdown = { requested: false };
       const diedEarly = { count: 0 };
 
-      const emptySnapshot = (): WorkerSnapshot => ({
-        handlersStarted: 0,
-        handlersFinished: 0,
-        methods: {},
-        events: {},
-        fastTrack: { attempts: 0, hits: 0 },
-      });
-
       if (numWorkers > 0) {
         const workerPath = path.resolve(__dirname, 'QueueBenchWorker.js');
 
@@ -262,7 +216,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
 
           const state: WorkerState = {
             worker: w,
-            latest: emptySnapshot(),
+            latest: counterSnapshot(createCounters()),
             baseline: EMPTY_AGGREGATE(),
             awaiting: null,
             alive: true,
@@ -368,7 +322,6 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
 
       const runStartedAt = Date.now();
       let phase: Phase = benchSettings.warmupQueries > 0 ? 'warmup' : 'measure';
-      let measureStartedAt = runStartedAt;
       let baseline = EMPTY_AGGREGATE();
       let baselineMain = EMPTY_AGGREGATE();
 
@@ -376,8 +329,8 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       let completed = 0;
       const failed = { continueWait: 0, timeout: 0, other: 0 };
       const errorSamples: string[] = [];
-      let latencies: number[] = [];
       let latenciesByPriority: Record<number, number[]> = {};
+      const latencies = () => Object.values(latenciesByPriority).flat();
 
       const inFlight = () => pushed - completed - failed.continueWait - failed.timeout - failed.other;
 
@@ -419,7 +372,6 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
             completed++;
 
             const latencyMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
-            latencies.push(latencyMs);
             (latenciesByPriority[priority] ||= []).push(latencyMs);
           } catch (e: any) {
             if (e instanceof ContinueWaitError) {
@@ -540,7 +492,6 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
         failed.continueWait = 0;
         failed.timeout = 0;
         failed.other = 0;
-        latencies = [];
         latenciesByPriority = {};
         errorSamples.splice(0);
         prevDriverCalls = 0;
@@ -548,7 +499,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       }
 
       phase = 'measure';
-      measureStartedAt = Date.now();
+      const measureStartedAt = Date.now();
 
       await runPusher(benchSettings.totalQueries, benchSettings.pushIntervalMs);
       const pushEndedAt = Date.now();
@@ -621,8 +572,6 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       const round = (v: number | null, digits = 3) => (v === null ? null : Number(v.toFixed(digits)));
 
       const result = {
-        // 2: driverCalls stops including the idle tail, and main/workers decompose the total
-        benchSchema: 2,
         runId: process.env.BENCH_RUN_ID || null,
         suite: process.env.BENCH_SUITE || null,
         label: process.env.BENCH_LABEL || null,
@@ -651,7 +600,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
           errorSamples,
           workersDiedEarly: diedEarly.count,
         },
-        latencyMs: percentiles(latencies),
+        latencyMs: percentiles(latencies()),
         latencyMsByPriority: Object.fromEntries(
           Object.entries(latenciesByPriority).map(([priority, samples]) => [priority, percentiles(samples)])
         ),

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBench.abstract.ts
@@ -3,18 +3,19 @@ import path from 'path';
 import { ChildProcess, fork } from 'child_process';
 import { createPromiseLock, pausePromise } from '@cubejs-backend/shared';
 import { QueuePriority } from '@cubejs-backend/base-driver';
-import { ContinueWaitError, QueryQueue, QueryQueueOptions, TimeoutError } from '../../src';
+import { ContinueWaitError, QueryQueueOptions, TimeoutError } from '../../src';
 import {
   BenchCounters,
+  cloneMethods,
+  createBenchQueue,
   createCounters,
   driverCallsTotal,
-  makeQueueDriverFactory,
   MethodCounter,
   mergeEvents,
   mergeMethods,
   percentiles,
 } from './instrument';
-import { ParentMessage, WorkerSnapshot } from './protocol';
+import { counterSnapshot, ParentMessage, WorkerSnapshot } from './protocol';
 
 export type QueryQueueTestOptions = Pick<QueryQueueOptions, 'cacheAndQueueDriver' | 'cubeStoreDriverFactory'> & {
   beforeAll?: () => Promise<void>,
@@ -65,7 +66,7 @@ const EMPTY_AGGREGATE = (): Aggregate => ({
 
 function toAggregate(source: Pick<BenchCounters, 'methods' | 'events' | 'handlersStarted' | 'handlersFinished' | 'fastTrack'>): Aggregate {
   return {
-    methods: JSON.parse(JSON.stringify(source.methods)),
+    methods: cloneMethods(source.methods),
     events: { ...source.events },
     handlersStarted: source.handlersStarted,
     handlersFinished: source.handlersFinished,
@@ -219,8 +220,10 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
             counters.events[event] = 1;
           }
 
+          // stderr, not stdout: stdout carries the BENCH_RESULT/BENCH_TICK lines the suite
+          // runner parses, and it is shared with every worker
           if (event.includes('error')) {
-            console.log(event, _params);
+            console.error(event, _params);
           }
         },
         queueDriverFactory: makeQueueDriverFactory(counters, options.cubeStoreDriverFactory),
@@ -238,6 +241,7 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       const workerStates: WorkerState[] = [];
       const numWorkers = options.workers || 0;
       const shutdown = { requested: false };
+      const diedEarly = { count: 0 };
 
       const emptySnapshot = (): WorkerSnapshot => ({
         handlersStarted: 0,
@@ -283,6 +287,9 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
           // timeout for a reply that cannot come, while the run reports as if it were still there
           w.on('exit', (code, signal) => {
             if (!shutdown.requested) {
+              // Counted into the result too: on stderr alone this reads as a healthy run in
+              // the .jsonl, and a degraded point would get compared against a whole one
+              diedEarly.count++;
               console.error(`[Worker ${i}] exited early with ${signal || `code ${code}`} — its counters stop here`);
             }
 
@@ -550,9 +557,15 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       await drain();
       const drainEndedAt = Date.now();
 
-      // Without a fresh pull the idle delta absorbs up to a tick of worker polling that predates it
+      // Everything the run reports as its cost comes from this one snapshot, taken after drain
+      // and before the idle tail: worker polling during the tail is never charged to the
+      // queries, and because the three views come from a single instant the per-process
+      // breakdown adds up to the total exactly. Without a fresh pull the idle delta would
+      // absorb up to a tick of worker polling that predates it.
       await collectWorkerSnapshots();
-      const aggBeforeIdle = subAggregate(snapshotAggregate(), baseline);
+      const measured = subAggregate(snapshotAggregate(), baseline);
+      const measuredMain = subAggregate(toAggregate(counters), baselineMain);
+      const measuredWorkers = workerStates.map((ws) => subAggregate(toAggregate(ws.latest), ws.baseline));
 
       if (benchSettings.idleTailMs > 0) {
         phase = 'idle';
@@ -562,8 +575,9 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       clearInterval(tickIntervalId);
       await collectWorkerSnapshots();
 
-      const finalAgg = subAggregate(snapshotAggregate(), baseline);
-      const idleDriverCalls = benchSettings.idleTailMs > 0 ? finalAgg.driverCalls - aggBeforeIdle.driverCalls : 0;
+      const idleDriverCalls = benchSettings.idleTailMs > 0
+        ? subAggregate(snapshotAggregate(), baseline).driverCalls - measured.driverCalls
+        : 0;
 
       shutdown.requested = true;
 
@@ -607,6 +621,8 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
       const round = (v: number | null, digits = 3) => (v === null ? null : Number(v.toFixed(digits)));
 
       const result = {
+        // 2: driverCalls stops including the idle tail, and main/workers decompose the total
+        benchSchema: 2,
         runId: process.env.BENCH_RUN_ID || null,
         suite: process.env.BENCH_SUITE || null,
         label: process.env.BENCH_LABEL || null,
@@ -633,35 +649,36 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
           inFlightAtEnd: inFlight(),
           failed: { ...failed, total: failed.continueWait + failed.timeout + failed.other },
           errorSamples,
+          workersDiedEarly: diedEarly.count,
         },
         latencyMs: percentiles(latencies),
         latencyMsByPriority: Object.fromEntries(
           Object.entries(latenciesByPriority).map(([priority, samples]) => [priority, percentiles(samples)])
         ),
         driverCalls: {
-          total: finalAgg.driverCalls,
-          perQuery: completed > 0 ? round(finalAgg.driverCalls / completed) : null,
+          total: measured.driverCalls,
+          perQuery: completed > 0 ? round(measured.driverCalls / completed) : null,
           peakPerSec: Math.round(peakDriverCallsPerSec),
-          byMethod: finalAgg.methods,
-          main: subAggregate(toAggregate(counters), baselineMain).methods,
-          workers: workerStates.map((ws) => subAggregate(toAggregate(ws.latest), ws.baseline).methods),
+          byMethod: measured.methods,
+          main: measuredMain.methods,
+          workers: measuredWorkers.map((agg) => agg.methods),
           fastTrack: {
-            ...finalAgg.fastTrack,
-            missRate: finalAgg.fastTrack.attempts > 0
-              ? round(1 - finalAgg.fastTrack.hits / finalAgg.fastTrack.attempts)
+            ...measured.fastTrack,
+            missRate: measured.fastTrack.attempts > 0
+              ? round(1 - measured.fastTrack.hits / measured.fastTrack.attempts)
               : null,
           },
         },
         events: {
-          merged: finalAgg.events,
-          main: subAggregate(toAggregate(counters), baselineMain).events,
-          workers: workerStates.map((ws) => subAggregate(toAggregate(ws.latest), ws.baseline).events),
+          merged: measured.events,
+          main: measuredMain.events,
+          workers: measuredWorkers.map((agg) => agg.events),
         },
         handlers: {
-          started: finalAgg.handlersStarted,
-          finished: finalAgg.handlersFinished,
-          main: counters.handlersFinished - baselineMain.handlersFinished,
-          workers: workerStates.map((ws) => ws.latest.handlersFinished - ws.baseline.handlersFinished),
+          started: measured.handlersStarted,
+          finished: measured.handlersFinished,
+          main: measuredMain.handlersFinished,
+          workers: measuredWorkers.map((agg) => agg.handlersFinished),
         },
         idle: {
           driverCalls: idleDriverCalls,
@@ -672,7 +689,12 @@ export function QueryQueueBenchmark(name: string, options: QueryQueueTestOptions
         connections: counters.connections,
       };
 
-      console.log(`BENCH_RESULT ${JSON.stringify(result)}`);
+      // stdout is a pipe under the suite runner, and a pipe write is asynchronous on POSIX —
+      // the process.exit below would be free to drop a half-written line. console.log offers
+      // no completion callback, so this one line goes out through write().
+      await new Promise<void>((resolve) => {
+        process.stdout.write(`BENCH_RESULT ${JSON.stringify(result)}\n`, () => resolve());
+      });
 
       if (!process.env.BENCH_RUN_ID) {
         console.dir({ message: 'Result', ...result }, { depth: null });

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBenchWorker.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBenchWorker.ts
@@ -4,25 +4,35 @@ import 'source-map-support/register';
 import { CubeStoreDriver } from '@cubejs-backend/cubestore-driver';
 import { pausePromise } from '@cubejs-backend/shared';
 import { QueryQueue } from '../../src';
+import { createCounters, makeQueueDriverFactory } from './instrument';
+import { WorkerMessage, WorkerSnapshot, WorkerStartMessage } from './protocol';
 
 if (!process.send) {
   throw new Error('QueueBenchWorker must be run as a child process with IPC');
 }
 
-const counters = {
-  handlersStarted: 0,
-  handlersFinished: 0,
-  events: {} as Record<string, number>,
-};
+// A killed run must not leave a worker polling Cube Store forever
+process.on('disconnect', () => process.exit(0));
+
+const counters = createCounters();
 
 let cubeStoreDriver: CubeStoreDriver;
 let queue: QueryQueue;
 let reconcileId: ReturnType<typeof setInterval>;
-let progressId: ReturnType<typeof setInterval>;
 
-process.on('message', async (msg: { type: string; tenantPrefix?: string; benchSettings?: { queueResponseSize: number; currency: number; handlerLatencyMs?: number }; reconcileInterval?: number }) => {
+function snapshot(): WorkerSnapshot {
+  return {
+    handlersStarted: counters.handlersStarted,
+    handlersFinished: counters.handlersFinished,
+    methods: JSON.parse(JSON.stringify(counters.methods)),
+    events: { ...counters.events },
+    fastTrack: { ...counters.fastTrack },
+  };
+}
+
+process.on('message', async (msg: WorkerMessage) => {
   if (msg.type === 'start') {
-    const { tenantPrefix, benchSettings, reconcileInterval } = msg as Required<typeof msg>;
+    const { tenantPrefix, benchSettings, reconcileIntervalMs } = msg as WorkerStartMessage;
 
     cubeStoreDriver = new CubeStoreDriver({});
 
@@ -30,7 +40,7 @@ process.on('message', async (msg: { type: string; tenantPrefix?: string; benchSe
       queryHandlers: {
         query: async () => {
           counters.handlersStarted++;
-          await pausePromise(benchSettings.handlerLatencyMs || 1500);
+          await pausePromise(benchSettings.handlerLatencyMs);
           counters.handlersFinished++;
 
           return {
@@ -49,9 +59,9 @@ process.on('message', async (msg: { type: string; tenantPrefix?: string; benchSe
       continueWaitTimeout: 60 * 2,
       executionTimeout: 20,
       orphanedTimeout: 60 * 5,
-      concurrency: benchSettings.currency,
+      concurrency: benchSettings.concurrency,
       cacheAndQueueDriver: 'cubestore',
-      cubeStoreDriverFactory: async () => cubeStoreDriver,
+      queueDriverFactory: makeQueueDriverFactory(counters, async () => cubeStoreDriver),
       logger: (event, _params) => {
         if (event in counters.events) {
           counters.events[event]++;
@@ -65,31 +75,27 @@ process.on('message', async (msg: { type: string; tenantPrefix?: string; benchSe
       },
     });
 
-    // Periodically reconcile to pick up pending queries from CubeStore
+    // A worker never submits, so it has no submit-time reconcile to bootstrap from. This poll is
+    // an artifact of the harness — production reconcile is event-driven — which is why its
+    // interval is a setting and lands in the reported run settings.
     reconcileId = setInterval(() => {
       queue.reconcileQueue();
-    }, reconcileInterval);
+    }, reconcileIntervalMs);
+  }
 
-    // Report counters to main process periodically
-    progressId = setInterval(() => {
-      process.send!({
-        type: 'counters',
-        data: { ...counters, events: { ...counters.events } },
-      });
-    }, 1000);
+  // Answering on request instead of pushing on a timer keeps the worker numbers inside the tick
+  // they belong to
+  if (msg.type === 'tickRequest') {
+    process.send!({ type: 'counters', seq: msg.seq, data: snapshot() });
   }
 
   if (msg.type === 'shutdown') {
     clearInterval(reconcileId);
-    clearInterval(progressId);
 
     await queue.shutdown();
     await cubeStoreDriver.release();
 
-    process.send!({
-      type: 'counters',
-      data: { ...counters, events: { ...counters.events } },
-    });
+    process.send!({ type: 'counters', seq: -1, data: snapshot() });
     process.send!({ type: 'done' });
     process.disconnect();
     process.exit(0);

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueBenchWorker.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueBenchWorker.ts
@@ -2,10 +2,9 @@
 import 'source-map-support/register';
 
 import { CubeStoreDriver } from '@cubejs-backend/cubestore-driver';
-import { pausePromise } from '@cubejs-backend/shared';
 import { QueryQueue } from '../../src';
-import { createCounters, makeQueueDriverFactory } from './instrument';
-import { WorkerMessage, WorkerSnapshot, WorkerStartMessage } from './protocol';
+import { countEvent, createBenchQueue, createCounters } from './instrument';
+import { counterSnapshot, WorkerMessage, WorkerStartMessage } from './protocol';
 
 if (!process.send) {
   throw new Error('QueueBenchWorker must be run as a child process with IPC');
@@ -14,21 +13,13 @@ if (!process.send) {
 // A killed run must not leave a worker polling Cube Store forever
 process.on('disconnect', () => process.exit(0));
 
+const RECONCILE_ERROR_EVENT = 'bench reconcile poll error';
+
 const counters = createCounters();
 
 let cubeStoreDriver: CubeStoreDriver;
 let queue: QueryQueue;
 let reconcileId: ReturnType<typeof setInterval>;
-
-function snapshot(): WorkerSnapshot {
-  return {
-    handlersStarted: counters.handlersStarted,
-    handlersFinished: counters.handlersFinished,
-    methods: JSON.parse(JSON.stringify(counters.methods)),
-    events: { ...counters.events },
-    fastTrack: { ...counters.fastTrack },
-  };
-}
 
 process.on('message', async (msg: WorkerMessage) => {
   if (msg.type === 'start') {
@@ -36,57 +27,34 @@ process.on('message', async (msg: WorkerMessage) => {
 
     cubeStoreDriver = new CubeStoreDriver({});
 
-    queue = new QueryQueue(`${tenantPrefix}#test_query_queue`, {
-      queryHandlers: {
-        query: async () => {
-          counters.handlersStarted++;
-          await pausePromise(benchSettings.handlerLatencyMs);
-          counters.handlersFinished++;
-
-          return {
-            payload: 'a'.repeat(benchSettings.queueResponseSize),
-          };
-        },
-        stream: async () => {
-          throw new Error('streaming handler is not supported for testing');
-        }
+    queue = createBenchQueue(
+      `${tenantPrefix}#test_query_queue`,
+      counters,
+      benchSettings,
+      {
+        cacheAndQueueDriver: 'cubestore',
+        cubeStoreDriverFactory: async () => cubeStoreDriver,
       },
-      cancelHandlers: {
-        query: async () => {
-          console.error('[Worker] Cancel handler was called for query');
-        },
-      },
-      continueWaitTimeout: 60 * 2,
-      executionTimeout: 20,
-      orphanedTimeout: 60 * 5,
-      concurrency: benchSettings.concurrency,
-      cacheAndQueueDriver: 'cubestore',
-      queueDriverFactory: makeQueueDriverFactory(counters, async () => cubeStoreDriver),
-      logger: (event, _params) => {
-        if (event in counters.events) {
-          counters.events[event]++;
-        } else {
-          counters.events[event] = 1;
-        }
-
-        if (event.includes('error')) {
-          console.log('[Worker]', event, _params);
-        }
-      },
-    });
+      '[Worker] ',
+    );
 
     // A worker never submits, so it has no submit-time reconcile to bootstrap from. This poll is
     // an artifact of the harness — production reconcile is event-driven — which is why its
     // interval is a setting and lands in the reported run settings.
     reconcileId = setInterval(() => {
-      queue.reconcileQueue();
+      // reconcileQueue rethrows, and an unhandled rejection takes the process down under
+      // Node's default policy — the run would then keep reporting as if the worker were here
+      queue.reconcileQueue().catch((e) => {
+        countEvent(counters, RECONCILE_ERROR_EVENT);
+        console.error('[Worker]', RECONCILE_ERROR_EVENT, e);
+      });
     }, reconcileIntervalMs);
   }
 
   // Answering on request instead of pushing on a timer keeps the worker numbers inside the tick
   // they belong to
   if (msg.type === 'tickRequest') {
-    process.send!({ type: 'counters', seq: msg.seq, data: snapshot() });
+    process.send!({ type: 'counters', seq: msg.seq, data: counterSnapshot(counters) });
   }
 
   if (msg.type === 'shutdown') {
@@ -95,7 +63,7 @@ process.on('message', async (msg: WorkerMessage) => {
     await queue.shutdown();
     await cubeStoreDriver.release();
 
-    process.send!({ type: 'counters', seq: -1, data: snapshot() });
+    process.send!({ type: 'counters', seq: -1, data: counterSnapshot(counters) });
     process.send!({ type: 'done' });
     process.disconnect();
     process.exit(0);

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueCubestore.bench.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueCubestore.bench.ts
@@ -28,7 +28,7 @@ const beforeAll = async () => {
 const workers = parseInt(process.env.WORKERS || '2', 10);
 
 QueryQueueBenchmark(
-  `CubeStore Queue (workers: ${workers})`,
+  'cubestore',
   {
     cacheAndQueueDriver: 'cubestore',
     cubeStoreDriverFactory,

--- a/packages/cubejs-query-orchestrator/test/benchmarks/QueueMemory.bench.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/QueueMemory.bench.ts
@@ -12,7 +12,7 @@ const beforeAll = async () => {
 };
 
 QueryQueueBenchmark(
-  'Memory Queue',
+  'memory',
   {
     cacheAndQueueDriver: 'memory',
     beforeAll,

--- a/packages/cubejs-query-orchestrator/test/benchmarks/instrument.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/instrument.ts
@@ -1,12 +1,12 @@
 import { CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
-import { MethodName } from '@cubejs-backend/shared';
+import { MethodName, pausePromise } from '@cubejs-backend/shared';
 import {
   AddToQueueResponse,
   QueueDriverConnectionInterface,
   QueueDriverInterface,
   QueuePriority,
 } from '@cubejs-backend/base-driver';
-import { LocalQueueDriver } from '../../src';
+import { LocalQueueDriver, QueryQueue, QueryQueueOptions } from '../../src';
 
 export type MethodCounter = { started: number, finished: number };
 
@@ -28,6 +28,10 @@ export function createCounters(): BenchCounters {
     handlersFinished: 0,
     fastTrack: { attempts: 0, hits: 0 },
   };
+}
+
+export function countEvent(counters: Pick<BenchCounters, 'events'>, event: string) {
+  counters.events[event] = (counters.events[event] || 0) + 1;
 }
 
 export function driverCallsTotal(counters: Pick<BenchCounters, 'methods'>): number {
@@ -53,6 +57,10 @@ export function mergeEvents(into: Record<string, number>, from: Record<string, n
   }
 
   return into;
+}
+
+export function cloneMethods(methods: Record<string, MethodCounter>): Record<string, MethodCounter> {
+  return mergeMethods({}, methods);
 }
 
 export type Percentiles = { count: number, mean: number, p50: number, p90: number, p95: number, p99: number, max: number };
@@ -87,6 +95,20 @@ async function fastTrackEligible(connection: QueueDriverConnectionInterface, pri
   return typeof useFastTrack === 'function' ? useFastTrack.call(connection, priority) : false;
 }
 
+/** `addToQueue` is wrapped separately, so that it can also record the fast track outcome */
+const TRACKED_METHODS: MethodName<QueueDriverConnectionInterface>[] = [
+  'getResult',
+  'getQueriesToCancel',
+  'getActiveAndToProcess',
+  'retrieveForProcessing',
+  'getQueryDef',
+  'setResultAndRemoveQuery',
+  'getQueryStageState',
+  'getResultBlocking',
+  'optimisticQueryUpdate',
+  'getQueryAndRemove',
+];
+
 function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInterface, counters: BenchCounters): QueueDriverConnectionInterface {
   function wrapAsyncMethod<M extends MethodName<QueueDriverConnectionInterface>>(methodName: M): any {
     return async (...args: Parameters<QueueDriverConnectionInterface[M]>) => {
@@ -109,6 +131,7 @@ function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInt
   const trackedAddToQueue = wrapAsyncMethod('addToQueue');
 
   const tracked: Record<string, any> = {
+    ...Object.fromEntries(TRACKED_METHODS.map((methodName) => [methodName, wrapAsyncMethod(methodName)])),
     addToQueue: async (...args: Parameters<QueueDriverConnectionInterface['addToQueue']>) => {
       const eligible = await fastTrackEligible(connection, args[3]);
       if (eligible) {
@@ -122,16 +145,6 @@ function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInt
 
       return result;
     },
-    getResult: wrapAsyncMethod('getResult'),
-    getQueriesToCancel: wrapAsyncMethod('getQueriesToCancel'),
-    getActiveAndToProcess: wrapAsyncMethod('getActiveAndToProcess'),
-    retrieveForProcessing: wrapAsyncMethod('retrieveForProcessing'),
-    getQueryDef: wrapAsyncMethod('getQueryDef'),
-    setResultAndRemoveQuery: wrapAsyncMethod('setResultAndRemoveQuery'),
-    getQueryStageState: wrapAsyncMethod('getQueryStageState'),
-    getResultBlocking: wrapAsyncMethod('getResultBlocking'),
-    optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
-    getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
   };
 
   // Spreading the connection would copy own properties only and silently drop every method that
@@ -191,4 +204,60 @@ export function makeQueueDriverFactory(counters: BenchCounters, cubeStoreDriverF
         throw new Error(`Unsupported driver: ${driverType}`);
     }
   };
+}
+
+export type BenchQueueSettings = {
+  queueResponseSize: number,
+  concurrency: number,
+  handlerLatencyMs: number,
+};
+
+/**
+ * The submitter and the workers have to run the same queue: any difference between the two
+ * would show up in the results as a difference between processes
+ */
+export function createBenchQueue(
+  queueName: string,
+  counters: BenchCounters,
+  settings: BenchQueueSettings,
+  options: Pick<QueryQueueOptions, 'cacheAndQueueDriver' | 'cubeStoreDriverFactory'>,
+  logPrefix = '',
+): QueryQueue {
+  return new QueryQueue(queueName, {
+    queryHandlers: {
+      query: async () => {
+        counters.handlersStarted++;
+        await pausePromise(settings.handlerLatencyMs);
+        counters.handlersFinished++;
+
+        return {
+          payload: 'a'.repeat(settings.queueResponseSize),
+        };
+      },
+      stream: async () => {
+        throw new Error('streaming handler is not supported for testing');
+      },
+    },
+    cancelHandlers: {
+      query: async () => {
+        console.error(`${logPrefix}Cancel handler was called for query`);
+      },
+    },
+    continueWaitTimeout: 60 * 2,
+    executionTimeout: 20,
+    orphanedTimeout: 60 * 5,
+    concurrency: settings.concurrency,
+    logger: (event, params) => {
+      countEvent(counters, event);
+
+      // stderr, not stdout: stdout carries the BENCH_RESULT/BENCH_TICK lines the suite
+      // runner parses, and it is shared with every worker
+      if (event.includes('error')) {
+        console.error(`${logPrefix}${event}`, params);
+      }
+    },
+    queueDriverFactory: makeQueueDriverFactory(counters, options.cubeStoreDriverFactory),
+    cacheAndQueueDriver: options.cacheAndQueueDriver,
+    cubeStoreDriverFactory: options.cubeStoreDriverFactory,
+  });
 }

--- a/packages/cubejs-query-orchestrator/test/benchmarks/instrument.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/instrument.ts
@@ -1,0 +1,194 @@
+import { CubeStoreQueueDriver } from '@cubejs-backend/cubestore-driver';
+import { MethodName } from '@cubejs-backend/shared';
+import {
+  AddToQueueResponse,
+  QueueDriverConnectionInterface,
+  QueueDriverInterface,
+  QueuePriority,
+} from '@cubejs-backend/base-driver';
+import { LocalQueueDriver } from '../../src';
+
+export type MethodCounter = { started: number, finished: number };
+
+export type BenchCounters = {
+  connections: number,
+  methods: Record<string, MethodCounter>,
+  events: Record<string, number>,
+  handlersStarted: number,
+  handlersFinished: number,
+  fastTrack: { attempts: number, hits: number },
+};
+
+export function createCounters(): BenchCounters {
+  return {
+    connections: 0,
+    methods: {},
+    events: {},
+    handlersStarted: 0,
+    handlersFinished: 0,
+    fastTrack: { attempts: 0, hits: 0 },
+  };
+}
+
+export function driverCallsTotal(counters: Pick<BenchCounters, 'methods'>): number {
+  return Object.values(counters.methods).reduce((acc, m) => acc + m.started, 0);
+}
+
+export function mergeMethods(into: Record<string, MethodCounter>, from: Record<string, MethodCounter>) {
+  for (const [name, m] of Object.entries(from)) {
+    if (name in into) {
+      into[name].started += m.started;
+      into[name].finished += m.finished;
+    } else {
+      into[name] = { started: m.started, finished: m.finished };
+    }
+  }
+
+  return into;
+}
+
+export function mergeEvents(into: Record<string, number>, from: Record<string, number>) {
+  for (const [name, count] of Object.entries(from)) {
+    into[name] = (into[name] || 0) + count;
+  }
+
+  return into;
+}
+
+export type Percentiles = { count: number, mean: number, p50: number, p90: number, p95: number, p99: number, max: number };
+
+export function percentiles(samples: number[]): Percentiles {
+  if (samples.length === 0) {
+    return { count: 0, mean: 0, p50: 0, p90: 0, p95: 0, p99: 0, max: 0 };
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const at = (q: number) => Math.round(sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1))]);
+
+  return {
+    count: sorted.length,
+    mean: Math.round(sorted.reduce((a, b) => a + b, 0) / sorted.length),
+    p50: at(0.5),
+    p90: at(0.9),
+    p95: at(0.95),
+    p99: at(0.99),
+    max: Math.round(sorted[sorted.length - 1]),
+  };
+}
+
+/**
+ * Asking the connection itself, rather than reading the env, covers the version capability check
+ * and the priority floor too, so a driver that cannot fast track never registers an attempt and
+ * the miss rate stays a property of the queue rather than of the deployment.
+ */
+async function fastTrackEligible(connection: QueueDriverConnectionInterface, priority: QueuePriority): Promise<boolean> {
+  const { useFastTrack } = connection as any;
+
+  return typeof useFastTrack === 'function' ? useFastTrack.call(connection, priority) : false;
+}
+
+function patchQueueDriverConnectionForTrack(connection: QueueDriverConnectionInterface, counters: BenchCounters): QueueDriverConnectionInterface {
+  function wrapAsyncMethod<M extends MethodName<QueueDriverConnectionInterface>>(methodName: M): any {
+    return async (...args: Parameters<QueueDriverConnectionInterface[M]>) => {
+      if (!(methodName in counters.methods)) {
+        counters.methods[methodName] = {
+          started: 1,
+          finished: 0,
+        };
+      } else {
+        counters.methods[methodName].started++;
+      }
+
+      const result = await (connection[methodName] as any)(...args);
+      counters.methods[methodName].finished++;
+
+      return result;
+    };
+  }
+
+  const trackedAddToQueue = wrapAsyncMethod('addToQueue');
+
+  const tracked: Record<string, any> = {
+    addToQueue: async (...args: Parameters<QueueDriverConnectionInterface['addToQueue']>) => {
+      const eligible = await fastTrackEligible(connection, args[3]);
+      if (eligible) {
+        counters.fastTrack.attempts++;
+      }
+
+      const result: AddToQueueResponse = await trackedAddToQueue(...args);
+      if (eligible && result[4]) {
+        counters.fastTrack.hits++;
+      }
+
+      return result;
+    },
+    getResult: wrapAsyncMethod('getResult'),
+    getQueriesToCancel: wrapAsyncMethod('getQueriesToCancel'),
+    getActiveAndToProcess: wrapAsyncMethod('getActiveAndToProcess'),
+    retrieveForProcessing: wrapAsyncMethod('retrieveForProcessing'),
+    getQueryDef: wrapAsyncMethod('getQueryDef'),
+    setResultAndRemoveQuery: wrapAsyncMethod('setResultAndRemoveQuery'),
+    getQueryStageState: wrapAsyncMethod('getQueryStageState'),
+    getResultBlocking: wrapAsyncMethod('getResultBlocking'),
+    optimisticQueryUpdate: wrapAsyncMethod('optimisticQueryUpdate'),
+    getQueryAndRemove: wrapAsyncMethod('getQueryAndRemove'),
+  };
+
+  // Spreading the connection would copy own properties only and silently drop every method that
+  // lives on the prototype and is not re-listed above — `updateHeartBeat` among them, which
+  // QueryQueue calls on a timer during a long handler
+  return new Proxy(connection, {
+    get: (target, prop) => {
+      if (typeof prop === 'string' && prop in tracked) {
+        return tracked[prop];
+      }
+
+      const value = Reflect.get(target, prop, target);
+
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+export function patchQueueDriverForTrack(driver: QueueDriverInterface, counters: BenchCounters): QueueDriverInterface {
+  return {
+    ...driver,
+    createConnection: async () => {
+      counters.connections++;
+
+      return patchQueueDriverConnectionForTrack(await driver.createConnection(), counters);
+    },
+    redisHash: (...args) => driver.redisHash(...args),
+    release: async (...args) => {
+      counters.connections--;
+
+      return driver.release(...args);
+    },
+  };
+}
+
+/**
+ * Both the main process and the workers count through the same wrapper, otherwise every run with
+ * `workers > 0` reports the driver calls of the main process only
+ */
+export function makeQueueDriverFactory(counters: BenchCounters, cubeStoreDriverFactory?: () => Promise<any>) {
+  return (driverType: string, queueDriverOptions: any) => {
+    switch (driverType) {
+      case 'memory':
+        return patchQueueDriverForTrack(
+          new LocalQueueDriver(queueDriverOptions) as any,
+          counters
+        );
+      case 'cubestore':
+        return patchQueueDriverForTrack(
+          new CubeStoreQueueDriver(
+            async () => cubeStoreDriverFactory(),
+            queueDriverOptions
+          ),
+          counters
+        );
+      default:
+        throw new Error(`Unsupported driver: ${driverType}`);
+    }
+  };
+}

--- a/packages/cubejs-query-orchestrator/test/benchmarks/protocol.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/protocol.ts
@@ -1,0 +1,31 @@
+import { MethodCounter } from './instrument';
+
+export type WorkerBenchSettings = {
+  queueResponseSize: number,
+  concurrency: number,
+  handlerLatencyMs: number,
+};
+
+export type WorkerStartMessage = {
+  type: 'start',
+  tenantPrefix: string,
+  benchSettings: WorkerBenchSettings,
+  reconcileIntervalMs: number,
+};
+
+export type WorkerMessage =
+  | WorkerStartMessage
+  | { type: 'tickRequest', seq: number }
+  | { type: 'shutdown' };
+
+export type WorkerSnapshot = {
+  handlersStarted: number,
+  handlersFinished: number,
+  methods: Record<string, MethodCounter>,
+  events: Record<string, number>,
+  fastTrack: { attempts: number, hits: number },
+};
+
+export type ParentMessage =
+  | { type: 'counters', seq: number, data: WorkerSnapshot }
+  | { type: 'done' };

--- a/packages/cubejs-query-orchestrator/test/benchmarks/protocol.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/protocol.ts
@@ -1,15 +1,9 @@
-import { MethodCounter } from './instrument';
-
-export type WorkerBenchSettings = {
-  queueResponseSize: number,
-  concurrency: number,
-  handlerLatencyMs: number,
-};
+import { BenchCounters, BenchQueueSettings, cloneMethods, MethodCounter } from './instrument';
 
 export type WorkerStartMessage = {
   type: 'start',
   tenantPrefix: string,
-  benchSettings: WorkerBenchSettings,
+  benchSettings: BenchQueueSettings,
   reconcileIntervalMs: number,
 };
 
@@ -29,3 +23,14 @@ export type WorkerSnapshot = {
 export type ParentMessage =
   | { type: 'counters', seq: number, data: WorkerSnapshot }
   | { type: 'done' };
+
+/** Detached from the live counters, so a snapshot in flight over IPC cannot keep moving */
+export function counterSnapshot(counters: Omit<BenchCounters, 'connections'>): WorkerSnapshot {
+  return {
+    handlersStarted: counters.handlersStarted,
+    handlersFinished: counters.handlersFinished,
+    methods: cloneMethods(counters.methods),
+    events: { ...counters.events },
+    fastTrack: { ...counters.fastTrack },
+  };
+}

--- a/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
@@ -10,6 +10,7 @@ import yargs from 'yargs';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { hideBin } from 'yargs/helpers';
 import { pausePromise } from '@cubejs-backend/shared';
+import { driverCallsTotal } from './instrument';
 import { BenchRun, estimateRunMs, rhoOf, Suite, SUITES, suiteByName } from './suites';
 
 type Args = {
@@ -262,6 +263,14 @@ async function executeRun(suite: Suite, benchRun: BenchRun, fastTrack: boolean, 
 
 const fmt = (v: any, digits = 2) => (typeof v === 'number' ? Number(v.toFixed(digits)) : '—');
 
+function markdown(header: string[], rows: (string | number)[][]): string {
+  return [
+    `| ${header.join(' | ')} |`,
+    `|${header.map(() => '---').join('|')}|`,
+    ...rows.map((row) => `| ${row.join(' | ')} |`),
+  ].join('\n');
+}
+
 /**
  * The workers poll reconcile on a timer that production does not have, and at a low ρ that poll is
  * most of the traffic — it dilutes the headline badly. The submitting process is the honest view.
@@ -273,7 +282,7 @@ function mainCallsPerQuery(record: RunRecord): number | null {
     return null;
   }
 
-  return Object.values<any>(methods).reduce((acc, m) => acc + m.started, 0) / completed;
+  return driverCallsTotal({ methods }) / completed;
 }
 
 /**
@@ -311,7 +320,7 @@ function markdownTable(records: RunRecord[]): string {
   }
 
   const header = ['run', 'ρ', 'rate q/s', 'done off→on', 'fail off→on', 'calls/pushed off→on', 'main calls/q off→on', 'Δ main', 'peak calls/s off→on', 'p95 ms off→on', 'elapsed s off→on', 'FT hit%', 'lost'];
-  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
+  const rows: (string | number)[][] = [];
 
   for (const [key, { off, on }] of byLabel) {
     const sample = on || off;
@@ -322,9 +331,9 @@ function markdownTable(records: RunRecord[]): string {
     const degraded = (off?.outcome?.workersDiedEarly ?? 0) > 0 || (on?.outcome?.workersDiedEarly ?? 0) > 0;
 
     if (off?.error || on?.error) {
-      lines.push(`| ${key} | ${[`off: ${off?.error || 'ok'}`, `on: ${on?.error || 'ok'}`].join(', ')} ${header.slice(2).map(() => '| —').join(' ')} |`);
+      rows.push([key, `off: ${off?.error || 'ok'}, on: ${on?.error || 'ok'}`, ...header.slice(2).map(() => '—')]);
     } else if (sample) {
-      lines.push(`| ${[
+      rows.push([
         degraded ? `⚠ ${key}` : key,
         fmt(sample.derived?.actualRho),
         fmt(sample.derived?.actualRateQps),
@@ -338,11 +347,11 @@ function markdownTable(records: RunRecord[]): string {
         `${fmt((off?.timing?.elapsedMs ?? 0) / 1000, 1)}→${fmt((on?.timing?.elapsedMs ?? 0) / 1000, 1)}`,
         typeof missRate === 'number' ? `${((1 - missRate) * 100).toFixed(1)}%` : '—',
         `${off?.events?.merged?.['Orphaned execution result'] ?? 0}→${on?.events?.merged?.['Orphaned execution result'] ?? 0}`,
-      ].join(' | ')} |`);
+      ]);
     }
   }
 
-  return lines.join('\n');
+  return markdown(header, rows);
 }
 
 function idleTable(records: RunRecord[]): string | null {
@@ -351,21 +360,17 @@ function idleTable(records: RunRecord[]): string | null {
     return null;
   }
 
-  const header = ['run', 'fast track', 'workers', 'reconcile ms', 'idle calls', 'calls/s/process'];
-  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
-
-  for (const r of idle) {
-    lines.push(`| ${[
+  return markdown(
+    ['run', 'fast track', 'workers', 'reconcile ms', 'idle calls', 'calls/s/process'],
+    idle.map((r) => [
       `${r.suite}/${r.label}`,
       r.settings.fastTrack ? 'on' : 'off',
       r.settings.workers,
       r.settings.workerReconcileMs,
       r.idle.driverCalls,
       fmt(r.idle.callsPerSecPerProcess),
-    ].join(' | ')} |`);
-  }
-
-  return lines.join('\n');
+    ]),
+  );
 }
 
 function report(records: RunRecord[]) {
@@ -381,15 +386,14 @@ function report(records: RunRecord[]) {
 
 function dryRun(suites: Suite[], args: Args) {
   let totalMs = 0;
-  const header = ['suite', 'run', 'axis', 'ρ', 'queries', 'period s', 'est. s per pass'];
-  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
+  const rows: (string | number)[][] = [];
 
   for (const suite of suites) {
     for (const benchRun of selectRuns(suite, args)) {
       const est = estimateRunMs(benchRun.env);
       totalMs += (est + args.settleMs) * args.fastTrack.length * args.repeat;
 
-      lines.push(`| ${[
+      rows.push([
         suite.name,
         benchRun.label,
         JSON.stringify(benchRun.axis),
@@ -397,11 +401,11 @@ function dryRun(suites: Suite[], args: Args) {
         benchRun.env.BENCH_TOTAL_QUERIES,
         fmt(parseInt(benchRun.env.BENCH_PERIOD_MS || '0', 10) / 1000, 0),
         Math.round(est / 1000),
-      ].join(' | ')} |`);
+      ]);
     }
   }
 
-  console.log(lines.join('\n'));
+  console.log(markdown(['suite', 'run', 'axis', 'ρ', 'queries', 'period s', 'est. s per pass'], rows));
   console.log(`\n${args.fastTrack.length} pass(es) per run — estimated total ${(totalMs / 60000).toFixed(0)} min`);
 }
 

--- a/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
@@ -28,6 +28,30 @@ type Args = {
 
 const commaList = (v: unknown): string[] => String(v).split(',').map((s) => s.trim()).filter(Boolean);
 
+const FAST_TRACK_PASSES: Record<string, boolean> = { on: true, true: true, off: false, false: false };
+
+/**
+ * Every other option is validated by yargs — `choices`, `check`, `strict`. Mapping an
+ * unrecognised token to `off` would run a pass the caller did not ask for and label it as if
+ * they had.
+ */
+function parseFastTrackPasses(v: unknown): boolean[] {
+  const passes = commaList(v).map((token) => {
+    const pass = FAST_TRACK_PASSES[token.toLowerCase()];
+    if (pass === undefined) {
+      throw new Error(`--fast-track: expected on/off, got "${token}"`);
+    }
+
+    return pass;
+  });
+
+  if (passes.length === 0) {
+    throw new Error('--fast-track needs at least one pass, e.g. --fast-track=off,on');
+  }
+
+  return passes;
+}
+
 function parseArgs(argv: string[]): Args {
   const parsed = yargs(argv)
     .scriptName('bench:suite')
@@ -51,7 +75,7 @@ function parseArgs(argv: string[]): Args {
     .option('fast-track', {
       describe: 'Which passes to run for each configuration',
       default: 'off,on',
-      coerce: (v: unknown) => commaList(v).map((p) => p === 'on' || p === 'true'),
+      coerce: parseFastTrackPasses,
     })
     .option('settle', {
       describe: 'Pause between runs, ms — lets the previous run\'s connections go away',
@@ -130,11 +154,29 @@ function resultsDir(): string {
   return dir;
 }
 
+// Seconds included: the sink appends, so a minute-granularity name silently merges two sweeps
+// of the same suites into one file and the summary then keeps only the last pair per label
 function stamp(): string {
-  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 16);
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
 }
 
 type RunRecord = any;
+
+/**
+ * A throw inside the readline listener escapes the run loop entirely — no sink.end(), no
+ * summary, and every remaining point in the sweep skipped. A corrupt line is reachable: the
+ * bench child shares its stdout pipe with every worker it forks, and a pipe only guarantees
+ * atomic writes up to PIPE_BUF.
+ */
+function parseBenchLine(line: string, prefix: string, onError: (message: string) => void): any | null {
+  try {
+    return JSON.parse(line.slice(prefix.length));
+  } catch (e: any) {
+    onError(`unparseable ${prefix.trim()} line (${e.message}): ${line.slice(0, 200)}`);
+
+    return null;
+  }
+}
 
 function selectRuns(suite: Suite, args: Args): BenchRun[] {
   return args.only ? suite.runs.filter((r) => args.only!.some((o) => r.label.includes(o))) : suite.runs;
@@ -162,14 +204,25 @@ async function executeRun(suite: Suite, benchRun: BenchRun, fastTrack: boolean, 
   });
 
   let result: RunRecord = null;
+  let malformed = 0;
+  const onMalformed = (message: string) => {
+    malformed++;
+    console.error(`  !! ${runId}: ${message}`);
+  };
 
   const rl = readline.createInterface({ input: child.stdout! });
   rl.on('line', (line) => {
     if (line.startsWith('BENCH_RESULT ')) {
-      result = JSON.parse(line.slice('BENCH_RESULT '.length));
-      sink.write(`${JSON.stringify({ type: 'run', ...result })}\n`);
+      const parsed = parseBenchLine(line, 'BENCH_RESULT ', onMalformed);
+      if (parsed) {
+        result = parsed;
+        sink.write(`${JSON.stringify({ type: 'run', ...result })}\n`);
+      }
     } else if (line.startsWith('BENCH_TICK ')) {
-      sink.write(`${JSON.stringify({ type: 'tick', ...JSON.parse(line.slice('BENCH_TICK '.length)) })}\n`);
+      const parsed = parseBenchLine(line, 'BENCH_TICK ', onMalformed);
+      if (parsed) {
+        sink.write(`${JSON.stringify({ type: 'tick', ...parsed })}\n`);
+      }
     } else {
       console.log(`  | ${line}`);
     }
@@ -189,7 +242,14 @@ async function executeRun(suite: Suite, benchRun: BenchRun, fastTrack: boolean, 
   clearTimeout(timer);
 
   if (!result) {
-    const error = timedOut ? `timed out after ${timeoutMs}ms` : `exited with code ${code} without a BENCH_RESULT`;
+    let error: string;
+    if (timedOut) {
+      error = `timed out after ${timeoutMs}ms`;
+    } else if (malformed > 0) {
+      error = `exited with code ${code}, and ${malformed} line(s) were unparseable`;
+    } else {
+      error = `exited with code ${code} without a BENCH_RESULT`;
+    }
     console.error(`  !! ${runId}: ${error}`);
     const failure = { runId, suite: suite.name, label: benchRun.label, axis: benchRun.axis, settings: { fastTrack }, error };
     sink.write(`${JSON.stringify({ type: 'run', ...failure })}\n`);
@@ -258,12 +318,14 @@ function markdownTable(records: RunRecord[]): string {
     const missRate = on?.driverCalls?.fastTrack?.missRate;
     const mainOff = mainCallsPerQuery(off);
     const mainOn = mainCallsPerQuery(on);
+    // A run that lost a worker measured fewer processes than its axis claims
+    const degraded = (off?.outcome?.workersDiedEarly ?? 0) > 0 || (on?.outcome?.workersDiedEarly ?? 0) > 0;
 
     if (off?.error || on?.error) {
       lines.push(`| ${key} | ${[`off: ${off?.error || 'ok'}`, `on: ${on?.error || 'ok'}`].join(', ')} ${header.slice(2).map(() => '| —').join(' ')} |`);
     } else if (sample) {
       lines.push(`| ${[
-        key,
+        degraded ? `⚠ ${key}` : key,
         fmt(sample.derived?.actualRho),
         fmt(sample.derived?.actualRateQps),
         `${off?.outcome?.completed ?? '—'}→${on?.outcome?.completed ?? '—'}`,
@@ -355,19 +417,29 @@ function dryRun(suites: Suite[], args: Args) {
   }
 
   if (args.report) {
-    const records = fs.readFileSync(args.report, 'utf-8')
-      .split('\n')
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l))
-      .filter((r) => r.type === 'run');
+    const records: RunRecord[] = [];
+    let unreadable = 0;
+
+    // A sweep that was killed leaves a truncated last line, and one throw here used to lose
+    // the whole file rather than the one record
+    for (const line of fs.readFileSync(args.report, 'utf-8').split('\n').filter((l) => l.trim())) {
+      try {
+        const record = JSON.parse(line);
+        if (record.type === 'run') {
+          records.push(record);
+        }
+      } catch (e: any) {
+        unreadable++;
+      }
+    }
+
+    if (unreadable > 0) {
+      console.error(`!! skipped ${unreadable} unreadable line(s) in ${args.report}`);
+    }
 
     report(records);
 
     return;
-  }
-
-  if (args.suites.length === 0) {
-    throw new Error('Usage: run-suite.js <suite|all> [--driver=…] [--fast-track=off,on] [--only=…] [--dry-run] | --list | --report <file.jsonl>');
   }
 
   const suites = args.suites.includes('all')

--- a/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/run-suite.ts
@@ -1,0 +1,411 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'source-map-support/register';
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { fork } from 'child_process';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import yargs from 'yargs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { hideBin } from 'yargs/helpers';
+import { pausePromise } from '@cubejs-backend/shared';
+import { BenchRun, estimateRunMs, rhoOf, Suite, SUITES, suiteByName } from './suites';
+
+type Args = {
+  suites: string[],
+  driver?: 'cubestore' | 'memory',
+  fastTrack: boolean[],
+  settleMs: number,
+  runTimeoutMs: number,
+  only?: string[],
+  repeat: number,
+  out?: string,
+  dryRun: boolean,
+  report?: string,
+  list: boolean,
+};
+
+const commaList = (v: unknown): string[] => String(v).split(',').map((s) => s.trim()).filter(Boolean);
+
+function parseArgs(argv: string[]): Args {
+  const parsed = yargs(argv)
+    .scriptName('bench:suite')
+    // A variadic positional is only collected by a command builder, and angle brackets would make
+    // it required, which --list and --report do not satisfy
+    .command('$0 [suites..]', 'Run queue benchmark suites, off and on, into a .jsonl', (y) => y
+      .positional('suites', {
+        describe: 'Suite names, or "all" for every suite except the smoke one',
+        type: 'string',
+        array: true,
+        default: [] as string[],
+      }))
+    .example('$0 S1 --dry-run', 'price the sweep before starting it')
+    .example('$0 S1 S6 --settle=5000', 'run two suites back to back')
+    .example('$0 S1 --only=rho=2.5 --repeat=3', 'one point, three times')
+    .example('$0 --report results.jsonl', 'redraw the table from a finished run')
+    .option('driver', {
+      describe: 'Override the driver the suite declares',
+      choices: ['cubestore', 'memory'] as const,
+    })
+    .option('fast-track', {
+      describe: 'Which passes to run for each configuration',
+      default: 'off,on',
+      coerce: (v: unknown) => commaList(v).map((p) => p === 'on' || p === 'true'),
+    })
+    .option('settle', {
+      describe: 'Pause between runs, ms — lets the previous run\'s connections go away',
+      type: 'number',
+      default: 3000,
+    })
+    .option('run-timeout', {
+      describe: 'Kill a run after this long, ms',
+      type: 'number',
+      default: 30 * 60 * 1000,
+    })
+    .option('only', {
+      describe: 'Comma separated substrings; keeps just the matching runs',
+      coerce: commaList,
+    })
+    // Above capacity a single pair is not enough to conclude from — the same point, several times
+    .option('repeat', {
+      describe: 'Run each selected point this many times, labelled #1, #2, …',
+      type: 'number',
+      default: 1,
+    })
+    .option('out', {
+      describe: 'Write the .jsonl here instead of .context/bench-results',
+      type: 'string',
+    })
+    .option('dry-run', {
+      describe: 'Print the matrix with computed \u03c1 and estimated wall clock, run nothing',
+      type: 'boolean',
+      default: false,
+    })
+    .option('report', {
+      describe: 'Redraw the summary from an existing .jsonl and exit',
+      type: 'string',
+    })
+    .option('list', {
+      describe: 'List the suites and exit',
+      type: 'boolean',
+      default: false,
+    })
+    .check((a) => {
+      if (!a.list && !a.report && (a.suites as string[]).length === 0) {
+        throw new Error('Name at least one suite, or pass --list / --report');
+      }
+      if (a.repeat < 1) {
+        throw new Error('--repeat must be at least 1');
+      }
+
+      return true;
+    })
+    .strict()
+    .wrap(Math.min(120, process.stdout.columns || 120))
+    .parseSync();
+
+  return {
+    suites: parsed.suites as string[],
+    driver: parsed.driver,
+    fastTrack: parsed.fastTrack,
+    settleMs: parsed.settle,
+    runTimeoutMs: parsed.runTimeout,
+    only: parsed.only,
+    repeat: parsed.repeat,
+    out: parsed.out,
+    dryRun: parsed.dryRun,
+    report: parsed.report,
+    list: parsed.list,
+  };
+}
+
+// dist/test/benchmarks -> dist -> package -> packages -> repo root
+const repoRoot = path.resolve(__dirname, '../../../../..');
+
+function resultsDir(): string {
+  const dir = path.resolve(repoRoot, '.context/bench-results');
+  fs.mkdirSync(dir, { recursive: true });
+
+  return dir;
+}
+
+function stamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 16);
+}
+
+type RunRecord = any;
+
+function selectRuns(suite: Suite, args: Args): BenchRun[] {
+  return args.only ? suite.runs.filter((r) => args.only!.some((o) => r.label.includes(o))) : suite.runs;
+}
+
+async function executeRun(suite: Suite, benchRun: BenchRun, fastTrack: boolean, args: Args, sink: fs.WriteStream): Promise<RunRecord> {
+  const driver = args.driver || suite.driver;
+  const entry = path.resolve(__dirname, driver === 'memory' ? 'QueueMemory.bench.js' : 'QueueCubestore.bench.js');
+  const runId = `${suite.name}/${benchRun.label}/${fastTrack ? 'on' : 'off'}`;
+
+  console.log(`\n=== ${runId} — ${JSON.stringify(benchRun.axis)} — est. ${Math.round(estimateRunMs(benchRun.env) / 1000)}s ===`);
+
+  const child = fork(entry, [], {
+    execArgv: process.execArgv,
+    stdio: ['inherit', 'pipe', 'inherit', 'ipc'],
+    env: {
+      ...process.env,
+      ...benchRun.env,
+      CUBEJS_QUEUE_FAST_TRACK: `${fastTrack}`,
+      BENCH_RUN_ID: runId,
+      BENCH_SUITE: suite.name,
+      BENCH_LABEL: benchRun.label,
+      BENCH_AXIS: JSON.stringify(benchRun.axis),
+    },
+  });
+
+  let result: RunRecord = null;
+
+  const rl = readline.createInterface({ input: child.stdout! });
+  rl.on('line', (line) => {
+    if (line.startsWith('BENCH_RESULT ')) {
+      result = JSON.parse(line.slice('BENCH_RESULT '.length));
+      sink.write(`${JSON.stringify({ type: 'run', ...result })}\n`);
+    } else if (line.startsWith('BENCH_TICK ')) {
+      sink.write(`${JSON.stringify({ type: 'tick', ...JSON.parse(line.slice('BENCH_TICK '.length)) })}\n`);
+    } else {
+      console.log(`  | ${line}`);
+    }
+  });
+
+  const timeoutMs = Math.max(args.runTimeoutMs, estimateRunMs(benchRun.env) * 2 + 120000);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGKILL');
+  }, timeoutMs);
+
+  // The child exits right after printing, so its last lines can still be unread at that point
+  const drained = new Promise<void>((resolve) => rl.on('close', resolve));
+  const code = await new Promise<number | null>((resolve) => child.on('exit', resolve));
+  await drained;
+  clearTimeout(timer);
+
+  if (!result) {
+    const error = timedOut ? `timed out after ${timeoutMs}ms` : `exited with code ${code} without a BENCH_RESULT`;
+    console.error(`  !! ${runId}: ${error}`);
+    const failure = { runId, suite: suite.name, label: benchRun.label, axis: benchRun.axis, settings: { fastTrack }, error };
+    sink.write(`${JSON.stringify({ type: 'run', ...failure })}\n`);
+
+    return failure;
+  }
+
+  return result;
+}
+
+const fmt = (v: any, digits = 2) => (typeof v === 'number' ? Number(v.toFixed(digits)) : '—');
+
+/**
+ * The workers poll reconcile on a timer that production does not have, and at a low ρ that poll is
+ * most of the traffic — it dilutes the headline badly. The submitting process is the honest view.
+ */
+function mainCallsPerQuery(record: RunRecord): number | null {
+  const methods = record?.driverCalls?.main;
+  const completed = record?.outcome?.completed;
+  if (!methods || !completed) {
+    return null;
+  }
+
+  return Object.values<any>(methods).reduce((acc, m) => acc + m.started, 0) / completed;
+}
+
+/**
+ * Where queries drop, per-completed is an efficiency reading and per-pushed is the cost one — the
+ * two diverge sharply and quoting only the first turns a flat cost into an apparent saving
+ */
+function callsPerPushed(record: RunRecord): number | null {
+  const total = record?.driverCalls?.total;
+  const pushed = record?.outcome?.pushed;
+
+  return total && pushed ? total / pushed : null;
+}
+
+function pct(off: number | null | undefined, on: number | null | undefined): string {
+  if (!off || on === null || on === undefined) {
+    return '—';
+  }
+
+  const delta = ((on - off) / off) * 100;
+
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)}%`;
+}
+
+function markdownTable(records: RunRecord[]): string {
+  const byLabel = new Map<string, { off?: RunRecord, on?: RunRecord }>();
+  for (const r of records) {
+    const key = `${r.suite}/${r.label}`;
+    const pair = byLabel.get(key) || {};
+    if (r.settings?.fastTrack) {
+      pair.on = r;
+    } else {
+      pair.off = r;
+    }
+    byLabel.set(key, pair);
+  }
+
+  const header = ['run', 'ρ', 'rate q/s', 'done off→on', 'fail off→on', 'calls/pushed off→on', 'main calls/q off→on', 'Δ main', 'peak calls/s off→on', 'p95 ms off→on', 'elapsed s off→on', 'FT hit%', 'lost'];
+  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
+
+  for (const [key, { off, on }] of byLabel) {
+    const sample = on || off;
+    const missRate = on?.driverCalls?.fastTrack?.missRate;
+    const mainOff = mainCallsPerQuery(off);
+    const mainOn = mainCallsPerQuery(on);
+
+    if (off?.error || on?.error) {
+      lines.push(`| ${key} | ${[`off: ${off?.error || 'ok'}`, `on: ${on?.error || 'ok'}`].join(', ')} ${header.slice(2).map(() => '| —').join(' ')} |`);
+    } else if (sample) {
+      lines.push(`| ${[
+        key,
+        fmt(sample.derived?.actualRho),
+        fmt(sample.derived?.actualRateQps),
+        `${off?.outcome?.completed ?? '—'}→${on?.outcome?.completed ?? '—'}`,
+        `${off?.outcome?.failed?.total ?? '—'}→${on?.outcome?.failed?.total ?? '—'}`,
+        `${fmt(callsPerPushed(off))}→${fmt(callsPerPushed(on))}`,
+        `${fmt(mainOff)}→${fmt(mainOn)}`,
+        pct(mainOff, mainOn),
+        `${off?.driverCalls?.peakPerSec ?? '—'}→${on?.driverCalls?.peakPerSec ?? '—'}`,
+        `${fmt(off?.latencyMs?.p95, 0)}→${fmt(on?.latencyMs?.p95, 0)}`,
+        `${fmt((off?.timing?.elapsedMs ?? 0) / 1000, 1)}→${fmt((on?.timing?.elapsedMs ?? 0) / 1000, 1)}`,
+        typeof missRate === 'number' ? `${((1 - missRate) * 100).toFixed(1)}%` : '—',
+        `${off?.events?.merged?.['Orphaned execution result'] ?? 0}→${on?.events?.merged?.['Orphaned execution result'] ?? 0}`,
+      ].join(' | ')} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function idleTable(records: RunRecord[]): string | null {
+  const idle = records.filter((r) => r.idle?.callsPerSecPerProcess !== null && r.idle?.callsPerSecPerProcess !== undefined);
+  if (idle.length === 0) {
+    return null;
+  }
+
+  const header = ['run', 'fast track', 'workers', 'reconcile ms', 'idle calls', 'calls/s/process'];
+  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
+
+  for (const r of idle) {
+    lines.push(`| ${[
+      `${r.suite}/${r.label}`,
+      r.settings.fastTrack ? 'on' : 'off',
+      r.settings.workers,
+      r.settings.workerReconcileMs,
+      r.idle.driverCalls,
+      fmt(r.idle.callsPerSecPerProcess),
+    ].join(' | ')} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function report(records: RunRecord[]) {
+  console.log('\n');
+  console.log(markdownTable(records));
+
+  const idle = idleTable(records);
+  if (idle) {
+    console.log('\nIdle floor\n');
+    console.log(idle);
+  }
+}
+
+function dryRun(suites: Suite[], args: Args) {
+  let totalMs = 0;
+  const header = ['suite', 'run', 'axis', 'ρ', 'queries', 'period s', 'est. s per pass'];
+  const lines = [`| ${header.join(' | ')} |`, `|${header.map(() => '---').join('|')}|`];
+
+  for (const suite of suites) {
+    for (const benchRun of selectRuns(suite, args)) {
+      const est = estimateRunMs(benchRun.env);
+      totalMs += (est + args.settleMs) * args.fastTrack.length * args.repeat;
+
+      lines.push(`| ${[
+        suite.name,
+        benchRun.label,
+        JSON.stringify(benchRun.axis),
+        fmt(rhoOf(benchRun.env)),
+        benchRun.env.BENCH_TOTAL_QUERIES,
+        fmt(parseInt(benchRun.env.BENCH_PERIOD_MS || '0', 10) / 1000, 0),
+        Math.round(est / 1000),
+      ].join(' | ')} |`);
+    }
+  }
+
+  console.log(lines.join('\n'));
+  console.log(`\n${args.fastTrack.length} pass(es) per run — estimated total ${(totalMs / 60000).toFixed(0)} min`);
+}
+
+(async () => {
+  const args = parseArgs(hideBin(process.argv));
+
+  if (args.list) {
+    for (const suite of SUITES) {
+      console.log(`${suite.name.padEnd(6)} ${suite.runs.length} runs, ${suite.driver} — ${suite.description}`);
+    }
+
+    return;
+  }
+
+  if (args.report) {
+    const records = fs.readFileSync(args.report, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l))
+      .filter((r) => r.type === 'run');
+
+    report(records);
+
+    return;
+  }
+
+  if (args.suites.length === 0) {
+    throw new Error('Usage: run-suite.js <suite|all> [--driver=…] [--fast-track=off,on] [--only=…] [--dry-run] | --list | --report <file.jsonl>');
+  }
+
+  const suites = args.suites.includes('all')
+    ? SUITES.filter((s) => s.name !== 'smoke')
+    : args.suites.map(suiteByName);
+
+  if (args.dryRun) {
+    dryRun(suites, args);
+
+    return;
+  }
+
+  const outPath = args.out || path.resolve(resultsDir(), `${suites.map((s) => s.name).join('+')}-${stamp()}.jsonl`);
+  const sink = fs.createWriteStream(outPath, { flags: 'a' });
+  console.log(`Writing to ${outPath}`);
+
+  const records: RunRecord[] = [];
+
+  for (const suite of suites) {
+    for (const benchRun of selectRuns(suite, args)) {
+      for (let pass = 0; pass < args.repeat; pass++) {
+        for (const fastTrack of args.fastTrack) {
+          const labelled = args.repeat > 1
+            ? { ...benchRun, label: `${benchRun.label}#${pass + 1}` }
+            : benchRun;
+          records.push(await executeRun(suite, labelled, fastTrack, args, sink));
+          // Let the previous run's connections and Cube Store's own bookkeeping settle
+          await pausePromise(args.settleMs);
+        }
+      }
+    }
+  }
+
+  await new Promise<void>((resolve) => sink.end(resolve));
+
+  report(records);
+  console.log(`\nResults: ${outPath}`);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/cubejs-query-orchestrator/test/benchmarks/suites.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/suites.ts
@@ -1,0 +1,255 @@
+import { QueuePriority } from '@cubejs-backend/base-driver';
+
+export type BenchRun = {
+  label: string,
+  axis: Record<string, number | string>,
+  env: Record<string, string>,
+};
+
+export type Suite = {
+  name: string,
+  description: string,
+  driver: 'cubestore' | 'memory',
+  runs: BenchRun[],
+};
+
+/**
+ * The published fast track numbers were all taken at reduced payloads and that was never written
+ * down anywhere. These are the same reduced values, stated once; S7 owns the payload axis.
+ */
+const DEFAULTS: Record<string, string> = {
+  WORKERS: '2',
+  BENCH_CONCURRENCY: '10',
+  BENCH_HANDLER_LATENCY_MS: '1500',
+  BENCH_RESPONSE_SIZE: `${64 * 1024}`,
+  BENCH_PAYLOAD_SIZE: `${16 * 1024}`,
+  BENCH_PRIORITY: `${QueuePriority.Interactive}`,
+  BENCH_WORKER_RECONCILE_MS: '50',
+  BENCH_WARMUP_QUERIES: '20',
+  BENCH_IDLE_TAIL_MS: '0',
+  BENCH_TICK_MS: '1000',
+};
+
+const num = (env: Record<string, string>, key: string) => parseInt(env[key] ?? DEFAULTS[key], 10);
+
+function run(label: string, axis: Record<string, number | string>, env: Record<string, string>): BenchRun {
+  return { label, axis, env: { ...DEFAULTS, ...env } };
+}
+
+export function capacityQps(concurrency: number, handlerLatencyMs: number): number {
+  return (concurrency * 1000) / handlerLatencyMs;
+}
+
+function periodForRho(totalQueries: number, rho: number, concurrency: number, handlerLatencyMs: number): number {
+  return Math.round((totalQueries * 1000) / (rho * capacityQps(concurrency, handlerLatencyMs)));
+}
+
+export function rhoOf(env: Record<string, string>): number | null {
+  const periodMs = num(env, 'BENCH_PERIOD_MS');
+  const total = num(env, 'BENCH_TOTAL_QUERIES');
+  if (!periodMs || !total) {
+    return null;
+  }
+
+  const rate = (total * 1000) / periodMs;
+
+  return rate / capacityQps(num(env, 'BENCH_CONCURRENCY'), num(env, 'BENCH_HANDLER_LATENCY_MS'));
+}
+
+/** Wall clock a run cannot go below: the arrival window, or the time capacity needs to chew through it */
+export function estimateRunMs(env: Record<string, string>): number {
+  const total = num(env, 'BENCH_TOTAL_QUERIES');
+  const capacity = capacityQps(num(env, 'BENCH_CONCURRENCY'), num(env, 'BENCH_HANDLER_LATENCY_MS'));
+  const drainMs = total > 0 ? (total / capacity) * 1000 : 0;
+  const warmupMs = num(env, 'BENCH_WARMUP_QUERIES') > 0
+    ? (num(env, 'BENCH_WARMUP_QUERIES') / capacity) * 1000 + 2000
+    : 0;
+
+  return Math.round(Math.max(num(env, 'BENCH_PERIOD_MS') || 0, drainMs) + num(env, 'BENCH_IDLE_TAIL_MS') + warmupMs);
+}
+
+const S1: Suite = {
+  name: 'S1',
+  description: 'ρ-sweep — the main chart. Driver calls per completed query against the load factor, points clustered around ρ=1 where the knee is.',
+  driver: 'cubestore',
+  runs: [0.5, 0.75, 0.9, 1.0, 1.25, 1.75, 2.5].map((rho) => run(
+    `rho=${rho}`,
+    { rho },
+    {
+      BENCH_TOTAL_QUERIES: '1000',
+      BENCH_PERIOD_MS: `${periodForRho(1000, rho, 10, 1500)}`,
+    }
+  )),
+};
+
+const S2: Suite = {
+  name: 'S2',
+  description: 'Fan-out at underload. The old report called the effect flat across processes, but measured it at ρ≈15 where the fast track degenerates.',
+  driver: 'cubestore',
+  runs: [0, 1, 2, 3, 4, 5].map((workers) => run(
+    `workers=${workers}`,
+    { workers, rho: 0.8 },
+    {
+      WORKERS: `${workers}`,
+      BENCH_TOTAL_QUERIES: '500',
+      BENCH_PERIOD_MS: `${periodForRho(500, 0.8, 10, 1500)}`,
+    }
+  )),
+};
+
+const S3: Suite = {
+  name: 'S3',
+  description: 'Burst then silence. The one shape where the fast track can be a net loss: an ADD_AND_RETRIEVE that comes back empty is a round trip spent for nothing.',
+  driver: 'cubestore',
+  runs: [50, 200].map((concurrency) => run(
+    `burst-c${concurrency}`,
+    { concurrency },
+    {
+      BENCH_CONCURRENCY: `${concurrency}`,
+      BENCH_TOTAL_QUERIES: '1000',
+      BENCH_PERIOD_MS: '5000',
+      BENCH_IDLE_TAIL_MS: '60000',
+    }
+  )),
+};
+
+const S4: Suite = {
+  name: 'S4',
+  description: 'Priority mix, half Interactive half Background. Checks that background never fast-tracks and that it does not starve while interactive does.',
+  driver: 'cubestore',
+  runs: [0.8, 1.5].map((rho) => run(
+    `mix-rho=${rho}`,
+    { rho },
+    {
+      BENCH_PRIORITY_MIX: '10:50,0:50',
+      BENCH_TOTAL_QUERIES: '1000',
+      BENCH_PERIOD_MS: `${periodForRho(1000, rho, 10, 1500)}`,
+    }
+  )),
+};
+
+function idleRun(workers: number, reconcileMs: number): BenchRun {
+  return run(
+    `idle-w${workers}-r${reconcileMs}`,
+    { workers, reconcileMs },
+    {
+      WORKERS: `${workers}`,
+      BENCH_TOTAL_QUERIES: '0',
+      BENCH_PERIOD_MS: '0',
+      BENCH_WARMUP_QUERIES: '0',
+      BENCH_IDLE_TAIL_MS: '60000',
+      BENCH_WORKER_RECONCILE_MS: `${reconcileMs}`,
+    }
+  );
+}
+
+const S5: Suite = {
+  name: 'S5',
+  description: 'Idle floor — driver calls per second per process on an empty queue. On idle the worker reconcile poll is the entire traffic, so both a harness-fast and a realistic interval are measured.',
+  driver: 'cubestore',
+  runs: [
+    // Nothing polls here: the submitter has no timer of its own and there are no workers, so this
+    // run is zero by construction. It is the control that says the rest of the table is the poll
+    // and nothing else — and it carries no reconcile axis, because that setting only reaches workers
+    idleRun(0, 50),
+    ...[1, 2, 4].flatMap((workers) => [50, 1000].map((reconcileMs) => idleRun(workers, reconcileMs))),
+  ],
+};
+
+const S6: Suite = {
+  name: 'S6',
+  description: 'Handler latency sweep at ρ=0.8. The shorter the handler, the larger the overhead share — the saving as a fraction of wall clock should peak at 100ms.',
+  driver: 'cubestore',
+  runs: [
+    { latencyMs: 100, windowMs: 60000 },
+    { latencyMs: 500, windowMs: 60000 },
+    { latencyMs: 1500, windowMs: 60000 },
+    // 1.6 q/s over a minute is too few samples for a p99, so this point gets a longer window
+    { latencyMs: 5000, windowMs: 180000 },
+  ].map(({ latencyMs, windowMs }) => {
+    const total = Math.round(0.8 * capacityQps(10, latencyMs) * (windowMs / 1000));
+
+    return run(
+      `L=${latencyMs}ms`,
+      { latencyMs, rho: 0.8 },
+      {
+        BENCH_HANDLER_LATENCY_MS: `${latencyMs}`,
+        BENCH_TOTAL_QUERIES: `${total}`,
+        BENCH_PERIOD_MS: `${windowMs}`,
+      }
+    );
+  }),
+};
+
+const S7: Suite = {
+  name: 'S7',
+  description: 'Payload sweep. ADD_AND_RETRIEVE carries the query def inline, so on fat payloads the saved round trips can be eaten by the bytes.',
+  driver: 'cubestore',
+  runs: [
+    // eslint-disable-next-line no-bitwise
+    ...[0, 256 * 1024, 5 << 20, 20 << 20].map((responseSize) => run(
+      `response=${responseSize}`,
+      { responseSize, axis: 'response' },
+      {
+        BENCH_RESPONSE_SIZE: `${responseSize}`,
+        BENCH_PAYLOAD_SIZE: `${16 * 1024}`,
+        BENCH_TOTAL_QUERIES: '300',
+        BENCH_PERIOD_MS: `${periodForRho(300, 0.8, 10, 1500)}`,
+      }
+    )),
+    ...[0, 16 * 1024, 256 * 1024, 1024 * 1024].map((payloadSize) => run(
+      `payload=${payloadSize}`,
+      { payloadSize, axis: 'payload' },
+      {
+        BENCH_RESPONSE_SIZE: `${64 * 1024}`,
+        BENCH_PAYLOAD_SIZE: `${payloadSize}`,
+        BENCH_TOTAL_QUERIES: '300',
+        BENCH_PERIOD_MS: `${periodForRho(300, 0.8, 10, 1500)}`,
+      }
+    )),
+  ],
+};
+
+const S8: Suite = {
+  name: 'S8',
+  description: 'Crossing ρ=1 from the capacity side instead of the arrival side, at a fixed 8.33 q/s. Tests whether what decides is the budget or the ratio.',
+  driver: 'cubestore',
+  runs: [5, 10, 15, 20, 50].map((concurrency) => run(
+    `c=${concurrency}`,
+    { concurrency, rho: Number((8.3333 / capacityQps(concurrency, 1500)).toFixed(3)) },
+    {
+      BENCH_CONCURRENCY: `${concurrency}`,
+      BENCH_TOTAL_QUERIES: '1000',
+      BENCH_PERIOD_MS: '120000',
+    }
+  )),
+};
+
+const SMOKE: Suite = {
+  name: 'smoke',
+  description: 'Two-minute self-check on the memory driver — verifies ticks, percentiles and the result line without a Cube Store.',
+  driver: 'memory',
+  runs: [0.5, 1.5].map((rho) => run(
+    `smoke-rho=${rho}`,
+    { rho },
+    {
+      WORKERS: '0',
+      BENCH_CONCURRENCY: '5',
+      BENCH_HANDLER_LATENCY_MS: '100',
+      BENCH_TOTAL_QUERIES: '200',
+      BENCH_PERIOD_MS: `${periodForRho(200, rho, 5, 100)}`,
+      BENCH_WARMUP_QUERIES: '10',
+    }
+  )),
+};
+
+export const SUITES: Suite[] = [S1, S2, S3, S4, S5, S6, S7, S8, SMOKE];
+
+export function suiteByName(name: string): Suite {
+  const suite = SUITES.find((s) => s.name.toLowerCase() === name.toLowerCase());
+  if (!suite) {
+    throw new Error(`Unknown suite: ${name}. Known: ${SUITES.map((s) => s.name).join(', ')}`);
+  }
+
+  return suite;
+}

--- a/packages/cubejs-query-orchestrator/test/benchmarks/suites.ts
+++ b/packages/cubejs-query-orchestrator/test/benchmarks/suites.ts
@@ -129,9 +129,12 @@ const S4: Suite = {
 };
 
 function idleRun(workers: number, reconcileMs: number): BenchRun {
+  // Nothing polls without a worker, so the interval is not an axis of the control run
+  const polled = workers > 0;
+
   return run(
-    `idle-w${workers}-r${reconcileMs}`,
-    { workers, reconcileMs },
+    polled ? `idle-w${workers}-r${reconcileMs}` : `idle-w${workers}`,
+    polled ? { workers, reconcileMs } : { workers },
     {
       WORKERS: `${workers}`,
       BENCH_TOTAL_QUERIES: '0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8781,7 +8781,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
   integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
-"@types/yargs@^17.0.8":
+"@types/yargs@^17.0.31", "@types/yargs@^17.0.8":
   version "17.0.31"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.31.tgz#8fd0089803fd55d8a285895a18b88cb71a99683c"
   integrity sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**
-->

**Description of Changes Made**

The queue benchmark reported its counters through `console.dir` and nothing else, so every number published about the fast track so far was hand-copied, and latency, time series and worker driver calls were not measured at all — this makes it emit one `BENCH_RESULT {json}` per run plus a `BENCH_TICK {json}` per second, counts fast-track attempts against hits, records the arrival rate the pusher actually achieved, and builds the workers' driver through the same tracking factory so runs with `workers > 0` stop reporting only the main process. On top of that it adds eight named suites (`yarn bench:suite <name>`) sweeping the one axis that decides everything — ρ = arrival rate / capacity — plus a runner that streams results to `.context/bench-results/*.jsonl`, prices a sweep with `--dry-run`, and repeats noisy points with `--repeat`.

Nothing under `src/` changes; the diff is the harness, one `package.json` script and the DEVELOPMENT.md section describing how to run it.

102 runs against Cube Store 1.7.25 put numbers on the feature: below capacity the fast track removes a flat third of the round trips (10.8 → 7.00 calls per query, unchanged across handler latency, payload size and concurrency), the hit rate falls from 100% to 1% between ρ=0.99 and ρ=1.24, above capacity there is nothing measurable either way, and a burst fast-tracks exactly one concurrency budget's worth. Two things the sweep turned up want a reviewer's eye rather than a chart: with the fast track on the worker processes execute *nothing* at any worker count, because the retrieval claims the item inside the submitting process before anything else can see it; and results are occasionally computed and then discarded when the queue item disappears before the acknowledge — that one is **not** the fast track's, it reproduces with the feature off under deep backlog, and what removes the item is still unknown.