### PR TITLE
fix(tesseract): fold nested multi-fact join legs into one scan

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -325,7 +325,12 @@ impl MultiFactJoinGroups {
             .map(|key| grouped.remove(&key).unwrap())
             .collect::<Vec<_>>();
 
-        if merge_nested && !Self::any_cube_has_pre_aggregations(query_tools, &groups)? {
+        // Cheapest question first: without a nested pair there is nothing to
+        // merge, and the pre-aggregation scan crosses the bridge once per cube.
+        if merge_nested
+            && Self::has_nested_pair(&groups)
+            && !Self::any_cube_has_pre_aggregations(query_tools, &groups)?
+        {
             Self::merge_nested_groups(&mut groups, &resolve)?;
         }
 
@@ -333,6 +338,16 @@ impl MultiFactJoinGroups {
             .into_iter()
             .map(|group| (group.tree, group.measures))
             .collect())
+    }
+
+    /// Whether any group's join tree is contained in another's - the only
+    /// shape `merge_nested_groups` can do anything with.
+    fn has_nested_pair(groups: &[GroupBuild]) -> bool {
+        groups.iter().any(|group| {
+            groups
+                .iter()
+                .any(|other| group.key.is_nested_in(&other.key))
+        })
     }
 
     /// Whether any cube these groups read defines a pre-aggregation.
@@ -405,7 +420,12 @@ impl MultiFactJoinGroups {
                     }
                     let mut hints = other.hints.clone();
                     hints.extend(&group.hints);
-                    let (key, tree) = resolve(&hints)?;
+                    // Resolving is a probe: a hint set the join graph refuses
+                    // means there is no merge to make here, not that the query
+                    // the groups came from is unplannable.
+                    let Ok((key, tree)) = resolve(&hints) else {
+                        continue;
+                    };
                     if key != other.key {
                         continue;
                     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -325,7 +325,7 @@ impl MultiFactJoinGroups {
             .map(|key| grouped.remove(&key).unwrap())
             .collect::<Vec<_>>();
 
-        if merge_nested {
+        if merge_nested && !Self::any_cube_has_pre_aggregations(query_tools, &groups)? {
             Self::merge_nested_groups(&mut groups, &resolve)?;
         }
 
@@ -333,6 +333,42 @@ impl MultiFactJoinGroups {
             .into_iter()
             .map(|group| (group.tree, group.measures))
             .collect())
+    }
+
+    /// Whether any cube these groups read defines a pre-aggregation.
+    ///
+    /// A rollup is matched against one group at a time, so groups folded
+    /// together can only be served by a rollup spanning all of them, which
+    /// usually does not exist - the query would fall back to reading the raw
+    /// tables, costing it far more than the scan the merge saves. Deciding this
+    /// up front is coarse: it stands down whenever a rollup could exist, not
+    /// only when one would actually have matched.
+    fn any_cube_has_pre_aggregations(
+        query_tools: &Rc<State>,
+        groups: &[GroupBuild],
+    ) -> Result<bool, CubeError> {
+        let mut seen = HashSet::new();
+        for group in groups.iter() {
+            let cubes = std::iter::once(group.tree.root().name().clone()).chain(
+                group
+                    .tree
+                    .joins()
+                    .iter()
+                    .map(|item| item.cube().name().clone()),
+            );
+            for cube_name in cubes {
+                if !seen.insert(cube_name.clone()) {
+                    continue;
+                }
+                let pre_aggregations = query_tools
+                    .cube_evaluator()
+                    .pre_aggregations_for_cube_as_array(cube_name)?;
+                if !pre_aggregations.is_empty() {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     }
 
     /// Folds a group into another one that walks the same cube graph further,
@@ -403,7 +439,10 @@ impl MultiFactJoinGroups {
     /// classified into is decided from its own join tree elsewhere.
     ///
     /// Multi-stage measures are planned through their own CTE pipeline rather
-    /// than as a leaf of this join, so they are never moved.
+    /// than as a leaf of this join, so they are never moved. Neither is a
+    /// member expression: it names no member to anchor it to a cube, so what it
+    /// reads is whatever rows the join it lands on produces - `COUNT(*)` over a
+    /// wider tree counts the fanned-out rows and answers a different question.
     fn group_survives_join(
         measures: &[Rc<MemberSymbol>],
         join: &Rc<JoinTree>,
@@ -412,16 +451,17 @@ impl MultiFactJoinGroups {
             if has_multi_stage_members(measure, false)? {
                 return Ok(false);
             }
-            for item in collect_multiplied_measures(measure, join)? {
-                if !item.multiplied {
-                    continue;
-                }
-                let survives = item
-                    .measure
-                    .as_measure()
-                    .map(|m| m.kind().survives_row_multiplication())
-                    .unwrap_or(false);
-                if !survives {
+            // `join` is only a candidate here, not the tree the query will
+            // render, so a shape it rejects means this merge is off - not that
+            // the query is unplannable.
+            let Ok(items) = collect_multiplied_measures(measure, join) else {
+                return Ok(false);
+            };
+            for item in items {
+                let Ok(leaf) = item.measure.as_measure() else {
+                    return Ok(false);
+                };
+                if item.multiplied && !leaf.kind().survives_row_multiplication() {
                     return Ok(false);
                 }
             }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -175,6 +175,16 @@ impl MeasuresJoinHints {
     }
 }
 
+/// One group while it is still being assembled: the measures gathered so far
+/// plus what it takes to rebuild their join tree - the `JoinKey` to compare
+/// trees by and the hints to resolve a merged tree from.
+struct GroupBuild {
+    key: JoinKey,
+    tree: Rc<JoinTree>,
+    measures: Vec<Rc<MemberSymbol>>,
+    hints: JoinHints,
+}
+
 // --- MultiFactJoinGroups: builds actual join trees ---
 
 /// Resolves a query's `MeasuresJoinHints` into concrete join trees
@@ -203,7 +213,30 @@ impl MultiFactJoinGroups {
         query_tools: Rc<State>,
         measures_join_hints: MeasuresJoinHints,
     ) -> Result<Self, CubeError> {
-        let groups = Self::build_groups(&query_tools, &measures_join_hints)?;
+        Self::build(query_tools, measures_join_hints, false)
+    }
+
+    /// Like `try_new`, but additionally folds a group into another one whose
+    /// join tree contains its own - see `merge_nested_groups` for when that is
+    /// allowed. One group less is one scan of the shared join less.
+    ///
+    /// Only the query's own grouping is built this way. Regrouping a measure
+    /// subset through `for_measures` never merges: a pre-aggregation is matched
+    /// against one leg at a time, so collapsing the legs of an already planned
+    /// query would cost it rollups that are worth far more than the scan saved.
+    pub fn try_new_merging_nested(
+        query_tools: Rc<State>,
+        measures_join_hints: MeasuresJoinHints,
+    ) -> Result<Self, CubeError> {
+        Self::build(query_tools, measures_join_hints, true)
+    }
+
+    fn build(
+        query_tools: Rc<State>,
+        measures_join_hints: MeasuresJoinHints,
+        merge_nested: bool,
+    ) -> Result<Self, CubeError> {
+        let groups = Self::build_groups(&query_tools, &measures_join_hints, merge_nested)?;
         let (dimension_paths, measure_paths) = Self::precompute_paths(&groups);
         Ok(Self {
             query_tools,
@@ -218,12 +251,13 @@ impl MultiFactJoinGroups {
     /// the shared `base_hints`.
     pub fn for_measures(&self, measures: &[Rc<MemberSymbol>]) -> Result<Self, CubeError> {
         let new_hints = self.measures_join_hints.for_measures(measures)?;
-        Self::try_new(self.query_tools.clone(), new_hints)
+        Self::build(self.query_tools.clone(), new_hints, false)
     }
 
     fn build_groups(
         query_tools: &Rc<State>,
         hints: &MeasuresJoinHints,
+        merge_nested: bool,
     ) -> Result<Vec<(Rc<JoinTree>, Vec<Rc<MemberSymbol>>)>, CubeError> {
         let join_tree_builder = JoinTreeBuilder::new(query_tools.clone());
         let resolve = |join_hints: &JoinHints| -> Result<(JoinKey, Rc<JoinTree>), CubeError> {
@@ -238,7 +272,7 @@ impl MultiFactJoinGroups {
                 vec![]
             } else {
                 let (key, join_tree) = resolve(&hints.base_hints)?;
-                vec![(Vec::new(), key, join_tree)]
+                vec![(Vec::new(), key, join_tree, hints.base_hints.clone())]
             }
         } else {
             hints
@@ -261,26 +295,138 @@ impl MultiFactJoinGroups {
                         )));
                     }
                     let (key, join_tree) = resolve(&measure_hints)?;
-                    Ok((vec![mh.measure.clone()], key, join_tree))
+                    Ok((vec![mh.measure.clone()], key, join_tree, measure_hints))
                 })
                 .collect::<Result<Vec<_>, _>>()?
         };
 
         let mut key_order: Vec<JoinKey> = Vec::new();
-        let mut grouped: HashMap<JoinKey, (Rc<JoinTree>, Vec<Rc<MemberSymbol>>)> = HashMap::new();
-        for (measures, key, join_tree) in measures_to_join {
+        let mut grouped: HashMap<JoinKey, GroupBuild> = HashMap::new();
+        for (measures, key, join_tree, join_hints) in measures_to_join {
             if let Some(entry) = grouped.get_mut(&key) {
-                entry.1.extend(measures);
+                entry.measures.extend(measures);
+                entry.hints.extend(&join_hints);
             } else {
                 key_order.push(key.clone());
-                grouped.insert(key, (join_tree, measures));
+                grouped.insert(
+                    key.clone(),
+                    GroupBuild {
+                        key,
+                        tree: join_tree,
+                        measures,
+                        hints: join_hints,
+                    },
+                );
             }
         }
 
-        Ok(key_order
+        let mut groups = key_order
             .into_iter()
             .map(|key| grouped.remove(&key).unwrap())
+            .collect::<Vec<_>>();
+
+        if merge_nested {
+            Self::merge_nested_groups(&mut groups, &resolve)?;
+        }
+
+        Ok(groups
+            .into_iter()
+            .map(|group| (group.tree, group.measures))
             .collect())
+    }
+
+    /// Folds a group into another one that walks the same cube graph further,
+    /// so both are answered by one scan of the shared part instead of two.
+    ///
+    /// The extra joins of the wider tree are `LEFT`, so every row of the
+    /// narrower one survives in it, each replicated one or more times. A
+    /// measure therefore reads the same rows and answers the same value in
+    /// both, provided that replication either does not reach it or does not
+    /// change what it computes - which is what `group_survives_join` decides.
+    ///
+    /// The wider tree is rebuilt from both groups' join hints before that
+    /// question is asked. A tree only knows whether it multiplies the cubes its
+    /// own hints named, and the cube a moving measure sits on may be in the
+    /// wider tree only as a stop on the way to something else, which would
+    /// otherwise answer "not multiplied" for a cube the tree does in fact
+    /// multiply. Rebuilding fills that in; a rebuild that comes back with a
+    /// different key built different joins than the group already has, and is
+    /// skipped rather than merged.
+    ///
+    /// Merging is re-checked against the accumulated measures on every pass, so
+    /// a chain of nested trees only collapses as far as every measure carried
+    /// along stays safe.
+    fn merge_nested_groups(
+        groups: &mut Vec<GroupBuild>,
+        resolve: &impl Fn(&JoinHints) -> Result<(JoinKey, Rc<JoinTree>), CubeError>,
+    ) -> Result<(), CubeError> {
+        loop {
+            let mut merged = None;
+            'outer: for (i, group) in groups.iter().enumerate() {
+                for (j, other) in groups.iter().enumerate() {
+                    if i == j || !group.key.is_nested_in(&other.key) {
+                        continue;
+                    }
+                    let mut hints = other.hints.clone();
+                    hints.extend(&group.hints);
+                    let (key, tree) = resolve(&hints)?;
+                    if key != other.key {
+                        continue;
+                    }
+                    if Self::group_survives_join(&group.measures, &tree)? {
+                        merged = Some((i, j, tree));
+                        break 'outer;
+                    }
+                }
+            }
+            let Some((from, into, tree)) = merged else {
+                return Ok(());
+            };
+            let group = groups.remove(from);
+            // Removing the earlier index shifts everything after it.
+            let into = if into > from { into - 1 } else { into };
+            let target = &mut groups[into];
+            target.measures.extend(group.measures);
+            target.hints.extend(&group.hints);
+            target.tree = tree;
+        }
+    }
+
+    /// Whether every measure of a group computes the same value, by the same
+    /// SQL, when evaluated over `join` instead of its own tree.
+    ///
+    /// A measure whose cube `join` does not multiply reads exactly its own
+    /// rows, so nothing changes. A multiplied one only qualifies if its value
+    /// is immune to replication; a key-based count is deliberately not
+    /// accepted, because staying correct would mean switching it to the
+    /// distinct `MultipliedCount` form, and the render form a measure is
+    /// classified into is decided from its own join tree elsewhere.
+    ///
+    /// Multi-stage measures are planned through their own CTE pipeline rather
+    /// than as a leaf of this join, so they are never moved.
+    fn group_survives_join(
+        measures: &[Rc<MemberSymbol>],
+        join: &Rc<JoinTree>,
+    ) -> Result<bool, CubeError> {
+        for measure in measures.iter() {
+            if has_multi_stage_members(measure, false)? {
+                return Ok(false);
+            }
+            for item in collect_multiplied_measures(measure, join)? {
+                if !item.multiplied {
+                    continue;
+                }
+                let survives = item
+                    .measure
+                    .as_measure()
+                    .map(|m| m.kind().survives_row_multiplication())
+                    .unwrap_or(false);
+                if !survives {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
     }
 
     /// Hints to use for a measure whose own hint set resolved to empty.
@@ -816,5 +962,103 @@ mod tests {
         // Unknown measure
         let unknown = ctx.create_symbol("customers.count").unwrap();
         assert!(groups.resolve_join_path_for_measure(&unknown).is_none());
+    }
+
+    fn nested_trees_groups(
+        measure_paths: &[&str],
+        merge_nested: bool,
+    ) -> (usize, Vec<Vec<String>>) {
+        let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees.yaml");
+        let ctx = TestContext::new(schema).unwrap();
+
+        let country = ctx.create_symbol("sites.country").unwrap();
+        let measures = measure_paths
+            .iter()
+            .map(|path| ctx.create_symbol(path).unwrap())
+            .collect_vec();
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[country])
+            .build(&measures)
+            .unwrap();
+
+        let groups = if merge_nested {
+            MultiFactJoinGroups::try_new_merging_nested(ctx.query_tools().clone(), hints).unwrap()
+        } else {
+            MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints).unwrap()
+        };
+
+        let grouped_measures = groups
+            .groups()
+            .iter()
+            .map(|(_, measures)| measures.iter().map(|m| m.full_name()).collect_vec())
+            .collect_vec();
+        (groups.num_groups(), grouped_measures)
+    }
+
+    #[test]
+    fn test_nested_trees_distinct_measures_merge() {
+        // `checkouts` is reached through `carts`, so the tree of a `carts`
+        // measure is contained in the tree of a `checkouts` one. Both measures
+        // are distinct counts, which the fan-out of the wider tree cannot
+        // change, so one group answers both.
+        let (num_groups, measures) =
+            nested_trees_groups(&["carts.unique_msid", "checkouts.unique_msid"], true);
+
+        assert_eq!(num_groups, 1);
+        assert_eq!(
+            measures,
+            vec![vec![
+                "checkouts.unique_msid".to_string(),
+                "carts.unique_msid".to_string()
+            ]]
+        );
+    }
+
+    #[test]
+    fn test_nested_trees_are_kept_apart_without_merging() {
+        let (num_groups, _) =
+            nested_trees_groups(&["carts.unique_msid", "checkouts.unique_msid"], false);
+
+        assert_eq!(num_groups, 2);
+    }
+
+    #[test]
+    fn test_nested_trees_plain_count_does_not_merge() {
+        // The wider tree splits every `carts` row into one row per checkout, so
+        // a plain count over it would answer the number of checkouts.
+        let (num_groups, _) = nested_trees_groups(&["carts.count", "checkouts.unique_msid"], true);
+
+        assert_eq!(num_groups, 2);
+    }
+
+    #[test]
+    fn test_nested_trees_sum_does_not_merge() {
+        let (num_groups, _) =
+            nested_trees_groups(&["carts.total_value", "checkouts.total_amount"], true);
+
+        assert_eq!(num_groups, 2);
+    }
+
+    #[test]
+    fn test_sibling_trees_do_not_merge() {
+        // `orders` and `returns` hang off `customers` side by side, so neither
+        // tree contains the other and there is no shared scan to fold into.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema).unwrap();
+
+        let orders_count = ctx.create_symbol("orders.count").unwrap();
+        let returns_count = ctx.create_symbol("returns.count").unwrap();
+        let customers_name = ctx.create_symbol("customers.name").unwrap();
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[customers_name])
+            .build(&[orders_count, returns_count])
+            .unwrap();
+
+        let groups =
+            MultiFactJoinGroups::try_new_merging_nested(ctx.query_tools().clone(), hints).unwrap();
+
+        assert_eq!(groups.num_groups(), 2);
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -322,7 +322,19 @@ impl QueryProperties {
             .add_filters(&self.dimensions_filters)
             .add_filters(&self.segments)
             .build(&self.all_used_measures()?)?;
-        MultiFactJoinGroups::try_new(self.query_tools.clone(), measures_join_hints)
+        // An ungrouped query returns raw rows rather than aggregates, so the
+        // replication the wider join tree introduces would reach the result
+        // directly. A pre-aggregation query describes the rollup to build, and
+        // matching compares its groups against the query's, so both sides have
+        // to be grouped the same way.
+        if self.ungrouped || self.pre_aggregation_query {
+            MultiFactJoinGroups::try_new(self.query_tools.clone(), measures_join_hints)
+        } else {
+            MultiFactJoinGroups::try_new_merging_nested(
+                self.query_tools.clone(),
+                measures_join_hints,
+            )
+        }
     }
 
     fn multi_fact_join_groups(&self) -> Result<&MultiFactJoinGroups, CubeError> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
@@ -23,14 +23,6 @@ pub struct JoinKey {
 }
 
 impl JoinKey {
-    pub fn root(&self) -> &String {
-        &self.root
-    }
-
-    pub fn joins(&self) -> &Vec<JoinItemStatic> {
-        &self.joins
-    }
-
     /// Whether this key's joins are all present in `other`, which holds
     /// strictly more of them - i.e. `other` walks the same cube graph from
     /// the same root and keeps walking.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
@@ -23,9 +23,12 @@ pub struct JoinKey {
 }
 
 impl JoinKey {
-    /// Whether this key's joins are all present in `other`, which holds
-    /// strictly more of them - i.e. `other` walks the same cube graph from
-    /// the same root and keeps walking.
+    /// Whether all of this key's joins appear in `other`, which walks from the
+    /// same root and holds strictly more of them.
+    ///
+    /// Containment of the edge set, not of a path: `other` may extend this key
+    /// along a sibling branch rather than along the same walk. That is still a
+    /// tree this key's rows survive in, which is all the caller needs.
     pub fn is_nested_in(&self, other: &JoinKey) -> bool {
         self.root == other.root
             && self.joins.len() < other.joins.len()

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
@@ -22,6 +22,25 @@ pub struct JoinKey {
     joins: Vec<JoinItemStatic>,
 }
 
+impl JoinKey {
+    pub fn root(&self) -> &String {
+        &self.root
+    }
+
+    pub fn joins(&self) -> &Vec<JoinItemStatic> {
+        &self.joins
+    }
+
+    /// Whether this key's joins are all present in `other`, which holds
+    /// strictly more of them - i.e. `other` walks the same cube graph from
+    /// the same root and keeps walking.
+    pub fn is_nested_in(&self, other: &JoinKey) -> bool {
+        self.root == other.root
+            && self.joins.len() < other.joins.len()
+            && self.joins.iter().all(|item| other.joins.contains(item))
+    }
+}
+
 pub struct QueryTools {
     cube_evaluator: Rc<dyn CubeEvaluator>,
     base_tools: Rc<dyn BaseTools>,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/aggregation_type.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/aggregation_type.rs
@@ -41,6 +41,23 @@ impl AggregationType {
         matches!(self, Self::CountDistinct | Self::CountDistinctApprox)
     }
 
+    /// Whether feeding a row more than once leaves the result unchanged.
+    ///
+    /// A distinct count collapses repeats by definition, and a minimum or a
+    /// maximum does not move when a value it has already seen arrives again.
+    /// `sum`, `avg`, `count` and `numberAgg` all count every row they are
+    /// given, so a repeated row shows up in the answer.
+    ///
+    /// Not the same question as `is_additive`, which asks whether partial
+    /// results can be rolled up further: `sum` is additive but sensitive to
+    /// repeats, `countDistinct` is insensitive to them but not additive.
+    pub fn is_duplicate_insensitive(&self) -> bool {
+        matches!(
+            self,
+            Self::Min | Self::Max | Self::CountDistinct | Self::CountDistinctApprox
+        )
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Sum => "sum",
@@ -123,6 +140,17 @@ mod tests {
         assert!(!AggregationType::CountDistinct.is_additive());
         assert!(AggregationType::CountDistinctApprox.is_additive());
         assert!(!AggregationType::NumberAgg.is_additive());
+    }
+
+    #[test]
+    fn test_is_duplicate_insensitive() {
+        assert!(AggregationType::Min.is_duplicate_insensitive());
+        assert!(AggregationType::Max.is_duplicate_insensitive());
+        assert!(AggregationType::CountDistinct.is_duplicate_insensitive());
+        assert!(AggregationType::CountDistinctApprox.is_duplicate_insensitive());
+        assert!(!AggregationType::Sum.is_duplicate_insensitive());
+        assert!(!AggregationType::Avg.is_duplicate_insensitive());
+        assert!(!AggregationType::NumberAgg.is_duplicate_insensitive());
     }
 
     #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -312,6 +312,20 @@ impl MeasureKind {
             | Self::Rank => None,
         }
     }
+
+    /// Whether the value this kind computes is unchanged when the rows it
+    /// reads are each replicated some number of times — and computed by the
+    /// same SQL either way.
+    ///
+    /// Strictly narrower than `regular_in_multiplied`: a key-based count is
+    /// also safe under multiplication, but only after switching to the
+    /// distinct `MultipliedCount` form, so it does not qualify here.
+    pub fn survives_row_multiplication(&self) -> bool {
+        match self {
+            Self::Aggregated(a) | Self::AggregatedState(a) => a.agg_type().is_distinct(),
+            Self::Count(_) | Self::MultipliedCount(_) | Self::Calculated(_) | Self::Rank => false,
+        }
+    }
 }
 
 impl SymbolDeps for MeasureKind {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -317,12 +317,16 @@ impl MeasureKind {
     /// reads are each replicated some number of times — and computed by the
     /// same SQL either way.
     ///
-    /// Strictly narrower than `regular_in_multiplied`: a key-based count is
-    /// also safe under multiplication, but only after switching to the
-    /// distinct `MultipliedCount` form, so it does not qualify here.
+    /// Neither narrower nor wider than `regular_in_multiplied`, which answers a
+    /// different question: a key-based count is safe under multiplication too,
+    /// but only once switched to the distinct `MultipliedCount` form, so it
+    /// does not qualify here; a minimum or a maximum needs no such switch and
+    /// qualifies, though that predicate turns it down.
     pub fn survives_row_multiplication(&self) -> bool {
         match self {
-            Self::Aggregated(a) | Self::AggregatedState(a) => a.agg_type().is_distinct(),
+            Self::Aggregated(a) | Self::AggregatedState(a) => {
+                a.agg_type().is_duplicate_insensitive()
+            }
             Self::Count(_) | Self::MultipliedCount(_) | Self::Calculated(_) | Self::Rank => false,
         }
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
@@ -1,0 +1,66 @@
+cubes:
+  - name: sites
+    sql: "SELECT * FROM sites"
+    joins:
+      - name: carts
+        relationship: one_to_many
+        sql: "{sites}.id = {carts.site_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: country
+        type: string
+        sql: country
+    measures:
+      - name: count
+        type: count
+
+  - name: carts
+    sql: "SELECT * FROM carts"
+    joins:
+      - name: checkouts
+        relationship: one_to_many
+        sql: "{carts}.id = {checkouts.cart_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: site_id
+        type: number
+        sql: site_id
+      - name: msid
+        type: string
+        sql: msid
+    measures:
+      - name: unique_msid
+        type: count_distinct
+        sql: msid
+      - name: count
+        type: count
+      - name: total_value
+        type: sum
+        sql: value
+
+  - name: checkouts
+    sql: "SELECT * FROM checkouts"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: cart_id
+        type: number
+        sql: cart_id
+      - name: msid
+        type: string
+        sql: msid
+    measures:
+      - name: unique_msid
+        type: count_distinct
+        sql: msid
+      - name: total_amount
+        type: sum
+        sql: amount

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
@@ -43,6 +43,15 @@ cubes:
       - name: total_value
         type: sum
         sql: value
+      - name: max_value
+        type: max
+        sql: value
+      - name: min_value
+        type: min
+        sql: value
+      - name: avg_value
+        type: avg
+        sql: value
 
   - name: checkouts
     sql: "SELECT * FROM checkouts"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees_pre_aggs.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees_pre_aggs.yaml
@@ -50,6 +50,15 @@ cubes:
       - name: total_value
         type: sum
         sql: value
+      - name: max_value
+        type: max
+        sql: value
+      - name: min_value
+        type: min
+        sql: value
+      - name: avg_value
+        type: avg
+        sql: value
 
   - name: checkouts
     sql: "SELECT * FROM checkouts"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees_pre_aggs.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees_pre_aggs.yaml
@@ -1,0 +1,80 @@
+cubes:
+  - name: sites
+    sql: "SELECT * FROM sites"
+    joins:
+      - name: carts
+        relationship: one_to_many
+        sql: "{sites}.id = {carts.site_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: country
+        type: string
+        sql: country
+    measures:
+      - name: count
+        type: count
+
+  - name: carts
+    sql: "SELECT * FROM carts"
+    pre_aggregations:
+      - name: carts_by_country
+        type: rollup
+        measures:
+          - unique_msid
+        dimensions:
+          - sites.country
+    joins:
+      - name: checkouts
+        relationship: one_to_many
+        sql: "{carts}.id = {checkouts.cart_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: site_id
+        type: number
+        sql: site_id
+      - name: msid
+        type: string
+        sql: msid
+    measures:
+      - name: unique_msid
+        type: count_distinct
+        sql: msid
+      - name: count
+        type: count
+      - name: total_value
+        type: sum
+        sql: value
+
+  - name: checkouts
+    sql: "SELECT * FROM checkouts"
+    pre_aggregations:
+      - name: checkouts_by_country
+        type: rollup
+        measures:
+          - unique_msid
+        dimensions:
+          - sites.country
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: cart_id
+        type: number
+        sql: cart_id
+      - name: msid
+        type: string
+        sql: msid
+    measures:
+      - name: unique_msid
+        type: count_distinct
+        sql: msid
+      - name: total_amount
+        type: sum
+        sql: amount

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/integration_nested_join_trees_tables.sql
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/seeds/integration_nested_join_trees_tables.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS checkouts CASCADE;
+DROP TABLE IF EXISTS carts CASCADE;
+DROP TABLE IF EXISTS sites CASCADE;
+
+CREATE TABLE sites (
+    id INTEGER PRIMARY KEY,
+    country TEXT NOT NULL
+);
+
+CREATE TABLE carts (
+    id INTEGER PRIMARY KEY,
+    site_id INTEGER NOT NULL REFERENCES sites(id),
+    msid TEXT NOT NULL,
+    value NUMERIC(10, 2) NOT NULL
+);
+
+CREATE TABLE checkouts (
+    id INTEGER PRIMARY KEY,
+    cart_id INTEGER NOT NULL REFERENCES carts(id),
+    msid TEXT NOT NULL,
+    amount NUMERIC(10, 2) NOT NULL
+);
+
+INSERT INTO sites (id, country) VALUES
+    (1, 'US'),
+    (2, 'US'),
+    (3, 'DE');
+
+-- Two carts of site 1 share a msid, so a distinct count over them differs
+-- from a plain count.
+INSERT INTO carts (id, site_id, msid, value) VALUES
+    (1, 1, 'm1', 10),
+    (2, 1, 'm1', 20),
+    (3, 2, 'm2', 30),
+    (4, 3, 'm3', 40);
+
+-- Cart 1 has two checkouts, so joining checkouts in splits its row. Carts 2
+-- and 4 have none, so they only survive the join as NULL-extended rows.
+INSERT INTO checkouts (id, cart_id, msid, amount) VALUES
+    (1, 1, 'x1', 100),
+    (2, 1, 'x2', 200),
+    (3, 3, 'x1', 300);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/mod.rs
@@ -15,6 +15,7 @@ mod member_expressions;
 mod modifiers;
 mod multi_fact;
 mod multi_stage;
+mod nested_join_trees;
 mod null_filters;
 mod pre_aggregations;
 mod propagate_subquery;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -9,9 +9,16 @@
 //! so they only ever replicate a row, and a distinct aggregation is immune to
 //! that. A plain count or a sum is not, and keeps its own group.
 
-use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::cube_bridge::member_expression::MemberExpressionExpressionDef;
+use crate::cube_bridge::member_sql::MemberSql;
+use crate::cube_bridge::options_member::OptionsMember;
+use crate::test_fixtures::cube_bridge::{
+    members_from_strings, MockBaseQueryOptions, MockMemberExpressionDefinition, MockMemberSql,
+    MockSchema,
+};
 use crate::test_fixtures::test_utils::TestContext;
 use indoc::indoc;
+use std::rc::Rc;
 
 fn create_context() -> TestContext {
     let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees.yaml");
@@ -136,4 +143,69 @@ async fn test_nested_trees_ungrouped_keeps_separate_scans() {
 
     let sql = ctx.build_sql(query).unwrap();
     assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+}
+
+fn make_measure_expression(name: &str, cube: &str, sql: &str) -> OptionsMember {
+    let member_sql: Rc<dyn MemberSql> = Rc::new(MockMemberSql::new(sql).unwrap());
+    let expr = MockMemberExpressionDefinition::builder()
+        .expression_name(Some(name.to_string()))
+        .name(Some(name.to_string()))
+        .cube_name(Some(cube.to_string()))
+        .expression(MemberExpressionExpressionDef::Sql(member_sql))
+        .build();
+    OptionsMember::MemberExpression(Rc::new(expr))
+}
+
+/// A `COUNT(*)` member expression references no member of any cube, so what it
+/// counts is decided entirely by the join tree it lands on. Moving it into a
+/// wider tree would silently turn it into a count of the fanned-out rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_count_star_expression_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let total_count = make_measure_expression("total_count", "sites", "COUNT(*)");
+    let mut measures = vec![total_count];
+    measures.extend(members_from_strings(vec!["checkouts.unique_msid"]));
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(measures))
+            .dimensions(Some(members_from_strings(vec!["sites.country"])))
+            .build(),
+    );
+
+    let sql = ctx.build_sql_from_options(options.clone()).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg_from_options(options, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// Each cube has its own rollup keyed by the shared dimension. Folding the
+/// groups leaves one query that no single rollup covers, so the merge has to
+/// stand down where per-leg rollups are available.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_separate_pre_aggs_still_match() {
+    let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees_pre_aggs.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query).unwrap();
+    let names: Vec<&str> = pre_aggrs.iter().map(|u| u.name().as_str()).collect();
+
+    assert_eq!(pre_aggrs.len(), 2, "got {names:?}");
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -1,0 +1,139 @@
+//! Measures whose join trees are nested one in the other: `carts` is reached
+//! from `sites`, `checkouts` from `carts`, so a measure on `checkouts` needs
+//! every join a measure on `carts` needs and one more.
+//!
+//! Grouping measures by the exact join tree puts such measures in separate
+//! groups, and each group re-scans the shared part of the join from scratch.
+//! They are folded into one group - one scan - whenever moving a measure into
+//! the wider tree cannot change what it computes: the extra joins are `LEFT`,
+//! so they only ever replicate a row, and a distinct aggregation is immune to
+//! that. A plain count or a sum is not, and keeps its own group.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+const SEED: &str = "integration_nested_join_trees_tables.sql";
+
+/// How many times the query reads the cube at the root of the join. One read
+/// per group is exactly the duplication that folding nested groups removes.
+fn base_scan_count(sql: &str) -> usize {
+    sql.matches(r#"AS "sites""#).count()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_distinct_measures_share_one_base_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// The same measure on its own, as the value the merged query must reproduce.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_distinct_measure_alone() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// A plain count would read one row per checkout instead of one per cart, so
+/// its group stays on its own tree.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_count_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.count
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// Same for a sum, which the replicated rows would inflate.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_sum_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.total_value
+          - checkouts.total_amount
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// An ungrouped query returns the joined rows themselves, so the replication
+/// the wider tree introduces would show up in the result.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_ungrouped_keeps_separate_scans() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+        ungrouped: true
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -209,3 +209,81 @@ async fn test_nested_trees_separate_pre_aggs_still_match() {
 
     assert_eq!(pre_aggrs.len(), 2, "got {names:?}");
 }
+
+/// A filter on the shallower cube leaves the trees nested, so the merge still
+/// happens and has to keep answering what the unmerged legs would.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_merge_with_filter_on_shallower_cube() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        filters:
+          - member: carts.msid
+            operator: equals
+            values:
+              - m1
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// A filter on the deeper cube pulls it into the base hints, so both measures
+/// resolve to the same tree and there is nothing left to merge.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_filter_on_deeper_cube_leaves_one_tree() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        filters:
+          - member: checkouts.msid
+            operator: equals
+            values:
+              - x1
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// Building a rollup describes the rows to store, and matching later compares
+/// the query's groups against the pre-aggregation's, so the build must be
+/// grouped the way an unmerged query is.
+#[test]
+fn test_nested_trees_pre_aggregation_query_keeps_separate_scans() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.unique_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        pre_aggregation_query: true
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -287,3 +287,75 @@ fn test_nested_trees_pre_aggregation_query_keeps_separate_scans() {
     let sql = ctx.build_sql(query).unwrap();
     assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
 }
+
+/// A minimum or a maximum does not move when the wider tree replicates the row
+/// it already saw, so it merges on the same grounds a distinct count does.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_min_max_share_one_base_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.max_value
+          - carts.min_value
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// The same measures on their own, as the values the merged query must
+/// reproduce.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_min_max_alone() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.max_value
+          - carts.min_value
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// An average counts every row it is given, so the replication would move it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_avg_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.avg_value
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+        order:
+          - id: sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_avg_keeps_its_own_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_avg_keeps_its_own_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__avg_value    | checkouts__unique_msid
+---------------+---------------------+-----------------------
+DE             | 40.0000000000000000 | 0                     
+US             | 20.0000000000000000 | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_count_keeps_its_own_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_count_keeps_its_own_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__count | checkouts__unique_msid
+---------------+--------------+-----------------------
+DE             | 1            | 0                     
+US             | 3            | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_count_star_expression_keeps_its_own_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_count_star_expression_keeps_its_own_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | total_count | checkouts__unique_msid
+---------------+-------------+-----------------------
+US             | 2           | 2                     
+DE             | 1           | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_distinct_measure_alone.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_distinct_measure_alone.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__unique_msid
+---------------+-------------------
+DE             | 1                 
+US             | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_distinct_measures_share_one_base_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_distinct_measures_share_one_base_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__unique_msid | checkouts__unique_msid
+---------------+--------------------+-----------------------
+DE             | 1                  | 0                     
+US             | 2                  | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_filter_on_deeper_cube_leaves_one_tree.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_filter_on_deeper_cube_leaves_one_tree.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__unique_msid | checkouts__unique_msid
+---------------+--------------------+-----------------------
+US             | 2                  | 1

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_merge_with_filter_on_shallower_cube.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_merge_with_filter_on_shallower_cube.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__unique_msid | checkouts__unique_msid
+---------------+--------------------+-----------------------
+US             | 1                  | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_min_max_alone.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_min_max_alone.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__max_value | carts__min_value
+---------------+------------------+-----------------
+DE             | 40.00            | 40.00           
+US             | 30.00            | 10.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_min_max_share_one_base_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_min_max_share_one_base_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__max_value | carts__min_value | checkouts__unique_msid
+---------------+------------------+------------------+-----------------------
+DE             | 40.00            | 40.00            | 0                     
+US             | 30.00            | 10.00            | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_sum_keeps_its_own_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_sum_keeps_its_own_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | carts__total_value | checkouts__total_amount
+---------------+--------------------+------------------------
+DE             | 40.00              | NULL                   
+US             | 60.00              | 600.00


### PR DESCRIPTION
## Summary

A query whose measures sit at different depths of one join chain planned a separate leg
per measure, and every leg re-scanned the shared part of the join from scratch. A funnel
modelled as `sites → carts → checkouts` paid for one full scan of the base per measure,
so adding measures multiplied the cost — two measures were already timing out on Trino.

Such legs are now folded into one wherever moving a measure into the wider join tree
provably cannot change what it computes. Note that this is not the star-shaped multi-fact
case (`orders` and `returns` under `customers`), which stays split as before — it is the
case where legs differ only by how far down one chain they walk, and never needed to be
separate at all.

## Changes

- `MultiFactJoinGroups::try_new_merging_nested` folds a group into one whose join tree
  contains its own. Safe because the extra joins are `LEFT` — they only ever replicate a
  row, never drop one — and only for measures immune to that replication: a distinct
  aggregation qualifies, a plain `count` or `sum` does not and keeps its own leg.
- The wider tree is rebuilt from the union of both groups' join hints before the fan-out
  question is asked. `multiplicationFactor` is only populated for the cubes a tree's own
  hints named (`JoinGraph.ts` maps it over `cubesToJoin`), so a cube reached in transit
  reports as unmultiplied and would otherwise let an inflating measure through. The
  rebuild produces the same joins — asserted by comparing the `JoinKey`.
- `MeasureKind::survives_row_multiplication`, deliberately narrower than the existing
  `regular_in_multiplied`: a key-based count is also safe under multiplication, but only
  after switching to the distinct `MultipliedCount` form, and the render form is decided
  from the measure's own tree elsewhere.
- Merging stands down for: multi-stage measures (own CTE pipeline), member expressions
  (`COUNT(*)` names no member, so what it counts is whatever rows the join produces),
  ungrouped queries (raw rows expose the replication), pre-aggregation queries, and
  regrouping through `for_measures`.
- It also stands down when any cube read by the groups defines a pre-aggregation at all.
  A rollup is matched against one leg at a time, so a merged query needs one spanning all
  of them; a rollup outweighs the scan saved. This guard is coarse — see below.

## Testing

New fixture with a three-cube chain and a seed built so right and wrong answers differ:
two carts of one site share a `msid` (distinct ≠ count), one cart has two checkouts
(fan-out), two carts have none (`LEFT JOIN` must keep them).

- 6 integration tests on Postgres, snapshots verified by hand against the seed. The key
  one: a distinct measure returns the same numbers selected alone and selected next to a
  deeper measure, while `count`/`sum` keep their own leg and their own values.
- 2 structural tests (scan count, per-leg rollups still matching) and 5 unit tests on the
  grouping itself — nested merges, siblings do not, plain `count` does not.
- Full suite green on real Postgres: 1287 tests, no existing snapshot changed.

## Follow-up

The pre-aggregation guard answers "could a rollup exist" rather than "did one match", so
the optimisation silently switches off for models with rollups on the fact cubes. Removing
it means two-pass planning in `TopLevelPlanner` — plan unmerged, try pre-aggregations,
replan merged on a miss — which needs `QueryProperties` to carry a merge flag. Left out of
this PR deliberately.

The merge also only takes effect through `is_simple_query()`, so a query that additionally
carries a multiplied or multi-stage measure keeps its regular legs unmerged.
