### PR TITLE
backport: Aug -> lts/v1.4

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -84,6 +84,7 @@ import { SubscriptionServer, WebSocketSendMessageFn } from './ws/subscription-se
 import { LocalSubscriptionStore } from './ws/local-subscription-store';
 import {
   getPivotQuery,
+  cubeSqlRequestSchema,
   getQueryGranularity,
   normalizeQuery,
   normalizeQueryCancelPreAggregations,
@@ -438,7 +439,12 @@ class ApiGateway {
         try {
           await this.assertApiScope('data', req.context?.securityContext);
 
-          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache);
+          const { error, value: body } = cubeSqlRequestSchema.validate(req.body);
+          if (error) {
+            throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
+          }
+
+          await this.sqlServer.execSql(body.query, res, req.context?.securityContext, body.cache);
         } catch (e: any) {
           this.handleError({
             e,
@@ -887,7 +893,7 @@ class ApiGateway {
         throw new UserError('No job description provided');
       }
 
-      const { error } = preAggsJobsRequestSchema.validate(query);
+      const { error, value } = preAggsJobsRequestSchema.validate(query);
       if (error) {
         throw new UserError(`Invalid Job query format: ${error.message || error.toString()}`);
       }
@@ -896,7 +902,7 @@ class ApiGateway {
         case 'post':
           result = await this.preAggregationsJobsPOST(
             context,
-            <PreAggsSelector>query.selector
+            <PreAggsSelector>value.selector
           );
           if (result.length === 0) {
             throw new UserError(

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -1,7 +1,7 @@
 import R from 'ramda';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Joi from 'joi';
-import { getEnv } from '@cubejs-backend/shared';
+import { canonicalTimezone, getEnv } from '@cubejs-backend/shared';
 
 import { UserError } from './user-error';
 import { dateParser } from './date-parser';
@@ -56,6 +56,18 @@ const evaluatedPatchMeasureExpression = parsedPatchMeasureExpression.keys({
 });
 
 const id = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
+
+const cacheModeSchema = Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache');
+
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  const name = canonicalTimezone(value);
+  if (!name) {
+    return helpers.message({ custom: '{{#label}} must be a valid IANA time zone, got "{{#tz}}"' }, { tz: value });
+  }
+
+  return name;
+}, 'timezone');
+
 // It might be member name, td+granularity or member expression
 const idOrMemberExpressionName = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+$|^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/);
 const dimensionWithTime = Joi.string().regex(/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/);
@@ -183,18 +195,25 @@ const querySchema = Joi.object().keys({
     Joi.array().items(Joi.array().min(2).ordered(idOrMemberExpressionName, Joi.valid('asc', 'desc')))
   ),
   segments: Joi.array().items(Joi.alternatives(id, memberExpression, parsedMemberExpression)),
-  timezone: Joi.string(),
+  timezone: timezoneSchema,
   limit: Joi.number().integer().strict().min(0),
   offset: Joi.number().integer().strict().min(0),
   total: Joi.boolean(),
   // @deprecated
   renewQuery: Joi.boolean(),
-  cacheMode: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
-  cache: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
+  cacheMode: cacheModeSchema,
+  cache: cacheModeSchema,
   ungrouped: Joi.boolean(),
   responseFormat: Joi.valid('default', 'compact'),
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
+});
+
+export const cubeSqlRequestSchema = Joi.object().keys({
+  query: Joi.string().required(),
+  timezone: timezoneSchema,
+  cache: cacheModeSchema,
+  throwContinueWait: Joi.boolean(),
 });
 
 const normalizeQueryOrder = order => {
@@ -218,7 +237,7 @@ export const preAggsJobsRequestSchema = Joi.object({
           securityContext: Joi.required(),
         })
       ).min(1).required(),
-      timezones: Joi.array().items(Joi.string()).min(1).required(),
+      timezones: Joi.array().items(timezoneSchema).min(1).required(),
       dataSources: Joi.array().items(Joi.string()),
       cubes: Joi.array().items(Joi.string()),
       preAggregations: Joi.array().items(Joi.string()),
@@ -328,7 +347,7 @@ function normalizeQueryCacheMode(query, cacheMode) {
  */
 const normalizeQuery = (query, persistent, cacheMode) => {
   query = normalizeQueryCacheMode(query, cacheMode);
-  const { error } = querySchema.validate(query);
+  const { error, value } = querySchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
@@ -345,7 +364,7 @@ const normalizeQuery = (query, persistent, cacheMode) => {
     dimension: d.split('.').slice(0, 2).join('.'),
     granularity: d.split('.')[2]
   }));
-  const timezone = query.timezone || 'UTC';
+  const timezone = value.timezone || 'UTC';
 
   const def = getEnv('dbQueryDefaultLimit') <= getEnv('dbQueryLimit')
     ? getEnv('dbQueryDefaultLimit')
@@ -421,8 +440,8 @@ const remapToQueryAdapterFormat = (query) => (query ? {
 const queryPreAggregationsSchema = Joi.object().keys({
   expand: Joi.array().items(Joi.string()),
   metadata: Joi.object(),
-  timezone: Joi.string(),
-  timezones: Joi.array().items(Joi.string()),
+  timezone: timezoneSchema,
+  timezones: Joi.array().items(timezoneSchema),
   preAggregations: Joi.array().items(Joi.object().keys({
     id: Joi.string().required(),
     cacheOnly: Joi.boolean(),
@@ -433,14 +452,14 @@ const queryPreAggregationsSchema = Joi.object().keys({
 });
 
 const normalizeQueryPreAggregations = (query, defaultValues) => {
-  const { error } = queryPreAggregationsSchema.validate(query);
+  const { error, value } = queryPreAggregationsSchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
   return {
     metadata: query.metadata,
-    timezones: query.timezones || (query.timezone && [query.timezone]) || defaultValues?.timezones || ['UTC'],
+    timezones: value.timezones || (value.timezone && [value.timezone]) || defaultValues?.timezones || ['UTC'],
     preAggregations: query.preAggregations,
     expand: query.expand
   };
@@ -448,7 +467,7 @@ const normalizeQueryPreAggregations = (query, defaultValues) => {
 
 const queryPreAggregationPreviewSchema = Joi.object().keys({
   preAggregationId: Joi.string().required(),
-  timezone: Joi.string().required(),
+  timezone: timezoneSchema.required(),
   versionEntry: Joi.object().required().keys({
     content_version: Joi.string(),
     last_updated_at: Joi.number(),
@@ -460,12 +479,12 @@ const queryPreAggregationPreviewSchema = Joi.object().keys({
 });
 
 const normalizeQueryPreAggregationPreview = (query) => {
-  const { error } = queryPreAggregationPreviewSchema.validate(query);
+  const { error, value } = queryPreAggregationPreviewSchema.validate(query);
   if (error) {
     throw new UserError(`Invalid query format: ${error.message || error.toString()}`);
   }
 
-  return query;
+  return { ...query, timezone: value.timezone };
 };
 
 const queryCancelPreAggregationPreviewSchema = Joi.object().keys({

--- a/packages/cubejs-api-gateway/test/normalize-query.test.ts
+++ b/packages/cubejs-api-gateway/test/normalize-query.test.ts
@@ -1,0 +1,146 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  cubeSqlRequestSchema,
+  normalizeQuery,
+  normalizeQueryPreAggregations,
+  normalizeQueryPreAggregationPreview,
+} from '../src/query';
+
+const baseQuery = {
+  measures: ['Foo.count'],
+  timezone: 'UTC',
+};
+
+describe('responseFormat validation', () => {
+  test.each(['default', 'compact'])(
+    'accepts responseFormat=%s',
+    (responseFormat) => {
+      const result = normalizeQuery({ ...baseQuery, responseFormat }, false);
+      expect(result.responseFormat).toBe(responseFormat);
+    }
+  );
+
+  test('rejects unknown responseFormat', () => {
+    expect(() => normalizeQuery({ ...baseQuery, responseFormat: 'arrow' }, false)).toThrow(/Invalid query format/);
+  });
+});
+
+describe('timezone validation', () => {
+  test.each(['UTC', 'America/New_York', 'Europe/Berlin', 'Asia/Tokyo'])(
+    'accepts valid IANA timezone %s',
+    (tz) => {
+      const result = normalizeQuery({ ...baseQuery, timezone: tz }, false);
+      expect(result.timezone).toBe(tz);
+    }
+  );
+
+  test.each([
+    ['america/new_york', 'America/New_York'],
+    ['AMERICA/NEW_YORK', 'America/New_York'],
+    ['utc', 'UTC'],
+    ['uTc', 'UTC'],
+  ])('accepts timezone case-insensitively and normalizes it: %s -> %s', (tz, expected) => {
+    const result = normalizeQuery({ ...baseQuery, timezone: tz }, false);
+    expect(result.timezone).toBe(expected);
+  });
+
+  test.each([
+    'Not/AZone',
+    '+05:00',
+    'foo/bar',
+  ])('rejects invalid timezone %j', (tz) => {
+    expect(() => normalizeQuery({ ...baseQuery, timezone: tz }, false)).toThrow(/Invalid query format/);
+  });
+
+  test('falls back to UTC when the query carries no timezone', () => {
+    const result = normalizeQuery({ measures: baseQuery.measures }, false);
+    expect(result.timezone).toBe('UTC');
+  });
+});
+
+describe('normalizeQueryPreAggregations timezone handling', () => {
+  test('normalizes timezone to canonical IANA name', () => {
+    const result = normalizeQueryPreAggregations({ timezone: 'america/new_york' }, undefined);
+    expect(result.timezones).toEqual(['America/New_York']);
+  });
+
+  test('normalizes timezones array to canonical IANA names', () => {
+    const result = normalizeQueryPreAggregations({ timezones: ['utc', 'europe/berlin'] }, undefined);
+    expect(result.timezones).toEqual(['UTC', 'Europe/Berlin']);
+  });
+
+  test('rejects invalid timezone', () => {
+    expect(() => normalizeQueryPreAggregations({ timezones: ['Not/AZone'] }, undefined)).toThrow(/Invalid query format/);
+  });
+});
+
+describe('normalizeQueryPreAggregationPreview timezone handling', () => {
+  const previewQuery = {
+    preAggregationId: 'cube.preAgg',
+    versionEntry: { content_version: 'a', structure_version: 'b' },
+  };
+
+  test('normalizes timezone to canonical IANA name', () => {
+    const result = normalizeQueryPreAggregationPreview({ ...previewQuery, timezone: 'america/new_york' });
+    expect(result.timezone).toBe('America/New_York');
+  });
+
+  test('rejects invalid timezone', () => {
+    expect(() => normalizeQueryPreAggregationPreview({ ...previewQuery, timezone: 'Not/AZone' })).toThrow(/Invalid query format/);
+  });
+});
+
+describe('cubeSqlRequestSchema', () => {
+  const baseBody = { query: 'SELECT 1' };
+
+  test('accepts a body with only the query', () => {
+    const { error, value } = cubeSqlRequestSchema.validate(baseBody);
+    expect(error).toBeUndefined();
+    expect(value).toEqual(baseBody);
+  });
+
+  test('accepts every supported field', () => {
+    const { error, value } = cubeSqlRequestSchema.validate({
+      ...baseBody,
+      timezone: 'America/Los_Angeles',
+      cache: 'stale-while-revalidate',
+      throwContinueWait: true,
+    });
+    expect(error).toBeUndefined();
+    expect(value.cache).toBe('stale-while-revalidate');
+    expect(value.throwContinueWait).toBe(true);
+  });
+
+  test('requires the query', () => {
+    expect(cubeSqlRequestSchema.validate({}).error?.message).toMatch(/"query" is required/);
+  });
+
+  test('rejects an unknown field', () => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, nope: 1 }).error).toBeDefined();
+  });
+
+  test('rejects an unknown cache mode', () => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, cache: 'sometimes' }).error).toBeDefined();
+  });
+
+  test.each([
+    ['america/new_york', 'America/New_York'],
+    ['uTc', 'UTC'],
+  ])('normalizes timezone %j -> %j', (tz, expected) => {
+    const { error, value } = cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz });
+    expect(error).toBeUndefined();
+    expect(value.timezone).toBe(expected);
+  });
+
+  test.each([
+    'Not/AZone',
+    'foo/bar',
+  ])('rejects invalid timezone %j', (tz) => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz }).error?.message)
+      .toMatch(/valid IANA time zone/);
+  });
+
+  test.each([null, '', 123, true])('rejects timezone %j', (tz) => {
+    expect(cubeSqlRequestSchema.validate({ ...baseBody, timezone: tz }).error).toBeDefined();
+  });
+});

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -2,6 +2,7 @@
 import { get } from 'env-var';
 import { displayCLIWarning } from './cli';
 import { isNativeSupported } from './platform';
+import { canonicalTimezone } from './timezone';
 
 export class InvalidConfiguration extends Error {
   public constructor(key: string, value: any, description: string) {
@@ -193,13 +194,25 @@ const variables: Record<string, (...args: any) => any> = {
   },
   refreshWorkerConcurrency: () => get('CUBEJS_REFRESH_WORKER_CONCURRENCY')
     .asIntPositive(),
-  // eslint-disable-next-line consistent-return
   scheduledRefreshTimezones: () => {
-    const timezones = get('CUBEJS_SCHEDULED_REFRESH_TIMEZONES').asString();
+    const timezones = get('CUBEJS_SCHEDULED_REFRESH_TIMEZONES')
+      .default('')
+      .asArray()
+      .map(timezone => timezone.trim())
+      .filter(Boolean);
 
-    if (timezones) {
-      return timezones.split(',').map(t => t.trim());
-    }
+    return timezones.map(raw => {
+      const timezone = canonicalTimezone(raw);
+      if (!timezone) {
+        throw new InvalidConfiguration(
+          'CUBEJS_SCHEDULED_REFRESH_TIMEZONES',
+          raw,
+          'Must be a comma-separated list of valid IANA time zone names, e.g. UTC,America/Los_Angeles.'
+        );
+      }
+
+      return timezone;
+    });
   },
   preAggregationsBuilder: () => get('CUBEJS_PRE_AGGREGATIONS_BUILDER').asBool(),
   gracefulShutdown: () => get('CUBEJS_GRACEFUL_SHUTDOWN')

--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -18,6 +18,7 @@ export * from './http-utils';
 export * from './cli';
 export * from './proxy';
 export * from './time';
+export * from './timezone';
 export * from './process';
 export * from './platform';
 export * from './FileRepository';

--- a/packages/cubejs-backend-shared/src/timezone.ts
+++ b/packages/cubejs-backend-shared/src/timezone.ts
@@ -1,0 +1,25 @@
+import moment from 'moment-timezone';
+
+/**
+ * Resolves `value` to a canonical tz-database zone name, matched case-insensitively,
+ * or `null` when it is unset or not a known zone.
+ *
+ * @throws {TypeError} when `value` is an empty string, or is neither a string nor unset.
+ */
+export function canonicalTimezone(value?: string | null): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    throw new TypeError(`Timezone must be a string, got ${typeof value}`);
+  }
+
+  if (value === '') {
+    throw new TypeError('Timezone must not be empty');
+  }
+
+  const zone = moment.tz.zone(value);
+
+  return zone ? zone.name : null;
+}

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -95,3 +95,52 @@ describe('getEnv', () => {
     expect(getEnv('livePreview')).toBe(false);
   });
 });
+
+describe('getEnv(scheduledRefreshTimezones)', () => {
+  afterEach(() => {
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+  });
+
+  test('scheduledRefreshTimezones - unset resolves to an empty list', () => {
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+  });
+
+  test('scheduledRefreshTimezones - trims and normalizes each entry', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'utc, europe/berlin';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC', 'Europe/Berlin']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'America/New_York';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['America/New_York']);
+  });
+
+  // Trailing/repeated separators are common in .env files and compose YAML.
+  test('scheduledRefreshTimezones - ignores empty entries', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,,America/Los_Angeles';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC', 'America/Los_Angeles']);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = ' UTC , ';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual(['UTC']);
+  });
+
+  test('scheduledRefreshTimezones - blank resolves to an empty list', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = '';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = '   ';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = ',';
+    expect(getEnv('scheduledRefreshTimezones')).toEqual([]);
+  });
+
+  test('scheduledRefreshTimezones(exception)', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,Nope/Zone';
+    expect(() => getEnv('scheduledRefreshTimezones')).toThrowError(
+      'Value "Nope/Zone" is not valid for CUBEJS_SCHEDULED_REFRESH_TIMEZONES. Must be a comma-separated list of valid IANA time zone names, e.g. UTC,America/Los_Angeles.'
+    );
+  });
+});

--- a/packages/cubejs-backend-shared/test/timezone.test.ts
+++ b/packages/cubejs-backend-shared/test/timezone.test.ts
@@ -1,0 +1,65 @@
+import { canonicalTimezone } from '../src/timezone';
+
+describe('canonicalTimezone', () => {
+  test.each([
+    ['UTC', 'UTC'],
+    ['utc', 'UTC'],
+    ['uTc', 'UTC'],
+    ['America/New_York', 'America/New_York'],
+    ['america/new_york', 'America/New_York'],
+    ['AMERICA/NEW_YORK', 'America/New_York'],
+    ['Etc/GMT+5', 'Etc/GMT+5'],
+    ['GMT', 'GMT'],
+    ['EST', 'EST'],
+  ])('resolves %j to the canonical name %j', (value, expected) => {
+    expect(canonicalTimezone(value)).toBe(expected);
+  });
+
+  // Pinned deliberately: resolving links to their target would change query cache keys and
+  // pre-agg partition names for deployments already using them.
+  test.each([
+    ['US/Pacific', 'US/Pacific'],
+    ['Asia/Calcutta', 'Asia/Calcutta'],
+    ['Europe/Kiev', 'Europe/Kiev'],
+  ])('keeps link name %j as-is', (value, expected) => {
+    expect(canonicalTimezone(value)).toBe(expected);
+  });
+
+  test.each([
+    'Not/AZone',
+    'Europ/Berlin',
+    'foo/bar',
+    '+05:00',
+    '+05',
+    '05',
+    // No trimming: API payloads must be exact.
+    ' UTC',
+    'UTC ',
+    '  UTC  ',
+  ])('returns null for invalid value %j', (value) => {
+    expect(canonicalTimezone(value)).toBeNull();
+  });
+
+  test.each([
+    undefined,
+    null,
+  ])('returns null for unset value %j', (value) => {
+    expect(canonicalTimezone(value)).toBeNull();
+  });
+
+  test('throws for an empty string', () => {
+    expect(() => canonicalTimezone('')).toThrow(TypeError);
+  });
+
+  // The casts are the point: real callers are plain JS, so the signature is not enforced.
+  test.each([
+    123,
+    0,
+    {},
+    [],
+    true,
+    false,
+  ])('throws for non-string %j', (value) => {
+    expect(() => canonicalTimezone(value as any)).toThrow(TypeError);
+  });
+});

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -18,6 +18,7 @@ import {
   FROM_PARTITION_RANGE,
   MAX_SOURCE_ROW_LIMIT,
   QueryAlias,
+  canonicalTimezone,
   getEnv,
   localTimestampToUtc,
   timeSeries as timeSeriesBase,
@@ -288,6 +289,18 @@ export class BaseQuery {
     this.from = this.options.from;
     this.multiStageQuery = this.options.multiStageQuery;
     this.timezone = this.options.timezone;
+
+    // Backstop for every dialect convertTz() sink: callers that bypass the API gateway
+    // (queryRewrite, refresh scheduler, SQL API sessions) reach the dialects through here.
+    if (this.timezone) {
+      const timezone = canonicalTimezone(this.timezone);
+      if (!timezone) {
+        throw new UserError(`Incorrect timezone ${this.timezone}`);
+      }
+
+      this.timezone = timezone;
+    }
+
     this.rowLimit = this.options.rowLimit;
     this.offset = this.options.offset;
     /** @type {import('./PreAggregations').PreAggregations} */
@@ -936,7 +949,7 @@ export class BaseQuery {
       dimensions: this.options.dimensions,
       segments: this.options.segments,
       timeDimensions: this.options.timeDimensions,
-      timezone: this.options.timezone,
+      timezone: this.timezone,
       joinGraph: this.joinGraph,
       cubeEvaluator: this.cubeEvaluator,
       order,
@@ -987,7 +1000,7 @@ export class BaseQuery {
       dimensions: this.options.dimensions,
       segments: this.options.segments,
       timeDimensions: this.options.timeDimensions,
-      timezone: this.options.timezone,
+      timezone: this.timezone,
       joinGraph: this.joinGraph,
       cubeEvaluator: this.cubeEvaluator,
       order,

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -99,6 +99,7 @@ describe('SQL Generation', () => {
           '      card_tbl AS "cards"  GROUP BY 1 ORDER BY 2 DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - time dimension', async () => {
       await compilers.compiler.compile();
 
@@ -126,6 +127,66 @@ describe('SQL Generation', () => {
       expect(queryAndParams[0]).toContain('GROUP BY 1, 2');
       expect(queryAndParams[0]).toContain('ORDER BY 2');
     });
+
+    const buildTimezoneQuery = (timezone: string) => new PostgresQuery(compilers, {
+      measures: ['cards.count'],
+      timeDimensions: [
+        {
+          dimension: 'cards.createdAt',
+          granularity: 'day',
+          dateRange: ['2021-01-01', '2021-01-02']
+        }
+      ],
+      timezone,
+      filters: [],
+    });
+
+    it.each([
+      'Not/AZone',
+      '+05:00',
+      '+05',
+      '05',
+      'foo/bar',
+    ])('rejects invalid timezone %j', async (timezone) => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery(timezone)).toThrow(UserError);
+    });
+
+    it.each([
+      'America/New_York',
+      'america/new_york',
+      'AMERICA/NEW_YORK',
+      'utc',
+      'uTc',
+    ])('accepts valid timezone regardless of case: %s', async (timezone) => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery(timezone)).not.toThrow();
+    });
+
+    it('renders a canonical timezone into SQL', async () => {
+      await compilers.compiler.compile();
+      const [sql] = buildTimezoneQuery('America/New_York').buildSqlAndParams();
+      expect(sql).toContain("AT TIME ZONE 'America/New_York'");
+    });
+
+    // Counterpart: query_tools.rs `format!("Incorrect timezone {}", timezone)`.
+    it('reports the invalid zone with the same message as the native planner', async () => {
+      await compilers.compiler.compile();
+      expect(() => buildTimezoneQuery('Not/AZone')).toThrow('Incorrect timezone Not/AZone');
+    });
+
+    // The native planner parses the zone case-sensitively, so the name reaching the
+    // dialects has to be the canonical one whichever planner runs.
+    it.each([
+      ['utc', 'UTC'],
+      ['america/new_york', 'America/New_York'],
+    ])('canonicalizes timezone %j to %j', async (timezone, expected) => {
+      await compilers.compiler.compile();
+      const query = buildTimezoneQuery(timezone);
+      expect(query.timezone).toBe(expected);
+      expect(query.buildSqlAndParams()[0]).toContain(`AT TIME ZONE '${expected}'`);
+    });
+
     it('Simple query - complex measure', async () => {
       await compilers.compiler.compile();
 
@@ -143,6 +204,7 @@ describe('SQL Generation', () => {
           '      card_tbl AS "cards" ';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - complex dimension', async () => {
       await compilers.compiler.compile();
 
@@ -163,6 +225,7 @@ describe('SQL Generation', () => {
           '      card_tbl AS "cards"  GROUP BY 1 ORDER BY 2 DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - CUBE dimension', async () => {
       await compilers.compiler.compile();
 
@@ -183,6 +246,7 @@ describe('SQL Generation', () => {
           '      card_tbl AS "cards"  GROUP BY 1 ORDER BY 2 DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - CUBE id', async () => {
       await compilers.compiler.compile();
 
@@ -203,6 +267,7 @@ describe('SQL Generation', () => {
           '      card_tbl AS "cards"  GROUP BY 1 ORDER BY 2 DESC';
       expect(queryAndParams[0]).toEqual(expected);
     });
+
     it('Simple query - simple filter', async () => {
       await compilers.compiler.compile();
 
@@ -246,6 +311,7 @@ describe('SQL Generation', () => {
       const expectedParams = ['type_value', 'not_type_value', 'type_value'];
       expect(queryAndParams[1]).toEqual(expectedParams);
     });
+
     it('Simple query - null and many equals filter', async () => {
       await compilers.compiler.compile();
 

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -24,7 +24,7 @@ import {
 } from './types';
 import { lookupDriverClass, isDriver } from './DriverResolvers';
 import type { CubejsServerCore } from './server';
-import optionsValidate from './optionsValidate';
+import { validateOptions } from './optionsValidate';
 
 const { version } = require('../../../package.json');
 
@@ -40,8 +40,7 @@ export class OptsHandler {
     private createOptions: CreateOptions,
     private systemOptions?: SystemOptions,
   ) {
-    this.assertOptions(createOptions);
-    const options = cloneDeep(this.createOptions);
+    const options = this.sanitizeOptions(cloneDeep(this.createOptions));
     options.driverFactory = this.getDriverFactory(options);
     options.dbType = this.getDbType(options);
     this.initializedOptions = this.initializeCoreOptions(options);
@@ -68,10 +67,11 @@ export class OptsHandler {
   private initializedOptions: ServerCoreInitializedOptions;
 
   /**
-   * Assert create options.
+   * Validate create options, returning them with every validated value
+   * canonicalized (scheduledRefreshTimeZones to IANA zone names).
    */
-  private assertOptions(opts: CreateOptions) {
-    optionsValidate(opts);
+  private sanitizeOptions<T extends CreateOptions>(opts: T): T {
+    const validated = validateOptions(opts);
 
     if (
       !this.isDevMode() &&
@@ -100,6 +100,8 @@ export class OptsHandler {
     //     },
     //   );
     // }
+
+    return validated;
   }
 
   /**

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -1,5 +1,15 @@
 import Joi from 'joi';
+import { canonicalTimezone } from '@cubejs-backend/shared';
 import DriverDependencies from './DriverDependencies';
+
+const timezoneSchema = Joi.string().custom((value, helpers) => {
+  const name = canonicalTimezone(value);
+  if (!name) {
+    return helpers.message({ custom: '{{#label}} must be a valid IANA time zone name, got "{{#tz}}"' }, { tz: value });
+  }
+
+  return name;
+}, 'timezone');
 
 const schemaQueueOptions = Joi.object().strict(true).keys({
   concurrency: Joi.number().min(1).integer(),
@@ -97,7 +107,7 @@ const schemaOptions = Joi.object().keys({
     Joi.number().min(0).integer()
   ),
   scheduledRefreshTimeZones: Joi.alternatives().try(
-    Joi.array().items(Joi.string()),
+    Joi.array().items(timezoneSchema),
     Joi.func()
   ),
   scheduledRefreshContexts: Joi.func(),
@@ -151,9 +161,11 @@ const schemaOptions = Joi.object().keys({
   fastReload: Joi.boolean(),
 });
 
-export default (options: any) => {
-  const { error } = schemaOptions.validate(options, { abortEarly: false });
+export function validateOptions<T>(options: T): T {
+  const { error, value } = schemaOptions.validate(options, { abortEarly: false });
   if (error) {
     throw new Error(`Invalid cube-server-core options: ${error.message || error.toString()}`);
   }
-};
+
+  return value;
+}

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -1260,3 +1260,36 @@ describe('OptsHandler class', () => {
     expect(permissions).toEqual(['graphql', 'meta', 'data', 'jobs']);
   });
 });
+
+describe('OptsHandler timezone validation', () => {
+  beforeEach(() => {
+    process.env.CUBEJS_DB_TYPE = 'postgres';
+  });
+
+  afterEach(() => {
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES;
+  });
+
+  test('must throw at construction if CUBEJS_SCHEDULED_REFRESH_TIMEZONES has an invalid entry', () => {
+    process.env.CUBEJS_SCHEDULED_REFRESH_TIMEZONES = 'UTC,Nope/Zone';
+
+    expect(() => new CubejsServerCoreExposed(conf))
+      .toThrow(/CUBEJS_SCHEDULED_REFRESH_TIMEZONES/);
+  });
+
+  test('must throw at construction if CreateOptions.scheduledRefreshTimeZones has an invalid entry', () => {
+    expect(() => new CubejsServerCoreExposed({
+      ...conf,
+      scheduledRefreshTimeZones: ['UTC', 'Nope/Zone'],
+    })).toThrow(/valid IANA time zone name/);
+  });
+
+  test('must canonicalize CreateOptions.scheduledRefreshTimeZones', () => {
+    const core = new CubejsServerCoreExposed({
+      ...conf,
+      scheduledRefreshTimeZones: ['utc', 'america/new_york'],
+    });
+
+    expect(core.options.scheduledRefreshTimeZones).toEqual(['UTC', 'America/New_York']);
+  });
+});

--- a/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
+++ b/packages/cubejs-server-core/test/unit/optionsValidate.test.ts
@@ -1,0 +1,47 @@
+import { validateOptions } from '../../src/core/optionsValidate';
+
+describe('validateOptions scheduledRefreshTimeZones', () => {
+  test('accepts valid IANA timezones', () => {
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] })).not.toThrow();
+  });
+
+  test('accepts a function', () => {
+    expect(() => validateOptions({ scheduledRefreshTimeZones: async () => ['UTC'] })).not.toThrow();
+  });
+
+  test('accepts timezones case-insensitively', () => {
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] })).not.toThrow();
+  });
+
+  test('returns canonical timezone names', () => {
+    expect(validateOptions({ scheduledRefreshTimeZones: ['utc', 'america/new_york'] }))
+      .toEqual({ scheduledRefreshTimeZones: ['UTC', 'America/New_York'] });
+  });
+
+  test('rejects an invalid timezone with a descriptive message', () => {
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['Not/AZone'] }))
+      .toThrow(/valid IANA time zone name/);
+  });
+
+  test('names the offending value in the error message', () => {
+    expect(() => validateOptions({ scheduledRefreshTimeZones: ['UTC', 'Europ/Berlin'] }))
+      .toThrow(/Europ\/Berlin/);
+  });
+});
+
+describe('validateOptions sanitized result', () => {
+  test('preserves function options by reference', () => {
+    const driverFactory = () => ({ type: 'postgres' });
+    const validated = validateOptions({ driverFactory });
+
+    expect(validated.driverFactory).toBe(driverFactory);
+  });
+
+  test('does not mutate the input', () => {
+    const options = { scheduledRefreshTimeZones: ['utc'] };
+    const validated = validateOptions(options);
+
+    expect(options.scheduledRefreshTimeZones).toEqual(['utc']);
+    expect(validated).not.toBe(options);
+  });
+});


### PR DESCRIPTION
Backport of d1ba22a31c to LTS v1.4.

`canonicalTimezone()` (new, in `@cubejs-backend/shared`) resolves a value to a canonical tz-database zone name case-insensitively, or null. It is wired into every entry point a timezone can arrive through:
