### PR TITLE
fix(backend-native): treat a client disconnect on /v1/cubesql as a graceful end

### DIFF
--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -513,8 +513,8 @@ async fn handle_sql_query(
                 // dropped, which is what happens now anyway. What must not
                 // happen is reporting it as a failure.
                 log::debug!(
-                    "Client disconnected before the result was fully written, span id: {:?}",
-                    span_id.as_ref().map(|span_id| &span_id.span_id)
+                    "Client disconnected before the result was fully written, span id: {}",
+                    span_id.as_ref().map(|s| s.span_id.as_str()).unwrap_or("-")
                 );
             }
             Ok(SqlQueryOutcome::Completed) => {

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -240,10 +240,11 @@ enum SqlQueryOutcome {
     Completed,
     /// The client closed the response stream before the result set was fully
     /// written, so this attempt delivered nothing. It is reported as a
-    /// `Continue wait`: that is the event which closes out an attempt that
-    /// produced no result, and closing it is what lets query history account
-    /// for the request's running time - `Load Request` is logged when the
-    /// attempt starts, so silence here would leave the request dangling.
+    /// `Continue wait`: the event query history already reads for an attempt
+    /// that produced no result. `Load Request` is logged when the attempt
+    /// starts, and nothing else reports this outcome - the JS promise being
+    /// awaited is simply abandoned - so without this the attempt has no end at
+    /// all and the time it spent cannot be attributed.
     ///
     /// Whether the client comes back is not something this end of the stream
     /// can know, and the reporting deliberately does not depend on it: under
@@ -255,14 +256,16 @@ enum SqlQueryOutcome {
     ClientDisconnected,
 }
 
-/// Records a `Continue wait` load event for a `/v1/cubesql` attempt that ends
-/// without delivering a result while the request itself continues.
+/// Records a `Continue wait` load event for a `/v1/cubesql` attempt that ended
+/// without delivering a result.
 ///
-/// `Load Request` is logged when the attempt starts, so leaving an attempt with
-/// no terminal event makes the request look perpetually in flight and its
-/// running time unaccountable. `Continue wait` is the event the query history
-/// consumer already reads for "not done, the client will be back", which is
-/// exactly what both callers mean.
+/// `Load Request` is logged when the attempt starts, so an attempt that reports
+/// nothing back leaves no way to attribute the time it spent. `Continue wait`
+/// is the event the query history consumer already reads for "this attempt
+/// produced no result", which is what happened. It does not by itself close the
+/// request - a polling client opens further attempts under the same request id,
+/// and CUB-4099 has one that ran 44 minutes over six of them - but it does give
+/// this attempt an end.
 async fn log_continue_wait(
     session: &Arc<Session>,
     span_id: &Option<Arc<SpanId>>,
@@ -551,13 +554,14 @@ async fn handle_sql_query(
                     span_id.as_ref().map(|s| s.span_id.as_str()).unwrap_or("-")
                 );
 
-                // `Load Request` was already logged above, so every outcome
-                // owes it a terminal event: without one the request dangles and
-                // its running time cannot be accounted for. `Continue wait` is
-                // the name query history already reads for an attempt that
-                // produced no result, rather than a new one it would log and
-                // drop. See `SqlQueryOutcome::ClientDisconnected` for why this
-                // is not gated on `throw_continue_wait`.
+                // Nothing else reports this outcome, so without this the
+                // attempt ends unrecorded and the time it spent cannot be
+                // attributed. `Continue wait` is the name query history already
+                // reads for an attempt that produced no result, rather than a
+                // new one it would log and drop. See
+                // `SqlQueryOutcome::ClientDisconnected` for why it is not gated
+                // on `throw_continue_wait`, and the `Err` arm below for why a
+                // real continue wait deliberately does not log here.
                 log_continue_wait(&session_clone, &span_id, sql_query).await?;
             }
             Ok(SqlQueryOutcome::Completed) => {
@@ -583,12 +587,16 @@ async fn handle_sql_query(
                     .await?;
             }
             Err(err) => {
-                if err.message.eq_ignore_ascii_case("continue wait") {
-                    // Same reasoning as the disconnect above: the client is
-                    // told to come back, and that has to be recorded for the
-                    // request's running time to add up.
-                    log_continue_wait(&session_clone, &span_id, sql_query).await?;
-                } else {
+                // A `Continue wait` that reaches this arm was produced by the
+                // JS side, which already reports it: `OrchestratorApi` logs it
+                // on `ContinueWaitError` and the gateway's `handleError` logs
+                // it again, both into the sink `logLoadEvent` writes to. #10649
+                // stopped this arm reporting it as a `Cube SQL Error`; logging
+                // it as anything from here would just be a third copy. The
+                // disconnect arm has no such JS-side counterpart - the promise
+                // it was awaiting is abandoned, unreported - which is why that
+                // one does log.
+                if !err.message.eq_ignore_ascii_case("continue wait") {
                     session_clone
                         .session_manager
                         .server

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -233,6 +233,20 @@ async fn write_jsonl_message(
     .await
 }
 
+/// How a `/v1/cubesql` request ended when nothing actually failed.
+enum SqlQueryOutcome {
+    /// The whole result set was streamed to the client.
+    Completed,
+    /// The client closed the response stream before the result set was fully
+    /// written. This is a graceful end of the request, not a query error: it is
+    /// the same situation as a `Continue wait` handed back to a client that
+    /// stops waiting for the result - nobody is waiting for the rows anymore,
+    /// so there is nothing left to do but stop. Reporting it as an error would
+    /// pollute error rates and query history with client-side navigation,
+    /// cancelled dashboards and closed browser tabs.
+    ClientDisconnected,
+}
+
 async fn handle_sql_query(
     services: Arc<NodeCubeServices>,
     native_auth_ctx: Arc<NativeSQLAuthContext>,
@@ -243,7 +257,7 @@ async fn handle_sql_query(
     timezone: Option<String>,
     throw_continue_wait: bool,
     request_id: Option<String>,
-) -> Result<(), CubeError> {
+) -> Result<SqlQueryOutcome, CubeError> {
     let span_id = Some(Arc::new(SpanId::new(
         request_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
         serde_json::json!({ "sql": sql_query }),
@@ -477,14 +491,22 @@ async fn handle_sql_query(
         };
 
         let result = tokio::select! {
+            // Dropping the `execute()` future here cancels the query stream,
+            // which is exactly what we want: there is no consumer left for it.
             _ = close_rx => {
-                Err(CubeError::internal("Client disconnected".to_string()))
+                Ok(SqlQueryOutcome::ClientDisconnected)
             }
-            res = execute() => res
+            res = execute() => res.map(|_| SqlQueryOutcome::Completed),
         };
 
         match &result {
-            Ok(_) => {
+            Ok(SqlQueryOutcome::ClientDisconnected) => {
+                log::debug!(
+                    "Client disconnected before the result was fully written, span id: {:?}",
+                    span_id.as_ref().map(|span_id| &span_id.span_id)
+                );
+            }
+            Ok(SqlQueryOutcome::Completed) => {
                 session_clone
                     .session_manager
                     .server
@@ -668,6 +690,9 @@ fn exec_sql(mut cx: FunctionContext) -> JsResult<JsValue> {
             };
 
             let args = match result {
+                // Includes `SqlQueryOutcome::ClientDisconnected`: the stream is
+                // already gone, so there is nobody to hand an error payload to,
+                // and a disconnect is not an error to report in the first place.
                 Ok(_) => vec![],
                 Err(err) => {
                     let mut error_response = Map::new();

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -3,6 +3,7 @@ use cubesql::compile::{convert_statement_to_cube_query, get_df_batches};
 use cubesql::config::processing_loop::ShutdownMode;
 use cubesql::sql::dataframe::arrow_to_column_type;
 use cubesql::sql::ColumnType;
+use cubesql::sql::Session;
 use cubesql::transport::{SpanId, TransportService};
 use futures::StreamExt;
 
@@ -238,13 +239,51 @@ enum SqlQueryOutcome {
     /// The whole result set was streamed to the client.
     Completed,
     /// The client closed the response stream before the result set was fully
-    /// written. This is a graceful end of the request, not a query error: it is
-    /// the same situation as a `Continue wait` handed back to a client that
-    /// stops waiting for the result - nobody is waiting for the rows anymore,
-    /// so there is nothing left to do but stop. Reporting it as an error would
-    /// pollute error rates and query history with client-side navigation,
-    /// cancelled dashboards and closed browser tabs.
+    /// written. This attempt delivered nothing, but the request is not over: a
+    /// `throwContinueWait` client polls with the same request id and comes back
+    /// for another attempt, and the queued query stays alive as long as it
+    /// keeps doing so. That makes this the same outcome as a `Continue wait`,
+    /// and it is reported as one - not as an error, and not silently, since a
+    /// terminal event is what lets query history account for the request's
+    /// running time.
     ClientDisconnected,
+}
+
+/// Records a `Continue wait` load event for a `/v1/cubesql` attempt that ends
+/// without delivering a result while the request itself continues.
+///
+/// `Load Request` is logged when the attempt starts, so leaving an attempt with
+/// no terminal event makes the request look perpetually in flight and its
+/// running time unaccountable. `Continue wait` is the event the query history
+/// consumer already reads for "not done, the client will be back", which is
+/// exactly what both callers mean.
+async fn log_continue_wait(
+    session: &Arc<Session>,
+    span_id: &Option<Arc<SpanId>>,
+    sql_query: &str,
+) -> Result<(), CubeError> {
+    let Some(auth_context) = session.state.auth_context() else {
+        return Ok(());
+    };
+
+    session
+        .session_manager
+        .server
+        .transport
+        .log_load_state(
+            span_id.clone(),
+            auth_context,
+            session.state.get_load_request_meta("sql"),
+            "Continue wait".to_string(),
+            serde_json::json!({
+                "query": {
+                    "sql": sql_query,
+                },
+                "apiType": "sql",
+                "duration": span_id.as_ref().map(|span_id| span_id.duration()),
+            }),
+        )
+        .await
 }
 
 async fn handle_sql_query(
@@ -501,21 +540,18 @@ async fn handle_sql_query(
 
         match &result {
             Ok(SqlQueryOutcome::ClientDisconnected) => {
-                // Deliberately no terminal load event, not even a non-error
-                // one. `Load Request` was already logged above, so a
-                // disconnected request stays open-ended for whoever consumes
-                // these events - unlike a `Continue wait`, whose client comes
-                // back with the same request id and closes the span on a later
-                // attempt. Naming a terminal event for it (`Load Request
-                // Cancelled` or such) only pays off once the query history
-                // consumer knows how to render it, and picking that name is
-                // not this change's call: until then it would be logged and
-                // dropped, which is what happens now anyway. What must not
-                // happen is reporting it as a failure.
                 log::debug!(
                     "Client disconnected before the result was fully written, span id: {}",
                     span_id.as_ref().map(|s| s.span_id.as_str()).unwrap_or("-")
                 );
+
+                // `Load Request` was already logged above, so every outcome
+                // owes it a terminal event: without one the request dangles and
+                // its running time cannot be accounted for. The client is
+                // expected back for another attempt, so the outcome is a
+                // `Continue wait` - the name query history already understands,
+                // rather than a new one it would log and drop.
+                log_continue_wait(&session_clone, &span_id, sql_query).await?;
             }
             Ok(SqlQueryOutcome::Completed) => {
                 session_clone
@@ -540,7 +576,12 @@ async fn handle_sql_query(
                     .await?;
             }
             Err(err) => {
-                if !err.message.eq_ignore_ascii_case("continue wait") {
+                if err.message.eq_ignore_ascii_case("continue wait") {
+                    // Same reasoning as the disconnect above: the client is
+                    // told to come back, and that has to be recorded for the
+                    // request's running time to add up.
+                    log_continue_wait(&session_clone, &span_id, sql_query).await?;
+                } else {
                     session_clone
                         .session_manager
                         .server

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -501,6 +501,17 @@ async fn handle_sql_query(
 
         match &result {
             Ok(SqlQueryOutcome::ClientDisconnected) => {
+                // Deliberately no terminal load event, not even a non-error
+                // one. `Load Request` was already logged above, so a
+                // disconnected request stays open-ended for whoever consumes
+                // these events - unlike a `Continue wait`, whose client comes
+                // back with the same request id and closes the span on a later
+                // attempt. Naming a terminal event for it (`Load Request
+                // Cancelled` or such) only pays off once the query history
+                // consumer knows how to render it, and picking that name is
+                // not this change's call: until then it would be logged and
+                // dropped, which is what happens now anyway. What must not
+                // happen is reporting it as a failure.
                 log::debug!(
                     "Client disconnected before the result was fully written, span id: {:?}",
                     span_id.as_ref().map(|span_id| &span_id.span_id)

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -239,13 +239,19 @@ enum SqlQueryOutcome {
     /// The whole result set was streamed to the client.
     Completed,
     /// The client closed the response stream before the result set was fully
-    /// written. This attempt delivered nothing, but the request is not over: a
-    /// `throwContinueWait` client polls with the same request id and comes back
-    /// for another attempt, and the queued query stays alive as long as it
-    /// keeps doing so. That makes this the same outcome as a `Continue wait`,
-    /// and it is reported as one - not as an error, and not silently, since a
-    /// terminal event is what lets query history account for the request's
-    /// running time.
+    /// written, so this attempt delivered nothing. It is reported as a
+    /// `Continue wait`: that is the event which closes out an attempt that
+    /// produced no result, and closing it is what lets query history account
+    /// for the request's running time - `Load Request` is logged when the
+    /// attempt starts, so silence here would leave the request dangling.
+    ///
+    /// Whether the client comes back is not something this end of the stream
+    /// can know, and the reporting deliberately does not depend on it: under
+    /// `throwContinueWait` it polls with the same request id and the queued
+    /// query stays alive while it keeps doing so, and without the flag this is
+    /// the end of the road. Either way the attempt is over having produced
+    /// nothing, which is all the event claims. What it must not claim is that
+    /// the query failed.
     ClientDisconnected,
 }
 
@@ -547,10 +553,11 @@ async fn handle_sql_query(
 
                 // `Load Request` was already logged above, so every outcome
                 // owes it a terminal event: without one the request dangles and
-                // its running time cannot be accounted for. The client is
-                // expected back for another attempt, so the outcome is a
-                // `Continue wait` - the name query history already understands,
-                // rather than a new one it would log and drop.
+                // its running time cannot be accounted for. `Continue wait` is
+                // the name query history already reads for an attempt that
+                // produced no result, rather than a new one it would log and
+                // drop. See `SqlQueryOutcome::ClientDisconnected` for why this
+                // is not gated on `throw_continue_wait`.
                 log_continue_wait(&session_clone, &span_id, sql_query).await?;
             }
             Ok(SqlQueryOutcome::Completed) => {

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -242,9 +242,18 @@ enum SqlQueryOutcome {
     /// written, so this attempt delivered nothing. It is reported as a
     /// `Continue wait`: the event query history already reads for an attempt
     /// that produced no result. `Load Request` is logged when the attempt
-    /// starts, and nothing else reports this outcome - the JS promise being
-    /// awaited is simply abandoned - so without this the attempt has no end at
-    /// all and the time it spent cannot be attributed.
+    /// starts, so without this the attempt usually has no end at all and the
+    /// time it spent cannot be attributed - dropping the future abandons the JS
+    /// load rather than cancelling it, and an abandoned load that resolves, or
+    /// never settles, reports nothing.
+    ///
+    /// The exception is an abandoned load that goes on to *reject*: it still
+    /// runs in its own promise (`sql-server.ts`), and the gateway routes the
+    /// rejection into `handleError`, which logs its own `Continue wait`. A
+    /// disconnect racing the continue-wait boundary therefore double-logs -
+    /// CUB-4099's disconnects cluster around 61s against a ~60s boundary, so
+    /// this is not rare. Two rows saying the same thing beat none, so the call
+    /// is not gated on it, but that is where a duplicate comes from.
     ///
     /// Whether the client comes back is not something this end of the stream
     /// can know, and the reporting deliberately does not depend on it: under
@@ -554,8 +563,8 @@ async fn handle_sql_query(
                     span_id.as_ref().map(|s| s.span_id.as_str()).unwrap_or("-")
                 );
 
-                // Nothing else reports this outcome, so without this the
-                // attempt ends unrecorded and the time it spent cannot be
+                // Usually nothing else reports this outcome, so without this
+                // the attempt ends unrecorded and the time it spent cannot be
                 // attributed. `Continue wait` is the name query history already
                 // reads for an attempt that produced no result, rather than a
                 // new one it would log and drop. See
@@ -593,9 +602,10 @@ async fn handle_sql_query(
                 // it again, both into the sink `logLoadEvent` writes to. #10649
                 // stopped this arm reporting it as a `Cube SQL Error`; logging
                 // it as anything from here would just be a third copy. The
-                // disconnect arm has no such JS-side counterpart - the promise
-                // it was awaiting is abandoned, unreported - which is why that
-                // one does log.
+                // disconnect arm usually has no such JS-side counterpart -
+                // the promise it was awaiting is abandoned rather than
+                // cancelled, and only reports if it later rejects - which is
+                // why that one does log.
                 if !err.message.eq_ignore_ascii_case("continue wait") {
                     session_clone
                         .session_manager

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -424,6 +424,94 @@ describe('SQLInterface', () => {
     await native.shutdownInterface(instance, 'fast');
   });
 
+  test('client disconnect ends the /cubesql stream gracefully, not as an error', async () => {
+    // A client that closes the response stream before the result set has been
+    // fully written (a cancelled dashboard, a closed browser tab, an aborted
+    // fetch) ends the request gracefully. It is the same situation as a
+    // `Continue wait` handed back to a client that stops waiting for the
+    // result: nobody is left to read the rows, so there is nothing to do but
+    // stop. It must not be reported as `Cube SQL Error` — that event feeds
+    // error rates and query history — and no error payload should be pushed
+    // into the stream that is already gone.
+    const loadEvents: string[] = [];
+    const methods = {
+      ...interfaceMethods(),
+      // Return data in both stream and non-stream mode: `CUBESQL_STREAM_MODE`
+      // only picks the streaming branch for limits above
+      // `non_streaming_query_max_row_limit`, and this test must behave the
+      // same either way.
+      sqlApiLoad: jest.fn(async ({ streaming, query }: any) => {
+        if (streaming) {
+          return { stream: new FakeRowStream(query) };
+        }
+        return {
+          results: [
+            {
+              annotation: {
+                measures: {},
+                dimensions: {},
+                segments: {},
+                timeDimensions: {},
+              },
+              data: {
+                members: ['KibanaSampleDataEcommerce.order_date'],
+                columns: [['2024-01-01T00:00:00.000']],
+              },
+            },
+          ],
+        };
+      }),
+      logLoadEvent: ({ event }: { event: string; properties: any }) => {
+        loadEvents.push(event);
+      },
+    };
+
+    const instance = await native.registerInterface({
+      ...methods,
+      canSwitchUserForSession: (_payload: any) => true,
+    });
+
+    const chunks: string[] = [];
+    const cubeSqlStream = new Writable({
+      write(chunk, _enc, callback) {
+        chunks.push(chunk.toString('utf-8'));
+        callback();
+        // Simulate the client going away right after the JSONL schema header.
+        this.destroy();
+      },
+    });
+    // The native side holds a reference to the stream and only learns it is
+    // gone through the `close` event, so the writes already in flight (and the
+    // final `end()`) hit a destroyed stream and emit ERR_STREAM_DESTROYED.
+    // Collect them instead of letting them become an unhandled 'error'.
+    const streamErrors: Error[] = [];
+    cubeSqlStream.on('error', (err) => {
+      streamErrors.push(err);
+    });
+
+    try {
+      await native.execSql(
+        instance,
+        'SELECT order_date FROM KibanaSampleDataEcommerce ORDER BY order_date DESC LIMIT 100000;',
+        cubeSqlStream
+      );
+
+      expect(loadEvents).toContain('Load Request');
+      expect(loadEvents).not.toContain('Cube SQL Error');
+      // Neither terminal event fires: the query never completed, and the
+      // disconnect is not a failure. Asserting this also keeps the test
+      // honest — it would pass vacuously if the query had simply finished
+      // before the `close` event arrived.
+      expect(loadEvents).not.toContain('Load Request Success');
+      // Only the schema header made it out, and nothing that looks like an
+      // error was written into the closed stream.
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.join('')).not.toContain('"error"');
+    } finally {
+      await native.shutdownInterface(instance, 'fast');
+    }
+  });
+
   test('external flag is surfaced in /cubesql JSONL schema header when set to true', async () => {
     // End-to-end coverage of the cubesql -> backend-native -> JSONL path:
     // the non-streaming `load` returns a V1LoadResponseColumnar with

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -424,104 +424,117 @@ describe('SQLInterface', () => {
     await native.shutdownInterface(instance, 'fast');
   });
 
-  test('client disconnect ends the /cubesql stream gracefully, not as an error', async () => {
+  // Both `throwContinueWait` states, because the flag is an opt-in that only
+  // `@cubejs-client/core` sets: with it the client polls and comes back for
+  // another attempt, without it this disconnect is the end of the road. The
+  // reporting is the same either way — the attempt delivered no result and has
+  // to be closed out — so pin both rather than leave the off case incidental.
+  test.each([
+    ['throwContinueWait off', undefined],
+    ['throwContinueWait on', true],
+  ])(
+    'client disconnect ends the /cubesql stream gracefully, not as an error (%s)',
+    async (_name, throwContinueWait) => {
     // A client that closes the response stream before the result set has been
-    // fully written (a cancelled dashboard, a closed browser tab, an aborted
-    // fetch) ends the request gracefully. It is the same situation as a
-    // `Continue wait` handed back to a client that stops waiting for the
-    // result: nobody is left to read the rows, so there is nothing to do but
-    // stop. It must not be reported as `Cube SQL Error` — that event feeds
-    // error rates and query history — and no error payload should be pushed
-    // into the stream that is already gone.
-    const loadEvents: string[] = [];
-    const methods = {
-      ...interfaceMethods(),
-      // Return data in both stream and non-stream mode: `CUBESQL_STREAM_MODE`
-      // only picks the streaming branch for limits above
-      // `non_streaming_query_max_row_limit`, and this test must behave the
-      // same either way.
-      sqlApiLoad: jest.fn(async ({ streaming, query }: any) => {
-        if (streaming) {
-          return { stream: new FakeRowStream(query) };
-        }
-        return {
-          results: [
-            {
-              annotation: {
-                measures: {},
-                dimensions: {},
-                segments: {},
-                timeDimensions: {},
+    // fully written ends the attempt without delivering anything. It must not
+    // be reported as `Cube SQL Error` — that event feeds error rates and query
+    // history — and no error payload should be pushed into the stream that is
+    // already gone.
+      const loadEvents: string[] = [];
+      const methods = {
+        ...interfaceMethods(),
+        // Return data in both stream and non-stream mode: `CUBESQL_STREAM_MODE`
+        // only picks the streaming branch for limits above
+        // `non_streaming_query_max_row_limit`, and this test must behave the
+        // same either way.
+        sqlApiLoad: jest.fn(async ({ streaming, query }: any) => {
+          if (streaming) {
+            return { stream: new FakeRowStream(query) };
+          }
+          return {
+            results: [
+              {
+                annotation: {
+                  measures: {},
+                  dimensions: {},
+                  segments: {},
+                  timeDimensions: {},
+                },
+                data: {
+                  members: ['KibanaSampleDataEcommerce.order_date'],
+                  columns: [['2024-01-01T00:00:00.000']],
+                },
               },
-              data: {
-                members: ['KibanaSampleDataEcommerce.order_date'],
-                columns: [['2024-01-01T00:00:00.000']],
-              },
-            },
-          ],
-        };
-      }),
-      logLoadEvent: ({ event }: { event: string; properties: any }) => {
-        loadEvents.push(event);
-      },
-    };
+            ],
+          };
+        }),
+        logLoadEvent: ({ event }: { event: string; properties: any }) => {
+          loadEvents.push(event);
+        },
+      };
 
-    const instance = await native.registerInterface({
-      ...methods,
-      canSwitchUserForSession: (_payload: any) => true,
-    });
+      const instance = await native.registerInterface({
+        ...methods,
+        canSwitchUserForSession: (_payload: any) => true,
+      });
 
-    const chunks: string[] = [];
-    const cubeSqlStream = new Writable({
-      write(chunk, _enc, callback) {
-        chunks.push(chunk.toString('utf-8'));
-        callback();
-        // Simulate the client going away right after the JSONL schema header.
-        this.destroy();
-      },
-    });
-    // The native side holds a reference to the stream and only learns it is
-    // gone through the `close` event, so the writes already in flight (and the
-    // final `end()`) hit a destroyed stream and emit ERR_STREAM_DESTROYED.
-    // Swallow them: an unhandled 'error' would fail the test.
-    cubeSqlStream.on('error', jest.fn());
-    // `exec_sql` delivers a failure as the *argument* to the stream's `end`,
-    // not through `write`, so the spy has to be in place before `execSql`
-    // roots the function.
-    const endSpy = jest.spyOn(cubeSqlStream, 'end');
+      const chunks: string[] = [];
+      const cubeSqlStream = new Writable({
+        write(chunk, _enc, callback) {
+          chunks.push(chunk.toString('utf-8'));
+          callback();
+          // Simulate the client going away right after the JSONL schema header.
+          this.destroy();
+        },
+      });
+      // The native side holds a reference to the stream and only learns it is
+      // gone through the `close` event, so the writes already in flight (and the
+      // final `end()`) hit a destroyed stream and emit ERR_STREAM_DESTROYED.
+      // Swallow them: an unhandled 'error' would fail the test.
+      cubeSqlStream.on('error', jest.fn());
+      // `exec_sql` delivers a failure as the *argument* to the stream's `end`,
+      // not through `write`, so the spy has to be in place before `execSql`
+      // roots the function.
+      const endSpy = jest.spyOn(cubeSqlStream, 'end');
 
-    try {
-      await native.execSql(
-        instance,
-        'SELECT order_date FROM KibanaSampleDataEcommerce ORDER BY order_date DESC LIMIT 100000;',
-        cubeSqlStream
-      );
+      try {
+        await native.execSql(
+          instance,
+          'SELECT order_date FROM KibanaSampleDataEcommerce ORDER BY order_date DESC LIMIT 100000;',
+          cubeSqlStream,
+          null,
+          'stale-if-slow',
+          undefined,
+          throwContinueWait
+        );
 
-      expect(loadEvents).toContain('Load Request');
-      expect(loadEvents).not.toContain('Cube SQL Error');
-      // `Load Request` is logged when the attempt starts, so the disconnect
-      // owes it a terminal event — otherwise the request dangles and query
-      // history cannot account for its running time. The one it gets is
-      // `Continue wait`, because the client is expected back for another
-      // attempt. Asserting `Load Request Success` is absent also keeps the
-      // test honest: it would pass vacuously had the query simply finished
-      // before the `close` event arrived.
-      expect(loadEvents).toContain('Continue wait');
-      expect(loadEvents).not.toContain('Load Request Success');
-      // The stream is closed with no error payload. This is the half of the
-      // fix that `loadEvents` does not cover, and it has to be asserted on
-      // `end` rather than on the written chunks: `exec_sql` passes the
-      // `{"error": ...}` JSONL line to `end` as an argument.
-      expect(endSpy).toHaveBeenCalled();
-      expect(endSpy.mock.calls[0]).toHaveLength(0);
-      // Only the JSONL schema header made it out — everything after it hit a
-      // stream that was already destroyed.
-      expect(chunks).toHaveLength(1);
-      expect(JSON.parse(chunks[0].trim()).schema).toBeDefined();
-    } finally {
-      await native.shutdownInterface(instance, 'fast');
+        expect(loadEvents).toContain('Load Request');
+        expect(loadEvents).not.toContain('Cube SQL Error');
+        // `Load Request` is logged when the attempt starts, so the disconnect
+        // owes it a terminal event — otherwise the request dangles and query
+        // history cannot account for its running time. `Continue wait` is the
+        // event that closes an attempt which produced no result, which is what
+        // happened here whether or not the client intends to poll again.
+        // Asserting `Load Request Success` is absent also keeps the test honest:
+        // it would pass vacuously had the query simply finished before the
+        // `close` event arrived.
+        expect(loadEvents).toContain('Continue wait');
+        expect(loadEvents).not.toContain('Load Request Success');
+        // The stream is closed with no error payload. This is the half of the
+        // fix that `loadEvents` does not cover, and it has to be asserted on
+        // `end` rather than on the written chunks: `exec_sql` passes the
+        // `{"error": ...}` JSONL line to `end` as an argument.
+        expect(endSpy).toHaveBeenCalled();
+        expect(endSpy.mock.calls[0]).toHaveLength(0);
+        // Only the JSONL schema header made it out — everything after it hit a
+        // stream that was already destroyed.
+        expect(chunks).toHaveLength(1);
+        expect(JSON.parse(chunks[0].trim()).schema).toBeDefined();
+      } finally {
+        await native.shutdownInterface(instance, 'fast');
+      }
     }
-  });
+  );
 
   test('external flag is surfaced in /cubesql JSONL schema header when set to true', async () => {
     // End-to-end coverage of the cubesql -> backend-native -> JSONL path:

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -499,10 +499,14 @@ describe('SQLInterface', () => {
 
       expect(loadEvents).toContain('Load Request');
       expect(loadEvents).not.toContain('Cube SQL Error');
-      // Neither terminal event fires: the query never completed, and the
-      // disconnect is not a failure. Asserting this also keeps the test
-      // honest — it would pass vacuously if the query had simply finished
+      // `Load Request` is logged when the attempt starts, so the disconnect
+      // owes it a terminal event — otherwise the request dangles and query
+      // history cannot account for its running time. The one it gets is
+      // `Continue wait`, because the client is expected back for another
+      // attempt. Asserting `Load Request Success` is absent also keeps the
+      // test honest: it would pass vacuously had the query simply finished
       // before the `close` event arrived.
+      expect(loadEvents).toContain('Continue wait');
       expect(loadEvents).not.toContain('Load Request Success');
       // The stream is closed with no error payload. This is the half of the
       // fix that `loadEvents` does not cover, and it has to be asserted on

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -483,11 +483,8 @@ describe('SQLInterface', () => {
     // The native side holds a reference to the stream and only learns it is
     // gone through the `close` event, so the writes already in flight (and the
     // final `end()`) hit a destroyed stream and emit ERR_STREAM_DESTROYED.
-    // Collect them instead of letting them become an unhandled 'error'.
-    const streamErrors: Error[] = [];
-    cubeSqlStream.on('error', (err) => {
-      streamErrors.push(err);
-    });
+    // Swallow them: an unhandled 'error' would fail the test.
+    cubeSqlStream.on('error', jest.fn());
     // `exec_sql` delivers a failure as the *argument* to the stream's `end`,
     // not through `write`, so the spy has to be in place before `execSql`
     // roots the function.

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -488,6 +488,10 @@ describe('SQLInterface', () => {
     cubeSqlStream.on('error', (err) => {
       streamErrors.push(err);
     });
+    // `exec_sql` delivers a failure as the *argument* to the stream's `end`,
+    // not through `write`, so the spy has to be in place before `execSql`
+    // roots the function.
+    const endSpy = jest.spyOn(cubeSqlStream, 'end');
 
     try {
       await native.execSql(
@@ -503,10 +507,16 @@ describe('SQLInterface', () => {
       // honest — it would pass vacuously if the query had simply finished
       // before the `close` event arrived.
       expect(loadEvents).not.toContain('Load Request Success');
-      // Only the schema header made it out, and nothing that looks like an
-      // error was written into the closed stream.
-      expect(chunks.length).toBeGreaterThan(0);
-      expect(chunks.join('')).not.toContain('"error"');
+      // The stream is closed with no error payload. This is the half of the
+      // fix that `loadEvents` does not cover, and it has to be asserted on
+      // `end` rather than on the written chunks: `exec_sql` passes the
+      // `{"error": ...}` JSONL line to `end` as an argument.
+      expect(endSpy).toHaveBeenCalled();
+      expect(endSpy.mock.calls[0]).toHaveLength(0);
+      // Only the JSONL schema header made it out — everything after it hit a
+      // stream that was already destroyed.
+      expect(chunks).toHaveLength(1);
+      expect(JSON.parse(chunks[0].trim()).schema).toBeDefined();
     } finally {
       await native.shutdownInterface(instance, 'fast');
     }

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -435,11 +435,11 @@ describe('SQLInterface', () => {
   ])(
     'client disconnect ends the /cubesql stream gracefully, not as an error (%s)',
     async (_name, throwContinueWait) => {
-    // A client that closes the response stream before the result set has been
-    // fully written ends the attempt without delivering anything. It must not
-    // be reported as `Cube SQL Error` — that event feeds error rates and query
-    // history — and no error payload should be pushed into the stream that is
-    // already gone.
+      // A client that closes the response stream before the result set has
+      // been fully written ends the attempt without delivering anything. It
+      // must not be reported as `Cube SQL Error` — that event feeds error rates
+      // and query history — and no error payload should be pushed into the
+      // stream that is already gone.
       const loadEvents: string[] = [];
       const methods = {
         ...interfaceMethods(),


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required — n/a, no user-facing surface changes

**Issue Reference this PR resolves**

[CUB-4099](https://linear.app/cube-d3/issue/CUB-4099/client-disconnected-an-query-was-cancelled-on-athena-queries)

**Description of Changes Made**

When the client closes the `/v1/cubesql` response stream before the result set has been fully written, `handle_sql_query` turned the stream's `close` event into `CubeError::internal("Client disconnected")`, which:

* logged a `Cube SQL Error` load event, so the request shows up as failed in query history and counts towards error rates, and
* pushed an `{"error": "Client disconnected"}` JSONL chunk into the stream that was already gone.

Neither is right, and the production traces behind CUB-4099 show why (evidence in the thread below). A `/v1/cubesql` client using `throwContinueWait` polls: each attempt returns `Continue wait` and the client comes back with the same `requestId`. When one of those intermediate connections closes, the request is not over — the client is still waiting. In the two traces on the ticket, the request's own last recorded event is `Continue wait` in one case and **`Load Request Success`** in the other, with `errorCount: 0` on every span; both are nevertheless displayed as failed with `Client disconnected`. So a query that completed successfully was being reported as an error.

`handle_sql_query` now returns a `SqlQueryOutcome` (`Completed` / `ClientDisconnected`) so the disconnect is modelled explicitly instead of being smuggled through an error string. On a disconnect: no `Cube SQL Error` event (a `debug!` line instead), and no error payload written back into the dead stream.

The Postgres shim already takes this view of a peer that went away — `BrokenPipe` / `UnexpectedEof` becomes `Ok(())` at the top level of `PostgresConnection::run_on` rather than an error.

**What this does NOT change, and what is probably the bigger half of CUB-4099**

Cancellation on disconnect is untouched: dropping the `execute()` future in the `select!` still tears down the in-flight query, exactly as before. The traces suggest that behaviour is itself implicated in the customer's problem — the `Client disconnected` rows cluster hard at ~61s, the Athena `Query was cancelled` rows cluster at ~61.2–61.5s, and the long retry sequence ends with `Removing orphaned query` after 44 minutes without ever delivering a result. Whether a disconnect on a continue-wait poll should cancel the underlying query, or leave it running for the next poll to re-attach to, is a separate design question with a much larger blast radius. Deliberately out of scope here; this PR only stops the misreporting.

**Testing**

New case in `packages/cubejs-backend-native/test/sql.test.ts` closes the response stream right after the JSONL schema header and asserts no `Cube SQL Error` load event and no error payload handed to the stream's `end`. Verified red on the pre-fix code (both assertions) and green on the fix — see the thread for the exact output.

Run against a debug build of the native module with and without `CUBESQL_STREAM_MODE=true` (8/8 in `sql.test.ts` both ways), plus `cargo check`, `cargo clippy`, `cargo fmt --check`, `tsc` and `eslint`. CI additionally runs this suite on Linux GNU, macOS-14 arm64 and Windows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqPZBF9nQh2G53bUwo91Ws)_