### PR TITLE
docs: restore the maintenance window page on the Mintlify docs site

### DIFF
--- a/docs-mintlify/admin/deployment/maintenance-window.mdx
+++ b/docs-mintlify/admin/deployment/maintenance-window.mdx
@@ -6,8 +6,9 @@ hidden: true
 
 <Note>
 
-Available on the [Enterprise plan](https://cube.dev/pricing) for
-[Dedicated deployments](/admin/deployment/deployment-types#dedicated).
+Available on the [Enterprise plan](https://cube.dev/pricing) with the
+[Single-tenant infrastructure](/admin/deployment/infrastructure#dedicated-infrastructure)
+add-on.
 
 </Note>
 

--- a/docs-mintlify/admin/deployment/maintenance-window.mdx
+++ b/docs-mintlify/admin/deployment/maintenance-window.mdx
@@ -1,0 +1,151 @@
+---
+title: Maintenance window
+description: Apply platform updates during a scheduled weekly time slot instead of immediately as they are released.
+---
+
+<Note>
+
+Available on the [Enterprise plan](https://cube.dev/pricing) for
+[Dedicated deployments](/admin/deployment/deployment-types#dedicated).
+
+</Note>
+
+Cube can apply platform updates to your infrastructure during a scheduled weekly
+time slot instead of immediately as they are released. This gives you control
+over **when** updates happen, reducing the risk of unexpected changes during
+peak hours.
+
+## How it works
+
+Cube automatically takes daily snapshots of all current service versions. Each
+snapshot captures a consistent, known-good combination of service versions at
+that point in time.
+
+A snapshot must be at least **24 hours old** before it becomes eligible for
+deployment. This ensures that only versions confirmed stable in production are
+promoted to tenants with a maintenance window enabled.
+
+During the configured maintenance window, the system automatically advances your
+deployment to the latest eligible snapshot. Outside of the window, no updates
+are applied.
+
+<Info>
+
+You do not choose specific versions. The system manages version progression
+automatically — the maintenance window only controls **when** the update
+happens.
+
+</Info>
+
+## What gets updated
+
+The maintenance window applies to all services for your deployment, including:
+
+- **Control-plane services** — the infrastructure serving the Cube UI, API, and
+  orchestration.
+- **Data-plane services** — the infrastructure responsible for query execution,
+  builds, and worker lifecycle in single-tenant regions.
+
+Both control-plane and data-plane services are updated to the same snapshot
+during the window.
+
+## Configuration
+
+Go to **Admin → Settings → Maintenance Window**:
+
+<Frame>
+  <img
+    src="https://ucarecdn.com/e6db33a7-0d5e-4e28-8494-554393eaf2cb/"
+    alt="Maintenance window settings"
+  />
+</Frame>
+
+1. Toggle **Enable Scheduled Maintenance Window** to on.
+2. Select the **Day of week** (e.g., Sunday).
+3. Select the **Time (UTC)** — the hour when the update window opens (e.g.,
+   02:00 UTC).
+
+Settings are saved automatically.
+
+<Warning>
+
+The maintenance window spans **one hour** starting from the selected time. For
+example, selecting 02:00 means updates may be applied between 02:00 and 02:59
+UTC on the selected day.
+
+</Warning>
+
+When you enable the maintenance window for the first time, the day defaults to
+**Sunday** and the time defaults to **02:00 UTC**. Your deployment is
+immediately assigned the latest eligible snapshot so that it starts from a
+known, stable version.
+
+## Active version
+
+When the maintenance window is enabled and your deployment has been updated at
+least once, an **Active Version** section appears below the schedule settings.
+
+The **Active Version** dropdown shows all snapshots that were active for your
+deployment within the last 7 days. The currently active snapshot is pre-selected
+and marked with `(current)`. To switch to a different version, select it from
+the dropdown. The change takes effect on the next reconciliation cycle.
+
+<Warning>
+
+Only snapshots from the last 7 days are available. If you need to revert to an
+older version, contact [support](/admin/account-billing/support).
+
+</Warning>
+
+## Upgrade now
+
+If a critical fix has been released and you don't want to wait for the next
+scheduled maintenance window, you can upgrade to the current production versions
+immediately.
+
+When the maintenance window is enabled, an **Upgrade Now** section appears at
+the bottom of the settings page. Click **Upgrade Now** to create a snapshot from
+the service versions currently running in production and switch your deployment
+to it right away. The button is disabled while the upgrade is in progress. Once
+complete, the new version will appear in the **Active Version** dropdown.
+
+<Info>
+
+Unlike the scheduled maintenance window, **Upgrade Now** does not require a
+24-hour eligibility buffer — it always uses the versions running in production
+at the time you click the button. If your deployment is already running those
+versions, the button will return an error.
+
+</Info>
+
+## FAQ
+
+### What happens if I disable the maintenance window?
+
+Your deployment returns to the default behavior — receiving updates immediately
+as they are released.
+
+### What if no new snapshot is available during my maintenance window?
+
+Nothing happens. The system only advances your deployment if a newer eligible
+snapshot exists. If you are already on the latest eligible snapshot, the
+maintenance window is a no-op.
+
+### How far behind the latest release will my services be?
+
+At most, your services will be behind by the interval between your maintenance
+windows (typically one week) plus the 24-hour eligibility buffer. For example,
+with a Sunday 02:00 UTC window, your services could be up to ~8 days behind the
+latest release in the worst case.
+
+### Can I roll back to a previous version?
+
+Yes. When the maintenance window is enabled, the settings page shows an **Active
+Version** dropdown listing all snapshots from the last 7 days. Select any of
+them to switch back. See [Active version](#active-version) above for details.
+
+### Can I trigger an immediate upgrade without waiting for the window?
+
+Yes. Use the **Upgrade Now** button on the settings page to upgrade to the
+current production versions immediately, without waiting for the 24-hour
+eligibility buffer. See [Upgrade now](#upgrade-now) above for details.

--- a/docs-mintlify/admin/deployment/maintenance-window.mdx
+++ b/docs-mintlify/admin/deployment/maintenance-window.mdx
@@ -1,6 +1,7 @@
 ---
 title: Maintenance window
 description: Apply platform updates during a scheduled weekly time slot instead of immediately as they are released.
+hidden: true
 ---
 
 <Note>

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -317,7 +317,6 @@
               "admin/deployment/encryption-keys",
               "admin/deployment/limits",
               "admin/deployment/infrastructure",
-              "admin/deployment/maintenance-window",
               {
                 "group": "Dedicated Infrastructure",
                 "root": "admin/deployment/dedicated/index",

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -317,6 +317,7 @@
               "admin/deployment/encryption-keys",
               "admin/deployment/limits",
               "admin/deployment/infrastructure",
+              "admin/deployment/maintenance-window",
               {
                 "group": "Dedicated Infrastructure",
                 "root": "admin/deployment/dedicated/index",

--- a/docs/redirects-new-docs.json
+++ b/docs/redirects-new-docs.json
@@ -2621,7 +2621,7 @@
   },
   {
     "source": "/product/administration/workspace/maintenance-window",
-    "destination": "https://docs.cube.dev/admin",
+    "destination": "https://docs.cube.dev/admin/deployment/maintenance-window",
     "permanent": true
   },
   {


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

The maintenance window page lived only on the deprecated Nextra site (`docs/content/product/administration/workspace/maintenance-window.mdx`) and was never migrated, so its public URL 308-redirected to the generic `/admin` index and the content was effectively unreachable.

- Port the page to `docs-mintlify/admin/deployment/maintenance-window.mdx`, converted to Mintlify conventions: frontmatter `title`/`description` instead of an H1, `<InfoBox>`/`<WarningBox>` → `<Info>`/`<Warning>`, `<Screenshot>` → `<Frame>`, `<Btn>` → a bold UI path.
- Apply current naming per `docs-mintlify/CLAUDE.md`: "Cube Cloud" → "Cube", "Enterprise and above plans" → "Enterprise plan", "dedicated regions" → "single-tenant regions". The plan/eligibility callout links to `/admin/deployment/deployment-types#dedicated`, matching where the legacy `[ref-dedicated]` pointed.
- Keep the page out of public navigation with `hidden: true` rather than a `docs.json` entry, mirroring the legacy `display: hidden` in `_meta.js` — the page was written as an internal-access doc. It stays reachable by direct link.
- Repoint the legacy redirect in `docs/redirects-new-docs.json` from `/admin` to the restored page.

Content is unchanged from the legacy page: the 24-hour eligibility buffer, the one-hour window, the Sunday 02:00 UTC defaults, the 7-day Active Version list, Upgrade Now, and the full FAQ all carry over verbatim in substance.

**Validation**

Docs-only change, no code paths touched. JSON validity of `docs.json` and `redirects-new-docs.json` verified; the screenshot URL returns 200 (`image/png`); both internal link targets exist. The Mintlify dev server was not run in this environment, so the visual render is unverified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuHRndNtkLRgGXUJMxdjFZ)_