### PR TITLE
feat(cubesql): Push UNION down to the data source

### DIFF
--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -70,6 +70,10 @@ export class DruidQuery extends BaseQuery {
     templates.functions.UTCTIMESTAMP = 'CURRENT_TIMESTAMP';
     delete templates.functions.WIDTH_BUCKET;
 
+    // Druid only accepts set operations in narrow forms and has no UNION of distinct rows,
+    // so the SQL API leaves them to post processing here.
+    delete templates.statements.union;
+
     return templates;
   }
 }

--- a/packages/cubejs-ksql-driver/src/KsqlQuery.ts
+++ b/packages/cubejs-ksql-driver/src/KsqlQuery.ts
@@ -79,6 +79,9 @@ export class KsqlQuery extends BaseQuery {
     // expressions instead of column ordinals.
     templates.statements.group_by_exprs = '{{ group_by | map(attribute=\'expr\') | join(\', \') }}';
     delete templates.functions.WIDTH_BUCKET;
+    // ksqlDB has no set operations, so the SQL API leaves them to post processing here.
+    delete templates.statements.union;
+
     return templates;
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4600,6 +4600,12 @@ export class BaseQuery {
           '{% if offset is not none %}\nOFFSET {{ offset }}{% endif %}',
         group_by_exprs: '{{ group_by | map(attribute=\'index\') | join(\', \') }}',
         join: '{{ join_type }} JOIN {{ source }} ON {{ condition }}',
+        union: '{% for query in queries %}(\n' +
+          '{{ query | indent(2, true) }}\n' +
+          ')' +
+          '{% if not loop.last %}\nUNION {% if not distinct %}ALL {% endif %}{% endif %}' +
+          '{% endfor %}' +
+          '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}',
         cte: '{{ alias }} AS ({{ query | indent(2, true) }})',
         time_series_select: 'SELECT date_from::timestamp AS "date_from",\n' +
           'date_to::timestamp AS "date_to" \n' +

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -383,6 +383,14 @@ export class BigqueryQuery extends BaseQuery {
     'GENERATE_TIMESTAMP_ARRAY(TIMESTAMP({{ range_source }}.{{ min_name }}), TIMESTAMP({{ range_source }}.{{ max_name }}), INTERVAL {{ granularity }})\n' +
     '{% endif %}' +
     ') AS d';
+    // GoogleSQL requires a set operator to say which mode it is: a bare UNION does not parse.
+    templates.statements.union = '{% for query in queries %}(\n' +
+      '{{ query | indent(2, true) }}\n' +
+      ')' +
+      '{% if not loop.last %}\nUNION {% if distinct %}DISTINCT{% else %}ALL{% endif %} {% endif %}' +
+      '{% endfor %}' +
+      '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}';
+
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -295,6 +295,15 @@ export class ClickHouseQuery extends BaseQuery {
     '{% endfor %}' +
     ') AS dates';
 
+    // ClickHouse rejects a bare UNION unless `union_default_mode` is set, so a set
+    // operation has to say which one it is.
+    templates.statements.union = '{% for query in queries %}(\n' +
+      '{{ query | indent(2, true) }}\n' +
+      ')' +
+      '{% if not loop.last %}\nUNION {% if distinct %}DISTINCT{% else %}ALL{% endif %} {% endif %}' +
+      '{% endfor %}' +
+      '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}';
+
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -359,6 +359,16 @@ export class MssqlQuery extends BaseQuery {
       '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}\nOFFSET {% if offset is not none %}{{ offset }}{% else %}0{% endif %} ROWS' +
       '\nFETCH NEXT {% if limit is not none %}{{ limit }}{% else %}2147483647{% endif %} ROWS ONLY{% endif %}' +
       '{% if ctes %}\nOPTION (MAXRECURSION 0){% endif %}';
+    // T-SQL has no LIMIT, and neither TOP nor OFFSET/FETCH can be attached to a set
+    // operation directly (OFFSET/FETCH also requires an ORDER BY), so a bounded set
+    // operation is read through a derived table.
+    templates.statements.union = '{% if limit is not none %}SELECT TOP {{ limit }} * FROM (\n{% endif %}' +
+      '{% for query in queries %}(\n' +
+      '{{ query | indent(2, true) }}\n' +
+      ')' +
+      '{% if not loop.last %}\nUNION {% if not distinct %}ALL {% endif %}{% endif %}' +
+      '{% endfor %}' +
+      '{% if limit is not none %}\n) AS union_result{% endif %}';
     // MSSQL has no boolean type — a segment projected as a dimension must be a BIT.
     templates.expressions.wrap_segment_select = 'CAST((CASE WHEN {{ expr }} THEN 1 ELSE 0 END) AS BIT)';
     // Reading a segment back from a pre-aggregation: it is a stored BIT column,

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -245,6 +245,13 @@ export class OracleQuery extends BaseQuery {
       '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}{% endif %}' +
       '{% if offset is not none %}\nOFFSET {{ offset }} ROWS{% endif %}' +
       '{% if limit is not none %}\nFETCH NEXT {{ limit }} ROWS ONLY{% endif %}';
+    // Oracle row-limiting syntax again: the base template ends a set operation with LIMIT.
+    templates.statements.union = '{% for query in queries %}(\n' +
+      '{{ query | indent(2, true) }}\n' +
+      ')' +
+      '{% if not loop.last %}\nUNION {% if not distinct %}ALL {% endif %}{% endif %}' +
+      '{% endfor %}' +
+      '{% if limit is not none %}\nFETCH NEXT {{ limit }} ROWS ONLY{% endif %}';
     // Oracle has no `::` cast and no `VALUES` row-constructor table source. Build the
     // series with TO_TIMESTAMP + UNION ALL SELECT ... FROM DUAL, and no `AS` before
     // the derived-table alias (Oracle forbids it). `seria` items are [from, to] pairs.

--- a/packages/cubejs-schema-compiler/src/adapter/SqliteQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SqliteQuery.ts
@@ -85,6 +85,9 @@ export class SqliteQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     delete templates.functions.WIDTH_BUCKET;
+    // A compound select takes no parenthesised operands in SQLite, so the SQL API leaves
+    // set operations to post processing here rather than pushing them down.
+    delete templates.statements.union;
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/test/unit/allDialects.ts
+++ b/packages/cubejs-schema-compiler/test/unit/allDialects.ts
@@ -4,6 +4,10 @@ import path from 'path';
 // Tests run from `dist`, so this resolves to the compiled adapters.
 const ADAPTER_DIR = path.join(__dirname, '..', '..', 'src', 'adapter');
 
+// The adapter directory holds far more than this; the floor is only here so a scan that
+// silently matched nothing fails loudly rather than passing every invariant vacuously.
+const MIN_DIALECTS = 10;
+
 /**
  * Every dialect, read off the adapter directory rather than listed by hand, so a dialect
  * added later cannot quietly escape an invariant asserted over all of them.
@@ -18,8 +22,10 @@ export function allDialects(): [string, any][] {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     .map(name => [name, require(path.join(ADAPTER_DIR, name))[name]] as [string, any]);
 
-  if (classes.length < 10) {
-    throw new Error(`Expected the adapter directory to hold more dialects than ${classes.length}`);
+  if (classes.length < MIN_DIALECTS) {
+    throw new Error(
+      `Expected the adapter directory to hold at least ${MIN_DIALECTS} dialects, found ${classes.length}`
+    );
   }
 
   return classes;

--- a/packages/cubejs-schema-compiler/test/unit/allDialects.ts
+++ b/packages/cubejs-schema-compiler/test/unit/allDialects.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+// Tests run from `dist`, so this resolves to the compiled adapters.
+const ADAPTER_DIR = path.join(__dirname, '..', '..', 'src', 'adapter');
+
+/**
+ * Every dialect, read off the adapter directory rather than listed by hand, so a dialect
+ * added later cannot quietly escape an invariant asserted over all of them.
+ *
+ * Paired with its name, which is what a caller needs to report which dialect failed.
+ */
+export function allDialects(): [string, any][] {
+  const classes = fs.readdirSync(ADAPTER_DIR)
+    // `.ts` keeps this working if the tests are ever run from source.
+    .map(file => file.match(/^(\w+Query)\.(?:ts|js)$/)?.[1])
+    .filter((name): name is string => !!name && name !== 'BaseQuery')
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    .map(name => [name, require(path.join(ADAPTER_DIR, name))[name]] as [string, any]);
+
+  if (classes.length < 10) {
+    throw new Error(`Expected the adapter directory to hold more dialects than ${classes.length}`);
+  }
+
+  return classes;
+}
+
+export function dialect(name: string): any {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  return require(path.join(ADAPTER_DIR, name))[name];
+}

--- a/packages/cubejs-schema-compiler/test/unit/positional-params.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/positional-params.test.ts
@@ -1,7 +1,6 @@
-import fs from 'fs';
-import path from 'path';
 import { BigqueryQuery } from '../../src/adapter/BigqueryQuery';
 import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { allDialects as allDialectsWithNames } from './allDialects';
 import { prepareJsCompiler } from './PrepareCompiler';
 
 // `?` placeholders are positional: a value referenced from two places in the
@@ -63,23 +62,6 @@ function placeholdersCount(sql: string) {
   return (sql.match(/\?/g) || []).length;
 }
 
-// Read off the directory rather than listed by hand, so a dialect added later
-// cannot quietly escape the invariant below.
-const ADAPTER_DIR = path.join(__dirname, '..', '..', 'src', 'adapter');
-
-function allDialects() {
-  const classes = fs.readdirSync(ADAPTER_DIR)
-    // Tests run from `dist`, so the adapter dir holds `.js`; `.ts` keeps this
-    // working if they are ever run from source.
-    .map(file => file.match(/^(\w+Query)\.(?:ts|js)$/)?.[1])
-    .filter((name): name is string => !!name && name !== 'BaseQuery')
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    .map(name => require(path.join(ADAPTER_DIR, name))[name]);
-
-  expect(classes.length).toBeGreaterThan(10);
-  return classes;
-}
-
 describe('positional params', () => {
   // Dialects whose placeholder carries the param index are free to share a param
   // between placeholders; those rendering a bare placeholder are not, since the
@@ -87,6 +69,8 @@ describe('positional params', () => {
   it('never reuses params on dialects whose placeholder omits the param index', async () => {
     const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(model);
     await compiler.compile();
+
+    const allDialects = () => allDialectsWithNames().map(([, QueryClass]) => QueryClass);
 
     const reusingPositionalDialects = allDialects().filter(QueryClass => {
       const query = new QueryClass({ joinGraph, cubeEvaluator, compiler }, {

--- a/packages/cubejs-schema-compiler/test/unit/positional-params.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/positional-params.test.ts
@@ -1,6 +1,6 @@
 import { BigqueryQuery } from '../../src/adapter/BigqueryQuery';
 import { PostgresQuery } from '../../src/adapter/PostgresQuery';
-import { allDialects as allDialectsWithNames } from './allDialects';
+import { allDialects } from './allDialects';
 import { prepareJsCompiler } from './PrepareCompiler';
 
 // `?` placeholders are positional: a value referenced from two places in the
@@ -70,9 +70,7 @@ describe('positional params', () => {
     const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(model);
     await compiler.compile();
 
-    const allDialects = () => allDialectsWithNames().map(([, QueryClass]) => QueryClass);
-
-    const reusingPositionalDialects = allDialects().filter(QueryClass => {
+    const reusingPositionalDialects = allDialects().filter(([, QueryClass]) => {
       const query = new QueryClass({ joinGraph, cubeEvaluator, compiler }, {
         measures: ['orders.count'],
         timezone: 'UTC',
@@ -80,7 +78,7 @@ describe('positional params', () => {
       const indexedPlaceholder = query.sqlTemplates().params.param.includes('param_index');
 
       return !indexedPlaceholder && query.shouldReuseParams;
-    }).map(QueryClass => QueryClass.name);
+    }).map(([name]) => name);
 
     expect(reusingPositionalDialects).toEqual([]);
   });

--- a/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
@@ -1,28 +1,13 @@
-import fs from 'fs';
-import path from 'path';
-
-// Read off the directory rather than listed by hand, so a dialect added later cannot
-// quietly escape the invariants below.
-const ADAPTER_DIR = path.join(__dirname, '..', '..', 'src', 'adapter');
-
-function allDialects(): [string, any][] {
-  const classes = fs.readdirSync(ADAPTER_DIR)
-    // Tests run from `dist`, so the adapter dir holds `.js`; `.ts` keeps this working if
-    // they are ever run from source.
-    .map(file => file.match(/^(\w+Query)\.(?:ts|js)$/)?.[1])
-    .filter((name): name is string => !!name && name !== 'BaseQuery')
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    .map(name => [name, require(path.join(ADAPTER_DIR, name))[name]] as [string, any]);
-
-  expect(classes.length).toBeGreaterThan(10);
-  return classes;
-}
+import { allDialects, dialect } from './allDialects';
 
 // `statements/union` is read by the SQL API when it pushes a set operation down to the
 // data source, and by nothing else, so these assertions are what stands between an edit
 // to one of these templates and a syntax error at a customer's warehouse.
 //
-// Only the templates are read here: a Query needs no compiled model to answer with them.
+// Only the templates are read here, off a bare prototype rather than a query built on a
+// compiled model. That reads the templates a dialect writes unconditionally, which every
+// `statements.union` is today; a dialect that gated one on instance state would need a
+// real query here, since `this` carries nothing.
 function unionTemplate(QueryClass: any): string | undefined {
   return QueryClass.prototype.sqlTemplates
     .call(Object.create(QueryClass.prototype))
@@ -60,17 +45,13 @@ describe('statements/union', () => {
 
   it('leaves the template undefined where a set operation cannot be expressed', () => {
     // A compound select takes no parenthesised operand in SQLite
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    const { SqliteQuery } = require(path.join(ADAPTER_DIR, 'SqliteQuery'));
-    expect(unionTemplate(SqliteQuery)).toBeUndefined();
+    expect(unionTemplate(dialect('SqliteQuery'))).toBeUndefined();
   });
 
   it('names the mode of the operation where the dialect requires it', () => {
     // GoogleSQL and ClickHouse both reject a bare UNION
     for (const name of ['BigqueryQuery', 'ClickHouseQuery']) {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      const QueryClass = require(path.join(ADAPTER_DIR, name))[name];
-      expect(unionTemplate(QueryClass)).toContain('{% if distinct %}DISTINCT{% else %}ALL{% endif %}');
+      expect(unionTemplate(dialect(name))).toContain('{% if distinct %}DISTINCT{% else %}ALL{% endif %}');
     }
   });
 
@@ -82,9 +63,7 @@ describe('statements/union', () => {
       ['MssqlQuery', 'SELECT TOP {{ limit }} * FROM ('],
     ];
     for (const [name, clause] of clauses) {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      const QueryClass = require(path.join(ADAPTER_DIR, name))[name];
-      expect(unionTemplate(QueryClass)).toContain(clause);
+      expect(unionTemplate(dialect(name))).toContain(clause);
     }
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
@@ -24,8 +24,10 @@ describe('statements/union', () => {
       return;
     }
 
+    // The operator itself: without it the rendered SQL is not a set operation at all
+    expect(template).toMatch(/\bUNION\b/);
     // Every query of the operation, rendered rather than merely looped over
-    expect(template).toContain('{% for query in queries %}');
+    expect(template).toMatch(/\{%\s*for query in queries\s*%\}/);
     expect(template).toContain('{{ query');
     // The row cap bounds the result of the whole operation, and is interpolated into the
     // clause that bounds it rather than only guarding it
@@ -37,9 +39,9 @@ describe('statements/union', () => {
     expect(template).toMatch(keepsDuplicates);
     expect(template.replace(new RegExp(keepsDuplicates.source, 'g'), '')).not.toContain('ALL');
     // Balanced tags: an unclosed block renders as a template error at query time
-    expect((template.match(/\{%\s*if /g) || []).length)
+    expect((template.match(/\{%\s*if\b/g) || []).length)
       .toEqual((template.match(/\{%\s*endif\s*%\}/g) || []).length);
-    expect((template.match(/\{%\s*for /g) || []).length)
+    expect((template.match(/\{%\s*for\b/g) || []).length)
       .toEqual((template.match(/\{%\s*endfor\s*%\}/g) || []).length);
   });
 

--- a/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
@@ -39,14 +39,18 @@ describe('statements/union', () => {
       return;
     }
 
-    // Every query of the operation, and only the ones it was given
+    // Every query of the operation, rendered rather than merely looped over
     expect(template).toContain('{% for query in queries %}');
-    // The row cap bounds the result of the whole operation
-    expect(template).toMatch(/\{%\s*if limit is not none\s*%\}/);
-    // However the dialect spells the operator, `ALL` is what keeps the duplicates, so it
-    // belongs to the branch that keeps them and to no other
-    expect(template).toMatch(/UNION.*ALL/s);
-    expect(template).toMatch(/\{%\s*if (not )?distinct\s*%\}/);
+    expect(template).toContain('{{ query');
+    // The row cap bounds the result of the whole operation, and is interpolated into the
+    // clause that bounds it rather than only guarding it
+    expect(template).toMatch(/\{%\s*if limit is not none\s*%\}[^]*\{\{\s*limit\s*\}\}/);
+    // However the dialect spells the operator, `ALL` is what keeps the duplicates, so
+    // every `ALL` sits on the branch that keeps them and nowhere else. The dialects write
+    // that branch two ways: naming only `ALL`, or naming both modes.
+    const keepsDuplicates = /\{%\s*if not distinct\s*%\}ALL|\{%\s*if distinct\s*%\}DISTINCT\{%\s*else\s*%\}ALL/;
+    expect(template).toMatch(keepsDuplicates);
+    expect(template.replace(new RegExp(keepsDuplicates.source, 'g'), '')).not.toContain('ALL');
     // Balanced tags: an unclosed block renders as a template error at query time
     expect((template.match(/\{%\s*if /g) || []).length)
       .toEqual((template.match(/\{%\s*endif\s*%\}/g) || []).length);

--- a/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/union-template.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+
+// Read off the directory rather than listed by hand, so a dialect added later cannot
+// quietly escape the invariants below.
+const ADAPTER_DIR = path.join(__dirname, '..', '..', 'src', 'adapter');
+
+function allDialects(): [string, any][] {
+  const classes = fs.readdirSync(ADAPTER_DIR)
+    // Tests run from `dist`, so the adapter dir holds `.js`; `.ts` keeps this working if
+    // they are ever run from source.
+    .map(file => file.match(/^(\w+Query)\.(?:ts|js)$/)?.[1])
+    .filter((name): name is string => !!name && name !== 'BaseQuery')
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    .map(name => [name, require(path.join(ADAPTER_DIR, name))[name]] as [string, any]);
+
+  expect(classes.length).toBeGreaterThan(10);
+  return classes;
+}
+
+// `statements/union` is read by the SQL API when it pushes a set operation down to the
+// data source, and by nothing else, so these assertions are what stands between an edit
+// to one of these templates and a syntax error at a customer's warehouse.
+//
+// Only the templates are read here: a Query needs no compiled model to answer with them.
+function unionTemplate(QueryClass: any): string | undefined {
+  return QueryClass.prototype.sqlTemplates
+    .call(Object.create(QueryClass.prototype))
+    .statements
+    .union;
+}
+
+describe('statements/union', () => {
+  it.each(allDialects())('%s renders every query, once, bounded', (_name, QueryClass) => {
+    const template = unionTemplate(QueryClass);
+    if (template === undefined) {
+      // Deliberately opted out: with no template the SQL API leaves the set operation to
+      // post processing rather than pushing down SQL the data source cannot parse
+      return;
+    }
+
+    // Every query of the operation, and only the ones it was given
+    expect(template).toContain('{% for query in queries %}');
+    // The row cap bounds the result of the whole operation
+    expect(template).toMatch(/\{%\s*if limit is not none\s*%\}/);
+    // However the dialect spells the operator, `ALL` is what keeps the duplicates, so it
+    // belongs to the branch that keeps them and to no other
+    expect(template).toMatch(/UNION.*ALL/s);
+    expect(template).toMatch(/\{%\s*if (not )?distinct\s*%\}/);
+    // Balanced tags: an unclosed block renders as a template error at query time
+    expect((template.match(/\{%\s*if /g) || []).length)
+      .toEqual((template.match(/\{%\s*endif\s*%\}/g) || []).length);
+    expect((template.match(/\{%\s*for /g) || []).length)
+      .toEqual((template.match(/\{%\s*endfor\s*%\}/g) || []).length);
+  });
+
+  it('leaves the template undefined where a set operation cannot be expressed', () => {
+    // A compound select takes no parenthesised operand in SQLite
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const { SqliteQuery } = require(path.join(ADAPTER_DIR, 'SqliteQuery'));
+    expect(unionTemplate(SqliteQuery)).toBeUndefined();
+  });
+
+  it('names the mode of the operation where the dialect requires it', () => {
+    // GoogleSQL and ClickHouse both reject a bare UNION
+    for (const name of ['BigqueryQuery', 'ClickHouseQuery']) {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      const QueryClass = require(path.join(ADAPTER_DIR, name))[name];
+      expect(unionTemplate(QueryClass)).toContain('{% if distinct %}DISTINCT{% else %}ALL{% endif %}');
+    }
+  });
+
+  it('bounds the operation with the row limiting clause of the dialect', () => {
+    const clauses: [string, string][] = [
+      ['PostgresQuery', 'LIMIT {{ limit }}'],
+      ['OracleQuery', 'FETCH NEXT {{ limit }} ROWS ONLY'],
+      // Neither TOP nor OFFSET/FETCH attaches to a compound query in T-SQL
+      ['MssqlQuery', 'SELECT TOP {{ limit }} * FROM ('],
+    ];
+    for (const [name, clause] of clauses) {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      const QueryClass = require(path.join(ADAPTER_DIR, name))[name];
+      expect(unionTemplate(QueryClass)).toContain(clause);
+    }
+  });
+});

--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -134,10 +134,14 @@ transform that walks the list itself.
   exists) about nodes the **pattern** already bound. Relationships between several
   matched nodes — "both sides reach the same data source" — belong in the pattern, by
   reusing one pattern variable in both places, so unification enforces them.
-  Caveat worth knowing: `wrapper-subqueries-wrapped-scan-to-pull` (`rules/wrapper/subquery.rs`)
-  re-contexts any `wrapper_pushdown_replacer` over a finished `cube_scan_wrapper` without
-  comparing input data sources — see the `TODO` on it — so unification alone does not
-  currently guarantee data-source agreement for plan-level list elements.
+- A push-down replacer must never end up on top of an already pulled-up subtree. Inputs
+  that arrive as a finished `cube_scan_wrapper(wrapper_pullup_replacer(..))` — the queries
+  of a set operation, the sides of a join — have nothing left to push into, so their list
+  carries a **pull-up** replacer and is consumed by pull-up rules. Putting a push-down
+  replacer there instead makes `wrapper-subqueries-wrapped-scan-to-pull`
+  (`rules/wrapper/subquery.rs`) match, which re-contexts the element without comparing
+  input data sources — see the `TODO` on it. That rule is for the subquery path only;
+  reaching it from anywhere else means the rules above it are shaped wrong.
 
 ### Debugging Query Compilation
 ```bash

--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -124,9 +124,12 @@ that match the list node itself — never by a transform that walks it.
   Build them with the flat branch of `add_expr_flat_list_node!` (or an equivalent that
   adds a single node with every element), register the node in `ListType`, and traverse
   with `flat_list_pushdown_pullup_rules` / `replacer_flat_push_down_node` /
-  `replacer_flat_pull_up_node`. The flat pull-up matches the whole list in one rule and
+  `replacer_flat_pull_up_node`, or `transforming_list_rewrite_with_lists_and_vars` when the
+  output needs a node no pattern can spell out (a cleared replacer context, an alias
+  converted to another node type). The flat pull-up matches the whole list in one rule and
   takes `top_level_elem_vars`, which is how a fact that must hold across every element —
-  all queries reaching the same data source — is enforced.
+  all queries reaching the same data source — is enforced: name the variable there and
+  unification does the rest, with no comparison of your own.
 - Generate the traversal with the existing helpers rather than by hand:
   `WrapperRules::list_pushdown_pullup_rules` / `flat_list_pushdown_pullup_rules`
   (or `replacer_push_down_node` / `replacer_pull_up_node` underneath them). They emit

--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -115,15 +115,23 @@ cargo bench
 
 ### Rewrite rules: never traverse a list recursively
 
-Every matcher must match exactly **one** level. Lists in the e-graph are cons cells,
-and they are consumed by dedicated rules that peel one cell at a time — never by a
-transform that walks the list itself.
+Every matcher must match exactly **one** level. A list is consumed by dedicated rules
+that match the list node itself — never by a transform that walks it.
 
+- **Lists are flat, not head/tail.** A list node holds all of its elements as children
+  (`UnionInputs(a, b, c)`), not nested cons cells (`UnionInputs(a, UnionInputs(b, ...))`).
+  Cons lists are legacy — do not add new ones, and prefer converting one you touch.
+  Build them with the flat branch of `add_expr_flat_list_node!` (or an equivalent that
+  adds a single node with every element), register the node in `ListType`, and traverse
+  with `flat_list_pushdown_pullup_rules` / `replacer_flat_push_down_node` /
+  `replacer_flat_pull_up_node`. The flat pull-up matches the whole list in one rule and
+  takes `top_level_elem_vars`, which is how a fact that must hold across every element —
+  all queries reaching the same data source — is enforced.
 - Generate the traversal with the existing helpers rather than by hand:
   `WrapperRules::list_pushdown_pullup_rules` / `flat_list_pushdown_pullup_rules`
   (or `replacer_push_down_node` / `replacer_pull_up_node` underneath them). They emit
-  the `-push-down`, `-pull-up` and `-tail` rules that distribute a replacer over a cons
-  cell and collect it back once both sides are done.
+  the `-push-down`, `-pull-up` and `-tail` rules that distribute a replacer over the
+  list's elements and collect it back once they are all done.
 - Push-down and pull-up are **separate rules**. Do not fold both directions, or the
   list walk, into one rewrite with a big transform.
 - Do not write an imperative reader over `egraph[id].nodes` to collect a list's

--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -113,6 +113,32 @@ cargo bench
 3. Add tests with snapshot expectations
 4. Update protocol-specific handling if needed
 
+### Rewrite rules: never traverse a list recursively
+
+Every matcher must match exactly **one** level. Lists in the e-graph are cons cells,
+and they are consumed by dedicated rules that peel one cell at a time — never by a
+transform that walks the list itself.
+
+- Generate the traversal with the existing helpers rather than by hand:
+  `WrapperRules::list_pushdown_pullup_rules` / `flat_list_pushdown_pullup_rules`
+  (or `replacer_push_down_node` / `replacer_pull_up_node` underneath them). They emit
+  the `-push-down`, `-pull-up` and `-tail` rules that distribute a replacer over a cons
+  cell and collect it back once both sides are done.
+- Push-down and pull-up are **separate rules**. Do not fold both directions, or the
+  list walk, into one rewrite with a big transform.
+- Do not write an imperative reader over `egraph[id].nodes` to collect a list's
+  elements inside a transform. An e-class holds many representations, so picking one is
+  arbitrary; the cons shape is also an implementation detail of how the list was built
+  (`add_plan_list_node!`), which a hand-rolled reader silently couples itself to.
+- A transform should only decide scalar facts (a flag, an alias, whether a template
+  exists) about nodes the **pattern** already bound. Relationships between several
+  matched nodes — "both sides reach the same data source" — belong in the pattern, by
+  reusing one pattern variable in both places, so unification enforces them.
+  Caveat worth knowing: `wrapper-subqueries-wrapped-scan-to-pull` (`rules/wrapper/subquery.rs`)
+  re-contexts any `wrapper_pushdown_replacer` over a finished `cube_scan_wrapper` without
+  comparing input data sources — see the `TODO` on it — so unification alone does not
+  currently guarantee data-source agreement for plan-level list elements.
+
 ### Debugging Query Compilation
 ```bash
 # Enable detailed logging

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -839,6 +839,13 @@ impl CubeScanWrapperNode {
                                 .map(|subq| subq.as_ref())
                                 .any(Self::has_ungrouped_wrapped_node)
                     }
+                } else if let Some(wrapped_union) = node.as_any().downcast_ref::<WrappedUnionNode>()
+                {
+                    wrapped_union
+                        .inputs
+                        .iter()
+                        .map(|input| input.as_ref())
+                        .any(Self::has_ungrouped_wrapped_node)
                 } else {
                     false
                 }
@@ -934,6 +941,18 @@ impl CubeScanWrapperNode {
                         node: Arc::new(new_node),
                     }))
                 } else if let Some(node) = wrapped_select_node {
+                    let mut new_node = node.clone();
+                    new_node.limit = Some(new_node.limit.map_or(query_limit as usize, |limit| {
+                        min(limit, query_limit as usize)
+                    }));
+                    Arc::new(LogicalPlan::Extension(Extension {
+                        node: Arc::new(new_node),
+                    }))
+                } else if let Some(node) = extension_node
+                    .as_any()
+                    .downcast_ref::<WrappedUnionNode>()
+                    .cloned()
+                {
                     let mut new_node = node.clone();
                     new_node.limit = Some(new_node.limit.map_or(query_limit as usize, |limit| {
                         min(limit, query_limit as usize)
@@ -1192,6 +1211,18 @@ impl CubeScanWrapperNode {
                             parent_data_source,
                         )
                         .await
+                } else if let Some(wrapped_union_node) = node_any.downcast_ref::<WrappedUnionNode>()
+                {
+                    wrapped_union_node
+                        .generate_sql(
+                            meta,
+                            transport,
+                            load_request_meta,
+                            state,
+                            values,
+                            parent_data_source,
+                        )
+                        .await
                 } else {
                     return Err(CubeError::internal(format!(
                         "Can't generate SQL for node: {node:?}"
@@ -1276,6 +1307,229 @@ impl UserDefinedLogicalNode for CubeScanWrapperNode {
             auth_context: self.auth_context.clone(),
             span_id: self.span_id.clone(),
             config_obj: self.config_obj.clone(),
+        })
+    }
+}
+
+/// A set operation whose inputs all push down to the same data source, rendered as a
+/// `UNION` in the generated SQL rather than run as post processing in DataFusion.
+///
+/// The row limit is not part of the plan the rewriter builds: like [`WrappedSelectNode`],
+/// this node is capped by [`CubeScanWrapperNode::set_max_limit_for_node`] when it ends up
+/// at the root of a wrapped plan.
+#[derive(Debug, Clone)]
+pub struct WrappedUnionNode {
+    pub schema: DFSchemaRef,
+    pub inputs: Vec<Arc<LogicalPlan>>,
+    /// `UNION` when set, `UNION ALL` when not
+    pub distinct: bool,
+    pub alias: Option<String>,
+    pub limit: Option<usize>,
+}
+
+impl WrappedUnionNode {
+    pub fn new(
+        schema: DFSchemaRef,
+        inputs: Vec<Arc<LogicalPlan>>,
+        distinct: bool,
+        alias: Option<String>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            schema,
+            inputs,
+            distinct,
+            alias,
+            limit,
+        }
+    }
+}
+
+impl WrappedUnionNode {
+    /// Renders every input as its own query and joins them into one set operation.
+    ///
+    /// Every input has to reach the same data source: a set operation the data source
+    /// evaluates cannot span two of them.
+    async fn generate_sql(
+        &self,
+        meta: &MetaContext,
+        transport: Arc<dyn TransportService>,
+        load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
+        values: Vec<Option<String>>,
+        parent_data_source: Option<&str>,
+    ) -> result::Result<SqlGenerationResult, CubeError> {
+        let Some((first_input, rest_inputs)) = self.inputs.split_first() else {
+            return Err(CubeError::internal(
+                "Can't generate SQL for wrapped union: no inputs".to_string(),
+            ));
+        };
+
+        let SqlGenerationResult {
+            data_source,
+            from_alias,
+            column_remapping,
+            mut sql,
+            request,
+        } = CubeScanWrapperNode::generate_sql_for_node_rec(
+            meta,
+            Arc::clone(&transport),
+            Arc::clone(&load_request_meta),
+            Arc::clone(&state),
+            Arc::clone(first_input),
+            // Every input must keep the column names of the union's schema, which is the
+            // schema of the first one
+            false,
+            values.clone(),
+            parent_data_source,
+        )
+        .await?;
+
+        let Some(data_source) = data_source else {
+            return Err(CubeError::internal(
+                "Can't generate SQL for wrapped union: no data source for the first input"
+                    .to_string(),
+            ));
+        };
+
+        let mut queries = Vec::with_capacity(self.inputs.len());
+        queries.push(sql.sql.to_string());
+
+        for input in rest_inputs {
+            let input_result = CubeScanWrapperNode::generate_sql_for_node_rec(
+                meta,
+                Arc::clone(&transport),
+                Arc::clone(&load_request_meta),
+                Arc::clone(&state),
+                Arc::clone(input),
+                false,
+                values.clone(),
+                Some(&data_source),
+            )
+            .await?;
+
+            if input_result.data_source.as_ref() != Some(&data_source) {
+                return Err(CubeError::internal(format!(
+                    "Can't generate SQL for wrapped union: inputs use different data sources, {:?} and {:?}",
+                    data_source, input_result.data_source
+                )));
+            }
+
+            // Every input generated its SQL on its own, so its placeholders reference its
+            // own values and have to be remapped onto the combined ones
+            let (input_sql, input_values) = input_result.sql.unpack();
+            let mapping = sql.add_values(input_values);
+            queries.push(SqlQuery::remap_placeholders(&input_sql, &mapping)?);
+        }
+
+        let generator = meta
+            .data_source_to_sql_generator
+            .get(&data_source)
+            .ok_or_else(|| {
+                CubeError::internal(format!(
+                    "Can't generate SQL for wrapped union: no sql generator for '{data_source}' data source"
+                ))
+            })?;
+
+        let resulting_sql = generator
+            .get_sql_templates()
+            .union(queries, self.distinct, self.limit)
+            .map_err(|e| {
+                CubeError::internal(format!("Can't generate SQL for wrapped union: {e}"))
+            })?;
+        sql.replace_sql(resulting_sql);
+
+        // Plans above see the union through a single alias, and read its columns by the
+        // names the first input gave them
+        let alias = self.alias.clone().or(from_alias);
+        let column_remapping = column_remapping
+            .map(|column_remapping| self.requalify_remapping(column_remapping, alias.as_deref()));
+
+        Ok(SqlGenerationResult {
+            data_source: Some(data_source),
+            from_alias: alias,
+            sql,
+            column_remapping,
+            request,
+        })
+    }
+
+    /// The union's own schema drops the qualifiers of the first input, or replaces them with
+    /// its alias, so a column reference from above can carry a qualifier the first input's
+    /// remapping has never seen. Add those references, pointing at the same targets.
+    fn requalify_remapping(
+        &self,
+        column_remapping: ColumnRemapping,
+        alias: Option<&str>,
+    ) -> ColumnRemapping {
+        let mut column_remapping = column_remapping;
+        for field in self.schema.fields() {
+            let name = field.name();
+            let Some(target) = column_remapping
+                .column_remapping
+                .get(&Column::from_name(name.clone()))
+                .cloned()
+            else {
+                continue;
+            };
+            for qualifier in alias.map(str::to_string).into_iter().chain(
+                field
+                    .qualifier()
+                    .filter(|qualifier| Some(qualifier.as_str()) != alias)
+                    .cloned(),
+            ) {
+                column_remapping.column_remapping.insert(
+                    Column {
+                        relation: Some(qualifier),
+                        name: name.clone(),
+                    },
+                    target.clone(),
+                );
+            }
+        }
+        column_remapping
+    }
+}
+
+impl UserDefinedLogicalNode for WrappedUnionNode {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        self.inputs.iter().map(|input| input.as_ref()).collect()
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "WrappedUnion: distinct={:?}, alias={:?}, limit={:?}",
+            self.distinct, self.alias, self.limit
+        )
+    }
+
+    fn from_template(
+        &self,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
+    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        assert_eq!(inputs.len(), self.inputs.len(), "input size inconsistent");
+        assert_eq!(exprs.len(), 0, "expression size inconsistent");
+
+        Arc::new(WrappedUnionNode {
+            schema: self.schema.clone(),
+            inputs: inputs.iter().cloned().map(Arc::new).collect(),
+            distinct: self.distinct,
+            alias: self.alias.clone(),
+            limit: self.limit,
         })
     }
 }

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -844,8 +844,7 @@ impl CubeScanWrapperNode {
                     wrapped_union
                         .inputs
                         .iter()
-                        .map(|input| input.as_ref())
-                        .any(Self::has_ungrouped_wrapped_node)
+                        .any(|input| Self::has_ungrouped_wrapped_node(input))
                 } else {
                     false
                 }
@@ -1343,9 +1342,7 @@ impl WrappedUnionNode {
             limit,
         }
     }
-}
 
-impl WrappedUnionNode {
     /// Renders every input as its own query and joins them into one set operation.
     ///
     /// Every input has to reach the same data source: a set operation the data source
@@ -1445,6 +1442,11 @@ impl WrappedUnionNode {
         let column_remapping = column_remapping
             .map(|column_remapping| self.requalify_remapping(column_remapping, alias.as_deref()));
 
+        // The column names of the union are the first input's, so its remapping is the one
+        // that describes them for the plans above.
+        // TODO only the first input's request is carried up, so the request that travels
+        //  with this SQL describes one input out of several. `WrappedSelectNode` drops the
+        //  requests of its joins the same way
         Ok(SqlGenerationResult {
             data_source: Some(data_source),
             from_alias: alias,

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -152,6 +152,20 @@ macro_rules! add_binary_expr_list_node {
     }};
 }
 
+/// A flat list node: every element is a child of one node. Lists are flat here, and the
+/// cons cells `add_plan_list_node!` builds are legacy.
+macro_rules! add_plan_flat_list_node {
+    ($converter:expr, $value_expr:expr, $query_params:expr, $ctx:expr, $field_variant:ident) => {{
+        let list = $value_expr
+            .iter()
+            .map(|expr| $converter.add_logical_plan_replace_params(expr, $query_params, $ctx))
+            .collect::<Result<Vec<_>, _>>()?;
+        $converter
+            .graph
+            .add(LogicalPlanLanguage::$field_variant(list))
+    }};
+}
+
 macro_rules! add_plan_list_node {
     ($converter:expr, $value_expr:expr, $query_params:expr, $ctx:expr, $field_variant:ident) => {{
         let list = $value_expr
@@ -698,7 +712,8 @@ impl LogicalPlanToLanguageConverter {
                 self.graph.add(LogicalPlanLanguage::Repartition([input]))
             }
             LogicalPlan::Union(node) => {
-                let inputs = add_plan_list_node!(self, node.inputs, query_params, ctx, UnionInputs);
+                let inputs =
+                    add_plan_flat_list_node!(self, node.inputs, query_params, ctx, UnionInputs);
                 let alias = add_data_node!(self, node.alias, UnionAlias);
                 self.graph.add(LogicalPlanLanguage::Union([inputs, alias]))
             }

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -3,7 +3,7 @@ use crate::{
     compile::{
         engine::df::{
             scan::{CubeScanNode, CubeScanOptions, MemberField},
-            wrapper::{CubeScanWrapperNode, WrappedSelectNode},
+            wrapper::{CubeScanWrapperNode, WrappedSelectNode, WrappedUnionNode},
         },
         rewrite::{
             analysis::LogicalPlanAnalysis,
@@ -30,7 +30,7 @@ use crate::{
             ValuesValues, WindowFunctionExprFun, WindowFunctionExprWindowFrame, WrappedSelectAlias,
             WrappedSelectDistinct, WrappedSelectJoinJoinType, WrappedSelectLimit,
             WrappedSelectOffset, WrappedSelectPushToCube, WrappedSelectSelectType,
-            WrappedSelectType,
+            WrappedSelectType, WrappedUnionAlias, WrappedUnionDistinct,
         },
         CubeContext,
     },
@@ -2370,6 +2370,40 @@ impl LanguageToLogicalPlanConverter {
                         alias,
                         distinct,
                         push_to_cube,
+                    )),
+                })
+            }
+            LogicalPlanLanguage::WrappedUnion(params) => {
+                let inputs = match_list_node_ids!(node_by_id, params[0], WrappedUnionInputs)
+                    .into_iter()
+                    .map(|n| self.to_logical_plan(n).map(Arc::new))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let distinct: bool = match_data_node!(node_by_id, params[1], WrappedUnionDistinct);
+                let alias: Option<String> =
+                    match_data_node!(node_by_id, params[2], WrappedUnionAlias);
+
+                let Some(first_input) = inputs.first() else {
+                    return Err(CubeError::internal(
+                        "Can't convert wrapped union with no inputs".to_string(),
+                    ));
+                };
+
+                // Same as `Union`: the inputs are union compatible, so the first one's schema
+                // stands for all of them
+                let schema = first_input.schema().as_ref().clone();
+                let schema = match alias {
+                    Some(ref alias) => schema.replace_qualifier(alias.as_str()),
+                    None => schema.strip_qualifiers(),
+                };
+
+                LogicalPlan::Extension(Extension {
+                    node: Arc::new(WrappedUnionNode::new(
+                        Arc::new(schema),
+                        inputs,
+                        distinct,
+                        alias,
+                        None,
                     )),
                 })
             }

--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -73,8 +73,12 @@ impl BestCubePlan {
             _ => 0,
         };
 
+        // What a wrapper does on its own, as opposed to merely holding a scan: a wrapper
+        // with none of it is an empty wrapper, and preferring it over the plain scan it
+        // wraps would be pointless
         let ast_size_inside_wrapper = match enode {
             LogicalPlanLanguage::WrappedSelect(_) => 1,
+            LogicalPlanLanguage::WrappedUnion(_) => 1,
             _ => 0,
         };
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -294,6 +294,15 @@ crate::plan_to_language! {
             join_type: JoinType,
         },
 
+        // A set operation over inputs that are all pushed down to the same data source.
+        // Unlike `Union`, which is post processing in DataFusion, this one renders as a
+        // `UNION` in the generated SQL and is evaluated by the data source itself.
+        WrappedUnion {
+            inputs: Vec<LogicalPlan>,
+            distinct: bool,
+            alias: Option<String>,
+        },
+
         CubeScan {
             alias_to_cube: Vec<(String, String)>,
             members: Vec<LogicalPlan>,
@@ -1648,6 +1657,14 @@ fn wrapped_select_joins(left: impl Display, right: impl Display) -> String {
 
 fn wrapped_select_joins_empty_tail() -> String {
     "WrappedSelectJoins".to_string()
+}
+
+fn wrapped_union(inputs: impl Display, distinct: impl Display, alias: impl Display) -> String {
+    format!("(WrappedUnion {inputs} {distinct} {alias})")
+}
+
+fn union(inputs: impl Display, alias: impl Display) -> String {
+    format!("(Union {inputs} {alias})")
 }
 
 fn wrapped_select_filter_expr(left: impl Display, right: impl Display) -> String {

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -977,6 +977,10 @@ struct ListNodeSearcher {
     list_pattern: Pattern<LogicalPlanLanguage>,
     elem_pattern: Pattern<LogicalPlanLanguage>,
     top_level_elem_vars: Vec<Var>,
+    /// Lists shorter than this do not match. A set operation needs it: one query is not a
+    /// union, and folding a `Distinct` into a single-query one would drop the deduplication
+    /// with no operator to render it on.
+    min_elements: usize,
 }
 
 impl ListNodeSearcher {
@@ -987,7 +991,13 @@ impl ListNodeSearcher {
             list_pattern: list_pattern.parse().unwrap(),
             elem_pattern: elem_pattern.parse().unwrap(),
             top_level_elem_vars: vec![],
+            min_elements: 1,
         }
+    }
+
+    fn with_min_elements(mut self, min_elements: usize) -> Self {
+        self.min_elements = min_elements;
+        self
     }
 
     fn with_top_level_elem_vars(mut self, vars: &[&str]) -> Self {
@@ -1066,7 +1076,7 @@ impl ListNodeSearcher {
         let list_id = list_subst[self.list_var];
         for node in egraph[list_id].iter() {
             let list_children = node.children();
-            if !self.match_node(node) || list_children.is_empty() {
+            if !self.match_node(node) || list_children.len() < self.min_elements.max(1) {
                 continue;
             }
 
@@ -1235,11 +1245,16 @@ struct ListNodeApplier {
     /// Runs once the substitution carries the list's own variables, so it can build nodes
     /// the pattern cannot spell out. Returning false drops this match.
     transform: Option<ListNodeTransform>,
+    /// The variables the transform inserts. Only these are exempt from egg's check that the
+    /// searcher binds every variable the applier uses, so a typo anywhere else in the
+    /// applier still fails when the rule is built rather than when it first matches.
+    transform_vars: Vec<Var>,
 }
 
 impl ListNodeApplier {
-    fn with_transform(mut self, transform: ListNodeTransform) -> Self {
+    fn with_transform(mut self, transform: ListNodeTransform, transform_vars: &[&str]) -> Self {
         self.transform = Some(transform);
+        self.transform_vars = transform_vars.iter().map(|v| v.parse().unwrap()).collect();
         self
     }
 }
@@ -1267,6 +1282,7 @@ impl ListNodeApplier {
     ) -> Self {
         Self {
             transform: None,
+            transform_vars: vec![],
             list_pattern: list_pattern.parse().unwrap(),
             lists: lists
                 .into_iter()
@@ -1328,17 +1344,12 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
     }
 
     fn vars(&self) -> Vec<Var> {
-        // A transform inserts variables of its own, which the searcher cannot bind. This is
-        // what `TransformingPattern` does by leaving `vars` at its empty default.
-        if self.transform.is_some() {
-            return vec![];
-        }
-
         let mut vars = self.list_pattern.vars();
         for list in &self.lists {
             vars.extend(list.elem_pattern.vars());
             vars.retain(|v| *v != list.new_list_var); // this is bound by the applier itself
         }
+        vars.retain(|v| !self.transform_vars.contains(v)); // and these by the transform
         vars
     }
 }
@@ -2516,6 +2527,8 @@ pub fn transforming_list_rewrite_with_lists_and_vars<T>(
     applier_pattern: &str,
     lists: impl IntoIterator<Item = ListApplierListPattern>,
     top_level_elem_vars: &[&str],
+    min_elements: usize,
+    transform_vars: &[&str],
     transform_fn: T,
 ) -> CubeRewrite
 where
@@ -2527,9 +2540,10 @@ where
         &searcher.pattern,
         &searcher.elem,
     )
-    .with_top_level_elem_vars(top_level_elem_vars);
-    let applier =
-        ListNodeApplier::from_lists(applier_pattern, lists).with_transform(Box::new(transform_fn));
+    .with_top_level_elem_vars(top_level_elem_vars)
+    .with_min_elements(min_elements);
+    let applier = ListNodeApplier::from_lists(applier_pattern, lists)
+        .with_transform(Box::new(transform_fn), transform_vars);
     Rewrite::new(name.to_string(), searcher, applier).unwrap()
 }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -936,6 +936,8 @@ pub enum ListType {
     WrappedSelectAggrExpr,
     WrappedSelectWindowExpr,
     CubeScanMembers,
+    UnionInputs,
+    WrappedUnionInputs,
 }
 
 impl ListType {
@@ -957,6 +959,8 @@ impl ListType {
             Self::WrappedSelectAggrExpr => wrapped_select_aggr_expr_empty_tail(),
             Self::WrappedSelectWindowExpr => wrapped_select_window_expr_empty_tail(),
             Self::CubeScanMembers => cube_scan_members_empty_tail(),
+            Self::UnionInputs => union_inputs_empty_tail(),
+            Self::WrappedUnionInputs => wrapped_union_inputs_empty_tail(),
         }
     }
 }
@@ -1042,6 +1046,12 @@ impl ListNodeSearcher {
             }
             ListType::CubeScanMembers => {
                 matches!(node, LogicalPlanLanguage::CubeScanMembers(_))
+            }
+            ListType::UnionInputs => {
+                matches!(node, LogicalPlanLanguage::UnionInputs(_))
+            }
+            ListType::WrappedUnionInputs => {
+                matches!(node, LogicalPlanLanguage::WrappedUnionInputs(_))
             }
         }
     }
@@ -1205,6 +1215,8 @@ impl ListNodeApplierList {
             ListType::WrappedSelectAggrExpr => LogicalPlanLanguage::WrappedSelectAggrExpr(list),
             ListType::WrappedSelectWindowExpr => LogicalPlanLanguage::WrappedSelectWindowExpr(list),
             ListType::CubeScanMembers => LogicalPlanLanguage::CubeScanMembers(list),
+            ListType::UnionInputs => LogicalPlanLanguage::UnionInputs(list),
+            ListType::WrappedUnionInputs => LogicalPlanLanguage::WrappedUnionInputs(list),
         }
     }
 }
@@ -1215,9 +1227,21 @@ pub struct ListApplierListPattern {
     elem_pattern: String,
 }
 
+type ListNodeTransform = Box<dyn Fn(&mut CubeEGraph, &mut Subst) -> bool + Sync + Send>;
+
 struct ListNodeApplier {
     list_pattern: PatternAst<LogicalPlanLanguage>,
     lists: Vec<ListNodeApplierList>,
+    /// Runs once the substitution carries the list's own variables, so it can build nodes
+    /// the pattern cannot spell out. Returning false drops this match.
+    transform: Option<ListNodeTransform>,
+}
+
+impl ListNodeApplier {
+    fn with_transform(mut self, transform: ListNodeTransform) -> Self {
+        self.transform = Some(transform);
+        self
+    }
 }
 
 impl ListNodeApplier {
@@ -1242,6 +1266,7 @@ impl ListNodeApplier {
         lists: impl IntoIterator<Item = ListApplierListPattern>,
     ) -> Self {
         Self {
+            transform: None,
             list_pattern: list_pattern.parse().unwrap(),
             lists: lists
                 .into_iter()
@@ -1287,6 +1312,11 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
             }
             let mut subst = subst.clone();
             subst.extend(list_substs[0].iter());
+            if let Some(transform) = &self.transform {
+                if !transform(egraph, &mut subst) {
+                    return;
+                }
+            }
             let new_id = egraph.add_instantiation(&self.list_pattern, &subst);
             if egraph.union(eclass, new_id) {
                 result_ids.push(new_id);
@@ -1298,6 +1328,12 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
     }
 
     fn vars(&self) -> Vec<Var> {
+        // A transform inserts variables of its own, which the searcher cannot bind. This is
+        // what `TransformingPattern` does by leaving `vars` at its empty default.
+        if self.transform.is_some() {
+            return vec![];
+        }
+
         let mut vars = self.list_pattern.vars();
         for list in &self.lists {
             vars.extend(list.elem_pattern.vars());
@@ -1667,16 +1703,8 @@ fn union(inputs: impl Display, alias: impl Display) -> String {
     format!("(Union {inputs} {alias})")
 }
 
-fn union_inputs(left: impl Display, right: impl Display) -> String {
-    format!("(UnionInputs {left} {right})")
-}
-
 fn union_inputs_empty_tail() -> String {
     "(UnionInputs)".to_string()
-}
-
-fn wrapped_union_inputs(left: impl Display, right: impl Display) -> String {
-    format!("(WrappedUnionInputs {left} {right})")
 }
 
 fn wrapped_union_inputs_empty_tail() -> String {
@@ -2475,6 +2503,34 @@ where
             Vec::new()
         }
     }
+}
+
+/// `list_rewrite_with_lists_and_vars` with a transform. The transform runs once the
+/// substitution carries the list's own variables — including the `top_level_elem_vars`
+/// every element agreed on — so it can build what a pattern cannot: a cleared replacer
+/// context, an alias converted to another node type.
+pub fn transforming_list_rewrite_with_lists_and_vars<T>(
+    name: &str,
+    list_type: ListType,
+    searcher: ListPattern,
+    applier_pattern: &str,
+    lists: impl IntoIterator<Item = ListApplierListPattern>,
+    top_level_elem_vars: &[&str],
+    transform_fn: T,
+) -> CubeRewrite
+where
+    T: Fn(&mut CubeEGraph, &mut Subst) -> bool + Sync + Send + 'static,
+{
+    let searcher = ListNodeSearcher::new(
+        list_type,
+        &searcher.list_var,
+        &searcher.pattern,
+        &searcher.elem,
+    )
+    .with_top_level_elem_vars(top_level_elem_vars);
+    let applier =
+        ListNodeApplier::from_lists(applier_pattern, lists).with_transform(Box::new(transform_fn));
+    Rewrite::new(name.to_string(), searcher, applier).unwrap()
 }
 
 pub fn transform_original_expr_to_alias(

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1667,6 +1667,22 @@ fn union(inputs: impl Display, alias: impl Display) -> String {
     format!("(Union {inputs} {alias})")
 }
 
+fn union_inputs(left: impl Display, right: impl Display) -> String {
+    format!("(UnionInputs {left} {right})")
+}
+
+fn union_inputs_empty_tail() -> String {
+    "(UnionInputs)".to_string()
+}
+
+fn wrapped_union_inputs(left: impl Display, right: impl Display) -> String {
+    format!("(WrappedUnionInputs {left} {right})")
+}
+
+fn wrapped_union_inputs_empty_tail() -> String {
+    "(WrappedUnionInputs)".to_string()
+}
+
 fn wrapped_select_filter_expr(left: impl Display, right: impl Display) -> String {
     format!("(WrappedSelectFilterExpr {} {})", left, right)
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -26,6 +26,7 @@ mod sort_expr;
 mod subquery;
 mod udaf_function;
 mod udf_function;
+mod union;
 mod window;
 mod window_function;
 mod wrapper_pull_up;
@@ -59,6 +60,7 @@ impl RewriteRules for WrapperRules {
 
         self.cube_scan_wrapper_rules(&mut rules);
         self.join_rules(&mut rules);
+        self.union_rules(&mut rules);
         self.wrapper_pull_up_rules(&mut rules);
         self.aggregate_rules(&mut rules);
         self.aggregate_rules_subquery(&mut rules);

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -3,9 +3,9 @@ use crate::{
         cube_scan_wrapper, distinct, rewrite,
         rewriter::{CubeEGraph, CubeRewrite},
         rules::wrapper::WrapperRules,
-        transforming_rewrite, union, union_inputs, union_inputs_empty_tail, wrapped_union,
-        wrapped_union_inputs, wrapped_union_inputs_empty_tail, wrapper_pullup_replacer,
-        wrapper_replacer_context, LogicalPlanLanguage, UnionAlias, WrappedUnionAlias,
+        transforming_list_rewrite_with_lists_and_vars, union, wrapped_union,
+        wrapper_pullup_replacer, wrapper_replacer_context, ListApplierListPattern, ListPattern,
+        ListType, LogicalPlanLanguage, UnionAlias, WrappedUnionAlias,
         WrapperReplacerContextAliasToCube, WrapperReplacerContextGroupedSubqueries,
         WrapperReplacerContextInputDataSource,
     },
@@ -18,73 +18,44 @@ impl WrapperRules {
     pub fn union_rules(&self, rules: &mut Vec<CubeRewrite>) {
         rules.extend(vec![
             // The queries of a union arrive already pulled up, so there is nothing to push
-            // into them and the list carries a pull-up replacer rather than a push-down one.
-            //
-            // Only the head of the list is matched, to bind the data source that every
-            // other query has to agree with; `wrapper-union-inputs-pull-up` is what checks
-            // the rest, one query at a time.
-            transforming_rewrite(
-                "wrapper-push-down-union-to-cube-scan",
-                union(
-                    union_inputs(
-                        cube_scan_wrapper(
-                            wrapper_pullup_replacer(
-                                "?head",
-                                wrapper_replacer_context(
-                                    "?head_alias_to_cube",
-                                    "?head_push_to_cube",
-                                    "?head_in_projection",
-                                    "?head_cube_members",
-                                    "?head_grouped_subqueries",
-                                    "?head_ungrouped_scan",
-                                    "?input_data_source",
-                                ),
+            // into them: the whole list is matched at once and every query is unwrapped into
+            // the set operation. `?input_data_source` is a top level element variable, so
+            // every query has to reach the same data source for this to match at all — a
+            // union spanning two of them is left to post processing without a check of its
+            // own.
+            transforming_list_rewrite_with_lists_and_vars(
+                "wrapper-pull-up-union",
+                ListType::UnionInputs,
+                ListPattern {
+                    pattern: union("?list", "?union_alias"),
+                    list_var: "?list".to_string(),
+                    elem: cube_scan_wrapper(
+                        wrapper_pullup_replacer(
+                            "?elem",
+                            wrapper_replacer_context(
+                                "?elem_alias_to_cube",
+                                "?elem_push_to_cube",
+                                "?elem_in_projection",
+                                "?elem_cube_members",
+                                "?elem_grouped_subqueries",
+                                "?elem_ungrouped_scan",
+                                "?input_data_source",
                             ),
-                            "CubeScanWrapperFinalized:false",
                         ),
-                        "?tail",
+                        "CubeScanWrapperFinalized:false",
                     ),
-                    "?union_alias",
-                ),
-                cube_scan_wrapper(
+                },
+                &cube_scan_wrapper(
                     wrapper_pullup_replacer(
                         wrapped_union(
-                            wrapper_pullup_replacer(
-                                union_inputs(
-                                    cube_scan_wrapper(
-                                        wrapper_pullup_replacer(
-                                            "?head",
-                                            wrapper_replacer_context(
-                                                "?head_alias_to_cube",
-                                                "?head_push_to_cube",
-                                                "?head_in_projection",
-                                                "?head_cube_members",
-                                                "?head_grouped_subqueries",
-                                                "?head_ungrouped_scan",
-                                                "?input_data_source",
-                                            ),
-                                        ),
-                                        "CubeScanWrapperFinalized:false",
-                                    ),
-                                    "?tail",
-                                ),
-                                wrapper_replacer_context(
-                                    "?out_alias_to_cube",
-                                    // A set operation is evaluated by the data source, so
-                                    // nothing above it reaches a Cube load query anymore
-                                    "WrapperReplacerContextPushToCube:false",
-                                    "WrapperReplacerContextInProjection:false",
-                                    "?out_cube_members",
-                                    "?out_grouped_subqueries",
-                                    "WrapperReplacerContextUngroupedScan:false",
-                                    "?input_data_source",
-                                ),
-                            ),
+                            "?new_list",
                             "WrappedUnionDistinct:false",
                             "?wrapped_union_alias",
                         ),
                         wrapper_replacer_context(
                             "?out_alias_to_cube",
+                            // A set operation is evaluated by the data source, so nothing
+                            // above it reaches a Cube load query anymore
                             "WrapperReplacerContextPushToCube:false",
                             "WrapperReplacerContextInProjection:false",
                             "?out_cube_members",
@@ -95,6 +66,12 @@ impl WrapperRules {
                     ),
                     "CubeScanWrapperFinalized:false",
                 ),
+                [ListApplierListPattern {
+                    list_type: ListType::WrappedUnionInputs,
+                    new_list_var: "?new_list".to_string(),
+                    elem_pattern: "?elem".to_string(),
+                }],
+                &["?input_data_source"],
                 self.transform_union(
                     "?union_alias",
                     "?input_data_source",
@@ -103,62 +80,6 @@ impl WrapperRules {
                     "?out_cube_members",
                     "?out_grouped_subqueries",
                 ),
-            ),
-            // One query of the set operation, peeled off the head of the list. The data
-            // source of the query and of the list are the same variable, so a query that
-            // reaches another one leaves a replacer behind rather than a union, and the
-            // plain post processing plan outprices it.
-            rewrite(
-                "wrapper-union-inputs-pull-up",
-                wrapper_pullup_replacer(
-                    union_inputs(
-                        cube_scan_wrapper(
-                            wrapper_pullup_replacer(
-                                "?head",
-                                wrapper_replacer_context(
-                                    "?head_alias_to_cube",
-                                    "?head_push_to_cube",
-                                    "?head_in_projection",
-                                    "?head_cube_members",
-                                    "?head_grouped_subqueries",
-                                    "?head_ungrouped_scan",
-                                    "?input_data_source",
-                                ),
-                            ),
-                            "CubeScanWrapperFinalized:false",
-                        ),
-                        "?tail",
-                    ),
-                    wrapper_replacer_context(
-                        "?alias_to_cube",
-                        "?push_to_cube",
-                        "?in_projection",
-                        "?cube_members",
-                        "?grouped_subqueries",
-                        "?ungrouped_scan",
-                        "?input_data_source",
-                    ),
-                ),
-                wrapped_union_inputs(
-                    "?head",
-                    wrapper_pullup_replacer(
-                        "?tail",
-                        wrapper_replacer_context(
-                            "?alias_to_cube",
-                            "?push_to_cube",
-                            "?in_projection",
-                            "?cube_members",
-                            "?grouped_subqueries",
-                            "?ungrouped_scan",
-                            "?input_data_source",
-                        ),
-                    ),
-                ),
-            ),
-            rewrite(
-                "wrapper-union-inputs-tail",
-                wrapper_pullup_replacer(union_inputs_empty_tail(), "?context"),
-                wrapped_union_inputs_empty_tail(),
             ),
             // `UNION` is `UNION ALL` with the duplicates dropped, so the data source can do
             // both at once and the deduplication does not have to happen in DataFusion

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -1,0 +1,239 @@
+use crate::{
+    compile::rewrite::{
+        cube_scan_wrapper, distinct, rewrite,
+        rewriter::{CubeEGraph, CubeRewrite},
+        rules::wrapper::WrapperRules,
+        transforming_rewrite, union, wrapped_union, wrapper_pullup_replacer,
+        wrapper_replacer_context, CubeScanWrapperFinalized, LogicalPlanLanguage, UnionAlias,
+        WrappedUnionAlias, WrapperReplacerContextAliasToCube,
+        WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextInputDataSource,
+    },
+    var, var_iter,
+};
+use egg::{Id, Subst};
+use std::collections::HashSet;
+
+impl WrapperRules {
+    pub fn union_rules(&self, rules: &mut Vec<CubeRewrite>) {
+        rules.extend(vec![
+            transforming_rewrite(
+                "wrapper-push-down-union",
+                union("?union_inputs", "?union_alias"),
+                cube_scan_wrapper(
+                    wrapper_pullup_replacer(
+                        wrapped_union(
+                            "?wrapped_union_inputs",
+                            "WrappedUnionDistinct:false",
+                            "?wrapped_union_alias",
+                        ),
+                        wrapper_replacer_context(
+                            "?alias_to_cube_out",
+                            // A set operation is evaluated by the data source, so nothing
+                            // above it can be pushed into a Cube load query anymore
+                            "WrapperReplacerContextPushToCube:false",
+                            "WrapperReplacerContextInProjection:false",
+                            "?cube_members_out",
+                            "?grouped_subqueries_out",
+                            "WrapperReplacerContextUngroupedScan:false",
+                            "?input_data_source_out",
+                        ),
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+                self.transform_union(
+                    "?union_inputs",
+                    "?union_alias",
+                    "?wrapped_union_inputs",
+                    "?wrapped_union_alias",
+                    "?alias_to_cube_out",
+                    "?cube_members_out",
+                    "?grouped_subqueries_out",
+                    "?input_data_source_out",
+                ),
+            ),
+            // `UNION` is `UNION ALL` with the duplicates dropped, so the data source can do
+            // both at once and the deduplication does not have to happen in DataFusion
+            rewrite(
+                "wrapper-push-down-distinct-to-union",
+                distinct(cube_scan_wrapper(
+                    wrapper_pullup_replacer(
+                        wrapped_union("?inputs", "WrappedUnionDistinct:false", "?alias"),
+                        "?context",
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                )),
+                cube_scan_wrapper(
+                    wrapper_pullup_replacer(
+                        wrapped_union("?inputs", "WrappedUnionDistinct:true", "?alias"),
+                        "?context",
+                    ),
+                    "CubeScanWrapperFinalized:false",
+                ),
+            ),
+        ]);
+    }
+
+    fn transform_union(
+        &self,
+        union_inputs_var: &'static str,
+        union_alias_var: &'static str,
+        wrapped_union_inputs_var: &'static str,
+        wrapped_union_alias_var: &'static str,
+        alias_to_cube_out_var: &'static str,
+        cube_members_out_var: &'static str,
+        grouped_subqueries_out_var: &'static str,
+        input_data_source_out_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let union_inputs_var = var!(union_inputs_var);
+        let union_alias_var = var!(union_alias_var);
+        let wrapped_union_inputs_var = var!(wrapped_union_inputs_var);
+        let wrapped_union_alias_var = var!(wrapped_union_alias_var);
+        let alias_to_cube_out_var = var!(alias_to_cube_out_var);
+        let cube_members_out_var = var!(cube_members_out_var);
+        let grouped_subqueries_out_var = var!(grouped_subqueries_out_var);
+        let input_data_source_out_var = var!(input_data_source_out_var);
+        move |egraph, subst| {
+            let Some(inputs) = Self::list_node_ids(egraph, subst[union_inputs_var]) else {
+                return false;
+            };
+            // A union of one is not a union, and an empty one has no data source to speak of
+            if inputs.len() < 2 {
+                return false;
+            }
+
+            let mut wrapped_inputs = Vec::with_capacity(inputs.len());
+            let mut data_source = None;
+            for input in inputs {
+                let Some((wrapped_input, input_data_source)) = Self::wrapped_input(egraph, input)
+                else {
+                    return false;
+                };
+                // Every input has to end up in the same query, so they all have to reach the
+                // same data source
+                match &data_source {
+                    None => data_source = Some(input_data_source),
+                    Some(data_source) if data_source == &input_data_source => {}
+                    Some(_) => return false,
+                }
+                wrapped_inputs.push(wrapped_input);
+            }
+
+            let Some(data_source) = data_source else {
+                return false;
+            };
+
+            let mut list = egraph.add(LogicalPlanLanguage::WrappedUnionInputs(vec![]));
+            for input in wrapped_inputs.into_iter().rev() {
+                list = egraph.add(LogicalPlanLanguage::WrappedUnionInputs(vec![input, list]));
+            }
+            subst.insert(wrapped_union_inputs_var, list);
+
+            let Some(alias) = var_iter!(egraph[subst[union_alias_var]], UnionAlias)
+                .cloned()
+                .next()
+            else {
+                return false;
+            };
+            subst.insert(
+                wrapped_union_alias_var,
+                egraph.add(LogicalPlanLanguage::WrappedUnionAlias(WrappedUnionAlias(
+                    alias,
+                ))),
+            );
+
+            subst.insert(
+                input_data_source_out_var,
+                egraph.add(LogicalPlanLanguage::WrapperReplacerContextInputDataSource(
+                    WrapperReplacerContextInputDataSource(Some(data_source)),
+                )),
+            );
+            // The inputs are complete queries by now, so nothing above the union can reach
+            // the cubes and members they were built from
+            subst.insert(
+                alias_to_cube_out_var,
+                egraph.add(LogicalPlanLanguage::WrapperReplacerContextAliasToCube(
+                    WrapperReplacerContextAliasToCube(vec![]),
+                )),
+            );
+            subst.insert(
+                cube_members_out_var,
+                egraph.add(LogicalPlanLanguage::CubeScanMembers(vec![])),
+            );
+            subst.insert(
+                grouped_subqueries_out_var,
+                egraph.add(
+                    LogicalPlanLanguage::WrapperReplacerContextGroupedSubqueries(
+                        WrapperReplacerContextGroupedSubqueries(vec![]),
+                    ),
+                ),
+            );
+
+            true
+        }
+    }
+
+    /// Ids of every element of a `UnionInputs` list, in order.
+    fn list_node_ids(egraph: &CubeEGraph, list: Id) -> Option<Vec<Id>> {
+        let mut ids = vec![];
+        let mut seen = HashSet::new();
+        let mut current = list;
+        loop {
+            // A list that contains itself is not a list this rule can work with, and
+            // following it would not terminate
+            if !seen.insert(current) {
+                return None;
+            }
+            let mut tail = None;
+            for node in egraph[current].nodes.iter() {
+                match node {
+                    LogicalPlanLanguage::UnionInputs(params) => match params[..] {
+                        [] => return Some(ids),
+                        [head, rest] => {
+                            ids.push(head);
+                            tail = Some(rest);
+                        }
+                        _ => return None,
+                    },
+                    _ => {}
+                }
+                if tail.is_some() {
+                    break;
+                }
+            }
+            current = tail?;
+        }
+    }
+
+    /// The plan a union input wraps, together with the data source it reaches, when that
+    /// input is a wrapper that is still open for nodes to be pushed into it.
+    fn wrapped_input(egraph: &CubeEGraph, input: Id) -> Option<(Id, String)> {
+        for node in egraph[input].nodes.iter() {
+            let LogicalPlanLanguage::CubeScanWrapper([wrapped, finalized]) = node else {
+                continue;
+            };
+            if !var_iter!(egraph[*finalized], CubeScanWrapperFinalized).any(|finalized| !finalized)
+            {
+                continue;
+            }
+            for node in egraph[*wrapped].nodes.iter() {
+                let LogicalPlanLanguage::WrapperPullupReplacer([plan, context]) = node else {
+                    continue;
+                };
+                for node in egraph[*context].nodes.iter() {
+                    let LogicalPlanLanguage::WrapperReplacerContext(params) = node else {
+                        continue;
+                    };
+                    let Some(data_source) =
+                        var_iter!(egraph[params[6]], WrapperReplacerContextInputDataSource)
+                            .flat_map(|data_source| data_source.clone())
+                            .next()
+                    else {
+                        continue;
+                    };
+                    return Some((*plan, data_source));
+                }
+            }
+        }
+        None
+    }
+}

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -9,7 +9,7 @@ use crate::{
         WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextInputDataSource,
     },
     transport::DataSource,
-    var, var_iter,
+    var, var_iter, var_list_iter,
 };
 use egg::{Id, Subst};
 use std::collections::HashSet;
@@ -186,39 +186,46 @@ impl WrapperRules {
 
     /// Ids of every element of a `UnionInputs` list, in order.
     ///
-    /// An e-class that holds more than one list is not a list this rule can read: picking
-    /// one of them would drop or reorder the queries of the union, and nothing downstream
-    /// checks that the list still matches the `Union` that was matched. Nothing merges two
-    /// different lists today, so this is a guard rather than a case to handle.
+    /// Mirrors `match_list_node_ids!`, which the converter uses to read this same list: an
+    /// element is any node that is not itself a `UnionInputs`, so the traversal does not
+    /// depend on the list being cons cells the way `add_plan_list_node!` builds it today.
+    ///
+    /// Unlike the converter it reads e-classes rather than one node per id, so it fails
+    /// closed where the converter has no such case: an e-class holding more than one
+    /// `UnionInputs` is not a list this rule can read, since picking one of them would drop
+    /// or reorder the queries of the union, and nothing downstream checks that the list
+    /// still matches the `Union` that was matched.
     fn list_node_ids(egraph: &CubeEGraph, list: Id) -> Option<Vec<Id>> {
-        let mut ids = vec![];
-        let mut seen = HashSet::new();
-        let mut current = list;
-        loop {
-            // A list that contains itself is not a list either, and following it would not
-            // terminate
-            if !seen.insert(current) {
-                return None;
-            }
-
-            let mut lists = egraph[current].nodes.iter().filter_map(|node| match node {
-                LogicalPlanLanguage::UnionInputs(params) => Some(params),
-                _ => None,
-            });
-            let list = lists.next()?;
+        fn collect(
+            egraph: &CubeEGraph,
+            id: Id,
+            seen: &mut HashSet<Id>,
+            ids: &mut Vec<Id>,
+        ) -> Option<()> {
+            let mut lists = var_list_iter!(egraph[id], UnionInputs);
+            let Some(list) = lists.next() else {
+                // Not a list node, so it is an element of the list that holds it
+                ids.push(id);
+                return Some(());
+            };
             if lists.next().is_some() {
                 return None;
             }
-
-            match list[..] {
-                [] => return Some(ids),
-                [head, tail] => {
-                    ids.push(head);
-                    current = tail;
-                }
-                _ => return None,
+            // A list that contains itself is not a list either, and following it would not
+            // terminate
+            if !seen.insert(id) {
+                return None;
             }
+
+            for id in list {
+                collect(egraph, *id, seen, ids)?;
+            }
+            Some(())
         }
+
+        let mut ids = vec![];
+        collect(egraph, list, &mut HashSet::new(), &mut ids)?;
+        Some(ids)
     }
 
     /// The plan a union input wraps, together with the data source it reaches, when that

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -3,54 +3,162 @@ use crate::{
         cube_scan_wrapper, distinct, rewrite,
         rewriter::{CubeEGraph, CubeRewrite},
         rules::wrapper::WrapperRules,
-        transforming_rewrite, union, wrapped_union, wrapper_pullup_replacer,
-        wrapper_replacer_context, CubeScanWrapperFinalized, LogicalPlanLanguage, UnionAlias,
-        WrappedUnionAlias, WrapperReplacerContextAliasToCube,
-        WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextInputDataSource,
+        transforming_rewrite, union, union_inputs, union_inputs_empty_tail, wrapped_union,
+        wrapped_union_inputs, wrapped_union_inputs_empty_tail, wrapper_pullup_replacer,
+        wrapper_replacer_context, LogicalPlanLanguage, UnionAlias, WrappedUnionAlias,
+        WrapperReplacerContextAliasToCube, WrapperReplacerContextGroupedSubqueries,
+        WrapperReplacerContextInputDataSource,
     },
     transport::DataSource,
-    var, var_iter, var_list_iter,
+    var, var_iter,
 };
-use egg::{Id, Subst};
-use std::collections::HashSet;
+use egg::Subst;
 
 impl WrapperRules {
     pub fn union_rules(&self, rules: &mut Vec<CubeRewrite>) {
         rules.extend(vec![
+            // The queries of a union arrive already pulled up, so there is nothing to push
+            // into them and the list carries a pull-up replacer rather than a push-down one.
+            //
+            // Only the head of the list is matched, to bind the data source that every
+            // other query has to agree with; `wrapper-union-inputs-pull-up` is what checks
+            // the rest, one query at a time.
             transforming_rewrite(
-                "wrapper-push-down-union",
-                union("?union_inputs", "?union_alias"),
+                "wrapper-push-down-union-to-cube-scan",
+                union(
+                    union_inputs(
+                        cube_scan_wrapper(
+                            wrapper_pullup_replacer(
+                                "?head",
+                                wrapper_replacer_context(
+                                    "?head_alias_to_cube",
+                                    "?head_push_to_cube",
+                                    "?head_in_projection",
+                                    "?head_cube_members",
+                                    "?head_grouped_subqueries",
+                                    "?head_ungrouped_scan",
+                                    "?input_data_source",
+                                ),
+                            ),
+                            "CubeScanWrapperFinalized:false",
+                        ),
+                        "?tail",
+                    ),
+                    "?union_alias",
+                ),
                 cube_scan_wrapper(
                     wrapper_pullup_replacer(
                         wrapped_union(
-                            "?wrapped_union_inputs",
+                            wrapper_pullup_replacer(
+                                union_inputs(
+                                    cube_scan_wrapper(
+                                        wrapper_pullup_replacer(
+                                            "?head",
+                                            wrapper_replacer_context(
+                                                "?head_alias_to_cube",
+                                                "?head_push_to_cube",
+                                                "?head_in_projection",
+                                                "?head_cube_members",
+                                                "?head_grouped_subqueries",
+                                                "?head_ungrouped_scan",
+                                                "?input_data_source",
+                                            ),
+                                        ),
+                                        "CubeScanWrapperFinalized:false",
+                                    ),
+                                    "?tail",
+                                ),
+                                wrapper_replacer_context(
+                                    "?out_alias_to_cube",
+                                    // A set operation is evaluated by the data source, so
+                                    // nothing above it reaches a Cube load query anymore
+                                    "WrapperReplacerContextPushToCube:false",
+                                    "WrapperReplacerContextInProjection:false",
+                                    "?out_cube_members",
+                                    "?out_grouped_subqueries",
+                                    "WrapperReplacerContextUngroupedScan:false",
+                                    "?input_data_source",
+                                ),
+                            ),
                             "WrappedUnionDistinct:false",
                             "?wrapped_union_alias",
                         ),
                         wrapper_replacer_context(
-                            "?alias_to_cube_out",
-                            // A set operation is evaluated by the data source, so nothing
-                            // above it can be pushed into a Cube load query anymore
+                            "?out_alias_to_cube",
                             "WrapperReplacerContextPushToCube:false",
                             "WrapperReplacerContextInProjection:false",
-                            "?cube_members_out",
-                            "?grouped_subqueries_out",
+                            "?out_cube_members",
+                            "?out_grouped_subqueries",
                             "WrapperReplacerContextUngroupedScan:false",
-                            "?input_data_source_out",
+                            "?input_data_source",
                         ),
                     ),
                     "CubeScanWrapperFinalized:false",
                 ),
                 self.transform_union(
-                    "?union_inputs",
                     "?union_alias",
-                    "?wrapped_union_inputs",
+                    "?input_data_source",
                     "?wrapped_union_alias",
-                    "?alias_to_cube_out",
-                    "?cube_members_out",
-                    "?grouped_subqueries_out",
-                    "?input_data_source_out",
+                    "?out_alias_to_cube",
+                    "?out_cube_members",
+                    "?out_grouped_subqueries",
                 ),
+            ),
+            // One query of the set operation, peeled off the head of the list. The data
+            // source of the query and of the list are the same variable, so a query that
+            // reaches another one leaves a replacer behind rather than a union, and the
+            // plain post processing plan outprices it.
+            rewrite(
+                "wrapper-union-inputs-pull-up",
+                wrapper_pullup_replacer(
+                    union_inputs(
+                        cube_scan_wrapper(
+                            wrapper_pullup_replacer(
+                                "?head",
+                                wrapper_replacer_context(
+                                    "?head_alias_to_cube",
+                                    "?head_push_to_cube",
+                                    "?head_in_projection",
+                                    "?head_cube_members",
+                                    "?head_grouped_subqueries",
+                                    "?head_ungrouped_scan",
+                                    "?input_data_source",
+                                ),
+                            ),
+                            "CubeScanWrapperFinalized:false",
+                        ),
+                        "?tail",
+                    ),
+                    wrapper_replacer_context(
+                        "?alias_to_cube",
+                        "?push_to_cube",
+                        "?in_projection",
+                        "?cube_members",
+                        "?grouped_subqueries",
+                        "?ungrouped_scan",
+                        "?input_data_source",
+                    ),
+                ),
+                wrapped_union_inputs(
+                    "?head",
+                    wrapper_pullup_replacer(
+                        "?tail",
+                        wrapper_replacer_context(
+                            "?alias_to_cube",
+                            "?push_to_cube",
+                            "?in_projection",
+                            "?cube_members",
+                            "?grouped_subqueries",
+                            "?ungrouped_scan",
+                            "?input_data_source",
+                        ),
+                    ),
+                ),
+            ),
+            rewrite(
+                "wrapper-union-inputs-tail",
+                wrapper_pullup_replacer(union_inputs_empty_tail(), "?context"),
+                wrapped_union_inputs_empty_tail(),
             ),
             // `UNION` is `UNION ALL` with the duplicates dropped, so the data source can do
             // both at once and the deduplication does not have to happen in DataFusion
@@ -76,51 +184,27 @@ impl WrapperRules {
 
     fn transform_union(
         &self,
-        union_inputs_var: &'static str,
         union_alias_var: &'static str,
-        wrapped_union_inputs_var: &'static str,
+        input_data_source_var: &'static str,
         wrapped_union_alias_var: &'static str,
         alias_to_cube_out_var: &'static str,
         cube_members_out_var: &'static str,
         grouped_subqueries_out_var: &'static str,
-        input_data_source_out_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
-        let union_inputs_var = var!(union_inputs_var);
         let union_alias_var = var!(union_alias_var);
-        let wrapped_union_inputs_var = var!(wrapped_union_inputs_var);
+        let input_data_source_var = var!(input_data_source_var);
         let wrapped_union_alias_var = var!(wrapped_union_alias_var);
         let alias_to_cube_out_var = var!(alias_to_cube_out_var);
         let cube_members_out_var = var!(cube_members_out_var);
         let grouped_subqueries_out_var = var!(grouped_subqueries_out_var);
-        let input_data_source_out_var = var!(input_data_source_out_var);
         let meta = self.meta_context.clone();
         move |egraph, subst| {
-            let Some(inputs) = Self::list_node_ids(egraph, subst[union_inputs_var]) else {
-                return false;
-            };
-            // A union of one is not a union, and an empty one has no data source to speak of
-            if inputs.len() < 2 {
-                return false;
-            }
-
-            let mut wrapped_inputs = Vec::with_capacity(inputs.len());
-            let mut data_source = None;
-            for input in inputs {
-                let Some((wrapped_input, input_data_source)) = Self::wrapped_input(egraph, input)
-                else {
-                    return false;
-                };
-                // Every input has to end up in the same query, so they all have to reach the
-                // same data source
-                match &data_source {
-                    None => data_source = Some(input_data_source),
-                    Some(data_source) if data_source == &input_data_source => {}
-                    Some(_) => return false,
-                }
-                wrapped_inputs.push(wrapped_input);
-            }
-
-            let Some(data_source) = data_source else {
+            let Some(data_source) = var_iter!(
+                egraph[subst[input_data_source_var]],
+                WrapperReplacerContextInputDataSource
+            )
+            .flat_map(|data_source| data_source.clone())
+            .next() else {
                 return false;
             };
 
@@ -133,12 +217,6 @@ impl WrapperRules {
             ) {
                 return false;
             }
-
-            let mut list = egraph.add(LogicalPlanLanguage::WrappedUnionInputs(vec![]));
-            for input in wrapped_inputs.into_iter().rev() {
-                list = egraph.add(LogicalPlanLanguage::WrappedUnionInputs(vec![input, list]));
-            }
-            subst.insert(wrapped_union_inputs_var, list);
 
             let Some(alias) = var_iter!(egraph[subst[union_alias_var]], UnionAlias)
                 .cloned()
@@ -153,14 +231,8 @@ impl WrapperRules {
                 ))),
             );
 
-            subst.insert(
-                input_data_source_out_var,
-                egraph.add(LogicalPlanLanguage::WrapperReplacerContextInputDataSource(
-                    WrapperReplacerContextInputDataSource(Some(data_source)),
-                )),
-            );
-            // The inputs are complete queries by now, so nothing above the union can reach
-            // the cubes and members they were built from
+            // The queries are complete by now, so nothing above the union can reach the
+            // cubes and members they were built from
             subst.insert(
                 alias_to_cube_out_var,
                 egraph.add(LogicalPlanLanguage::WrapperReplacerContextAliasToCube(
@@ -182,91 +254,5 @@ impl WrapperRules {
 
             true
         }
-    }
-
-    /// Ids of every element of a `UnionInputs` list, in order.
-    ///
-    /// Mirrors `match_list_node_ids!`, which the converter uses to read this same list: an
-    /// element is any node that is not itself a `UnionInputs`, so the traversal does not
-    /// depend on the list being cons cells the way `add_plan_list_node!` builds it today.
-    ///
-    /// Unlike the converter it reads e-classes rather than one node per id, so it fails
-    /// closed where the converter has no such case: an e-class holding more than one
-    /// `UnionInputs` is not a list this rule can read, since picking one of them would drop
-    /// or reorder the queries of the union, and nothing downstream checks that the list
-    /// still matches the `Union` that was matched.
-    fn list_node_ids(egraph: &CubeEGraph, list: Id) -> Option<Vec<Id>> {
-        fn collect(
-            egraph: &CubeEGraph,
-            id: Id,
-            seen: &mut HashSet<Id>,
-            ids: &mut Vec<Id>,
-        ) -> Option<()> {
-            let mut lists = var_list_iter!(egraph[id], UnionInputs);
-            let Some(list) = lists.next() else {
-                // Not a list node, so it is an element of the list that holds it
-                ids.push(id);
-                return Some(());
-            };
-            if lists.next().is_some() {
-                return None;
-            }
-            // A list that contains itself is not a list either, and following it would not
-            // terminate
-            if !seen.insert(id) {
-                return None;
-            }
-
-            for id in list {
-                collect(egraph, *id, seen, ids)?;
-            }
-            Some(())
-        }
-
-        let mut ids = vec![];
-        collect(egraph, list, &mut HashSet::new(), &mut ids)?;
-        Some(ids)
-    }
-
-    /// The plan a union input wraps, together with the data source it reaches, when that
-    /// input is a wrapper that is still open for nodes to be pushed into it.
-    ///
-    /// One input can be wrapped in several ways, and the plan is the same in all of them, so
-    /// any one will do. The data source is not allowed to differ between them: this rule is
-    /// what decides that every input reaches the same one, and reading an arbitrary answer
-    /// to that question would let a union span two of them.
-    fn wrapped_input(egraph: &CubeEGraph, input: Id) -> Option<(Id, String)> {
-        let mut wrapped = None;
-        for node in egraph[input].nodes.iter() {
-            let LogicalPlanLanguage::CubeScanWrapper([plan, finalized]) = node else {
-                continue;
-            };
-            if !var_iter!(egraph[*finalized], CubeScanWrapperFinalized).any(|finalized| !finalized)
-            {
-                continue;
-            }
-            for node in egraph[*plan].nodes.iter() {
-                let LogicalPlanLanguage::WrapperPullupReplacer([plan, context]) = node else {
-                    continue;
-                };
-                for node in egraph[*context].nodes.iter() {
-                    let LogicalPlanLanguage::WrapperReplacerContext(params) = node else {
-                        continue;
-                    };
-                    for data_source in
-                        var_iter!(egraph[params[6]], WrapperReplacerContextInputDataSource)
-                            .flat_map(|data_source| data_source.clone())
-                    {
-                        match &wrapped {
-                            None => wrapped = Some((*plan, data_source)),
-                            Some((_, wrapped_data_source))
-                                if wrapped_data_source == &data_source => {}
-                            Some(_) => return None,
-                        }
-                    }
-                }
-            }
-        }
-        wrapped
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -8,6 +8,7 @@ use crate::{
         WrappedUnionAlias, WrapperReplacerContextAliasToCube,
         WrapperReplacerContextGroupedSubqueries, WrapperReplacerContextInputDataSource,
     },
+    transport::DataSource,
     var, var_iter,
 };
 use egg::{Id, Subst};
@@ -92,6 +93,7 @@ impl WrapperRules {
         let cube_members_out_var = var!(cube_members_out_var);
         let grouped_subqueries_out_var = var!(grouped_subqueries_out_var);
         let input_data_source_out_var = var!(input_data_source_out_var);
+        let meta = self.meta_context.clone();
         move |egraph, subst| {
             let Some(inputs) = Self::list_node_ids(egraph, subst[union_inputs_var]) else {
                 return false;
@@ -121,6 +123,16 @@ impl WrapperRules {
             let Some(data_source) = data_source else {
                 return false;
             };
+
+            // A data source that has no union template cannot render a set operation, and
+            // there is no way back to post processing once this plan is chosen
+            if !Self::can_rewrite_template(
+                &DataSource::Specific(&data_source),
+                &meta,
+                "statements/union",
+            ) {
+                return false;
+            }
 
             let mut list = egraph.add(LogicalPlanLanguage::WrappedUnionInputs(vec![]));
             for input in wrapped_inputs.into_iter().rev() {
@@ -173,49 +185,60 @@ impl WrapperRules {
     }
 
     /// Ids of every element of a `UnionInputs` list, in order.
+    ///
+    /// An e-class that holds more than one list is not a list this rule can read: picking
+    /// one of them would drop or reorder the queries of the union, and nothing downstream
+    /// checks that the list still matches the `Union` that was matched. Nothing merges two
+    /// different lists today, so this is a guard rather than a case to handle.
     fn list_node_ids(egraph: &CubeEGraph, list: Id) -> Option<Vec<Id>> {
         let mut ids = vec![];
         let mut seen = HashSet::new();
         let mut current = list;
         loop {
-            // A list that contains itself is not a list this rule can work with, and
-            // following it would not terminate
+            // A list that contains itself is not a list either, and following it would not
+            // terminate
             if !seen.insert(current) {
                 return None;
             }
-            let mut tail = None;
-            for node in egraph[current].nodes.iter() {
-                match node {
-                    LogicalPlanLanguage::UnionInputs(params) => match params[..] {
-                        [] => return Some(ids),
-                        [head, rest] => {
-                            ids.push(head);
-                            tail = Some(rest);
-                        }
-                        _ => return None,
-                    },
-                    _ => {}
-                }
-                if tail.is_some() {
-                    break;
-                }
+
+            let mut lists = egraph[current].nodes.iter().filter_map(|node| match node {
+                LogicalPlanLanguage::UnionInputs(params) => Some(params),
+                _ => None,
+            });
+            let list = lists.next()?;
+            if lists.next().is_some() {
+                return None;
             }
-            current = tail?;
+
+            match list[..] {
+                [] => return Some(ids),
+                [head, tail] => {
+                    ids.push(head);
+                    current = tail;
+                }
+                _ => return None,
+            }
         }
     }
 
     /// The plan a union input wraps, together with the data source it reaches, when that
     /// input is a wrapper that is still open for nodes to be pushed into it.
+    ///
+    /// One input can be wrapped in several ways, and the plan is the same in all of them, so
+    /// any one will do. The data source is not allowed to differ between them: this rule is
+    /// what decides that every input reaches the same one, and reading an arbitrary answer
+    /// to that question would let a union span two of them.
     fn wrapped_input(egraph: &CubeEGraph, input: Id) -> Option<(Id, String)> {
+        let mut wrapped = None;
         for node in egraph[input].nodes.iter() {
-            let LogicalPlanLanguage::CubeScanWrapper([wrapped, finalized]) = node else {
+            let LogicalPlanLanguage::CubeScanWrapper([plan, finalized]) = node else {
                 continue;
             };
             if !var_iter!(egraph[*finalized], CubeScanWrapperFinalized).any(|finalized| !finalized)
             {
                 continue;
             }
-            for node in egraph[*wrapped].nodes.iter() {
+            for node in egraph[*plan].nodes.iter() {
                 let LogicalPlanLanguage::WrapperPullupReplacer([plan, context]) = node else {
                     continue;
                 };
@@ -223,17 +246,20 @@ impl WrapperRules {
                     let LogicalPlanLanguage::WrapperReplacerContext(params) = node else {
                         continue;
                     };
-                    let Some(data_source) =
+                    for data_source in
                         var_iter!(egraph[params[6]], WrapperReplacerContextInputDataSource)
                             .flat_map(|data_source| data_source.clone())
-                            .next()
-                    else {
-                        continue;
-                    };
-                    return Some((*plan, data_source));
+                    {
+                        match &wrapped {
+                            None => wrapped = Some((*plan, data_source)),
+                            Some((_, wrapped_data_source))
+                                if wrapped_data_source == &data_source => {}
+                            Some(_) => return None,
+                        }
+                    }
                 }
             }
         }
-        None
+        wrapped
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -72,6 +72,15 @@ impl WrapperRules {
                     elem_pattern: "?elem".to_string(),
                 }],
                 &["?input_data_source"],
+                // One query is not a union, and folding a `Distinct` into a single query
+                // one would leave the deduplication with no operator to render it on
+                2,
+                &[
+                    "?wrapped_union_alias",
+                    "?out_alias_to_cube",
+                    "?out_cube_members",
+                    "?out_grouped_subqueries",
+                ],
                 self.transform_union(
                     "?union_alias",
                     "?input_data_source",

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -729,6 +729,15 @@ OFFSET {{ offset }}{% endif %}"#.to_string(),
                         "{{ join_type }} JOIN {{ source }} ON {{ condition }}".to_string(),
                     ),
                     (
+                        "statements/union".to_string(),
+                        r#"{% for query in queries %}(
+{{ query | indent(2, true) }}
+){% if not loop.last %}
+UNION {% if not distinct %}ALL {% endif %}{% endif %}{% endfor %}{% if limit is not none %}
+LIMIT {{ limit }}{% endif %}"#
+                            .to_string(),
+                    ),
+                    (
                         "statements/group_by_exprs".to_string(),
                         "{{ group_by | map(attribute='index') | join(', ') }}".to_string(),
                     ),
@@ -828,6 +837,47 @@ fn get_test_tenant_ctx_with_meta_and_templates(
 
 pub fn get_test_tenant_ctx_with_meta(meta: Vec<CubeMeta>) -> Arc<MetaContext> {
     get_test_tenant_ctx_with_meta_and_templates(meta, vec![])
+}
+
+/// The standard test meta with its cubes spread across several data sources: every cube
+/// named in `cube_data_sources` reaches the data source it is paired with, everything else
+/// reaches `default`.
+pub fn get_test_tenant_ctx_with_cube_data_sources(
+    cube_data_sources: Vec<(&str, &str)>,
+) -> Arc<MetaContext> {
+    let data_source_for_cube = |cube: &str| {
+        cube_data_sources
+            .iter()
+            .find(|(name, _)| *name == cube)
+            .map_or("default", |(_, data_source)| *data_source)
+            .to_string()
+    };
+
+    let meta = get_test_meta();
+    let member_to_data_source: HashMap<_, _> = meta
+        .iter()
+        .flat_map(|cube| {
+            let data_source = data_source_for_cube(&cube.name);
+            cube.dimensions
+                .iter()
+                .map(|d| &d.name)
+                .chain(cube.measures.iter().map(|m| &m.name))
+                .chain(cube.segments.iter().map(|s| &s.name))
+                .map(move |member| (member.clone(), data_source.clone()))
+        })
+        .collect();
+
+    let data_source_to_sql_generator = member_to_data_source
+        .values()
+        .map(|data_source| (data_source.clone(), sql_generator(vec![])))
+        .collect();
+
+    Arc::new(MetaContext::new(
+        meta,
+        member_to_data_source,
+        data_source_to_sql_generator,
+        Uuid::new_v4(),
+    ))
 }
 
 pub async fn get_test_session(

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -17,7 +17,7 @@ use crate::{
             convert_select_to_query_plan, convert_select_to_query_plan_customized,
             convert_select_to_query_plan_with_config, convert_sql_to_cube_query,
             get_test_session_with_config, get_test_tenant_ctx_with_cube_data_sources,
-            init_testing_logger, LogicalPlanTestUtils, TestContext,
+            init_testing_logger, member_expression_sql, LogicalPlanTestUtils, TestContext,
         },
         DatabaseProtocol,
     },
@@ -3693,13 +3693,25 @@ async fn test_wrapper_union_three_queries_not_pushed_down_keeps_every_query() {
     assert_eq!(
         union.inputs.len(),
         3,
-        "every query survives the round trip: {:?}",
+        "one input per query: {:?}",
         logical_plan
     );
+    // The list is written and read back positionally, so identity and order are what the
+    // flat conversion put at risk: a reader that reversed it, or yielded one query twice,
+    // would still leave three of everything. Order is not cosmetic for a union — the output
+    // column names come from the first query, and `WrappedUnionNode` renders it specially.
     assert_eq!(
-        logical_plan.find_cube_scans().len(),
-        3,
-        "every query keeps its own scan: {:?}",
+        logical_plan
+            .find_cube_scans()
+            .iter()
+            .map(|scan| member_expression_sql(&scan.request.dimensions))
+            .collect::<Vec<_>>(),
+        vec![
+            vec!["KibanaSampleDataEcommerce.customer_gender".to_string()],
+            vec!["Logs.content".to_string()],
+            vec!["KibanaSampleDataEcommerce.notes".to_string()],
+        ],
+        "every query survives the round trip, in order: {:?}",
         logical_plan
     );
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3519,4 +3519,43 @@ async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
         "limited branches: {:?}",
         requests
     );
+
+    // A limit above the `UNION` reaches the branches only when there is nothing between them
+    // that it cannot move through: `UnionSortLimitPushDown` copies it into each input, and
+    // the regular limit push down carries it to the scans
+    let requests = context
+        .convert_sql_to_cube_query(
+            "SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
+             FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+             UNION ALL \
+             SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
+             FROM Logs GROUP BY 1, 2 \
+             LIMIT 1000",
+        )
+        .await
+        .expect("union all under a limit should compile")
+        .as_logical_plan()
+        .find_cube_scans()
+        .into_iter()
+        .map(|scan| scan.request)
+        .collect::<Vec<_>>();
+    assert!(
+        requests.iter().all(|request| request.limit == Some(1000)),
+        "branches under an outer limit: {:?}",
+        requests
+    );
+
+    // The `DISTINCT` of a plain `UNION` is such a node, so the same limit stops above it and
+    // the branches stay unlimited
+    let error = context
+        .convert_sql_to_cube_query(&format!("{query} LIMIT 1000"))
+        .await
+        .expect_err("outer limit should not reach branches through the union's distinct");
+    assert!(
+        error
+            .to_string()
+            .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
+        "unexpected error: {}",
+        error
+    );
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3630,6 +3630,36 @@ async fn test_wrapper_union_different_data_sources_not_pushed_down() {
     );
 }
 
+/// A data source with no union template cannot render a set operation. The rule has to
+/// know that before the plan is chosen, because SQL generation has no way back to post
+/// processing.
+#[tokio::test]
+async fn test_wrapper_union_without_template_not_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan_customized(
+        "SELECT 'MX' AS table_type, customer_gender AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+        // An empty template removes it from this data source
+        vec![("statements/union".to_string(), "".to_string())],
+    )
+    .await
+    .as_logical_plan();
+
+    assert!(
+        matches!(logical_plan, LogicalPlan::Union(_)),
+        "the union is left to post processing: {:?}",
+        logical_plan
+    );
+}
+
 /// A `Sort` directly above a union is not pushed down yet: the select it would be pushed
 /// into projects nothing, and a query without a projection is not SQL. The union itself is
 /// still pushed down, and the sort of its truncated result is still post processing that

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -15,8 +15,9 @@ use crate::{
         rewrite::rewriter::Rewriter,
         test::{
             convert_select_to_query_plan, convert_select_to_query_plan_customized,
-            convert_select_to_query_plan_with_config, init_testing_logger, LogicalPlanTestUtils,
-            TestContext,
+            convert_select_to_query_plan_with_config, convert_sql_to_cube_query,
+            get_test_session_with_config, get_test_tenant_ctx_with_cube_data_sources,
+            init_testing_logger, LogicalPlanTestUtils, TestContext,
         },
         DatabaseProtocol,
     },
@@ -3245,8 +3246,11 @@ async fn test_wrapper_limitless_post_processing_ignored_in_stream_mode() {
 }
 
 /// A limit bounds the rows of the query it sits on, not of a query beside it. Summing
-/// limits and limitless scans over the whole plan would let the limited branch here stand
-/// in for the unlimited one, and the union would read a truncated half without saying so.
+/// limits and limitless scans over the whole plan would let the limited query here stand in
+/// for the unlimited one, and the union would read a truncated half without saying so.
+///
+/// The two queries read different data sources, so the union cannot be pushed down and is
+/// left to post processing, which is what makes the pairing observable at all.
 #[tokio::test]
 async fn test_wrapper_limitless_post_processing_sibling_without_limit() {
     if !Rewriter::sql_push_down_enabled() {
@@ -3256,16 +3260,21 @@ async fn test_wrapper_limitless_post_processing_sibling_without_limit() {
 
     let mut config = ConfigObjImpl::default();
     config.fail_on_limitless_post_processing = true;
-    let context = TestContext::with_config(DatabaseProtocol::PostgreSQL, Arc::new(config)).await;
+    let meta = get_test_tenant_ctx_with_cube_data_sources(vec![("Logs", "other")]);
+    let session =
+        get_test_session_with_config(DatabaseProtocol::PostgreSQL, Arc::new(config), meta.clone())
+            .await;
 
-    let error = context
-        .convert_sql_to_cube_query(
-            "(SELECT customer_gender AS g FROM KibanaSampleDataEcommerce GROUP BY 1 LIMIT 10) \
-             UNION ALL \
-             (SELECT customer_gender AS g FROM KibanaSampleDataEcommerce GROUP BY 1)",
-        )
-        .await
-        .expect_err("union with an unlimited branch should fail");
+    let error = convert_sql_to_cube_query(
+        &"(SELECT customer_gender AS g FROM KibanaSampleDataEcommerce GROUP BY 1 LIMIT 10) \
+          UNION ALL \
+          (SELECT content AS g FROM Logs GROUP BY 1)"
+            .to_string(),
+        meta,
+        session,
+    )
+    .await
+    .expect_err("union with an unlimited query should fail");
     assert!(
         error
             .to_string()
@@ -3401,12 +3410,10 @@ async fn test_wrapper_limitless_post_processing_ungrouped_aggregate() {
 /// A `UNION` of two `SELECT DISTINCT`s over different cubes, the shape a BI user writes to
 /// list the values of a dimension across two views.
 ///
-/// Nothing about it can be pushed down: the branches read different cubes, so each one is a
-/// Cube query of its own and the `UNION` can only be run in DataFusion. DataFusion also
-/// collapses the per-branch `DISTINCT`s into the one above the `UNION`, which leaves each
-/// branch an ungrouped scan of raw rows rather than the grouped request a `SELECT DISTINCT`
-/// on its own compiles to. Both branches are then truncated to the row cap before the
-/// `DISTINCT` ever sees them, so values missing from the answer are missing silently.
+/// It used to be planned as a `DISTINCT` over a `UNION` of two ungrouped scans, both of them
+/// truncated to the row cap before the deduplication ever saw them, so values missing from
+/// the answer went missing silently. Both queries reach the same data source, so the whole
+/// set operation is pushed down to it instead.
 #[tokio::test]
 async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
     if !Rewriter::sql_push_down_enabled() {
@@ -3420,37 +3427,230 @@ async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
                  SELECT DISTINCT 'Pharmacy Claims (RX)' AS table_type, content AS market \
                  FROM Logs";
 
-    // Without the check the query still runs, over two truncated ungrouped scans
+    let mut config = ConfigObjImpl::default();
+    config.fail_on_limitless_post_processing = true;
+    let context = TestContext::with_config(DatabaseProtocol::PostgreSQL, Arc::new(config)).await;
+
+    let logical_plan = context
+        .convert_sql_to_cube_query(query)
+        .await
+        .expect("union of two queries to the same data source should compile")
+        .as_logical_plan();
+
+    // Nothing is left above the pushed down query
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(sql.contains("UNION"), "union is pushed down: {sql}");
+    assert!(
+        logical_plan
+            .find_cube_scans()
+            .iter()
+            .all(|scan| { scan.request.ungrouped == Some(true) && scan.request.limit.is_none() }),
+        "the queries themselves stay unlimited, inside the pushed down SQL: {logical_plan:?}"
+    );
+}
+
+/// The queries of a `UNION` reach the same data source, so the data source can evaluate the
+/// whole set operation and nothing is left for DataFusion to do on top of two truncated
+/// halves.
+#[tokio::test]
+async fn test_wrapper_union_all_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT 'MX' AS table_type, customer_gender AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(
+        sql.contains("KibanaSampleDataEcommerce.customer_gender") && sql.contains("Logs.content"),
+        "both queries are in the pushed down SQL: {sql}"
+    );
+    // The row cap lands on the result of the whole set operation, not on either query
+    assert!(
+        sql.trim_end().ends_with(&format!(
+            "LIMIT {}",
+            ConfigObjImpl::default().non_streaming_query_max_row_limit
+        )),
+        "the row cap bounds the union: {sql}"
+    );
+}
+
+/// A plain `UNION` drops duplicates, which the data source does as part of the same set
+/// operation: it is `UNION ALL` with `ALL` left off, not a separate deduplication.
+#[tokio::test]
+async fn test_wrapper_union_distinct_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT DISTINCT 'MX' AS table_type, customer_gender AS market \
+         FROM KibanaSampleDataEcommerce \
+         UNION \
+         SELECT DISTINCT 'RX' AS table_type, content AS market FROM Logs"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("UNION") && !sql.contains("UNION ALL"),
+        "distinct union is pushed down as UNION: {sql}"
+    );
+}
+
+/// The queries of a `UNION` are a list, not a pair
+#[tokio::test]
+async fn test_wrapper_union_three_queries_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT 'MX' AS table_type, customer_gender AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'DX' AS table_type, notes AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+    assert_eq!(
+        sql.matches("UNION ALL").count(),
+        2,
+        "all three queries are pushed down: {sql}"
+    );
+}
+
+/// A pushed down union is a query like any other, so a projection and a filter above it are
+/// pushed into a select that reads from it.
+#[tokio::test]
+async fn test_wrapper_union_filter_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        "SELECT market FROM ( \
+           SELECT 'MX' AS table_type, customer_gender AS market \
+           FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+           UNION ALL \
+           SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2 \
+         ) markets WHERE market = 'female'"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert!(
+        logical_plan.find_filter().is_none(),
+        "no filter is left to post processing: {logical_plan:?}"
+    );
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(
+        sql.contains("WHERE"),
+        "the filter reads from the pushed down union: {sql}"
+    );
+}
+
+/// A set operation is evaluated by one data source, so queries that reach two of them cannot
+/// be pushed down and the union stays in DataFusion.
+#[tokio::test]
+async fn test_wrapper_union_different_data_sources_not_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_cube_data_sources(vec![("Logs", "other")]);
+    let session = get_test_session_with_config(
+        DatabaseProtocol::PostgreSQL,
+        Arc::new(ConfigObjImpl::default()),
+        meta.clone(),
+    )
+    .await;
+
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT 'MX' AS table_type, customer_gender AS market \
+          FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+          UNION ALL \
+          SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2"
+            .to_string(),
+        meta,
+        session,
+    )
+    .await
+    .expect("union of two data sources should compile")
+    .as_logical_plan();
+
+    assert_eq!(
+        logical_plan.find_cube_scans().len(),
+        2,
+        "every query keeps its own scan: {logical_plan:?}"
+    );
+    assert!(
+        matches!(logical_plan, LogicalPlan::Union(_)),
+        "the union is left to post processing: {logical_plan:?}"
+    );
+}
+
+/// A `Sort` directly above a union is not pushed down yet: the select it would be pushed
+/// into projects nothing, and a query without a projection is not SQL. The union itself is
+/// still pushed down, and the sort of its truncated result is still post processing that
+/// `CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING` reports.
+#[tokio::test]
+async fn test_wrapper_union_sort_left_to_post_processing() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query = "SELECT 'MX' AS table_type, customer_gender AS market \
+                 FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+                 UNION ALL \
+                 SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2 \
+                 ORDER BY 1, 2";
+
     let logical_plan =
         convert_select_to_query_plan(query.to_string(), DatabaseProtocol::PostgreSQL)
             .await
             .as_logical_plan();
-    let requests = logical_plan
-        .find_cube_scans()
-        .into_iter()
-        .map(|scan| scan.request)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        requests,
-        vec![
-            V1LoadRequestQuery {
-                measures: Some(vec![]),
-                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
-                segments: Some(vec![]),
-                order: Some(vec![]),
-                ungrouped: Some(true),
-                ..Default::default()
-            },
-            V1LoadRequestQuery {
-                measures: Some(vec![]),
-                dimensions: Some(vec!["Logs.content".to_string()]),
-                segments: Some(vec![]),
-                order: Some(vec![]),
-                ungrouped: Some(true),
-                ..Default::default()
-            },
-        ]
+    assert!(
+        matches!(logical_plan, LogicalPlan::Sort(_)),
+        "the sort is left to post processing: {logical_plan:?}"
     );
+    let sql = logical_plan
+        .find_cube_scan_wrapped_sql_deep()
+        .wrapped_sql
+        .sql;
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
 
     let mut config = ConfigObjImpl::default();
     config.fail_on_limitless_post_processing = true;
@@ -3458,104 +3658,53 @@ async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
     let error = context
         .convert_sql_to_cube_query(query)
         .await
-        .expect_err("union of unlimited branches should fail");
+        .expect_err("sorting a truncated union should fail");
     assert!(
         error
             .to_string()
             .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
-        "unexpected error: {}",
-        error
+        "unexpected error: {error}"
     );
+}
 
-    // Grouping each branch instead of distinct-ing it is the better query - the data source
-    // does the deduplication, so the cap lands on distinct values rather than raw rows - but
-    // the branches are still unlimited, so the `UNION` on top can still truncate
-    let grouped = "SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
-                   FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
-                   UNION \
-                   SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
-                   FROM Logs GROUP BY 1, 2";
-    let requests = convert_select_to_query_plan(grouped.to_string(), DatabaseProtocol::PostgreSQL)
-        .await
-        .as_logical_plan()
+/// A limit on one query of a union bounds that query, and the row cap bounds the result of
+/// the whole set operation. Both end up in the pushed down SQL, so neither query is read
+/// through the other's limit.
+#[tokio::test]
+async fn test_wrapper_union_limited_query_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan(
+        "(SELECT customer_gender AS g FROM KibanaSampleDataEcommerce GROUP BY 1 LIMIT 10) \
+         UNION ALL \
+         (SELECT content AS g FROM Logs GROUP BY 1)"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .as_logical_plan();
+
+    let limits = logical_plan
         .find_cube_scans()
         .into_iter()
-        .map(|scan| scan.request)
+        .map(|scan| scan.request.limit)
         .collect::<Vec<_>>();
-    assert!(
-        requests.iter().all(|request| request.ungrouped.is_none()),
-        "grouped branches: {:?}",
-        requests
-    );
-    let error = context
-        .convert_sql_to_cube_query(grouped)
-        .await
-        .expect_err("union of unlimited grouped branches should fail");
-    assert!(
-        error
-            .to_string()
-            .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
-        "unexpected error: {}",
-        error
+    assert_eq!(
+        limits,
+        vec![Some(10), None],
+        "the limit stays with the query it was written on"
     );
 
-    // A limit on each branch bounds what the `UNION` reads, and the check passes
-    let limited = "(SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
-                   FROM KibanaSampleDataEcommerce GROUP BY 1, 2 LIMIT 1000) \
-                   UNION \
-                   (SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
-                   FROM Logs GROUP BY 1, 2 LIMIT 1000)";
-    let requests = context
-        .convert_sql_to_cube_query(limited)
-        .await
-        .expect("union of limited branches should compile")
-        .as_logical_plan()
-        .find_cube_scans()
-        .into_iter()
-        .map(|scan| scan.request)
-        .collect::<Vec<_>>();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
     assert!(
-        requests.iter().all(|request| request.limit == Some(1000)),
-        "limited branches: {:?}",
-        requests
-    );
-
-    // A limit above the `UNION` reaches the branches only when there is nothing between them
-    // that it cannot move through: `UnionSortLimitPushDown` copies it into each input, and
-    // the regular limit push down carries it to the scans
-    let requests = context
-        .convert_sql_to_cube_query(
-            "SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
-             FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
-             UNION ALL \
-             SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
-             FROM Logs GROUP BY 1, 2 \
-             LIMIT 1000",
-        )
-        .await
-        .expect("union all under a limit should compile")
-        .as_logical_plan()
-        .find_cube_scans()
-        .into_iter()
-        .map(|scan| scan.request)
-        .collect::<Vec<_>>();
-    assert!(
-        requests.iter().all(|request| request.limit == Some(1000)),
-        "branches under an outer limit: {:?}",
-        requests
-    );
-
-    // The `DISTINCT` of a plain `UNION` is such a node, so the same limit stops above it and
-    // the branches stay unlimited
-    let error = context
-        .convert_sql_to_cube_query(&format!("{query} LIMIT 1000"))
-        .await
-        .expect_err("outer limit should not reach branches through the union's distinct");
-    assert!(
-        error
-            .to_string()
-            .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
-        "unexpected error: {}",
-        error
+        sql.trim_end().ends_with(&format!(
+            "LIMIT {}",
+            ConfigObjImpl::default().non_streaming_query_max_row_limit
+        )),
+        "the row cap bounds the union: {sql}"
     );
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3660,6 +3660,50 @@ async fn test_wrapper_union_without_template_not_pushed_down() {
     );
 }
 
+/// A union left to post processing keeps every one of its queries. `UnionInputs` is a flat
+/// list, so the converter reads it back with `match_list_node_ids!` rather than by walking
+/// cons cells — this pins that round trip at more than two queries, where the two shapes
+/// differ.
+#[tokio::test]
+async fn test_wrapper_union_three_queries_not_pushed_down_keeps_every_query() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let logical_plan = convert_select_to_query_plan_customized(
+        "SELECT 'MX' AS table_type, customer_gender AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2 \
+         UNION ALL \
+         SELECT 'DX' AS table_type, notes AS market \
+         FROM KibanaSampleDataEcommerce GROUP BY 1, 2"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+        // An empty template removes it from this data source
+        vec![("statements/union".to_string(), "".to_string())],
+    )
+    .await
+    .as_logical_plan();
+
+    let LogicalPlan::Union(union) = &logical_plan else {
+        panic!("the union is left to post processing: {:?}", logical_plan);
+    };
+    assert_eq!(
+        union.inputs.len(),
+        3,
+        "every query survives the round trip: {:?}",
+        logical_plan
+    );
+    assert_eq!(
+        logical_plan.find_cube_scans().len(),
+        3,
+        "every query keeps its own scan: {:?}",
+        logical_plan
+    );
+}
+
 /// A `Sort` directly above a union is not pushed down yet: the select it would be pushed
 /// into projects nothing, and a query without a projection is not SQL. The union itself is
 /// still pushed down, and the sort of its truncated result is still post processing that

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3397,3 +3397,126 @@ async fn test_wrapper_limitless_post_processing_ungrouped_aggregate() {
         error
     );
 }
+
+/// A `UNION` of two `SELECT DISTINCT`s over different cubes, the shape a BI user writes to
+/// list the values of a dimension across two views.
+///
+/// Nothing about it can be pushed down: the branches read different cubes, so each one is a
+/// Cube query of its own and the `UNION` can only be run in DataFusion. DataFusion also
+/// collapses the per-branch `DISTINCT`s into the one above the `UNION`, which leaves each
+/// branch an ungrouped scan of raw rows rather than the grouped request a `SELECT DISTINCT`
+/// on its own compiles to. Both branches are then truncated to the row cap before the
+/// `DISTINCT` ever sees them, so values missing from the answer are missing silently.
+#[tokio::test]
+async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query = "SELECT DISTINCT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
+                 FROM KibanaSampleDataEcommerce \
+                 UNION \
+                 SELECT DISTINCT 'Pharmacy Claims (RX)' AS table_type, content AS market \
+                 FROM Logs";
+
+    // Without the check the query still runs, over two truncated ungrouped scans
+    let logical_plan =
+        convert_select_to_query_plan(query.to_string(), DatabaseProtocol::PostgreSQL)
+            .await
+            .as_logical_plan();
+    let requests = logical_plan
+        .find_cube_scans()
+        .into_iter()
+        .map(|scan| scan.request)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requests,
+        vec![
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ungrouped: Some(true),
+                ..Default::default()
+            },
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["Logs.content".to_string()]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                ungrouped: Some(true),
+                ..Default::default()
+            },
+        ]
+    );
+
+    let mut config = ConfigObjImpl::default();
+    config.fail_on_limitless_post_processing = true;
+    let context = TestContext::with_config(DatabaseProtocol::PostgreSQL, Arc::new(config)).await;
+    let error = context
+        .convert_sql_to_cube_query(query)
+        .await
+        .expect_err("union of unlimited branches should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
+        "unexpected error: {}",
+        error
+    );
+
+    // Grouping each branch instead of distinct-ing it is the better query - the data source
+    // does the deduplication, so the cap lands on distinct values rather than raw rows - but
+    // the branches are still unlimited, so the `UNION` on top can still truncate
+    let grouped = "SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
+                   FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+                   UNION \
+                   SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
+                   FROM Logs GROUP BY 1, 2";
+    let requests = convert_select_to_query_plan(grouped.to_string(), DatabaseProtocol::PostgreSQL)
+        .await
+        .as_logical_plan()
+        .find_cube_scans()
+        .into_iter()
+        .map(|scan| scan.request)
+        .collect::<Vec<_>>();
+    assert!(
+        requests.iter().all(|request| request.ungrouped.is_none()),
+        "grouped branches: {:?}",
+        requests
+    );
+    let error = context
+        .convert_sql_to_cube_query(grouped)
+        .await
+        .expect_err("union of unlimited grouped branches should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
+        "unexpected error: {}",
+        error
+    );
+
+    // A limit on each branch bounds what the `UNION` reads, and the check passes
+    let limited = "(SELECT 'Medical Claims (MX)' AS table_type, customer_gender AS market \
+                   FROM KibanaSampleDataEcommerce GROUP BY 1, 2 LIMIT 1000) \
+                   UNION \
+                   (SELECT 'Pharmacy Claims (RX)' AS table_type, content AS market \
+                   FROM Logs GROUP BY 1, 2 LIMIT 1000)";
+    let requests = context
+        .convert_sql_to_cube_query(limited)
+        .await
+        .expect("union of limited branches should compile")
+        .as_logical_plan()
+        .find_cube_scans()
+        .into_iter()
+        .map(|scan| scan.request)
+        .collect::<Vec<_>>();
+    assert!(
+        requests.iter().all(|request| request.limit == Some(1000)),
+        "limited branches: {:?}",
+        requests
+    );
+}

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3439,13 +3439,14 @@ async fn test_wrapper_limitless_post_processing_union_of_distinct_selects() {
 
     // Nothing is left above the pushed down query
     let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-    assert!(sql.contains("UNION"), "union is pushed down: {sql}");
+    assert!(sql.contains("UNION"), "union is pushed down: {}", sql);
     assert!(
         logical_plan
             .find_cube_scans()
             .iter()
             .all(|scan| { scan.request.ungrouped == Some(true) && scan.request.limit.is_none() }),
-        "the queries themselves stay unlimited, inside the pushed down SQL: {logical_plan:?}"
+        "the queries themselves stay unlimited, inside the pushed down SQL: {:?}",
+        logical_plan
     );
 }
 
@@ -3471,10 +3472,11 @@ async fn test_wrapper_union_all_push_down() {
 
     let logical_plan = query_plan.as_logical_plan();
     let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {}", sql);
     assert!(
         sql.contains("KibanaSampleDataEcommerce.customer_gender") && sql.contains("Logs.content"),
-        "both queries are in the pushed down SQL: {sql}"
+        "both queries are in the pushed down SQL: {}",
+        sql
     );
     // The row cap lands on the result of the whole set operation, not on either query
     assert!(
@@ -3482,7 +3484,8 @@ async fn test_wrapper_union_all_push_down() {
             "LIMIT {}",
             ConfigObjImpl::default().non_streaming_query_max_row_limit
         )),
-        "the row cap bounds the union: {sql}"
+        "the row cap bounds the union: {}",
+        sql
     );
 }
 
@@ -3509,7 +3512,8 @@ async fn test_wrapper_union_distinct_push_down() {
     let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
     assert!(
         sql.contains("UNION") && !sql.contains("UNION ALL"),
-        "distinct union is pushed down as UNION: {sql}"
+        "distinct union is pushed down as UNION: {}",
+        sql
     );
 }
 
@@ -3542,7 +3546,8 @@ async fn test_wrapper_union_three_queries_push_down() {
     assert_eq!(
         sql.matches("UNION ALL").count(),
         2,
-        "all three queries are pushed down: {sql}"
+        "all three queries are pushed down: {}",
+        sql
     );
 }
 
@@ -3570,13 +3575,15 @@ async fn test_wrapper_union_filter_push_down() {
     let logical_plan = query_plan.as_logical_plan();
     assert!(
         logical_plan.find_filter().is_none(),
-        "no filter is left to post processing: {logical_plan:?}"
+        "no filter is left to post processing: {:?}",
+        logical_plan
     );
     let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {}", sql);
     assert!(
         sql.contains("WHERE"),
-        "the filter reads from the pushed down union: {sql}"
+        "the filter reads from the pushed down union: {}",
+        sql
     );
 }
 
@@ -3613,11 +3620,13 @@ async fn test_wrapper_union_different_data_sources_not_pushed_down() {
     assert_eq!(
         logical_plan.find_cube_scans().len(),
         2,
-        "every query keeps its own scan: {logical_plan:?}"
+        "every query keeps its own scan: {:?}",
+        logical_plan
     );
     assert!(
         matches!(logical_plan, LogicalPlan::Union(_)),
-        "the union is left to post processing: {logical_plan:?}"
+        "the union is left to post processing: {:?}",
+        logical_plan
     );
 }
 
@@ -3644,13 +3653,14 @@ async fn test_wrapper_union_sort_left_to_post_processing() {
             .as_logical_plan();
     assert!(
         matches!(logical_plan, LogicalPlan::Sort(_)),
-        "the sort is left to post processing: {logical_plan:?}"
+        "the sort is left to post processing: {:?}",
+        logical_plan
     );
     let sql = logical_plan
         .find_cube_scan_wrapped_sql_deep()
         .wrapped_sql
         .sql;
-    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {}", sql);
 
     let mut config = ConfigObjImpl::default();
     config.fail_on_limitless_post_processing = true;
@@ -3663,7 +3673,8 @@ async fn test_wrapper_union_sort_left_to_post_processing() {
         error
             .to_string()
             .contains("CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING"),
-        "unexpected error: {error}"
+        "unexpected error: {}",
+        error
     );
 }
 
@@ -3699,12 +3710,13 @@ async fn test_wrapper_union_limited_query_push_down() {
     );
 
     let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
-    assert!(sql.contains("UNION ALL"), "union is pushed down: {sql}");
+    assert!(sql.contains("UNION ALL"), "union is pushed down: {}", sql);
     assert!(
         sql.trim_end().ends_with(&format!(
             "LIMIT {}",
             ConfigObjImpl::default().non_streaming_query_max_row_limit
         )),
-        "the row cap bounds the union: {sql}"
+        "the row cap bounds the union: {}",
+        sql
     );
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3750,3 +3750,38 @@ async fn test_wrapper_union_limited_query_push_down() {
         sql
     );
 }
+
+/// A pushed down union is a query the rest of the wrapper can build on: joining against one
+/// reads it as a subquery of the Cube query, rather than leaving the union to DataFusion.
+#[tokio::test]
+async fn test_wrapper_union_in_join_push_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let sql = convert_select_to_query_plan(
+        "SELECT k.customer_gender, u.market \
+         FROM KibanaSampleDataEcommerce k \
+         JOIN ( \
+           SELECT 'MX' AS table_type, customer_gender AS market \
+           FROM KibanaSampleDataEcommerce GROUP BY 1, 2 \
+           UNION ALL \
+           SELECT 'RX' AS table_type, content AS market FROM Logs GROUP BY 1, 2 \
+         ) u ON k.customer_gender = u.market \
+         GROUP BY 1, 2"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .as_logical_plan()
+    .find_cube_scan_wrapped_sql()
+    .wrapped_sql
+    .sql;
+
+    assert!(
+        sql.contains("UNION ALL"),
+        "the join reads a pushed down union: {}",
+        sql
+    );
+}

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -3779,9 +3779,21 @@ async fn test_wrapper_union_in_join_push_down() {
     .wrapped_sql
     .sql;
 
+    // The union has to be in the SQL as the join's subquery, not merely somewhere in it:
+    // a union that lost its join, or a join that lost its union, would both be wrong
     assert!(
         sql.contains("UNION ALL"),
-        "the join reads a pushed down union: {}",
+        "the union is pushed down: {}",
+        sql
+    );
+    assert!(
+        sql.contains("subqueryJoins"),
+        "the union is read as the join's subquery: {}",
+        sql
+    );
+    assert!(
+        sql.contains("KibanaSampleDataEcommerce.customer_gender") && sql.contains("Logs.content"),
+        "both queries of the union are in the pushed down SQL: {}",
         sql
     );
 }

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -1090,6 +1090,20 @@ impl SqlTemplates {
             context! { join_type => join_type, source => source, condition => condition },
         )
     }
+
+    /// Renders `queries` as a single set operation: `UNION` when `distinct`, `UNION ALL`
+    /// otherwise. `limit` bounds the result of the whole operation, not of any one query.
+    pub fn union(
+        &self,
+        queries: Vec<String>,
+        distinct: bool,
+        limit: Option<usize>,
+    ) -> Result<String, CubeError> {
+        self.render_template(
+            "statements/union",
+            context! { queries => queries, distinct => distinct, limit => limit },
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

CORE-819

**Description of Changes Made**

Follows #11559, now merged: that change makes the planner prefer SQL pushdown over limitless post processing, and this adds the pushdown a `UNION` had nothing to fall back to. Rebased onto master.

A `UNION` had no representation in the wrapper at all — no rule, no node, and `LogicalPlan::Union` in `generate_sql_for_node` was a commented-out placeholder — so the set operation always ran in DataFusion on top of Cube queries the row limit had already truncated. The reported shape is:

```sql
SELECT DISTINCT 'Medical Claims (MX)' AS table_type, market_abbreviation
FROM tdp_claims_mx_ast_monthly_view
UNION
SELECT DISTINCT 'Pharmacy Claims (RX)' AS table_type, market_abbreviations AS market_abbreviation
FROM tdp_claims_rx_ast_monthly_view
```

DataFusion collapses the per-query `DISTINCT`s into the one above the `UNION`, which leaves each query an ungrouped scan of raw rows rather than the grouped request a `SELECT DISTINCT` on its own compiles to. Both halves are cut off at the row cap before the deduplication ever sees them, so markets missing from the answer go missing silently.

**What this adds**

- `WrappedUnion`, a language node and plan node the rewriter can put a union into, alongside `WrappedSelect`. It renders through a new `statements/union` template, so dialects can override how a set operation is written.
- `wrapper-push-down-union`, which moves the wrapper of every query into one wrapper around the union. Every query must reach the same data source; a union is a list rather than a pair, so the rule walks it and takes any number of queries.
- `wrapper-push-down-distinct-to-union`, which folds the `DISTINCT` of a plain `UNION` into the node — `UNION` is `UNION ALL` with the duplicates dropped, and the data source does both at once.
- `ast_size_inside_wrapper` counts `WrappedUnion`. Without this the union wrapper reads as an empty wrapper and `empty_wrappers`, which outranks `limitless_post_processing`, throws the pushdown away.

Once the union is inside a wrapper, the existing rules compose with it: a projection or a filter above it is pushed into a select that reads from it, and `set_max_limit_for_node` caps the result of the whole operation instead of each query.

**Scope**

- Queries that reach different data sources are left in post processing — one data source cannot evaluate a set operation over another's rows. Pinned by a test, and it is what CUB-4076 asks for separately.
- A `Sort` directly above a union is still post processing. The select it would push into projects nothing, and a query without a projection is not SQL. `CUBESQL_FAIL_ON_LIMITLESS_POST_PROCESSING` reports it, and there is a test pinning both halves of that.
- A `LIMIT` above a union is unchanged: `UnionSortLimitPushDown` copies it into each query, which bounds them, and the union stays where it is.

**One test from #11559 changed**

`test_wrapper_limitless_post_processing_sibling_without_limit` pinned that a limited query cannot stand in for an unlimited one beside it under a union. With this change that union is pushed down, so the pairing it was written against no longer happens there. The test now uses two data sources, where the union really is left to post processing, and keeps asserting the same property. `test_wrapper_union_limited_query_push_down` covers the pushed down case: the `LIMIT 10` stays inside its own query and the row cap bounds the union.

**Tests**

857 lib tests passing on the rebased branch; `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` clean, and 27 `schema-compiler` unit tests covering the dialect templates. New coverage: `UNION ALL`, `UNION`, three queries, a filter above a union, a limited query, two data sources, a join over a pushed down union, a dialect without the template, and the sort limitation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo5DArPYy2Q7ER7HyMo1Ao)_