### PR TITLE
docs: document undocumented customer-facing changes from the last week

### DIFF
--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -16,7 +16,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 - **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it to a workbook as a re-runnable report (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
-- **Save to Workbook** – Export insights to [Workbooks](/docs/explore-analyze/workbooks) for further analysis
+- **Save to Workbook or as an exploration** – Ask the agent to save a result, either into a [workbook](/docs/explore-analyze/workbooks) as a report or, if you don't name a workbook, as a standalone [exploration](/docs/explore-analyze/explore) for further analysis
 
 ## Discover available fields
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -61,7 +61,8 @@ A modal window with an authentication prompt will appear. Choose the deployments
 that you want to work with in Google Sheets and click **Authorize**.
 Once you see the `Access Granted` message, close the modal window.
 
-If you want to revoke the authentication, open the add-on menu and click
+The add-on menu shows the current tenant, Cube account, deployment, and signed-in
+user. If you want to revoke the authentication, open the add-on menu and click
 **Sign out**.
 
 ## Create reports via pivot table
@@ -80,7 +81,13 @@ Google Cloud for Sheets works only with [views][ref-views], not cubes.
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
 the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+remove members from a query. Drag members within **Measures** to reorder them
+in the output.
+
+When a dimension is on **Columns**, the **Measure position** option controls
+how measures nest relative to the column values: **After columns** (default)
+nests measures under each column value, while **Before columns** makes each
+measure span all column values.
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -244,6 +244,12 @@ work together.
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
 guessing them.
 
+`runQuery` also takes an optional `branchName` to query a [dev branch][ref-dev-mode]
+instead of the deployed model — use it to verify a data model edit before committing it.
+Every response reports the branch it actually ran against (`null` means the deployed
+model). Keep `branchName` identical across paginated calls: dropping it on a later page
+re-runs the query against the deployed model instead of continuing on the branch.
+
 ### Dashboard authoring
 
 These tools build [workbooks][ref-workbooks] and [dashboards][ref-dashboards]

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -69,7 +69,8 @@ A modal window with an authentication prompt will appear. Choose the deployments
 that you want to work with in Microsoft Excel and click **Authorize**.
 Once you see the `Access Granted` message, close the modal window.
 
-If you want to revoke the authentication, open the add-in menu and click
+The add-in menu shows the current tenant, Cube account, deployment, and signed-in
+user. If you want to revoke the authentication, open the add-in menu and click
 **Sign out**.
 
 ## Create reports via pivot table
@@ -88,7 +89,13 @@ Cube Cloud for Excel works only with [views][ref-views], not cubes.
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
 the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+remove members from a query. Drag members within **Measures** to reorder them
+in the output.
+
+When a dimension is on **Columns**, the **Measure position** option controls
+how measures nest relative to the column values: **After columns** (default)
+nests measures under each column value, while **Before columns** makes each
+measure span all column values.
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Recurring audit of recent `cube-js/cube` and `cubedevinc/cubejs-enterprise` changes against `docs-mintlify`, filtered per the [customer-facing criteria](https://github.com/cubedevinc/cubejs-enterprise/blob/master/.claude/shared/customer-facing-criteria.md). Four undocumented, shipped, customer-facing changes:

* **docs(mcp)**: `runQuery`'s new optional `branchName` param — lets an MCP client verify a data-model edit against its dev branch before committing (CUB-3732).
* **docs(chat)**: Analytics Chat can now save a result as a standalone exploration (not just into a workbook) when you don't name a workbook (CUB-4109).
* **docs(sheets, excel)**: the pivot builder's Measures pane is now reorderable, and a new "Measure position" option controls whether measures nest under each column value or each measure spans all column values (CUB-2405).
* **docs(sheets, excel)**: the add-in/add-on menu now shows the current tenant, Cube account, deployment, and signed-in user (CUB-4096).

Everything else reviewed in this window was either already documented in its own PR, an internal/super-admin-only change, or a partial rollout (dbt workspace publish, CUB-3964) better tracked separately once it completes — filed as a Linear ticket instead.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014z7xqaGDhByEBLWMT4SCe7

---
_Generated by [Claude Code](https://claude.ai/code/session_014z7xqaGDhByEBLWMT4SCe7)_