### PR TITLE
docs: Cube Store message size limits

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1014,7 +1014,7 @@ can pick it up, and it is written to the cache under its cache key — so a
 result set larger than the transport limit cannot be delivered at all,
 however fast the query that produced it was.
 
-A cache entry above `CUBESTORE_CACHE_MAX_ENTRY_SIZE` is rejected explicitly,
+A cache entry at or above `CUBESTORE_CACHE_MAX_ENTRY_SIZE` is rejected explicitly,
 with `Unable to SET cache with '<key>' key, exceeds maximum allowed size for
 payload: <size>, max allowed: <limit>`.
 

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1021,18 +1021,8 @@ payload: <size>, max allowed: <limit>`.
 <Warning>
 
 **Known limitation.** A message above the *transport* limit is not answered
-with an error. Cube Store logs `Websocket error: Capacity(MessageTooLong {
-size: ..., max_size: ... })` and closes the connection. The driver treats
-that as Cube Store having gone away and, on reconnect, resends everything
-that was still in flight — including the oversized message, which
-immediately kills the new connection too.
-
-The deployment then reports `ConnectionError: CubeStore connection error:
-write EPIPE` every few seconds for as long as the loop runs. Because all
-queries on a node share one connection, *unrelated* queries fail alongside
-the oversized one, so the same query can appear to succeed and fail seconds
-apart.
-
+with an error. The deployment then reports `ConnectionError: CubeStore connection error:
+write EPIPE`.
 </Warning>
 
 If a query hits this limit, reduce the size of its result set — add filters

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1027,11 +1027,10 @@ write EPIPE`.
 </Warning>
 
 If a query hits this limit, reduce the size of its result set — add filters
-or a lower `limit`, drop dimensions, or split it into several queries. If it
-is a full-table extract, load it from your data source directly instead of
-through Cube's cache. Self-hosted deployments can also raise
-`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` up to 256 MiB, but that only moves the
-ceiling — a result set that grows past the new value brings the failure back.
+or a lower `limit`, drop dimensions, or split it into several queries.
+Self-hosted deployments can raise the ceiling instead, but
+`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` and `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`
+have to go up together, since a message is sent as a single frame.
 
 ### Why it lives in Cube Store
 

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1023,6 +1023,7 @@ payload: <size>, max allowed: <limit>`.
 **Known limitation.** A message above the *transport* limit is not answered
 with an error. The deployment then reports `ConnectionError: CubeStore connection error:
 write EPIPE`.
+
 </Warning>
 
 If a query hits this limit, reduce the size of its result set — add filters

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -996,6 +996,52 @@ Because detection is timestamp-based and cancellation is idempotent, it
 does not matter which instance notices first: recovery works even if the
 failed node never comes back.
 
+### Message size limits
+
+Cube talks to the cache and queue store over a single WebSocket connection
+per node, and every cache entry, queue payload, and query result crosses it
+as one message. That transport has a hard ceiling:
+
+| Limit | Environment variable | Default | Allowed range |
+|---|---|---|---|
+| Transport message size | `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` | 64 MiB | 16 MiB — 256 MiB |
+| Transport frame size | `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` | 64 MiB | 4 MiB — 256 MiB |
+| Single cache entry | `CUBESTORE_CACHE_MAX_ENTRY_SIZE` | 63 MiB | up to transport message size − 1 MiB |
+
+Query results are the usual reason these limits are reached. A result is
+handed to the queue store so that every API instance waiting on that query
+can pick it up, and it is written to the cache under its cache key — so a
+result set larger than the transport limit cannot be delivered at all,
+however fast the query that produced it was.
+
+A cache entry above `CUBESTORE_CACHE_MAX_ENTRY_SIZE` is rejected explicitly,
+with `Unable to SET cache with '<key>' key, exceeds maximum allowed size for
+payload: <size>, max allowed: <limit>`.
+
+<Warning>
+
+**Known limitation.** A message above the *transport* limit is not answered
+with an error. Cube Store logs `Websocket error: Capacity(MessageTooLong {
+size: ..., max_size: ... })` and closes the connection. The driver treats
+that as Cube Store having gone away and, on reconnect, resends everything
+that was still in flight — including the oversized message, which
+immediately kills the new connection too.
+
+The deployment then reports `ConnectionError: CubeStore connection error:
+write EPIPE` every few seconds for as long as the loop runs. Because all
+queries on a node share one connection, *unrelated* queries fail alongside
+the oversized one, so the same query can appear to succeed and fail seconds
+apart.
+
+</Warning>
+
+If a query hits this limit, reduce the size of its result set — add filters
+or a lower `limit`, drop dimensions, or split it into several queries. If it
+is a full-table extract, load it from your data source directly instead of
+through Cube's cache. Self-hosted deployments can also raise
+`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` up to 256 MiB, but that only moves the
+ceiling — a result set that grows past the new value brings the failure back.
+
 ### Why it lives in Cube Store
 
 Folding the cache and queue into Cube Store is itself a design decision in

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -998,9 +998,9 @@ failed node never comes back.
 
 ### Message size limits
 
-Cube talks to the cache and queue store over a single WebSocket connection
-per node, and every cache entry, queue payload, and query result crosses it
-as one message. That transport has a hard ceiling:
+Cube talks to the cache and queue store over a WebSocket connection, and
+every cache entry, queue payload, and query result crosses it as one
+message. That transport has a hard ceiling:
 
 | Limit | Environment variable | Default | Allowed range |
 |---|---|---|---|

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1870,6 +1870,18 @@ The address/port pair for Cube Store's MySQL-compatible interface.
 | ------------------------- | ---------------------- | --------------------- |
 | A valid address/port pair | `0.0.0.0:3306`         | `0.0.0.0:3306`        |
 
+## `CUBESTORE_CACHE_MAX_ENTRY_SIZE`
+
+The maximum size of a single entry in Cube Store's
+[cache store](/docs/pre-aggregations/cube-store-architecture#cache-and-queue-store).
+Larger entries are rejected. Cannot exceed
+[`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE`](#cubestore_transport_max_message_size)
+minus 1 MiB.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A size, e.g. `63MiB` | `63MiB`           | `63MiB`               |
+
 ## `CUBESTORE_DATA_DIR`
 
 A path on the local filesystem to store a local replica of the data. Must be
@@ -2133,6 +2145,26 @@ If `true`, then sends telemetry to Cube.
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true`                 | `true`                |
+
+## `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE`
+
+The maximum size of a single message on the WebSocket connection between Cube
+and Cube Store. Messages above this size close the connection; see
+[message size limits](/docs/pre-aggregations/cube-store-architecture#message-size-limits).
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A size from `16MiB` to `256MiB` | `64MiB` | `64MiB`     |
+
+## `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`
+
+The maximum size of a single WebSocket frame on the connection between Cube
+and Cube Store. A message is split into frames, so this can be smaller than
+[`CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE`](#cubestore_transport_max_message_size).
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A size from `4MiB` to `256MiB` | `64MiB`  | `64MiB`              |
 
 ## `CUBESTORE_WAL_SPLIT_THRESHOLD`
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Cube talks to the cache and queue store over one WebSocket connection per node, and query results are delivered through it (`QUEUE ACK`) and written to the cache, so a result set above the transport ceiling cannot be delivered at all. A message over that ceiling is not answered with an error — Cube Store logs `Capacity(MessageTooLong { .. })` and closes the socket, and `WebSocketConnection` resends everything in flight on reconnect (including the oversized message), which kills each new connection and surfaces as a loop of `ConnectionError: CubeStore connection error: write EPIPE` that also fails unrelated queries sharing the connection.

This adds a "Message size limits" section to the Cube Store architecture page covering those limits, the known limitation, and how to stay under it, plus reference entries for the three previously undocumented env vars `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` (64 MiB, 16–256 MiB), `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE` (64 MiB, 4–256 MiB) and `CUBESTORE_CACHE_MAX_ENTRY_SIZE` (63 MiB, capped at message size − 1 MiB). Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)