### PR TITLE
docs: view-level measures and multi-fact derived metrics, plus a schema-compiler test

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -640,6 +640,7 @@
                       "recipes/data-modeling/nested-aggregates",
                       "recipes/data-modeling/filtered-aggregates",
                       "recipes/data-modeling/share-of-total",
+                      "recipes/data-modeling/average-order-value",
                       "recipes/data-modeling/period-over-period"
                     ]
                   },

--- a/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
+++ b/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
@@ -315,7 +315,8 @@ single metric derived from both, such as revenue per order where revenue and
 order count come from different fact tables. Neither cube can define it, because
 neither can reference the other's measures.
 
-Define it on the view instead, and mark it [`multi_stage`][ref-multi-stage]:
+Define it as a [measure of the view][ref-view-measures] instead, and mark it
+[`multi_stage`][ref-multi-stage]:
 
 <CodeGroup>
 

--- a/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
+++ b/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
@@ -308,6 +308,101 @@ The combined result shows measures from each fact table side by side:
 Charlie has no orders and Diana has no returns — both are still included
 with `NULL` values for the missing fact table.
 
+## Combining facts in one measure
+
+Putting measures from two facts side by side is often not the goal — you want a
+single metric derived from both, such as revenue per order where revenue and
+order count come from different fact tables. Neither cube can define it, because
+neither can reference the other's measures.
+
+Define it on the view instead, and mark it [`multi_stage`][ref-multi-stage]:
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: customer_overview
+    cubes:
+      - join_path: orders
+        prefix: true
+        includes:
+          - count
+          - total_amount
+      - join_path: returns
+        prefix: true
+        includes:
+          - total_refund
+      - join_path: customers
+        includes:
+          - name
+          - city
+      - join_path: dates
+        includes:
+          - date
+
+    measures:
+      - name: refund_rate
+        type: number
+        multi_stage: true
+        sql: "{CUBE.returns_total_refund} / NULLIF({CUBE.orders_total_amount}, 0)"
+```
+
+```javascript title="JavaScript"
+view(`customer_overview`, {
+  cubes: [
+    {
+      join_path: orders,
+      prefix: true,
+      includes: [`count`, `total_amount`]
+    },
+    {
+      join_path: returns,
+      prefix: true,
+      includes: [`total_refund`]
+    },
+    {
+      join_path: customers,
+      includes: [`name`, `city`]
+    },
+    {
+      join_path: dates,
+      includes: [`date`]
+    }
+  ],
+
+  measures: {
+    refund_rate: {
+      type: `number`,
+      multi_stage: true,
+      sql: `${CUBE.returns_total_refund} / NULLIF(${CUBE.orders_total_amount}, 0)`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+`multi_stage` is what makes this work. It defers the expression to a stage that
+runs _after_ the per-fact subqueries have been aggregated and joined, so the
+division happens once per row of the combined result:
+
+```sql
+-- one aggregating subquery per fact, at the query's grain
+SUM(orders.amount)   GROUP BY city
+SUM(returns.refund)  GROUP BY city
+-- final stage, once the two are joined on city
+total_refund / NULLIF(total_amount, 0)
+```
+
+Without `multi_stage`, the same expression is planned as an ordinary calculated
+measure. Cube then looks for a single join tree covering both fact cubes, finds
+none — the facts only meet through the shared dimensions — and the query fails
+with `Can't find join path to join …`, naming both facts. If you see that error
+on a measure that spans facts, `multi_stage` is what's missing.
+
+The measure is queried like any other, on its own or next to its components, and
+grouped by any of the shared dimensions.
+
 ## Joining views in the SQL API
 
 You don't have to define a dedicated multi-fact view to get multi-fact
@@ -518,14 +613,28 @@ the multi-fact join on the full set of common dimensions.
 **Common dimension filters** (like `city = 'New York'` or `date > '2025-01-01'`)
 are applied to every subquery, ensuring consistent filtering across all facts.
 
-**Fact-specific filters** (like `orders.status = 'completed'`) are applied only
-to that fact's subquery. Other fact subqueries remain unaffected.
-
 **Measure filters** (like `orders_count > 1`) are applied as `HAVING`
 conditions after the subqueries are joined.
 
-[Segments][ref-segments] that belong to a specific fact table are applied only
-to that fact's subquery.
+**Fact-specific filters and [segments][ref-segments]** — anything that belongs to
+one fact table rather than a shared dimension — can't be used in a multi-fact
+query. Every grouped dimension, filter and segment has to be reachable from all
+facts, so a query that carries one fails with `Can't find join path to join …`.
+The same members are fine as soon as only that fact's measures are requested,
+since the query is no longer multi-fact.
+
+To narrow one fact inside a multi-fact query, put the condition in the measure's
+own [`filters`][ref-measure-filters] on its cube. It travels with the measure
+into that fact's subquery and leaves the others alone:
+
+```yaml
+measures:
+  - name: completed_amount
+    sql: amount
+    type: sum
+    filters:
+      - sql: "{CUBE}.status = 'completed'"
+```
 
 ## Join path requirements
 
@@ -533,9 +642,13 @@ to that fact's subquery.
 - Dimension tables should be included in the view at **root-level join paths**,
   not nested under a specific fact (e.g., `customers`, not `orders.customers`)
 - Use `prefix` on fact cubes to disambiguate identically named members
+- Everything a multi-fact query groups or filters by must be shared by all facts
 
 [ref-views]: /docs/data-modeling/views
 [ref-view-ref]: /reference/data-modeling/view
 [ref-segments]: /reference/data-modeling/segments
+[ref-measure-filters]: /reference/data-modeling/measures#filters
+[ref-multi-stage]: /reference/data-modeling/measures#multi_stage
+[ref-view-measures]: /reference/data-modeling/view#measures
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [link-tesseract]: https://cube.dev/blog/introducing-tesseract

--- a/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
+++ b/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
@@ -502,16 +502,19 @@ GROUP BY 1, 2
 
 ### Filtering the join
 
-Filters on top of the join are supported and are applied to the merged query:
+Filters on top of the join are pushed into the merged query:
 
-- A `WHERE` clause is pushed into the merged scan. A predicate on a dimension
-  shared by all facts filters the whole result; a predicate on a fact-specific
-  dimension filters only that fact's subquery.
+- A `WHERE` clause is pushed into the merged scan, becoming a filter on the
+  member the predicate refers to.
 - A predicate in the `ON` clause that the planner can attach to a single side
   (for example, a condition on the optional side of a `LEFT JOIN`) becomes a
   filter on that fact. Predicates that the SQL planner can't push to one side
   of an outer join (such as a left-table condition in a `LEFT JOIN ON`) aren't
   supported by the planner and will raise an error.
+
+Pushing the predicate in is only the first step: the merged query is then
+planned like any other multi-fact query, so the member it filters on must be
+[shared by all facts](#filters-and-segments).
 
 ### Join type
 
@@ -618,10 +621,11 @@ conditions after the subqueries are joined.
 
 **Fact-specific filters and [segments][ref-segments]** — anything that belongs to
 one fact table rather than a shared dimension — can't be used in a multi-fact
-query. Every grouped dimension, filter and segment has to be reachable from all
-facts, so a query that carries one fails with `Can't find join path to join …`.
-The same members are fine as soon as only that fact's measures are requested,
-since the query is no longer multi-fact.
+query, however it is written: a `WHERE` clause in the SQL API, a filter in the
+REST (JSON) API, or a segment. Every grouped dimension, filter and segment has
+to be reachable from all facts, so a query that carries one fails with
+`Can't find join path to join …`. The same members are fine as soon as only
+that fact's measures are requested, since the query is no longer multi-fact.
 
 To narrow one fact inside a multi-fact query, put the condition in the measure's
 own [`filters`][ref-measure-filters] on its cube. It travels with the measure

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -289,21 +289,14 @@ The one exception is a metric whose parts live in different cubes, so there is
 no single cube it could belong to. A view can define its own
 [measures][ref-view-measures] and [dimensions][ref-view-dimensions] as long as
 their `sql` only combines members the view already includes — a member that
-reads a column instead is rejected at compile time. Here `orders` joins
-`line_items` `one_to_many`:
+reads a column instead is rejected at compile time:
 
 <CodeGroup>
 
 ```yaml title="YAML"
 views:
   - name: orders_overview
-    cubes:
-      - join_path: orders
-        includes:
-          - total_amount
-      - join_path: orders.line_items
-        includes:
-          - count
+    # cubes: … includes orders.total_amount and line_items.count
 
     measures:
       - name: average_line_value
@@ -314,16 +307,7 @@ views:
 
 ```javascript title="JavaScript"
 view(`orders_overview`, {
-  cubes: [
-    {
-      join_path: orders,
-      includes: [`total_amount`]
-    },
-    {
-      join_path: orders.line_items,
-      includes: [`count`]
-    }
-  ],
+  // cubes: … includes orders.total_amount and line_items.count
 
   measures: {
     average_line_value: {
@@ -339,9 +323,10 @@ view(`orders_overview`, {
 
 [`multi_stage`][ref-multi-stage] matters whenever the parts come from different
 cubes: it aggregates each of them before combining, instead of evaluating the
-expression inside one joined scan where a `one_to_many` join would inflate the
-numerator. If the cubes don't join to each other at all, see [multi-fact
-views][ref-multi-fact-views].
+expression inside one joined scan where a `one_to_many` join between them would
+inflate the numerator. If the cubes don't join to each other at all, see
+[multi-fact views][ref-multi-fact-views]. The full example, with the `cubes`
+block, is on the [view reference][ref-view-measures].
 
 ### Control visibility
 

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -283,6 +283,60 @@ control which members are exposed, how they're named, and how they're
 organized. This keeps your model [DRY][wiki-dry] and makes maintenance
 straightforward.
 
+### Define a metric on a view when it spans cubes
+
+The one exception is a metric whose parts live in different cubes, so there is
+no single cube it could belong to. A view can define its own
+[measures][ref-view-measures] and [dimensions][ref-view-dimensions] as long as
+their `sql` only combines members the view already includes:
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: orders
+        includes:
+          - total_amount
+      - join_path: line_items
+        includes:
+          - count
+
+    measures:
+      - name: average_line_value
+        type: number
+        sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
+```
+
+```javascript title="JavaScript"
+view(`orders_overview`, {
+  cubes: [
+    {
+      join_path: orders,
+      includes: [`total_amount`]
+    },
+    {
+      join_path: line_items,
+      includes: [`count`]
+    }
+  ],
+
+  measures: {
+    average_line_value: {
+      type: `number`,
+      sql: `${CUBE.total_amount} / NULLIF(${CUBE.count}, 0)`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+A view member that reads a column instead of a member is rejected at compile
+time — that logic belongs in a cube. If the referenced measures come from cubes
+that don't join to each other, see [multi-fact views][ref-multi-fact-views].
+
 ### Control visibility
 
 Not every view should be publicly accessible. Use [`public`][ref-view-public]
@@ -450,6 +504,9 @@ parameters.
 [ref-view-description]: /reference/data-modeling/view#description
 [ref-view-title]: /reference/data-modeling/view#title
 [ref-view-public]: /reference/data-modeling/view#public
+[ref-view-measures]: /reference/data-modeling/view#measures
+[ref-view-dimensions]: /reference/data-modeling/view#dimensions
+[ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
 [ref-view-folders]: /reference/data-modeling/view#folders
 [ref-access-policies]: /reference/data-modeling/data-access-policies
 [ref-ai-context]: /docs/data-modeling/ai-context

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -289,12 +289,12 @@ The one exception is a metric whose parts live in different cubes, so there is
 no single cube it could belong to. A view can define its own
 [measures][ref-view-measures] and [dimensions][ref-view-dimensions] as long as
 their `sql` only combines members the view already includes — a member that
-reads a column instead is rejected at compile time.
+reads a column instead is rejected at compile time. Here `orders` joins
+`line_items` `one_to_many`:
 
 <CodeGroup>
 
 ```yaml title="YAML"
-# orders joins line_items one_to_many
 views:
   - name: orders_overview
     cubes:

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -294,13 +294,14 @@ reads a column instead is rejected at compile time.
 <CodeGroup>
 
 ```yaml title="YAML"
+# orders joins line_items one_to_many
 views:
   - name: orders_overview
     cubes:
       - join_path: orders
         includes:
           - total_amount
-      - join_path: line_items
+      - join_path: orders.line_items
         includes:
           - count
 
@@ -319,7 +320,7 @@ view(`orders_overview`, {
       includes: [`total_amount`]
     },
     {
-      join_path: line_items,
+      join_path: orders.line_items,
       includes: [`count`]
     }
   ],

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -288,7 +288,8 @@ straightforward.
 The one exception is a metric whose parts live in different cubes, so there is
 no single cube it could belong to. A view can define its own
 [measures][ref-view-measures] and [dimensions][ref-view-dimensions] as long as
-their `sql` only combines members the view already includes:
+their `sql` only combines members the view already includes — a member that
+reads a column instead is rejected at compile time.
 
 <CodeGroup>
 
@@ -306,6 +307,7 @@ views:
     measures:
       - name: average_line_value
         type: number
+        multi_stage: true
         sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
 ```
 
@@ -325,6 +327,7 @@ view(`orders_overview`, {
   measures: {
     average_line_value: {
       type: `number`,
+      multi_stage: true,
       sql: `${CUBE.total_amount} / NULLIF(${CUBE.count}, 0)`
     }
   }
@@ -333,9 +336,11 @@ view(`orders_overview`, {
 
 </CodeGroup>
 
-A view member that reads a column instead of a member is rejected at compile
-time — that logic belongs in a cube. If the referenced measures come from cubes
-that don't join to each other, see [multi-fact views][ref-multi-fact-views].
+[`multi_stage`][ref-multi-stage] matters whenever the parts come from different
+cubes: it aggregates each of them before combining, instead of evaluating the
+expression inside one joined scan where a `one_to_many` join would inflate the
+numerator. If the cubes don't join to each other at all, see [multi-fact
+views][ref-multi-fact-views].
 
 ### Control visibility
 
@@ -506,6 +511,7 @@ parameters.
 [ref-view-public]: /reference/data-modeling/view#public
 [ref-view-measures]: /reference/data-modeling/view#measures
 [ref-view-dimensions]: /reference/data-modeling/view#dimensions
+[ref-multi-stage]: /reference/data-modeling/measures#multi_stage
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
 [ref-view-folders]: /reference/data-modeling/view#folders
 [ref-access-policies]: /reference/data-modeling/data-access-policies

--- a/docs-mintlify/recipes/data-modeling/average-order-value.mdx
+++ b/docs-mintlify/recipes/data-modeling/average-order-value.mdx
@@ -1,0 +1,338 @@
+---
+title: Calculating average order value
+description: Define AOV as a single measure when its numerator and denominator live in the same cube, or in two fact tables at different grains.
+---
+
+## Use case
+
+Average order value (AOV) — sometimes called basket size — is revenue divided by
+the number of orders. It looks like a one-line calculation, but where the two
+parts live decides how it is modeled:
+
+- **[Same cube](#same-cube)** — both parts are measures of one fact table.
+- **[Two fact tables](#across-two-fact-tables)** — revenue is aggregated at one
+  grain (say, day/item/location) and orders are counted at another (transaction
+  lines). This is the common shape in retail models.
+
+In both cases AOV is a ratio of two aggregates, so it must be computed _after_
+its parts are aggregated — never as a row-level `amount / orders` expression.
+
+## Same cube
+
+When both parts are measures of the same cube, define AOV as a calculated
+measure that divides them:
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: orders
+    sql_table: orders
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+    measures:
+      - name: revenue
+        sql: amount
+        type: sum
+        format: currency
+
+      - name: count
+        type: count
+
+      - name: average_order_value
+        sql: "{revenue} / NULLIF({count}, 0)"
+        type: number
+        format: currency
+```
+
+```javascript title="JavaScript"
+cube(`orders`, {
+  sql_table: `orders`,
+
+  dimensions: {
+    id: { sql: `id`, type: `number`, primary_key: true }
+  },
+
+  measures: {
+    revenue: { sql: `amount`, type: `sum`, format: `currency` },
+    count: { type: `count` },
+
+    average_order_value: {
+      sql: `${revenue} / NULLIF(${count}, 0)`,
+      type: `number`,
+      format: `currency`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+`NULLIF` guards the division so a group with no orders returns `NULL` rather
+than failing.
+
+## Across two fact tables
+
+Retail models usually split the two parts. Sales dollars come from a
+pre-aggregated daily table (`item_location_sales`, one row per day, item and
+location), while the transaction count comes from the line-item table
+(`sales_line_item`, one row per transaction line). The two never join to each
+other — they meet through shared `items`, `locations` and `dates` cubes, which
+makes this a [multi-fact query][ref-multi-fact-views].
+
+<Warning>
+
+Multi-fact views and multi-stage measures are powered by Tesseract, the
+[next-generation data modeling engine][link-tesseract]. In versions before
+v1.7.0, it was not enabled by default.
+
+</Warning>
+
+### 1. Define each part on the cube that owns it
+
+The denominator counts distinct transactions and excludes exchanges and
+non-store channels. Write that logic once, as measure
+[`filters`][ref-measure-filters] on the line-item cube, so every consumer picks
+it up by including the measure — never restate it per view:
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: sales_line_item
+    sql_table: sales_line_item
+
+    joins:
+      - name: items
+        sql: "{CUBE}.item_id = {items.id}"
+        relationship: many_to_one
+      - name: locations
+        sql: "{CUBE}.location_id = {locations.id}"
+        relationship: many_to_one
+      - name: dates
+        sql: "DATE_TRUNC('day', {CUBE}.sold_at) = {dates.date}"
+        relationship: many_to_one
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+    measures:
+      - name: transactions_without_returns
+        sql: transaction_id
+        type: count_distinct
+        filters:
+          - sql: "{CUBE}.transaction_type <> 'EXCHANGE'"
+          - sql: "{CUBE}.fulfillment_channel_group IN ('IN_STORE', 'SHIP_FROM_STORE')"
+
+  - name: item_location_sales
+    sql_table: item_location_sales
+
+    joins:
+      - name: items
+        sql: "{CUBE}.item_id = {items.id}"
+        relationship: many_to_one
+      - name: locations
+        sql: "{CUBE}.location_id = {locations.id}"
+        relationship: many_to_one
+      - name: dates
+        sql: "DATE_TRUNC('day', {CUBE}.date) = {dates.date}"
+        relationship: many_to_one
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+    measures:
+      - name: sales_amount
+        sql: sales_amount
+        type: sum
+        format: currency
+```
+
+```javascript title="JavaScript"
+cube(`sales_line_item`, {
+  sql_table: `sales_line_item`,
+
+  joins: {
+    items: {
+      sql: `${CUBE}.item_id = ${items.id}`,
+      relationship: `many_to_one`
+    },
+    locations: {
+      sql: `${CUBE}.location_id = ${locations.id}`,
+      relationship: `many_to_one`
+    },
+    dates: {
+      sql: `DATE_TRUNC('day', ${CUBE}.sold_at) = ${dates.date}`,
+      relationship: `many_to_one`
+    }
+  },
+
+  dimensions: {
+    id: { sql: `id`, type: `number`, primary_key: true }
+  },
+
+  measures: {
+    transactions_without_returns: {
+      sql: `transaction_id`,
+      type: `count_distinct`,
+      filters: [
+        { sql: `${CUBE}.transaction_type <> 'EXCHANGE'` },
+        { sql: `${CUBE}.fulfillment_channel_group IN ('IN_STORE', 'SHIP_FROM_STORE')` }
+      ]
+    }
+  }
+})
+
+cube(`item_location_sales`, {
+  sql_table: `item_location_sales`,
+
+  joins: {
+    items: {
+      sql: `${CUBE}.item_id = ${items.id}`,
+      relationship: `many_to_one`
+    },
+    locations: {
+      sql: `${CUBE}.location_id = ${locations.id}`,
+      relationship: `many_to_one`
+    },
+    dates: {
+      sql: `DATE_TRUNC('day', ${CUBE}.date) = ${dates.date}`,
+      relationship: `many_to_one`
+    }
+  },
+
+  dimensions: {
+    id: { sql: `id`, type: `number`, primary_key: true }
+  },
+
+  measures: {
+    sales_amount: { sql: `sales_amount`, type: `sum`, format: `currency` }
+  }
+})
+```
+
+</CodeGroup>
+
+Both facts join to the same `items`, `locations` and `dates` cubes. The `dates`
+spine matters: without it the two facts have no common time member to group by,
+since one is keyed by day and the other by timestamp.
+
+### 2. Define AOV on the view
+
+Neither cube can define AOV — neither can reference the other's measures. Define
+it as a [measure of the view][ref-view-measures] and mark it
+[`multi_stage`][ref-multi-stage]:
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: retail_analysis
+    cubes:
+      - join_path: item_location_sales
+        includes:
+          - sales_amount
+      - join_path: sales_line_item
+        includes:
+          - transactions_without_returns
+      - join_path: dates
+        includes:
+          - date
+      - join_path: items
+        includes:
+          - department
+      - join_path: locations
+        includes:
+          - region
+
+    measures:
+      - name: aov_basket
+        type: number
+        format: currency
+        multi_stage: true
+        sql: "{CUBE.sales_amount} / NULLIF({CUBE.transactions_without_returns}, 0)"
+```
+
+```javascript title="JavaScript"
+view(`retail_analysis`, {
+  cubes: [
+    {
+      join_path: item_location_sales,
+      includes: [`sales_amount`]
+    },
+    {
+      join_path: sales_line_item,
+      includes: [`transactions_without_returns`]
+    },
+    {
+      join_path: dates,
+      includes: [`date`]
+    },
+    {
+      join_path: items,
+      includes: [`department`]
+    },
+    {
+      join_path: locations,
+      includes: [`region`]
+    }
+  ],
+
+  measures: {
+    aov_basket: {
+      type: `number`,
+      format: `currency`,
+      multi_stage: true,
+      sql: `${CUBE.sales_amount} / NULLIF(${CUBE.transactions_without_returns}, 0)`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+The shared dimension cubes sit at root-level join paths, so `date`, `department`
+and `region` are common to both facts and can be grouped by.
+
+### 3. Query it
+
+Querying `aov_basket` by `region` aggregates each fact on its own, stitches the
+two results on the shared dimension, and takes the division over the joined rows:
+
+```sql
+-- one aggregating subquery per fact, at the query's grain
+SUM(item_location_sales.sales_amount)                GROUP BY region
+COUNT(DISTINCT CASE WHEN … THEN transaction_id END)  GROUP BY region
+-- final stage, once the two are joined on region
+sales_amount / NULLIF(transactions_without_returns, 0)
+```
+
+The measure filters travel into the line-item subquery, so the exchange and
+channel rules are applied exactly where they were defined.
+
+<Note>
+
+`multi_stage: true` is what defers the division until both facts have been
+aggregated. Without it, Cube plans the expression as an ordinary calculated
+measure, looks for a single join tree covering both fact cubes, and fails with
+`Can't find join path to join 'locations', 'item_location_sales',
+'sales_line_item'`.
+
+</Note>
+
+[ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
+[ref-multi-stage]: /reference/data-modeling/measures#multi_stage
+[ref-measure-filters]: /reference/data-modeling/measures#filters
+[ref-view-measures]: /reference/data-modeling/view#measures
+[link-tesseract]: https://cube.dev/blog/introducing-tesseract

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -579,13 +579,14 @@ bare `{member}` does not resolve inside a view.
 <CodeGroup>
 
 ```yaml title="YAML"
+# orders joins line_items one_to_many
 views:
   - name: orders_overview
     cubes:
       - join_path: orders
         includes:
           - total_amount
-      - join_path: line_items
+      - join_path: orders.line_items
         includes:
           - count
 
@@ -604,7 +605,7 @@ view(`orders_overview`, {
       includes: [`total_amount`]
     },
     {
-      join_path: line_items,
+      join_path: orders.line_items,
       includes: [`count`]
     }
   ],

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -592,6 +592,7 @@ views:
     measures:
       - name: average_line_value
         type: number
+        multi_stage: true
         sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
 ```
 
@@ -611,6 +612,7 @@ view(`orders_overview`, {
   measures: {
     average_line_value: {
       type: `number`,
+      multi_stage: true,
       sql: `${CUBE.total_amount} / NULLIF(${CUBE.count}, 0)`
     }
   }
@@ -624,9 +626,19 @@ member — is rejected at compile time with `View 'orders_overview' defines own
 member 'orders_overview.average_line_value'`. Move that definition to a cube and
 include it instead.
 
-When the referenced measures come from cubes that don't join to each other, mark
-the view measure [`multi_stage`][ref-ref-multi-stage] so it is evaluated after
-each fact has been aggregated. See [multi-fact views][ref-multi-fact-views].
+Mark a measure that combines members of **different cubes**
+[`multi_stage`][ref-ref-multi-stage], as above. Without it the expression is
+evaluated inside a single joined scan, which is only correct when nothing in it
+is affected by the join:
+
+- Across cubes joined `one_to_many`, an aggregate on the one side is taken over
+  the rows the join multiplied, so the result is silently inflated.
+- Across cubes that don't join to each other at all, there is no single join
+  tree to evaluate it in and the query fails with `Can't find join path to
+  join …`. See [multi-fact views][ref-multi-fact-views].
+
+`multi_stage` defers the expression until each referenced measure has been
+aggregated on its own, so neither happens.
 
 ### `dimensions`
 

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -576,10 +576,11 @@ different cubes, which therefore has no single cube to live in.
 Reference the included members as `{CUBE.member}` (or `{view_name.member}`); a
 bare `{member}` does not resolve inside a view.
 
+In the example below, `orders` joins `line_items` `one_to_many`:
+
 <CodeGroup>
 
 ```yaml title="YAML"
-# orders joins line_items one_to_many
 views:
   - name: orders_overview
     cubes:

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -566,6 +566,111 @@ If you'd like to override the [format][ref-dim-format] of a member, you can use 
 If you'd like to override the [metadata][ref-dim-meta] of a member, you can use the
 `meta` parameter. Note that the `meta` is overridded as a whole.
 
+### `measures`
+
+The `measures` parameter defines measures on the view itself. A view measure is
+always _derived_: its `sql` may only reference members that the view already
+includes, never columns of a table. Use it for a metric whose parts come from
+different cubes, which therefore has no single cube to live in.
+
+Reference the included members as `{CUBE.member}` (or `{view_name.member}`); a
+bare `{member}` does not resolve inside a view.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: orders
+        includes:
+          - total_amount
+      - join_path: line_items
+        includes:
+          - count
+
+    measures:
+      - name: average_line_value
+        type: number
+        sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
+```
+
+```javascript title="JavaScript"
+view(`orders_overview`, {
+  cubes: [
+    {
+      join_path: orders,
+      includes: [`total_amount`]
+    },
+    {
+      join_path: line_items,
+      includes: [`count`]
+    }
+  ],
+
+  measures: {
+    average_line_value: {
+      type: `number`,
+      sql: `${CUBE.total_amount} / NULLIF(${CUBE.count}, 0)`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+A view measure that owns its SQL — anything that reads a column rather than a
+member — is rejected at compile time with `View 'orders_overview' defines own
+member 'orders_overview.average_line_value'`. Move that definition to a cube and
+include it instead.
+
+When the referenced measures come from cubes that don't join to each other, mark
+the view measure [`multi_stage`][ref-ref-multi-stage] so it is evaluated after
+each fact has been aggregated. See [multi-fact views][ref-multi-fact-views].
+
+### `dimensions`
+
+The `dimensions` parameter defines dimensions on the view itself, under the same
+rule as [`measures`](#measures): the `sql` may only combine members the view
+already includes.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: orders.products
+        includes:
+          - category
+          - name
+
+    dimensions:
+      - name: category_and_name
+        type: string
+        sql: "{CUBE.category} || ' / ' || {CUBE.name}"
+```
+
+```javascript title="JavaScript"
+view(`orders_overview`, {
+  cubes: [
+    {
+      join_path: orders.products,
+      includes: [`category`, `name`]
+    }
+  ],
+
+  dimensions: {
+    category_and_name: {
+      type: `string`,
+      sql: `${CUBE.category} || ' / ' || ${CUBE.name}`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
 ### `folders`
 
 The `folders` parameter is used to organize members of a view (e.g., dimensions,
@@ -991,6 +1096,8 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-apis]: /reference
 [ref-ref-cubes]: /reference/data-modeling/cube
+[ref-ref-multi-stage]: /reference/data-modeling/measures#multi_stage
+[ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
 [ref-ref-hierarchies]: /reference/data-modeling/hierarchies
 [ref-ref-dap]: /reference/data-modeling/data-access-policies
 [ref-rest-query-ops]: /reference/core-data-apis/rest-api/query-format#filters-operators

--- a/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
@@ -419,8 +419,10 @@ views:
   it('aggregates each side before dividing when the measure is multi_stage', () => {
     const sql = buildFanOutSql('orders_overview.average_line_value_multi_stage');
 
-    // `sum` is taken in a leg that never joins line_items, so nothing multiplies it.
-    expect(sql).toMatch(/sum\("orders"\.amount\) "orders__total_amount"[\s\S]*?GROUP BY 1/);
+    // `sum` is taken in a leg that never joins line_items, so nothing multiplies
+    // it. The span is tempered against `line_items` so the assertion fails if
+    // that leg ever picks the join back up.
+    expect(sql).toMatch(/sum\("orders"\.amount\) "orders__total_amount"(?:(?!line_items)[\s\S])*?GROUP BY 1/);
     expect(sql).not.toMatch(/sum\("orders"\.amount\) \/ NULLIF/);
     // The division happens over the two aggregated columns.
     expect(sql).toMatch(/"orders__total_amount" \/ NULLIF\("[^"]+"\."line_items__count", 0\)/);

--- a/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
@@ -151,14 +151,14 @@ views:
         includes:
           - region
     measures:
-      # References inside a view measure are resolved against the view, so they
-      # have to be written as \`{view.member}\`; a bare \`{member}\` does not
-      # resolve. \`multi_stage\` is what lets the ratio be evaluated after both
-      # facts have been aggregated - see the tests below.
+      # References inside a view measure are resolved against the view, so both
+      # \`{CUBE.member}\` and \`{view_name.member}\` work - one of each below - while
+      # a bare \`{member}\` does not resolve at all. \`multi_stage\` is what lets the
+      # ratio be evaluated after both facts have been aggregated.
       - name: aov_basket
         type: number
         multi_stage: true
-        sql: "{retail_analysis.sales_amount} / NULLIF({retail_analysis.transactions_without_returns}, 0)"
+        sql: "{CUBE.sales_amount} / NULLIF({CUBE.transactions_without_returns}, 0)"
       # Same expression without \`multi_stage\`, kept to pin what happens when
       # the ratio is planned as an ordinary calculated measure.
       - name: aov_basket_single_stage
@@ -166,10 +166,14 @@ views:
         sql: "{retail_analysis.sales_amount} / NULLIF({retail_analysis.transactions_without_returns}, 0)"
 `;
 
-const buildSql = async (query: any, useNativeSqlPlanner: boolean = true) => {
-  const compilers = prepareYamlCompiler(model);
-  await compilers.compiler.compile();
+let compilers: any;
 
+beforeAll(async () => {
+  compilers = prepareYamlCompiler(model);
+  await compilers.compiler.compile();
+});
+
+const buildSql = (query: any, useNativeSqlPlanner: boolean = true) => {
   const [sql] = new PostgresQuery(compilers, {
     timezone: 'UTC',
     useNativeSqlPlanner,
@@ -182,16 +186,18 @@ const buildSql = async (query: any, useNativeSqlPlanner: boolean = true) => {
 // Both facts, aggregated on their own before anything is combined.
 const SALES_AMOUNT_AGGREGATE = /sum\("item_location_sales"\.sales_amount\)/;
 const TRANSACTIONS_AGGREGATE = /COUNT\(DISTINCT CASE WHEN .* THEN "sales_line_item"\.transaction_id END\)/;
-// The ratio, taken over the two aggregates once they are lined up on the
-// query's dimensions.
+// The ratio, taken over the two per-fact aggregate columns once they are lined
+// up on the query's dimensions. The subquery aliases the planner puts in front
+// of those columns are deliberately not pinned - only that the numerator and
+// denominator are the aggregated columns, in that order.
 const RATIO_OVER_AGGREGATES =
-  /"q_0"\."item_location_sales__sales_amount" \/ NULLIF\("q_1"\."sales_line_item__transactions_without_returns", 0\)/;
+  /"item_location_sales__sales_amount" \/ NULLIF\("[^"]+"\."sales_line_item__transactions_without_returns", 0\)/;
 
 // Multi-fact queries are planned by Tesseract only, so everything that is
 // expected to produce SQL runs against the native planner.
 describe('Multi-fact derived measure defined on a view', () => {
   it('aggregates each fact cube separately when the components are queried side by side', async () => {
-    const sql = await buildSql({
+    const sql = buildSql({
       measures: [
         'retail_analysis.sales_amount',
         'retail_analysis.transactions_without_returns',
@@ -211,7 +217,7 @@ describe('Multi-fact derived measure defined on a view', () => {
   });
 
   it('divides the two facts once both have been aggregated to the query grain', async () => {
-    const sql = await buildSql({
+    const sql = buildSql({
       measures: ['retail_analysis.aov_basket'],
       dimensions: ['retail_analysis.region'],
     });
@@ -224,7 +230,7 @@ describe('Multi-fact derived measure defined on a view', () => {
   });
 
   it('divides the two facts on the shared date spine', async () => {
-    const sql = await buildSql({
+    const sql = buildSql({
       measures: ['retail_analysis.aov_basket'],
       timeDimensions: [{ dimension: 'retail_analysis.date', granularity: 'day' }],
     });
@@ -235,7 +241,7 @@ describe('Multi-fact derived measure defined on a view', () => {
   });
 
   it('returns the ratio next to its components', async () => {
-    const sql = await buildSql({
+    const sql = buildSql({
       measures: [
         'retail_analysis.sales_amount',
         'retail_analysis.transactions_without_returns',
@@ -250,7 +256,7 @@ describe('Multi-fact derived measure defined on a view', () => {
   });
 
   it('filters the ratio by a dimension shared between the facts', async () => {
-    const sql = await buildSql({
+    const sql = buildSql({
       measures: ['retail_analysis.aov_basket'],
       dimensions: ['retail_analysis.region'],
       filters: [{
@@ -270,37 +276,153 @@ describe('Multi-fact derived measure defined on a view', () => {
   // ordinary calculated measure, so the planner looks for a single join tree
   // covering both fact cubes and there is none - the two facts only meet
   // through the shared dimensions.
-  it('cannot plan the ratio when the view measure is not multi_stage', async () => {
-    await expect(buildSql({
+  it('cannot plan the ratio when the view measure is not multi_stage', () => {
+    expect(() => buildSql({
       measures: ['retail_analysis.aov_basket_single_stage'],
       dimensions: ['retail_analysis.region'],
-    })).rejects.toThrow(/Can't find join path to join .*item_location_sales.*sales_line_item/);
+    })).toThrow(/Can't find join path to join .*item_location_sales.*sales_line_item/);
   });
 
   // Current behaviour, pinned. A segment is the other place cube-owned filter
   // logic could be written once and reused; it does not survive the multi-fact
   // split, so shared filter logic has to live in the measure's own `filters:`
   // (which does travel - see the first test).
-  it('cannot plan a multi-fact query that carries a segment', async () => {
-    await expect(buildSql({
+  it('cannot plan a multi-fact query that carries a segment', () => {
+    expect(() => buildSql({
       measures: ['retail_analysis.aov_basket'],
       dimensions: ['retail_analysis.region'],
       segments: ['retail_analysis.net_sale_transactions'],
-    })).rejects.toThrow(/Can't find join path to join/);
+    })).toThrow(/Can't find join path to join/);
+  });
 
-    // The same segment is fine as long as only its own cube is queried.
-    const sql = await buildSql({
+  it('applies the segment when only its own fact is queried', () => {
+    const sql = buildSql({
       measures: ['retail_analysis.transactions_without_returns'],
       dimensions: ['retail_analysis.region'],
       segments: ['retail_analysis.net_sale_transactions'],
     });
+
     expect(sql).toContain('"sales_line_item".transaction_type NOT IN (\'RETURN\', \'EXCHANGE\')');
   });
 
-  it('is not planned by the legacy planner', async () => {
-    await expect(buildSql({
+  it('is not planned by the legacy planner', () => {
+    expect(() => buildSql({
       measures: ['retail_analysis.aov_basket'],
       dimensions: ['retail_analysis.region'],
-    }, false)).rejects.toThrow(/Can't find join path to join/);
+    }, false)).toThrow(/Can't find join path to join/);
+  });
+
+  // The reference forms a view measure accepts. `{CUBE.member}` and
+  // `{view_name.member}` are both in the model above; a bare `{member}` is
+  // rejected while the view is compiled, so it needs a model of its own.
+  it('rejects a bare member reference in a view measure', async () => {
+    const bareRef = model.replace(
+      '{CUBE.sales_amount} / NULLIF({CUBE.transactions_without_returns}, 0)',
+      '{sales_amount} / NULLIF({transactions_without_returns}, 0)'
+    );
+
+    await expect(prepareYamlCompiler(bareRef).compiler.compile())
+      .rejects.toThrow(/sales_amount is not defined/);
+  });
+});
+
+// The other reason a view measure spanning cubes wants `multi_stage`: even when
+// the cubes DO join, a plain calculated measure is evaluated inside the single
+// joined scan, so a `sum` on the one side is taken over rows the join has
+// multiplied. `multi_stage` aggregates each side first, then divides.
+describe('Derived view measure over a fanned-out join', () => {
+  const fanOutModel = `
+cubes:
+  - name: orders
+    sql: >
+      SELECT 1 AS id, 100 AS amount, 'NYC' AS city UNION ALL
+      SELECT 2 AS id, 200 AS amount, 'NYC' AS city
+    joins:
+      - name: line_items
+        sql: "{CUBE}.id = {line_items}.order_id"
+        relationship: one_to_many
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: city
+        sql: "{CUBE}.city"
+        type: string
+    measures:
+      - name: total_amount
+        sql: "{CUBE}.amount"
+        type: sum
+
+  - name: line_items
+    sql: >
+      SELECT 10 AS id, 1 AS order_id UNION ALL
+      SELECT 11 AS id, 1 AS order_id UNION ALL
+      SELECT 12 AS id, 2 AS order_id
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+    measures:
+      - name: count
+        type: count
+
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: orders
+        includes:
+          - total_amount
+          - city
+      - join_path: orders.line_items
+        includes:
+          - count
+
+    measures:
+      - name: average_line_value
+        type: number
+        sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
+      - name: average_line_value_multi_stage
+        type: number
+        multi_stage: true
+        sql: "{CUBE.total_amount} / NULLIF({CUBE.count}, 0)"
+`;
+
+  let fanOutCompilers: any;
+
+  beforeAll(async () => {
+    fanOutCompilers = prepareYamlCompiler(fanOutModel);
+    await fanOutCompilers.compiler.compile();
+  });
+
+  const buildFanOutSql = (measure: string) => {
+    const [sql] = new PostgresQuery(fanOutCompilers, {
+      timezone: 'UTC',
+      useNativeSqlPlanner: true,
+      measures: [measure],
+      dimensions: ['orders_overview.city'],
+    }).buildSqlAndParams();
+
+    return sql;
+  };
+
+  // Current behaviour, pinned: `sum` runs over the multiplied rows of the join,
+  // so the numerator is larger than the same measure queried on its own.
+  it('inlines a plain calculated measure into the multiplied join', () => {
+    const sql = buildFanOutSql('orders_overview.average_line_value');
+
+    expect(sql).toMatch(/sum\("orders"\.amount\) \/ NULLIF\(count\("line_items"\.id\), 0\)/);
+    expect(sql).toContain('"orders".id = "line_items".order_id');
+  });
+
+  it('aggregates each side before dividing when the measure is multi_stage', () => {
+    const sql = buildFanOutSql('orders_overview.average_line_value_multi_stage');
+
+    // `sum` is taken in a leg that never joins line_items, so nothing multiplies it.
+    expect(sql).toMatch(/sum\("orders"\.amount\) "orders__total_amount"[\s\S]*?GROUP BY 1/);
+    expect(sql).not.toMatch(/sum\("orders"\.amount\) \/ NULLIF/);
+    // The division happens over the two aggregated columns.
+    expect(sql).toMatch(/"orders__total_amount" \/ NULLIF\("[^"]+"\."line_items__count", 0\)/);
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts
@@ -1,0 +1,306 @@
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+// AOV ("basket") as a retailer models it: the numerator and the denominator sit
+// in two different fact tables at two different grains.
+//
+//   sales_line_item     - one row per transaction line
+//   item_location_sales - one row per day/item/location
+//
+// `transactions_without_returns` is a count distinct of transaction ids on the
+// line-item cube, narrowed by filters that belong to that cube (transaction
+// type, fulfillment channel group). Those filters are written once, on the cube
+// that owns the columns, and every consumer picks them up by including the
+// measure - they are never restated in a view. `sales_amount` is a plain sum on
+// the day/item/location cube.
+//
+// The ratio of the two is authored as a measure of the view rather than per
+// consumer. The line-item side has to be aggregated to the query grain before
+// it can divide a sum coming from the other fact table, which is the multi-fact
+// path: both facts join to the shared `items`, `locations` and `dates` cubes,
+// but never to each other.
+const model = `
+cubes:
+  - name: items
+    sql: >
+      SELECT 1 AS id, 'Bakery' AS department UNION ALL
+      SELECT 2 AS id, 'Produce' AS department
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: department
+        sql: "{CUBE}.department"
+        type: string
+
+  - name: locations
+    sql: >
+      SELECT 1 AS id, 'West' AS region UNION ALL
+      SELECT 2 AS id, 'East' AS region
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: region
+        sql: "{CUBE}.region"
+        type: string
+
+  # Date spine shared by both facts. Without it the two facts have no common
+  # time member to stitch on: one is keyed by day, the other by timestamp.
+  - name: dates
+    sql: >
+      SELECT '2026-01-01'::timestamp AS date UNION ALL
+      SELECT '2026-01-02'::timestamp AS date
+    dimensions:
+      - name: date
+        sql: "{CUBE}.date"
+        type: time
+        primary_key: true
+
+  - name: sales_line_item
+    sql: >
+      SELECT 1 AS id, 100 AS transaction_id, 1 AS item_id, 1 AS location_id,
+             'SALE' AS transaction_type, 'IN_STORE' AS fulfillment_channel_group,
+             '2026-01-01'::timestamp AS sold_at
+    joins:
+      - name: items
+        sql: "{CUBE}.item_id = {items}.id"
+        relationship: many_to_one
+      - name: locations
+        sql: "{CUBE}.location_id = {locations}.id"
+        relationship: many_to_one
+      - name: dates
+        sql: "DATE_TRUNC('day', {CUBE}.sold_at) = {dates.date}"
+        relationship: many_to_one
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: transaction_id
+        sql: "{CUBE}.transaction_id"
+        type: number
+      - name: transaction_type
+        sql: "{CUBE}.transaction_type"
+        type: string
+      - name: fulfillment_channel_group
+        sql: "{CUBE}.fulfillment_channel_group"
+        type: string
+      - name: sold_at
+        sql: "{CUBE}.sold_at"
+        type: time
+    segments:
+      - name: net_sale_transactions
+        sql: "{CUBE}.transaction_type NOT IN ('RETURN', 'EXCHANGE')"
+    measures:
+      - name: transactions_without_returns
+        sql: "{CUBE}.transaction_id"
+        type: count_distinct
+        filters:
+          - sql: "{CUBE}.transaction_type <> 'EXCHANGE'"
+          - sql: "{CUBE}.fulfillment_channel_group IN ('IN_STORE', 'SHIP_FROM_STORE')"
+
+  - name: item_location_sales
+    sql: >
+      SELECT 1 AS id, 1 AS item_id, 1 AS location_id,
+             '2026-01-01'::timestamp AS date, 30 AS sales_amount
+    joins:
+      - name: items
+        sql: "{CUBE}.item_id = {items}.id"
+        relationship: many_to_one
+      - name: locations
+        sql: "{CUBE}.location_id = {locations}.id"
+        relationship: many_to_one
+      - name: dates
+        sql: "DATE_TRUNC('day', {CUBE}.date) = {dates.date}"
+        relationship: many_to_one
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: date
+        sql: "{CUBE}.date"
+        type: time
+    measures:
+      - name: sales_amount
+        sql: "{CUBE}.sales_amount"
+        type: sum
+
+views:
+  - name: retail_analysis
+    cubes:
+      - join_path: item_location_sales
+        includes:
+          - sales_amount
+      - join_path: sales_line_item
+        includes:
+          - transactions_without_returns
+          - net_sale_transactions
+      # The shared dimension cubes sit at root-level join paths so their
+      # dimensions are common to both facts.
+      - join_path: dates
+        includes:
+          - date
+      - join_path: items
+        includes:
+          - department
+      - join_path: locations
+        includes:
+          - region
+    measures:
+      # References inside a view measure are resolved against the view, so they
+      # have to be written as \`{view.member}\`; a bare \`{member}\` does not
+      # resolve. \`multi_stage\` is what lets the ratio be evaluated after both
+      # facts have been aggregated - see the tests below.
+      - name: aov_basket
+        type: number
+        multi_stage: true
+        sql: "{retail_analysis.sales_amount} / NULLIF({retail_analysis.transactions_without_returns}, 0)"
+      # Same expression without \`multi_stage\`, kept to pin what happens when
+      # the ratio is planned as an ordinary calculated measure.
+      - name: aov_basket_single_stage
+        type: number
+        sql: "{retail_analysis.sales_amount} / NULLIF({retail_analysis.transactions_without_returns}, 0)"
+`;
+
+const buildSql = async (query: any, useNativeSqlPlanner: boolean = true) => {
+  const compilers = prepareYamlCompiler(model);
+  await compilers.compiler.compile();
+
+  const [sql] = new PostgresQuery(compilers, {
+    timezone: 'UTC',
+    useNativeSqlPlanner,
+    ...query,
+  }).buildSqlAndParams();
+
+  return sql;
+};
+
+// Both facts, aggregated on their own before anything is combined.
+const SALES_AMOUNT_AGGREGATE = /sum\("item_location_sales"\.sales_amount\)/;
+const TRANSACTIONS_AGGREGATE = /COUNT\(DISTINCT CASE WHEN .* THEN "sales_line_item"\.transaction_id END\)/;
+// The ratio, taken over the two aggregates once they are lined up on the
+// query's dimensions.
+const RATIO_OVER_AGGREGATES =
+  /"q_0"\."item_location_sales__sales_amount" \/ NULLIF\("q_1"\."sales_line_item__transactions_without_returns", 0\)/;
+
+// Multi-fact queries are planned by Tesseract only, so everything that is
+// expected to produce SQL runs against the native planner.
+describe('Multi-fact derived measure defined on a view', () => {
+  it('aggregates each fact cube separately when the components are queried side by side', async () => {
+    const sql = await buildSql({
+      measures: [
+        'retail_analysis.sales_amount',
+        'retail_analysis.transactions_without_returns',
+      ],
+      dimensions: ['retail_analysis.region'],
+    });
+
+    expect(sql).toMatch(SALES_AMOUNT_AGGREGATE);
+    expect(sql).toMatch(TRANSACTIONS_AGGREGATE);
+    // The line-item filters travel with the measure - the view does not restate
+    // them.
+    expect(sql).toContain('"sales_line_item".transaction_type <> \'EXCHANGE\'');
+    expect(sql).toContain('"sales_line_item".fulfillment_channel_group IN (\'IN_STORE\', \'SHIP_FROM_STORE\')');
+    // Each fact reaches the shared dimension through its own join.
+    expect(sql).toContain('"item_location_sales".location_id = "locations".id');
+    expect(sql).toContain('"sales_line_item".location_id = "locations".id');
+  });
+
+  it('divides the two facts once both have been aggregated to the query grain', async () => {
+    const sql = await buildSql({
+      measures: ['retail_analysis.aov_basket'],
+      dimensions: ['retail_analysis.region'],
+    });
+
+    expect(sql).toMatch(SALES_AMOUNT_AGGREGATE);
+    expect(sql).toMatch(TRANSACTIONS_AGGREGATE);
+    expect(sql).toMatch(RATIO_OVER_AGGREGATES);
+    // The division is not pushed into either fact's own aggregation.
+    expect(sql).not.toMatch(/sum\("item_location_sales"\.sales_amount\) \/ NULLIF/);
+  });
+
+  it('divides the two facts on the shared date spine', async () => {
+    const sql = await buildSql({
+      measures: ['retail_analysis.aov_basket'],
+      timeDimensions: [{ dimension: 'retail_analysis.date', granularity: 'day' }],
+    });
+
+    expect(sql).toContain('DATE_TRUNC(\'day\', "item_location_sales".date) = "dates".date');
+    expect(sql).toContain('DATE_TRUNC(\'day\', "sales_line_item".sold_at) = "dates".date');
+    expect(sql).toMatch(RATIO_OVER_AGGREGATES);
+  });
+
+  it('returns the ratio next to its components', async () => {
+    const sql = await buildSql({
+      measures: [
+        'retail_analysis.sales_amount',
+        'retail_analysis.transactions_without_returns',
+        'retail_analysis.aov_basket',
+      ],
+      dimensions: ['retail_analysis.department'],
+    });
+
+    expect(sql).toMatch(SALES_AMOUNT_AGGREGATE);
+    expect(sql).toMatch(TRANSACTIONS_AGGREGATE);
+    expect(sql).toMatch(RATIO_OVER_AGGREGATES);
+  });
+
+  it('filters the ratio by a dimension shared between the facts', async () => {
+    const sql = await buildSql({
+      measures: ['retail_analysis.aov_basket'],
+      dimensions: ['retail_analysis.region'],
+      filters: [{
+        member: 'retail_analysis.department',
+        operator: 'equals',
+        values: ['Bakery'],
+      }],
+    });
+
+    expect(sql).toMatch(RATIO_OVER_AGGREGATES);
+    // Both facts are narrowed, each through its own join to `items`.
+    expect(sql).toContain('"item_location_sales".item_id = "items".id');
+    expect(sql).toContain('"sales_line_item".item_id = "items".id');
+  });
+
+  // Current behaviour, pinned. Without `multi_stage` the ratio is planned as an
+  // ordinary calculated measure, so the planner looks for a single join tree
+  // covering both fact cubes and there is none - the two facts only meet
+  // through the shared dimensions.
+  it('cannot plan the ratio when the view measure is not multi_stage', async () => {
+    await expect(buildSql({
+      measures: ['retail_analysis.aov_basket_single_stage'],
+      dimensions: ['retail_analysis.region'],
+    })).rejects.toThrow(/Can't find join path to join .*item_location_sales.*sales_line_item/);
+  });
+
+  // Current behaviour, pinned. A segment is the other place cube-owned filter
+  // logic could be written once and reused; it does not survive the multi-fact
+  // split, so shared filter logic has to live in the measure's own `filters:`
+  // (which does travel - see the first test).
+  it('cannot plan a multi-fact query that carries a segment', async () => {
+    await expect(buildSql({
+      measures: ['retail_analysis.aov_basket'],
+      dimensions: ['retail_analysis.region'],
+      segments: ['retail_analysis.net_sale_transactions'],
+    })).rejects.toThrow(/Can't find join path to join/);
+
+    // The same segment is fine as long as only its own cube is queried.
+    const sql = await buildSql({
+      measures: ['retail_analysis.transactions_without_returns'],
+      dimensions: ['retail_analysis.region'],
+      segments: ['retail_analysis.net_sale_transactions'],
+    });
+    expect(sql).toContain('"sales_line_item".transaction_type NOT IN (\'RETURN\', \'EXCHANGE\')');
+  });
+
+  it('is not planned by the legacy planner', async () => {
+    await expect(buildSql({
+      measures: ['retail_analysis.aov_basket'],
+      dimensions: ['retail_analysis.region'],
+    }, false)).rejects.toThrow(/Can't find join path to join/);
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Covers the multi-fact derived metric shape (AOV / basket size) end to end: a test that pins the behaviour, and the docs for it.

**Test** — `packages/cubejs-schema-compiler/test/unit/multi-fact-derived-measure-in-view.test.ts`

A ratio measure authored on a view whose numerator (`SUM` of sales amount, day/item/location grain) and denominator (`COUNT(DISTINCT)` of transaction ids narrowed by filters owned by the line-item cube, transaction-line grain) live in two fact cubes that only meet through shared `items`, `locations` and `dates` cubes.

The working shape is a `multi_stage` view measure: each fact is aggregated on its own, the legs are stitched on the shared keys, and the division happens in a final stage. The test also pins the current limits — the same expression without `multi_stage`, and any multi-fact query carrying a segment, both fail with `Can't find join path`; the legacy planner does not plan multi-fact queries at all.

A second block covers the other reason a cross-cube view measure wants `multi_stage`: across cubes that *do* join `one_to_many`, a plain calculated measure is evaluated inside the joined scan and its `sum` runs over the multiplied rows — a silently inflated numerator rather than a hard failure.

**Docs**

- `reference/data-modeling/view.mdx` — new `measures` and `dimensions` parameters. A view member is always derived: its `sql` may only combine members the view already includes (`{CUBE.member}`; a bare `{member}` does not resolve), and one that reads a column is rejected at compile time. States the `multi_stage` rule with both of its reasons.
- `docs/data-modeling/views.mdx` — a short section on the case view measures exist for, next to "Keep shared logic in cubes", linking the reference for the full example.
- `docs/data-modeling/multi-fact-views.mdx` — new "Combining facts in one measure" section on `multi_stage`, including the `Can't find join path` error you get without it.
- `recipes/data-modeling/average-order-value.mdx` — new recipe covering both shapes: a plain calculated measure when both parts sit in one cube, and a `multi_stage` view measure when they don't. Registered in `docs.json`.
- `docs/data-modeling/multi-fact-views.mdx` — corrects the "Filters and segments" section. It claimed fact-specific filters and segments are applied only to that fact's subquery; in practice both fail the query with `Can't find join path`, because every grouped dimension, filter and segment has to be reachable from all facts. A measure's own `filters` is what narrows one fact. Verified against the page's own example model.

Every YAML sample in the changed docs was compiled and its SQL checked against the native planner, with one deliberate exception: the snippet on `views.mdx` elides its `cubes` block to a comment, following the convention on `cubes.mdx` and `data-access-policies.mdx`. The complete, compiled version of that model is the one on the view reference.

Test output:

```
PASS dist/test/unit/multi-fact-derived-measure-in-view.test.js
  Multi-fact derived measure defined on a view
    ✓ aggregates each fact cube separately when the components are queried side by side
    ✓ divides the two facts once both have been aggregated to the query grain
    ✓ divides the two facts on the shared date spine
    ✓ returns the ratio next to its components
    ✓ filters the ratio by a dimension shared between the facts
    ✓ cannot plan the ratio when the view measure is not multi_stage
    ✓ cannot plan a multi-fact query that carries a segment
    ✓ applies the segment when only its own fact is queried
    ✓ is not planned by the legacy planner
    ✓ rejects a bare member reference in a view measure
  Derived view measure over a fanned-out join
    ✓ inlines a plain calculated measure into the multiplied join
    ✓ aggregates each side before dividing when the measure is multi_stage

Tests:       12 passed, 12 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLzMjTkAfG9tjDmjVR3EL2
