### PR TITLE
fix(release): repair lerna-publish.sh's release step and bump cleanup

### DIFF
--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -30,14 +30,18 @@ fi
 # that lacks one, and a newly created one is untracked, so `git restore` alone
 # would leave it behind - the pathspecs below match the workspace globs
 # ("workspaces" in package.json) and nothing else in the tree.
+# INT and TERM are named alongside EXIT so an interrupted run is covered without
+# relying on the shell running an EXIT trap for an untrapped signal; the handler
+# disarms itself first so its own `exit` cannot run the cleanup a second time.
 cleanup_bump() {
   status=$?
+  trap - EXIT INT TERM
   echo "Cleaning up temporary version bump..."
   git restore --staged --worktree . || true
   git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
   exit $status
 }
-trap cleanup_bump EXIT
+trap cleanup_bump EXIT INT TERM
 
 echo "Step 1: bumping versions (no commit/push)..."
 yarn lerna version $BUMP \
@@ -61,7 +65,7 @@ if git status --porcelain | grep -q '^ M yarn.lock'; then
 fi
 
 # The version commit, tag and release are meant to survive, so stop cleaning up.
-trap - EXIT
+trap - EXIT INT TERM
 
 echo "Step 4: commit, tag and push version..."
 yarn lerna version $BUMP \

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -3,9 +3,36 @@ set -e
 
 . .gh-token
 
-BUMP=$1
-if [ "x$BUMP" == "x" ]; then
-  BUMP=patch
+usage() {
+  echo "Usage: $0 [bump] [-y|--yes]"
+  echo
+  echo "  bump        version bump to pass to lerna (default: patch)"
+  echo "  -y, --yes   skip lerna's confirmation prompt for the release step"
+  echo
+  echo "The release step asks for confirmation before it commits, tags, pushes and"
+  echo "creates the GitHub release. Pass --yes to run it unattended."
+}
+
+BUMP=patch
+CONFIRM=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) CONFIRM=(--yes) ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "Error: unknown option: $1"; echo; usage; exit 1 ;;
+    *) BUMP="$1" ;;
+  esac
+  shift
+done
+
+# Without --yes the release step prompts, and lerna's prompt cannot be answered
+# where stdin is not a terminal - it fails there with a bare exit 1 that says
+# nothing about why. Say it here instead.
+if [ ${#CONFIRM[@]} -eq 0 ] && [ ! -t 0 ]; then
+  echo "Error: stdin is not a terminal, so the release step's confirmation prompt"
+  echo "cannot be answered. Re-run with --yes to release unattended."
+  exit 1
 fi
 
 # Cleanup below discards staged as well as unstaged changes to tracked files.
@@ -53,8 +80,10 @@ trap cleanup_bump EXIT
 trap 'cleanup_bump INT' INT
 trap 'cleanup_bump TERM' TERM
 
+# Always unattended: this bump is thrown away by the cleanup above, so there is
+# nothing for an operator to confirm. Only the release step below asks.
 echo "Step 1: bumping versions (no commit/push)..."
-yarn lerna version $BUMP \
+yarn lerna version "$BUMP" \
   --conventional-commits \
   --force-publish \
   --exact \
@@ -78,9 +107,9 @@ fi
 trap - EXIT INT TERM
 
 echo "Step 4: commit, tag and push version..."
-yarn lerna version $BUMP \
+yarn lerna version "$BUMP" \
   --conventional-commits \
   --force-publish \
   --exact \
   --create-release=github \
-  --yes
+  "${CONFIRM[@]}"

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -8,17 +8,36 @@ if [ "x$BUMP" == "x" ]; then
   BUMP=patch
 fi
 
-# Step 4 cleans up with `git restore --staged --worktree .`, which discards both
-# staged and unstaged changes to tracked files. Refuse to start if the tree
-# already carries any, so that cleanup can only ever undo what this script did.
+# Cleanup below discards staged as well as unstaged changes to tracked files.
+# Refuse to start if the tree already carries any, so that cleanup can only ever
+# undo what this script itself did. This gate runs before the trap is installed,
+# so a tree it rejects is never touched.
 # Untracked files are deliberately not checked: `git restore` cannot touch them,
 # and build output that no .gitignore covers must not block a release.
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   echo "Error: working tree has uncommitted changes to tracked files."
-  echo "Commit or stash them before releasing - step 4 cleanup would discard them."
+  echo "Commit or stash them before releasing - cleanup would discard them."
+  echo "If this is leftover state from a failed release run, discard it with:"
+  echo "  git restore --staged --worktree ."
   GIT_PAGER=cat git status --short --untracked-files=no
   exit 1
 fi
+
+# `set -e` aborts the script before the bump is undone if step 1 or step 2 fails,
+# so clean up from an EXIT trap rather than inline: otherwise a failed run leaves
+# behind the bumped, partly staged tree that trips lerna's working tree
+# validation on the next run. lerna also writes a CHANGELOG.md for any package
+# that lacks one, and a newly created one is untracked, so `git restore` alone
+# would leave it behind - the pathspecs below match the workspace globs
+# ("workspaces" in package.json) and nothing else in the tree.
+cleanup_bump() {
+  status=$?
+  echo "Cleaning up temporary version bump..."
+  git restore --staged --worktree . || true
+  git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
+  exit $status
+}
+trap cleanup_bump EXIT
 
 echo "Step 1: bumping versions (no commit/push)..."
 yarn lerna version $BUMP \
@@ -38,18 +57,13 @@ if git status --porcelain | grep -q '^ M yarn.lock'; then
   echo "If you see any new entries in yarn.lock with @cubejs-*/* packages - probably not all packages versions were updated."
   GIT_PAGER=cat git diff yarn.lock
 
-  echo "Step 4: cleaning up temporary version bump..."
-  git restore --staged --worktree .
-  git clean -fdq -- '*CHANGELOG.md'
-
   exit 1
 fi
 
-echo "Step 4: cleaning up temporary version bump..."
-git restore --staged --worktree .
-git clean -fdq -- '*CHANGELOG.md'
+# The version commit, tag and release are meant to survive, so stop cleaning up.
+trap - EXIT
 
-echo "Step 5: commit, tag and push version..."
+echo "Step 4: commit, tag and push version..."
 yarn lerna version $BUMP \
   --conventional-commits \
   --force-publish \

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -27,13 +27,13 @@ if git status --porcelain | grep -q '^ M yarn.lock'; then
   GIT_PAGER=cat git diff yarn.lock
 
   echo "Step 4: cleaning up temporary version bump..."
-  git restore .
+  git restore --staged --worktree .
 
   exit 1
 fi
 
 echo "Step 4: cleaning up temporary version bump..."
-git restore .
+git restore --staged --worktree .
 
 echo "Step 5: commit, tag and push version..."
 yarn lerna version $BUMP \
@@ -41,3 +41,4 @@ yarn lerna version $BUMP \
   --force-publish \
   --exact \
   --create-release=github \
+  --yes

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -32,16 +32,26 @@ fi
 # ("workspaces" in package.json) and nothing else in the tree.
 # INT and TERM are named alongside EXIT so an interrupted run is covered without
 # relying on the shell running an EXIT trap for an untrapped signal; the handler
-# disarms itself first so its own `exit` cannot run the cleanup a second time.
+# disarms itself first so its own `exit` cannot run the cleanup a second time,
+# then re-raises the signal so an interrupted run does not exit 0.
 cleanup_bump() {
   status=$?
+  sig=$1
   trap - EXIT INT TERM
   echo "Cleaning up temporary version bump..."
   git restore --staged --worktree . || true
   git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
+  if [ -n "$sig" ]; then
+    # Die from the signal now that it is untrapped, so the caller sees the run
+    # was interrupted. Exiting with $? instead would report the last completed
+    # command's status, which is 0 when the signal lands between commands.
+    kill -"$sig" $$
+  fi
   exit $status
 }
-trap cleanup_bump EXIT INT TERM
+trap cleanup_bump EXIT
+trap 'cleanup_bump INT' INT
+trap 'cleanup_bump TERM' TERM
 
 echo "Step 1: bumping versions (no commit/push)..."
 yarn lerna version $BUMP \

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -8,6 +8,18 @@ if [ "x$BUMP" == "x" ]; then
   BUMP=patch
 fi
 
+# Step 4 cleans up with `git restore --staged --worktree .`, which discards both
+# staged and unstaged changes to tracked files. Refuse to start if the tree
+# already carries any, so that cleanup can only ever undo what this script did.
+# Untracked files are deliberately not checked: `git restore` cannot touch them,
+# and build output that no .gitignore covers must not block a release.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  echo "Error: working tree has uncommitted changes to tracked files."
+  echo "Commit or stash them before releasing - step 4 cleanup would discard them."
+  GIT_PAGER=cat git status --short --untracked-files=no
+  exit 1
+fi
+
 echo "Step 1: bumping versions (no commit/push)..."
 yarn lerna version $BUMP \
   --conventional-commits \
@@ -28,12 +40,14 @@ if git status --porcelain | grep -q '^ M yarn.lock'; then
 
   echo "Step 4: cleaning up temporary version bump..."
   git restore --staged --worktree .
+  git clean -fdq -- '*CHANGELOG.md'
 
   exit 1
 fi
 
 echo "Step 4: cleaning up temporary version bump..."
 git restore --staged --worktree .
+git clean -fdq -- '*CHANGELOG.md'
 
 echo "Step 5: commit, tag and push version..."
 yarn lerna version $BUMP \

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-. .gh-token
-
 usage() {
   echo "Usage: $0 [bump] [-y|--yes]"
   echo
@@ -34,6 +32,11 @@ if [ ${#CONFIRM[@]} -eq 0 ] && [ ! -t 0 ]; then
   echo "cannot be answered. Re-run with --yes to release unattended."
   exit 1
 fi
+
+# GH_TOKEN, for the release step's --create-release=github. Sourced after the
+# argument checks so that --help works on a checkout that has no .gh-token yet
+# - the file is gitignored, so a fresh clone never has one.
+. .gh-token
 
 # Cleanup below discards staged as well as unstaged changes to tracked files.
 # Refuse to start if the tree already carries any, so that cleanup can only ever

--- a/lerna-publish.sh
+++ b/lerna-publish.sh
@@ -50,24 +50,29 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   exit 1
 fi
 
-# `set -e` aborts the script before the bump is undone if step 1 or step 2 fails,
-# so clean up from an EXIT trap rather than inline: otherwise a failed run leaves
-# behind the bumped, partly staged tree that trips lerna's working tree
-# validation on the next run. lerna also writes a CHANGELOG.md for any package
-# that lacks one, and a newly created one is untracked, so `git restore` alone
-# would leave it behind - the pathspecs below match the workspace globs
-# ("workspaces" in package.json) and nothing else in the tree.
+# Step 4 undoes the bump on the happy path, but `set -e` aborts before reaching
+# it if step 1 or step 2 fails, so the same restore also runs from a trap:
+# otherwise a failed run leaves behind the bumped, partly staged tree that trips
+# lerna's working tree validation on the next run.
+# lerna also writes a CHANGELOG.md for any package that lacks one, and a newly
+# created one is untracked, so `git restore` alone would leave it behind - the
+# pathspecs match the workspace globs ("workspaces" in package.json) and
+# nothing else in the tree.
 # INT and TERM are named alongside EXIT so an interrupted run is covered without
 # relying on the shell running an EXIT trap for an untrapped signal; the handler
 # disarms itself first so its own `exit` cannot run the cleanup a second time,
 # then re-raises the signal so an interrupted run does not exit 0.
+restore_bump() {
+  git restore --staged --worktree . || true
+  git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
+}
+
 cleanup_bump() {
   status=$?
   sig=$1
   trap - EXIT INT TERM
   echo "Cleaning up temporary version bump..."
-  git restore --staged --worktree . || true
-  git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
+  restore_bump
   if [ -n "$sig" ]; then
     # Die from the signal now that it is untrapped, so the caller sees the run
     # was interrupted. Exiting with $? instead would report the last completed
@@ -103,10 +108,18 @@ if git status --porcelain | grep -q '^ M yarn.lock'; then
   exit 1
 fi
 
-# The version commit, tag and release are meant to survive, so stop cleaning up.
+# Step 1's bump has to come back out before the real one: lerna reads the
+# versions in the tree to compute the next ones, and refuses to commit over a
+# dirty tree at all. This is the happy path, not error handling - the trap
+# below only covers the runs that never get here.
+echo "Step 4: cleaning up temporary version bump..."
+restore_bump
+
+# Restore first, then disarm, so an interrupt during the restore is still
+# covered. From here the version commit, tag and release are meant to survive.
 trap - EXIT INT TERM
 
-echo "Step 4: commit, tag and push version..."
+echo "Step 5: commit, tag and push version..."
 yarn lerna version "$BUMP" \
   --conventional-commits \
   --force-publish \


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`lerna-publish.sh` could not complete a release. Found and fixed while cutting one today. (1) is the release blocker; (2)–(4) are the failure modes around it.

**1. The release step could never run**

The file ended with a dangling line continuation:

```sh
yarn lerna version $BUMP \
  --conventional-commits \
  --force-publish \
  --exact \
  --create-release=github \   # <- EOF, nothing follows
```

The trailing `\` on the last line silently swallowed whatever was meant to follow it, so the step ran with no confirmation flag and stopped at lerna's `Are you sure you want to create these versions? (ynh)` prompt — which cannot be answered where stdin is not a terminal, and there fails with a bare exit 1 that says nothing about why.

Since that step commits, tags, pushes and creates the GitHub release, the prompt is worth keeping for an operator at a terminal. So confirmation is the default and non-interactive is opt-in:

```
./lerna-publish.sh              # asks before releasing
./lerna-publish.sh --yes        # unattended
./lerna-publish.sh minor --yes  # bump is still positional
```

Running without `--yes` where stdin is not a terminal now fails up front, before the two-minute bump rather than after it, naming the flag to pass. Step 1's bump keeps `--yes` unconditionally: it is thrown away before the release step, so there is nothing there for an operator to confirm.

`. .gh-token` is sourced below the argument loop, so `--help` and the unknown-option path work on a fresh clone — `.gh-token` is gitignored, so a fresh checkout never has one, and under `set -e` sourcing it first killed both. It still sits before any real work, so a release run on a tokenless checkout fails immediately rather than after the bump.

**2. Cleanup left the Cargo files staged**

Cleanup used `git restore .`, which only restores the working tree from the index. The cubestore `version` lifecycle hook (`rust/cubestore/scripts/sync-cargo-version.js`) bumps and **stages** `rust/cubestore/Cargo.toml` and `rust/cubestore/Cargo.lock`, so after the dry-run bump those two stayed staged at the bumped version:

```
M  rust/cubestore/Cargo.lock
M  rust/cubestore/cubestore/Cargo.toml
```

That leaves the tree dirty, and the next run then aborts on lerna's working tree validation. `git restore --staged --worktree .` restores the index as well.

**3. Cleanup never ran on the abort paths**

Step 4 undoes step 1's bump on the happy path — that restore is required, not error handling: lerna reads the versions in the tree to compute the next ones, and refuses to commit over a dirty tree at all. But `set -e` aborts before reaching it if step 1's lerna call or step 2's `yarn install` fails, leaving behind exactly the bumped, partly staged tree that (2) exists to prevent. Not theoretical: step 2 failed during this very release on a corrupted Cypress binary download.

So the restore lives in `restore_bump`, called explicitly on the happy path and from a trap for the runs that never get there:

```sh
restore_bump() {
  git restore --staged --worktree . || true
  git clean -fdq -- 'packages/*/CHANGELOG.md' 'rust/*/CHANGELOG.md' || true
}

cleanup_bump() {
  status=$?
  sig=$1
  trap - EXIT INT TERM
  echo "Cleaning up temporary version bump..."
  restore_bump
  if [ -n "$sig" ]; then
    kill -"$sig" $$
  fi
  exit $status
}
trap cleanup_bump EXIT
trap 'cleanup_bump INT' INT
trap 'cleanup_bump TERM' TERM
```

- The trap is installed **after** the pre-flight gate below, never before — otherwise the gate's own `exit 1` would discard the very changes it refused to touch.
- Step 4 restores and *then* disarms, so an interrupt during the restore is still covered. From there the version commit, tag and release are meant to survive.
- On the `EXIT` path the handler preserves the original exit status, so a cleanup hiccup can't mask why the release failed.
- `INT`/`TERM` are named so an interrupted run is covered without relying on the shell running an `EXIT` trap for an untrapped signal. bash does do that (verified on 5.2.21, signalling both the process and the process group), but the guarantee is better stated than inferred.
- The handler disarms itself first, so its own exit cannot re-enter through the still-armed `EXIT` trap and clean up twice.
- On a signal path it re-raises rather than exiting with `$?`. In a handler `$?` is the last *completed* command's status, which is 0 whenever bash reaps a successful child before handling the pending signal — measured, and an interrupted run exited 0 before this. Re-raising makes the parent see a genuine signal death instead of a release that claims success.

**4. Guarding cleanup against pre-existing work**

Restoring the index widens what cleanup can destroy: on a dirty tree it would discard changes the operator had staged before invoking the script, and an index-only change has no reflog to recover from. So the script refuses to start unless the tree is clean, which makes cleanup only ever able to undo what the script itself did:

```sh
if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
```

The gate checks tracked files only. `git restore` cannot touch untracked paths, so they are outside the blast radius being guarded, and untracked build output that no `.gitignore` covers must not block a release. Its advice also names the discard command, since leftover state from a failed run is the likeliest way to trip it — and neither committing nor stashing a half-finished version bump is what the operator wants.

The `git clean` pathspecs match the workspace globs (`"workspaces": ["rust/*", "packages/*"]`), covering every `CHANGELOG.md` lerna can create for a package that lacks one — those are untracked, so `git restore` alone would leave one behind to trip validation on the next run — while leaving an untracked `CHANGELOG.md` the operator holds elsewhere in the tree alone.

**Verification**

`bash -n` passes. The script was then run end-to-end with `yarn` stubbed and real `git`. The stub stages a tracked file to simulate the cubestore hook, and on the release step asserts `git status --porcelain` is empty:

| case | exit | tree at release step | tree after | cleanups |
|---|---|---|---|---|
| `--yes`, clean tree | 0 | empty | clean | 0 |
| no `--yes`, real pty | 0 | empty (argv carries no `--yes`, so lerna prompts) | clean | 0 |
| no `--yes`, stdin not a terminal | 1 | — | untouched, no `yarn` invoked | 0 |
| step 1 fails after staging | 7 (preserved) | — | clean | 1 |
| step 2 `yarn install` fails | 3 (preserved) | — | clean | 1 |
| step 3 `yarn.lock` drift | 1 | — | clean | 1 |
| dirty tree → gate | 1 | — | staged blob byte-identical | 0 |
| SIGINT mid-bump | 130 (`Interrupt`) | — | clean | 1 |
| SIGTERM mid-bump | 143 (`Terminated`) | — | clean | 1 |

That release-step assertion is worth calling out, because an earlier revision of this PR dropped the happy-path restore and the matrix without it recorded the bug as the expected result — a stubbed `yarn` neither validates the working tree nor recomputes versions. With the assertion, that revision reads `TREE AT RELEASE STEP: [M  CONTRIBUTING.md  M README.md ]` instead of passing.

`--help` and the unknown-option path were checked with `.gh-token` moved aside (exit 0 with usage, exit 1 with usage), while a real run on a tokenless checkout still fails on the missing token. `cleanups=1` rather than 2 is what the handler's self-disarm buys; 130/143 rather than 0 is what the re-raise buys. With `--yes` the assembled argv is:

```
Step 1: lerna version patch --conventional-commits --force-publish --exact --no-git-tag-version --no-push --yes
Step 5: lerna version patch --conventional-commits --force-publish --exact --create-release=github --yes
```

The scoped clean was also checked against a synthetic new package: it removes an untracked `packages/<pkg>/CHANGELOG.md`, leaves an unrelated untracked file in the same directory alone, and matches nothing in the tree today (all 56 packages already have one, so this is a latent gap that bites when a package is added).

No package code is touched, so there are no package tests to run for this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015kRxi2jizmJQKt9cuv4vmg)_