### PR TITLE
docs: document recent Cube Cloud console-ui and REST API additions

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -75,14 +75,16 @@ allowance resets at the start of each calendar month.
 
 ## Tracking usage
 
-Administrators can monitor token consumption from two tabs in the billing
-settings page:
+Remaining allocation from per-seat grants and token packages is shown on the
+**Overview** tab of the billing settings page.
 
-- **AI Usage** — spend per user or per role over a billing period, with a
-  chart and a table. Supports the account's standard billing period presets
-  as well as a custom date range.
-- **AI Requests** — the raw request log over a rolling time window, with a
-  live tail of new requests as they come in.
+Detailed consumption is broken down on two further tabs:
+
+- **AI Usage** — token usage and spend (in dollars), per user or per role,
+  over a billing period, with a chart and a table. Supports the account's
+  standard billing period presets as well as a custom date range.
+- **AI Requests** — the raw request log, defaulting to the last 24 hours,
+  with a live tail of new requests as they come in.
 
 ## When limits are reached
 

--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -75,12 +75,14 @@ allowance resets at the start of each calendar month.
 
 ## Tracking usage
 
-Administrators can monitor token consumption through the **AI Tokens Usage**
-tab in the billing settings page. The dashboard shows:
+Administrators can monitor token consumption from two tabs in the billing
+settings page:
 
-- Total token usage over time
-- Remaining allocation from per-seat grants and token packages
-- Breakdown by usage dimension
+- **AI Usage** — spend per user or per role over a billing period, with a
+  chart and a table. Supports the account's standard billing period presets
+  as well as a custom date range.
+- **AI Requests** — the raw request log over a rolling time window, with a
+  live tail of new requests as they come in.
 
 ## When limits are reached
 

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -6269,7 +6269,8 @@ components:
         completedAt:
           description: >-
             When the sync finished, as an ISO 8601 timestamp, or `null` while it is still running.
-            Use durationMs to show how long a run took rather than subtracting this from startedAt.
+            Use `durationMs` to show how long a run took rather than subtracting this from
+            `startedAt`.
           oneOf:
             - type: string
             - type: 'null'

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -6160,9 +6160,9 @@ components:
     DbtSyncLogEntry:
       properties:
         durationMs:
+          description: For a phase line, how long the phase took, in milliseconds. `null` otherwise.
           oneOf:
             - type: integer
-              description: For a phase line, how long the phase took, in milliseconds.
             - type: 'null'
         level:
           description: info or error.
@@ -6170,9 +6170,9 @@ components:
         message:
           type: string
         phase:
+          description: The phase this line belongs to, e.g. dbt-compile. `null` for a non-phase line.
           oneOf:
             - type: string
-              description: The phase this line belongs to, e.g. dbt-compile.
             - type: 'null'
         stream:
           description: >-
@@ -6267,42 +6267,41 @@ components:
           description: The Cube branch this sync wrote its generated cubes to.
           type: string
         completedAt:
+          description: >-
+            When the sync finished, as an ISO 8601 timestamp, or `null` while it is still running.
+            Use durationMs to show how long a run took rather than subtracting this from startedAt.
           oneOf:
             - type: string
-              description: >-
-                When the sync finished, as an ISO 8601 timestamp, or absent while it is still
-                running. Use durationMs to show how long a run took rather than subtracting this
-                from startedAt.
             - type: 'null'
         deploymentId:
           type: integer
         durationMs:
+          description: How long the sync took, in milliseconds. `null` while the sync is running.
           oneOf:
             - type: integer
-              description: How long the sync took, in milliseconds.
             - type: 'null'
         errorMessage:
+          description: Why the sync stopped. `null` unless the run failed.
           oneOf:
             - type: string
-              description: Why the sync stopped. Present only for a failed run.
             - type: 'null'
         failedPhase:
+          description: The phase that failed, e.g. dbt-compile. `null` unless the run failed.
           oneOf:
             - type: string
-              description: The phase that failed, e.g. dbt-compile.
             - type: 'null'
         gitRef:
+          description: The dbt-repository ref this sync was run against, when pinned. `null` otherwise.
           oneOf:
             - type: string
-              description: The dbt-repository ref this sync was run against, when pinned.
             - type: 'null'
         lastStage:
+          description: The pipeline stage the run reached, e.g. COMPILING_DBT.
           oneOf:
             - type: string
-              description: The pipeline stage the run reached, e.g. COMPILING_DBT.
             - type: 'null'
         phases:
-          description: Per-phase timings, in the order they ran. Absent while the sync is running.
+          description: Per-phase timings, in the order they ran. Omitted while the sync is still running.
           items:
             $ref: '#/components/schemas/DbtSyncRunPhase'
           type: array
@@ -6327,9 +6326,9 @@ components:
         triggerContext:
           $ref: '#/components/schemas/DbtSyncRunTriggerContext'
         userId:
+          description: The Cube user who started the sync, when a user started it. `null` otherwise.
           oneOf:
             - type: integer
-              description: The Cube user who started the sync, when a user started it.
             - type: 'null'
       required:
         - syncJobId
@@ -6374,29 +6373,29 @@ components:
     DbtSyncRunStats:
       properties:
         cubeCount:
+          description: How many cubes the sync generated.
           oneOf:
             - type: integer
-              description: How many cubes the sync generated.
             - type: 'null'
         generatedFileCount:
+          description: How many files the sync wrote to the branch it created.
           oneOf:
             - type: integer
-              description: How many files the sync wrote to the branch it created.
             - type: 'null'
         macros:
+          description: dbt macros found in the manifest.
           oneOf:
             - type: integer
-              description: dbt macros found in the manifest.
             - type: 'null'
         models:
+          description: dbt models found in the manifest.
           oneOf:
             - type: integer
-              description: dbt models found in the manifest.
             - type: 'null'
         sources:
+          description: dbt sources found in the manifest.
           oneOf:
             - type: integer
-              description: dbt sources found in the manifest.
             - type: 'null'
       type: object
     DbtSyncRunTriggerContext:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -272,6 +272,71 @@ paths:
       tags:
         - Deployments
   /api/v1/deployments/{deploymentId}/dbt-sync:
+    get:
+      operationId: listDbtSyncs
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: status
+          required: false
+          schema:
+            oneOf:
+              - type: string
+              - type: 'null'
+            enum:
+              - RUNNING
+              - COMPLETED
+              - FAILED
+              - CANCELLED
+              - UNKNOWN
+        - in: query
+          name: trigger
+          required: false
+          schema:
+            oneOf:
+              - type: string
+              - type: 'null'
+            enum:
+              - manual
+              - api
+              - webhook
+              - agent
+              - unknown
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: first
+          required: false
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DbtSyncRunListResponse'
+          description: ''
+      summary: List dbt syncs for a deployment
+      tags:
+        - dbt Sync
+      x-mint:
+        content: >-
+          Returns this deployment's dbt sync history, newest first, backed by durable records rather
+          than the live workflow engine — so a run stays listable long after `GET
+          /dbt-sync/{syncJobId}` stops answering for it. Cancelled runs are included; narrow the list
+          with `status` or `trigger`.
+
+
+          Results are paged with cursor pagination: pass `first` for the page size and `after` (the
+          previous response's `pageInfo.endCursor`) for the next page.
     post:
       operationId: startDbtSync
       parameters:
@@ -368,6 +433,35 @@ paths:
       summary: Get the result of a completed dbt sync
       tags:
         - dbt Sync
+  /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/logs:
+    get:
+      operationId: getDbtSyncLogs
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: syncJobId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DbtSyncLogEntriesListResponse'
+          description: ''
+      summary: Get the log of a dbt sync
+      tags:
+        - dbt Sync
+      x-mint:
+        content: >-
+          Returns the sync's log as line records describing each phase's timing and outcome, plus the
+          failure text for a failed phase. This is not dbt's full console output — that is not
+          captured yet. Always returned as a single page (`pageInfo.hasNextPage` is `false`).
   /api/v1/deployments/{deploymentId}/env-vars:
     get:
       operationId: getEnvVariables
@@ -6052,6 +6146,49 @@ components:
       required:
         - path
       type: object
+    DbtSyncLogEntriesListResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/DbtSyncLogEntry'
+          type: array
+        pageInfo:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - items
+        - pageInfo
+      type: object
+    DbtSyncLogEntry:
+      properties:
+        durationMs:
+          oneOf:
+            - type: integer
+              description: For a phase line, how long the phase took, in milliseconds.
+            - type: 'null'
+        level:
+          description: info or error.
+          type: string
+        message:
+          type: string
+        phase:
+          oneOf:
+            - type: string
+              description: The phase this line belongs to, e.g. dbt-compile.
+            - type: 'null'
+        stream:
+          description: >-
+            Always "system" in this version. "stdout" and "stderr" join it once dbt's own output is
+            captured, so treat this as an open set.
+          type: string
+        timestamp:
+          description: When the line was produced, as an ISO 8601 timestamp.
+          type: string
+      required:
+        - timestamp
+        - level
+        - stream
+        - message
+      type: object
     DbtSyncManifestStats:
       properties:
         macros:
@@ -6124,6 +6261,154 @@ components:
         - cubeCount
         - completedAt
         - durationMs
+      type: object
+    DbtSyncRun:
+      properties:
+        branchName:
+          description: The Cube branch this sync wrote its generated cubes to.
+          type: string
+        completedAt:
+          oneOf:
+            - type: string
+              description: >-
+                When the sync finished, as an ISO 8601 timestamp, or absent while it is still
+                running. Use durationMs to show how long a run took rather than subtracting this
+                from startedAt.
+            - type: 'null'
+        deploymentId:
+          type: integer
+        durationMs:
+          oneOf:
+            - type: integer
+              description: How long the sync took, in milliseconds.
+            - type: 'null'
+        errorMessage:
+          oneOf:
+            - type: string
+              description: Why the sync stopped. Present only for a failed run.
+            - type: 'null'
+        failedPhase:
+          oneOf:
+            - type: string
+              description: The phase that failed, e.g. dbt-compile.
+            - type: 'null'
+        gitRef:
+          oneOf:
+            - type: string
+              description: The dbt-repository ref this sync was run against, when pinned.
+            - type: 'null'
+        lastStage:
+          oneOf:
+            - type: string
+              description: The pipeline stage the run reached, e.g. COMPILING_DBT.
+            - type: 'null'
+        phases:
+          description: Per-phase timings, in the order they ran. Absent while the sync is running.
+          items:
+            $ref: '#/components/schemas/DbtSyncRunPhase'
+          type: array
+        startedAt:
+          description: When the sync started, as an ISO 8601 timestamp.
+          type: string
+        stats:
+          $ref: '#/components/schemas/DbtSyncRunStats'
+        status:
+          description: >-
+            RUNNING, COMPLETED, FAILED, CANCELLED or UNKNOWN. UNKNOWN means the outcome could not be
+            established and is deliberately distinct from FAILED. Treat an unrecognized value as
+            non-terminal.
+          type: string
+        syncJobId:
+          type: string
+        trigger:
+          description: >-
+            What started the sync: manual (the Cube Cloud UI), api (this REST API), webhook (a push
+            to the dbt repository), agent (Cube AI), or unknown.
+          type: string
+        triggerContext:
+          $ref: '#/components/schemas/DbtSyncRunTriggerContext'
+        userId:
+          oneOf:
+            - type: integer
+              description: The Cube user who started the sync, when a user started it.
+            - type: 'null'
+      required:
+        - syncJobId
+        - deploymentId
+        - status
+        - trigger
+        - branchName
+        - startedAt
+      type: object
+    DbtSyncRunListResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/DbtSyncRun'
+          type: array
+        pageInfo:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - items
+        - pageInfo
+      type: object
+    DbtSyncRunPhase:
+      properties:
+        durationMs:
+          description: How long the phase took, in milliseconds.
+          type: integer
+        outcome:
+          description: ok or failed.
+          type: string
+        phase:
+          description: Phase token, e.g. repo-clone, dbt-deps, dbt-compile.
+          type: string
+        startedOffsetMs:
+          description: When the phase began, in milliseconds after the sync started.
+          type: integer
+      required:
+        - phase
+        - startedOffsetMs
+        - durationMs
+        - outcome
+      type: object
+    DbtSyncRunStats:
+      properties:
+        cubeCount:
+          oneOf:
+            - type: integer
+              description: How many cubes the sync generated.
+            - type: 'null'
+        generatedFileCount:
+          oneOf:
+            - type: integer
+              description: How many files the sync wrote to the branch it created.
+            - type: 'null'
+        macros:
+          oneOf:
+            - type: integer
+              description: dbt macros found in the manifest.
+            - type: 'null'
+        models:
+          oneOf:
+            - type: integer
+              description: dbt models found in the manifest.
+            - type: 'null'
+        sources:
+          oneOf:
+            - type: integer
+              description: dbt sources found in the manifest.
+            - type: 'null'
+      type: object
+    DbtSyncRunTriggerContext:
+      description: Provenance for a webhook-triggered sync. Refs only — never the pusher.
+      properties:
+        headSha:
+          type: string
+        pushedBranch:
+          type: string
+        targetBranch:
+          type: string
       type: object
     DbtSyncStatusResponse:
       properties:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -6320,7 +6320,7 @@ components:
           type: string
         trigger:
           description: >-
-            What started the sync: manual (the Cube Cloud UI), api (this REST API), webhook (a push
+            What started the sync: manual (the Cube UI), api (this REST API), webhook (a push
             to the dbt repository), agent (Cube AI), or unknown.
           type: string
         triggerContext:

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -284,9 +284,7 @@ paths:
           name: status
           required: false
           schema:
-            oneOf:
-              - type: string
-              - type: 'null'
+            type: string
             enum:
               - RUNNING
               - COMPLETED
@@ -297,9 +295,7 @@ paths:
           name: trigger
           required: false
           schema:
-            oneOf:
-              - type: string
-              - type: 'null'
+            type: string
             enum:
               - manual
               - api

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -307,12 +307,15 @@ paths:
           required: false
           schema:
             type: string
+          description: Opaque cursor for the next page; pass the previous response's `pageInfo.endCursor`.
         - in: query
           name: first
           required: false
           schema:
-            minimum: 1
             type: integer
+            minimum: 1
+            maximum: 200
+          description: Page size for cursor pagination (default 100, max 200).
       responses:
         '200':
           content:

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -853,9 +853,11 @@
                 "openapi": "/api-reference/api.yaml",
                 "pages": [
                   "POST /api/v1/deployments/{deploymentId}/dbt-sync",
+                  "GET /api/v1/deployments/{deploymentId}/dbt-sync",
                   "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}",
                   "DELETE /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}",
-                  "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/result"
+                  "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/result",
+                  "GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/logs"
                 ]
               },
               {

--- a/docs-mintlify/docs/organize-content/sharing.mdx
+++ b/docs-mintlify/docs/organize-content/sharing.mdx
@@ -158,6 +158,22 @@ All current and future content added to the folder will inherit its
 permissions. This makes folders ideal for organizing content by team or
 project, where everyone on the team needs the same level of access.
 
+## Duplicating shared content
+
+Duplicating a workbook or dashboard that's shared with others prompts you to
+choose whether the copy should keep that sharing. The dialog names who the
+source is shared with and offers a **Copy sharing and embedding settings**
+option:
+
+- **Checked** — the copy is shared with the same users, groups, and
+  organization-wide access as the source. If the source is a published,
+  signed-embeddable dashboard, the copy keeps that setting too.
+- **Unchecked (default)** — the copy is created unshared, regardless of how
+  the source was shared.
+
+If the source isn't shared with anyone, the copy is created immediately
+without showing this dialog.
+
 ## Sharing explorations for spreadsheet integrations
 
 When you share an exploration with a user, that exploration becomes

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -51,6 +51,29 @@ Keep the following behavior in mind:
 - Embed users can't edit content shared from the main workspace. Opening a shared workbook shows its published dashboard, so a workbook must have a published dashboard for users to open it.
 - Removing the share from the **All embed users** group removes those items from embed users' workspaces immediately.
 
+## Customize the dashboard header
+
+By default, a dashboard opened in Creator Mode shows its full header bar: back
+button, title, edit button, and duplicate button. Since your host application
+already frames the embed in its own chrome, you can hide any of these controls
+individually via launch options on the embed URL, so nothing is duplicated:
+
+```text
+https://your-tenant.cubecloud.dev/embed/d/{deploymentId}/app?session={sessionId}&showDashboardBackButton=false
+```
+
+| Parameter | Hides |
+| --- | --- |
+| `showDashboardHeader=false` | The entire header bar |
+| `showDashboardBackButton=false` | The back button |
+| `showDashboardTitle=false` | The dashboard title |
+| `showDashboardEditButton=false` | The edit button |
+| `showDashboardDuplicateButton=false` | The duplicate button |
+
+Each control is independent — for example, hiding the back button while
+keeping the title is a normal combination. Only the exact value `false` hides
+a control; any other value (or omitting the parameter) leaves it visible.
+
 ## Sharing workbooks and dashboards
 
 Embed users in Creator Mode can share the workbooks and dashboards they build with other users, the same way they would in the full Cube app.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -64,15 +64,22 @@ https://your-tenant.cubecloud.dev/embed/d/{deploymentId}/app?session={sessionId}
 
 | Parameter | Hides |
 | --- | --- |
-| `showDashboardHeader=false` | The entire header bar |
+| `showDashboardHeader=false` | The entire header bar, including all controls below |
 | `showDashboardBackButton=false` | The back button |
 | `showDashboardTitle=false` | The dashboard title |
 | `showDashboardEditButton=false` | The edit button |
 | `showDashboardDuplicateButton=false` | The duplicate button |
 
-Each control is independent — for example, hiding the back button while
-keeping the title is a normal combination. Only the exact value `false` hides
-a control; any other value (or omitting the parameter) leaves it visible.
+`showDashboardHeader=false` hides the whole bar regardless of the other
+parameters. The four individual controls are independent of each other — for
+example, hiding the back button while keeping the title is a normal
+combination. Only the exact value `false` hides a control; any other value
+(or omitting the parameter) leaves it visible.
+
+These are launch-time URL parameters, read from the embed URL itself — unlike
+[`showDashboardChat`](/embedding/iframe/dashboards#show-or-hide-the-ai-chat),
+they are not available as `settings.*` fields on
+[Generate Session][ref-generate-session].
 
 ## Sharing workbooks and dashboards
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet _(n/a — docs-only change)_
- [x] Docs have been added / updated if required

**Description of Changes Made**

Part of a recurring sweep that cross-checks recent `cubedevinc/cubejs-enterprise` changes against these docs. Four customer-facing changes shipped in the last week without a docs update; this PR closes those gaps:

- **Creator Mode embedding** (`embedding/iframe/creator-mode.mdx`): documents the five new `showDashboard*` launch options (`showDashboardHeader`, `showDashboardBackButton`, `showDashboardTitle`, `showDashboardEditButton`, `showDashboardDuplicateButton`) that let a host app hide individual dashboard-header controls so its own chrome isn't duplicated.
- **AI Tokens** (`admin/account-billing/ai-tokens.mdx`): the "Tracking usage" section still described a single "AI Tokens Usage" tab; it was split into **AI Usage** (spend by user/role over a billing period) and **AI Requests** (the raw request log with a live tail). Updated the section to describe both.
- **Sharing** (`docs/organize-content/sharing.mdx`): duplicating a shared workbook or dashboard now opens a dialog asking whether the copy should inherit the source's sharing (and, for a published dashboard, its signed-embedding setting). Added a "Duplicating shared content" subsection.
- **Public REST API** (`api-reference/api.yaml`, `docs.json`): documents two new endpoints on the `dbt Sync` group — `GET /api/v1/deployments/{deploymentId}/dbt-sync` (sync history, cursor-paginated, filterable by `status`/`trigger`) and `GET /api/v1/deployments/{deploymentId}/dbt-sync/{syncJobId}/logs` (per-phase log entries). These were hand-authored against the `DbtSyncPublicController` source and its DTOs in `cubejs-enterprise` (the normal `extract-api.mjs` regeneration path needs a built console-server and a private spec file not available in this session) — worth a second look from someone who can run the real extractor to confirm the schema matches exactly.

Everything else surfaced by the sweep either already had a paired `docs:` commit in the same window, or was filtered out as not customer-facing per `cubejs-enterprise/.claude/shared/customer-facing-criteria.md` (internal tooling, unwired code, pure UI reorganizations with no new capability, or silent correctness fixes with no documented behavior to correct).

No large, docs-page-worthy features were found this round, so no Linear ticket was needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWqZttrgrBdKoURowMUUMs)_