### PR TITLE
fix(server-core): release orchestrators evicted from the LRU

### DIFF
--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -98,6 +98,10 @@ export class WebSocketConnection {
   // keeps it (and the orchestrator holding it) alive for the life of the process.
   private closed: boolean = false;
 
+  // Bounds the drain a close waits out, armed only while a closed connection
+  // still has messages in flight.
+  private closeTimer: NodeJS.Timeout | null = null;
+
   public constructor(url: string) {
     this.url = url;
     this.messageCounter = 1;
@@ -126,10 +130,6 @@ export class WebSocketConnection {
       });
 
       webSocket.readyPromise = new Promise<CubeStoreWebSocket>((resolve, reject) => {
-        // Whether readyPromise is already settled, i.e. whether a retry still has
-        // somebody to answer.
-        let established = false;
-
         webSocket.lastHeartBeat = new Date();
         const pingInterval = setInterval(() => {
           if (webSocket.readyState === WebSocket.OPEN) {
@@ -163,10 +163,7 @@ export class WebSocketConnection {
             resolveSend();
           });
         });
-        webSocket.on('open', () => {
-          established = true;
-          resolve(webSocket);
-        });
+        webSocket.on('open', () => resolve(webSocket));
         webSocket.on('error', (err) => {
           if ((err as any).code === MAX_PAYLOAD_EXCEEDED_CODE) {
             // Cube Store answered with a message bigger than this connection
@@ -192,21 +189,10 @@ export class WebSocketConnection {
 
           this.currentConnectionTry += 1;
 
+          // The socket is done either way, so stop its heartbeat now rather than
+          // relying on a 'close' that may not follow: the interval is what keeps
+          // the socket, and everything reachable from it, alive.
           webSocket.teardown();
-          webSocket.terminate();
-
-          // Retrying is only useful while somebody is waiting for this socket to
-          // come up. Once it is established, reconnecting here would raise a
-          // connection nobody asked for and keep it alive with its own heartbeat:
-          // what was in flight is re-sent by the 'close' handler, and a later
-          // query establishes a new connection through initWebSocket().
-          if (established) {
-            if (webSocket === this.webSocket) {
-              this.webSocket = null;
-            }
-
-            return;
-          }
 
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
@@ -351,7 +337,7 @@ export class WebSocketConnection {
 
           if (httpMessage.commandType() === HttpCommand.HttpError) {
             resolver.reject(new QueryError(`${httpMessage.command(new HttpError())?.error()}`));
-            this.closeIfDrained();
+            this.closeIfDrained(webSocket);
             return;
           }
 
@@ -362,7 +348,7 @@ export class WebSocketConnection {
             resolver.reject(e);
           }
 
-          this.closeIfDrained();
+          this.closeIfDrained(webSocket);
         });
       });
 
@@ -592,22 +578,68 @@ export class WebSocketConnection {
   public close() {
     this.closed = true;
 
-    this.closeIfDrained();
+    const socket = this.webSocket;
+
+    this.closeIfDrained(socket);
+
+    if (!socket || socket !== this.webSocket || this.closeTimer) {
+      return;
+    }
+
+    // Bound the drain. Cube Store keeps answering the 5s pings of a connection
+    // whose query is simply never completed, so `noHeartBeatTimeout` never
+    // fires and nothing else would call `closeIfDrained()` again: a single
+    // wedged message would keep this socket, and the interval that makes it
+    // reachable, for the life of the process -- the very leak being fixed,
+    // behind a narrower door. A stuck message costs one query instead.
+    this.closeTimer = setTimeout(() => {
+      this.closeTimer = null;
+
+      const unanswered = Object.keys(socket.sentMessages);
+
+      socket.teardown();
+
+      if (socket === this.webSocket) {
+        this.webSocket = null;
+      }
+
+      const error = new ConnectionError(
+        `Cube Store connection was closed with ${unanswered.length} message(s) still unanswered`
+      );
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const key of unanswered) {
+        const message = socket.sentMessages[key];
+        delete socket.sentMessages[key];
+        message.reject(error);
+      }
+
+      socket.terminate();
+    }, this.noHeartBeatTimeout * 1000);
+
+    this.closeTimer.unref();
   }
 
   /**
-   * Closes the socket once nothing is in flight on it. A no-op until close() has
+   * Closes `socket` once nothing is in flight on it. A no-op until close() has
    * been called, so an ordinary idle connection is left alone.
+   *
+   * Takes the socket rather than reading `this.webSocket`: a late answer can
+   * arrive on a socket the re-send path has already superseded, and that must
+   * not be read as the current connection having drained.
    */
-  private closeIfDrained() {
-    const socket = this.webSocket;
-
-    if (!this.closed || !socket) {
+  private closeIfDrained(socket: CubeStoreWebSocket | null) {
+    if (!this.closed || !socket || socket !== this.webSocket) {
       return;
     }
 
     if (Object.keys(socket.sentMessages).length) {
       return;
+    }
+
+    if (this.closeTimer) {
+      clearTimeout(this.closeTimer);
+      this.closeTimer = null;
     }
 
     // Stop the heartbeat before closing rather than leaving it to the 'close'

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -214,11 +214,23 @@ export class WebSocketConnection {
           webSocket.teardown();
 
           if (this.closed) {
-            // Nothing to retry towards: `initWebSocket()` refuses once closed,
-            // and whatever was in flight is dealt with by the 'close' handler.
+            // Nothing to retry towards: `initWebSocket()` refuses once closed.
+            // Whatever was written to the socket is rejected by the 'close'
+            // handler, which `ws` emits after an 'error' -- the drain bound
+            // cannot catch it any more, since `teardown()` above has already
+            // stopped the interval that evaluates it.
             if (webSocket === this.webSocket) {
               this.webSocket = null;
             }
+
+            // A no-op once this socket has opened, and the only thing left that
+            // can settle `readyPromise` if it has not: `teardown()` has stopped
+            // the interval, the 'close' handler does not touch it, and the retry
+            // that used to settle it by adoption is skipped just above. A socket
+            // closed while still CONNECTING would otherwise leave the
+            // `sendMessage` awaiting it pending for good -- a request hung on
+            // nothing, which is worse than the failure it replaced.
+            reject(new ConnectionError('Cube Store connection is closed'));
 
             return;
           }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -98,9 +98,9 @@ export class WebSocketConnection {
   // keeps it (and the orchestrator holding it) alive for the life of the process.
   private closed: boolean = false;
 
-  // Bounds the drain a close waits out, armed only while a closed connection
-  // still has messages in flight.
-  private closeTimer: NodeJS.Timeout | null = null;
+  // When close() was asked for, so the heartbeat can bound the wait for the
+  // messages that were still in flight at that point.
+  private closedAt: Date | null = null;
 
   public constructor(url: string) {
     this.url = url;
@@ -134,6 +134,25 @@ export class WebSocketConnection {
         const pingInterval = setInterval(() => {
           if (webSocket.readyState === WebSocket.OPEN) {
             webSocket.ping();
+          }
+
+          if (this.closed) {
+            // A closed connection is kept only for the messages already in
+            // flight, and this is where that wait is both re-checked and
+            // bounded. It has to be bounded here rather than by the heartbeat
+            // check below: Cube Store keeps answering the pings of a connection
+            // whose query is simply never completed, so that check never fires
+            // and a single wedged message would keep this socket -- and this
+            // interval, which is what makes it reachable -- for the life of the
+            // process. Pinging continues meanwhile, so a connection that is
+            // draining legitimately is not dropped for inactivity.
+            if (this.closedAt && new Date().getTime() - this.closedAt.getTime() > this.noHeartBeatTimeout * 1000) {
+              this.abandonClose(webSocket);
+            } else {
+              this.closeIfDrained(webSocket);
+            }
+
+            return;
           }
 
           if (new Date().getTime() - webSocket.lastHeartBeat.getTime() > this.noHeartBeatTimeout * 1000) {
@@ -577,47 +596,39 @@ export class WebSocketConnection {
    */
   public close() {
     this.closed = true;
+    this.closedAt = new Date();
 
-    const socket = this.webSocket;
+    // Straight away when there is nothing in flight; otherwise the heartbeat
+    // takes it from here, both to notice the drain finishing and to bound it.
+    this.closeIfDrained(this.webSocket);
+  }
 
-    this.closeIfDrained(socket);
+  /**
+   * Gives up on the messages a closed connection was waiting for, so that one
+   * Cube Store never answers costs a query rather than a permanently open
+   * socket.
+   */
+  private abandonClose(socket: CubeStoreWebSocket) {
+    const unanswered = Object.keys(socket.sentMessages);
 
-    if (!socket || socket !== this.webSocket || this.closeTimer) {
-      return;
+    socket.teardown();
+
+    if (socket === this.webSocket) {
+      this.webSocket = null;
     }
 
-    // Bound the drain. Cube Store keeps answering the 5s pings of a connection
-    // whose query is simply never completed, so `noHeartBeatTimeout` never
-    // fires and nothing else would call `closeIfDrained()` again: a single
-    // wedged message would keep this socket, and the interval that makes it
-    // reachable, for the life of the process -- the very leak being fixed,
-    // behind a narrower door. A stuck message costs one query instead.
-    this.closeTimer = setTimeout(() => {
-      this.closeTimer = null;
+    const error = new ConnectionError(
+      `Cube Store connection was closed with ${unanswered.length} message(s) still unanswered`
+    );
 
-      const unanswered = Object.keys(socket.sentMessages);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of unanswered) {
+      const message = socket.sentMessages[key];
+      delete socket.sentMessages[key];
+      message.reject(error);
+    }
 
-      socket.teardown();
-
-      if (socket === this.webSocket) {
-        this.webSocket = null;
-      }
-
-      const error = new ConnectionError(
-        `Cube Store connection was closed with ${unanswered.length} message(s) still unanswered`
-      );
-
-      // eslint-disable-next-line no-restricted-syntax
-      for (const key of unanswered) {
-        const message = socket.sentMessages[key];
-        delete socket.sentMessages[key];
-        message.reject(error);
-      }
-
-      socket.terminate();
-    }, this.noHeartBeatTimeout * 1000);
-
-    this.closeTimer.unref();
+    socket.terminate();
   }
 
   /**
@@ -635,11 +646,6 @@ export class WebSocketConnection {
 
     if (Object.keys(socket.sentMessages).length) {
       return;
-    }
-
-    if (this.closeTimer) {
-      clearTimeout(this.closeTimer);
-      this.closeTimer = null;
     }
 
     // Stop the heartbeat before closing rather than leaving it to the 'close'

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -213,9 +213,26 @@ export class WebSocketConnection {
           // the socket, and everything reachable from it, alive.
           webSocket.teardown();
 
+          if (this.closed) {
+            // Nothing to retry towards: `initWebSocket()` refuses once closed,
+            // and whatever was in flight is dealt with by the 'close' handler.
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            return;
+          }
+
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
-              resolve(this.initWebSocket());
+              // `.then(resolve, reject)` rather than `resolve(promise)`: once
+              // this socket's `readyPromise` has settled, `resolve` returns
+              // without adopting -- so a rejection handed to it is never
+              // observed, and an unhandled rejection is fatal under Node's
+              // default. The retry above cannot reject for `closed` any more,
+              // but a close landing between this timer being armed and firing
+              // still can, as can anything else `initWebSocket()` throws.
+              this.initWebSocket().then(resolve, reject);
             }, this.retryWaitTime());
           } else {
             reject(new ConnectionError(

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -206,8 +206,6 @@ export class WebSocketConnection {
             return;
           }
 
-          this.currentConnectionTry += 1;
-
           // The socket is done either way, so stop its heartbeat now rather than
           // relying on a 'close' that may not follow: the interval is what keeps
           // the socket, and everything reachable from it, alive.
@@ -234,6 +232,11 @@ export class WebSocketConnection {
 
             return;
           }
+
+          // Counted here rather than above the branch: the closed path does not
+          // attempt a connection, and this counter both paces the retries and
+          // spends the `maxConnectRetries` budget a genuinely cold connect needs.
+          this.currentConnectionTry += 1;
 
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
@@ -624,8 +627,14 @@ export class WebSocketConnection {
    * none.
    */
   public close() {
-    this.closed = true;
-    this.closedAt = new Date();
+    if (!this.closed) {
+      this.closed = true;
+      // First asked for, not most recently: `release()` closes the data-source
+      // and external drivers separately, which is the same connection twice when
+      // one `CubeStoreDriver` backs both, and re-stamping would restart the bound
+      // each time.
+      this.closedAt = new Date();
+    }
 
     // Straight away when there is nothing in flight; otherwise the heartbeat
     // takes it from here, both to notice the drain finishing and to bound it.

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -67,6 +67,9 @@ interface CubeStoreWebSocket extends WebSocket {
   // A failure that killed this socket and that re-sending can't fix, so the
   // message that caused it is rejected instead of being re-sent.
   fatalError: Error | null;
+  // Stops the heartbeat interval, which otherwise keeps a reference to this socket
+  // (and the socket itself alive) even when nothing else points to the connection.
+  teardown: () => void;
 }
 
 export class WebSocketConnection {
@@ -88,6 +91,13 @@ export class WebSocketConnection {
 
   private cubeStoreVersion: string | null = null;
 
+  // Set by close(), and never unset: a closed connection stays open only for the
+  // messages already in flight and never establishes another socket. Without it
+  // close() does not actually close anything -- the 'close' handler re-sends
+  // whatever was pending over a fresh connection, and the heartbeat on that one
+  // keeps it (and the orchestrator holding it) alive for the life of the process.
+  private closed: boolean = false;
+
   public constructor(url: string) {
     this.url = url;
     this.messageCounter = 1;
@@ -99,6 +109,13 @@ export class WebSocketConnection {
   }
 
   protected async initWebSocket(): Promise<CubeStoreWebSocket> {
+    if (this.closed) {
+      // Refusing here is what makes close() terminal: it covers a query issued
+      // after the release as well as the re-send path, whose `catch` then
+      // rejects the messages that were in flight instead of re-opening for them.
+      throw new ConnectionError('Cube Store connection is closed');
+    }
+
     if (!this.webSocket) {
       const headers: Record<string, string> = {};
       headers['x-process-id'] = getProcessUid();
@@ -109,6 +126,10 @@ export class WebSocketConnection {
       });
 
       webSocket.readyPromise = new Promise<CubeStoreWebSocket>((resolve, reject) => {
+        // Whether readyPromise is already settled, i.e. whether a retry still has
+        // somebody to answer.
+        let established = false;
+
         webSocket.lastHeartBeat = new Date();
         const pingInterval = setInterval(() => {
           if (webSocket.readyState === WebSocket.OPEN) {
@@ -119,6 +140,8 @@ export class WebSocketConnection {
             webSocket.close();
           }
         }, 5000);
+
+        webSocket.teardown = () => clearInterval(pingInterval);
 
         webSocket.sendAsync = async (message: Uint8Array) => new Promise<void>((resolveSend) => {
           // If socket is closing this message should be resent
@@ -140,7 +163,10 @@ export class WebSocketConnection {
             resolveSend();
           });
         });
-        webSocket.on('open', () => resolve(webSocket));
+        webSocket.on('open', () => {
+          established = true;
+          resolve(webSocket);
+        });
         webSocket.on('error', (err) => {
           if ((err as any).code === MAX_PAYLOAD_EXCEEDED_CODE) {
             // Cube Store answered with a message bigger than this connection
@@ -166,6 +192,22 @@ export class WebSocketConnection {
 
           this.currentConnectionTry += 1;
 
+          webSocket.teardown();
+          webSocket.terminate();
+
+          // Retrying is only useful while somebody is waiting for this socket to
+          // come up. Once it is established, reconnecting here would raise a
+          // connection nobody asked for and keep it alive with its own heartbeat:
+          // what was in flight is re-sent by the 'close' handler, and a later
+          // query establishes a new connection through initWebSocket().
+          if (established) {
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            return;
+          }
+
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
               resolve(this.initWebSocket());
@@ -188,7 +230,7 @@ export class WebSocketConnection {
           webSocket.lastHeartBeat = new Date();
         });
         webSocket.on('close', (code: number, reason: Buffer) => {
-          clearInterval(pingInterval);
+          webSocket.teardown();
 
           const pending = Object.keys(webSocket.sentMessages);
 
@@ -259,6 +301,13 @@ export class WebSocketConnection {
 
             setTimeout(async () => {
               try {
+                // Everything this re-send was scheduled for has been settled in
+                // the meantime, so there is nothing left to carry over and a new
+                // connection would just stay open on its heartbeat.
+                if (!Object.keys(webSocket.sentMessages).length) {
+                  return;
+                }
+
                 const nextWebSocket = await this.initWebSocket();
                 const resent = Object.keys(webSocket.sentMessages);
 
@@ -302,6 +351,7 @@ export class WebSocketConnection {
 
           if (httpMessage.commandType() === HttpCommand.HttpError) {
             resolver.reject(new QueryError(`${httpMessage.command(new HttpError())?.error()}`));
+            this.closeIfDrained();
             return;
           }
 
@@ -311,6 +361,8 @@ export class WebSocketConnection {
           } catch (e) {
             resolver.reject(e);
           }
+
+          this.closeIfDrained();
         });
       });
 
@@ -530,9 +582,39 @@ export class WebSocketConnection {
     return this.cubeStoreVersion ?? '0.0.0';
   }
 
+  /**
+   * Closes the connection for good. Messages already in flight are given the
+   * chance to be answered -- an eviction can happen mid-query, and failing one
+   * that Cube Store is already working on would fail the request -- so the
+   * socket goes away once the last of them settles, or right away if there are
+   * none.
+   */
   public close() {
-    if (this.webSocket) {
-      this.webSocket.close();
+    this.closed = true;
+
+    this.closeIfDrained();
+  }
+
+  /**
+   * Closes the socket once nothing is in flight on it. A no-op until close() has
+   * been called, so an ordinary idle connection is left alone.
+   */
+  private closeIfDrained() {
+    const socket = this.webSocket;
+
+    if (!this.closed || !socket) {
+      return;
     }
+
+    if (Object.keys(socket.sentMessages).length) {
+      return;
+    }
+
+    // Stop the heartbeat before closing rather than leaving it to the 'close'
+    // handler: it is the timer, not the socket, that keeps this whole graph
+    // reachable, so it should not outlive the decision to close by even a tick.
+    socket.teardown();
+    this.webSocket = null;
+    socket.close();
   }
 }

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -264,6 +264,40 @@ describe('WebSocketConnection', () => {
       }
     }, JEST_TIMEOUT);
 
+    it('does not leave an unhandled rejection when a closed connection errors', async () => {
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => { unhandled.push(reason); };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        connection = new WebSocketConnection(server.url);
+
+        // Establish it, so this socket's `readyPromise` is already settled.
+        await expectAnsweredBy(query('SELECT 1'), 0);
+
+        const socket = (connection as any).webSocket;
+        connection.close();
+
+        // A post-open 'error' on a closed connection. Emitted rather than
+        // provoked because `ws` reports a dying socket as 'close' here, while
+        // the errors that do reach this handler in the wild -- a protocol error,
+        // or a connect retry still pending from before the close -- are not
+        // reproducible against the mock. The handler's contract is the subject:
+        // it schedules a retry, `initWebSocket()` refuses once closed, and
+        // handing that rejection to an already-settled `resolve` leaves nobody
+        // to observe it, which is fatal under Node's default
+        // --unhandled-rejections=throw.
+        socket.emit('error', Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
+
+        // Past the retry the handler schedules.
+        await new Promise((resolve) => { setTimeout(resolve, 2500); });
+
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    }, JEST_TIMEOUT);
+
     it('does not re-open when the socket dies while draining', async () => {
       connection = new WebSocketConnection(server.url);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -238,6 +238,32 @@ describe('WebSocketConnection', () => {
       expect(server.connections.length).toBe(1);
     }, JEST_TIMEOUT);
 
+    it('gives up on a message Cube Store never answers instead of holding the socket', async () => {
+      // The bound the close waits out. Cube Store keeps answering the pings of a
+      // connection whose query never completes, so without it nothing would ever
+      // close this socket again.
+      process.env.CUBEJS_CUBESTORE_NO_HEART_BEAT_TIMEOUT = '1';
+
+      try {
+        connection = new WebSocketConnection(server.url);
+
+        server.handler = () => undefined;
+
+        const promise = query('SELECT 1');
+        await server.waitForMessages(1);
+
+        connection.close();
+
+        await expect(promise).rejects.toThrow(ConnectionError);
+        await expect(promise).rejects.toThrow('1 message(s) still unanswered');
+
+        await waitUntil(() => closedOnTheServer(0), 'the connection to be closed anyway');
+        expect((connection as any).webSocket).toBeNull();
+      } finally {
+        delete process.env.CUBEJS_CUBESTORE_NO_HEART_BEAT_TIMEOUT;
+      }
+    }, JEST_TIMEOUT);
+
     it('does not re-open when the socket dies while draining', async () => {
       connection = new WebSocketConnection(server.url);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -264,6 +264,21 @@ describe('WebSocketConnection', () => {
       }
     }, JEST_TIMEOUT);
 
+    it('rejects a query that is still connecting when the connection is closed', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      // `initWebSocket()` creates the socket synchronously, so this close lands
+      // while it is still CONNECTING -- an eviction while the very first query
+      // of an orchestrator is connecting. `ws` reports closing a CONNECTING
+      // socket as an 'error', and nothing else left would settle the promise
+      // the query is awaiting.
+      const promise = query('SELECT 1');
+      connection.close();
+
+      await expect(promise).rejects.toThrow(ConnectionError);
+      await expect(promise).rejects.toThrow('Cube Store connection is closed');
+    }, JEST_TIMEOUT);
+
     it('does not leave an unhandled rejection when a closed connection errors', async () => {
       const unhandled: unknown[] = [];
       const onUnhandled = (reason: unknown) => { unhandled.push(reason); };

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -1,7 +1,8 @@
 import { Socket } from 'net';
+import WebSocket from 'ws';
 
 import { WebSocketConnection } from '../src/WebSocketConnection';
-import { MessageTooLargeError, QueryError } from '../src/errors';
+import { ConnectionError, MessageTooLargeError, QueryError } from '../src/errors';
 import { QueryResultFormat } from '../codegen';
 import {
   answeredBy,
@@ -45,6 +46,22 @@ const waitForBufferedWrite = async (socket: Socket) => {
     }
 
     await new Promise((resolve) => { setImmediate(resolve); });
+  }
+};
+
+/**
+ * Polls until `condition` holds, for assertions about a socket that is torn down
+ * a few ticks after the call that asked for it.
+ */
+const waitUntil = async (condition: () => boolean, description: string) => {
+  const deadline = Date.now() + 5000;
+
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+
+    await new Promise((resolve) => { setTimeout(resolve, 25); });
   }
 };
 
@@ -167,6 +184,79 @@ describe('WebSocketConnection', () => {
 
     await expectAnsweredBy(query('SELECT 1'), 1);
   }, JEST_TIMEOUT);
+
+  describe('close', () => {
+    /** Whether Cube Store has seen the connection go away. */
+    const closedOnTheServer = (index: number) => server.connection(index).ws.readyState === WebSocket.CLOSED;
+
+    it('closes the socket when nothing is in flight', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      await expectAnsweredBy(query('SELECT 1'), 0);
+
+      connection.close();
+
+      await waitUntil(() => closedOnTheServer(0), 'Cube Store to see the connection close');
+      expect((connection as any).webSocket).toBeNull();
+    }, JEST_TIMEOUT);
+
+    it('keeps the connection open until an in-flight query is answered', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      let answer: () => void = () => undefined;
+      server.handler = (message, mockConnection) => {
+        answer = () => mockConnection.ws.send(
+          buildErrorMessage(message.messageId, answeredBy(mockConnection.index))
+        );
+      };
+
+      const promise = query('SELECT 1');
+      await server.waitForMessages(1);
+
+      // An eviction can land mid-query, and Cube Store is already working on the
+      // answer, so closing must not drop it: the socket stays OPEN rather than
+      // going into CLOSING out from under the query.
+      connection.close();
+      expect((connection as any).webSocket.readyState).toBe(WebSocket.OPEN);
+
+      answer();
+      await expectAnsweredBy(promise, 0);
+
+      await waitUntil(() => closedOnTheServer(0), 'the connection to close once drained');
+      expect(server.connections.length).toBe(1);
+    }, JEST_TIMEOUT);
+
+    it('does not establish a new connection for a query issued after close', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      await expectAnsweredBy(query('SELECT 1'), 0);
+      connection.close();
+
+      // The released driver is still reachable from whoever held it, and this is
+      // the call that used to re-open the socket the release had just closed.
+      await expect(query('SELECT 2')).rejects.toThrow(ConnectionError);
+      expect(server.connections.length).toBe(1);
+    }, JEST_TIMEOUT);
+
+    it('does not re-open when the socket dies while draining', async () => {
+      connection = new WebSocketConnection(server.url);
+
+      // Cube Store never answers, so the query is still in flight at close.
+      server.handler = () => undefined;
+
+      const promise = query('SELECT 1');
+      await server.waitForMessages(1);
+
+      connection.close();
+      clientSocket().destroy(epipe());
+
+      // The re-send path would ordinarily raise a fresh connection here, whose
+      // heartbeat is exactly what kept an evicted orchestrator alive. Failing
+      // the query is the honest outcome once the connection is closed.
+      await expect(promise).rejects.toThrow(ConnectionError);
+      expect(server.connections.length).toBe(1);
+    }, JEST_TIMEOUT);
+  });
 
   describe('message size limit', () => {
     const MAX_MESSAGE_SIZE = 1024 * 1024;

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -3,7 +3,6 @@ import * as stream from 'stream';
 import pt from 'promise-timeout';
 import {
   ContinueWaitError,
-  DriverFactory,
   DriverFactoryByDataSource,
   DriverType,
   QueryBody,
@@ -22,19 +21,6 @@ export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
 export class OrchestratorApi {
   private seenDataSources: Record<string, boolean> = {};
 
-  /**
-   * Whether anything has built the external (Cube Store) driver. The factory
-   * *creates* the connection on first call -- `server.ts` builds the driver and
-   * runs `testConnection()` inside it -- so releasing it unconditionally would
-   * have an orchestrator that never touched Cube Store open a connection on
-   * eviction purely to close it. `seenDataSources` guards the data-source loop
-   * the same way.
-   */
-  private externalDriverCreated: boolean = false;
-
-  /** The factory as provided, before the tracking wrapper below. */
-  private readonly untrackedExternalDriverFactory?: DriverFactory;
-
   protected orchestrator: QueryOrchestrator;
 
   protected readonly continueWaitTimeout: number;
@@ -45,24 +31,6 @@ export class OrchestratorApi {
     protected readonly options: OrchestratorApiOptions
   ) {
     this.continueWaitTimeout = this.options.continueWaitTimeout || 10;
-
-    const { externalDriverFactory } = this.options;
-
-    if (externalDriverFactory) {
-      this.untrackedExternalDriverFactory = externalDriverFactory;
-
-      // Wrapped before `QueryOrchestrator` captures it off `options`, so every
-      // caller that can build the driver goes through the flag, and marked on
-      // fulfilment: `server.ts` releases the driver and clears its memo when
-      // `testConnection()` fails, so a build that threw left nothing open.
-      this.options.externalDriverFactory = async () => {
-        const driver = await externalDriverFactory();
-
-        this.externalDriverCreated = true;
-
-        return driver;
-      };
-    }
 
     this.orchestrator = new QueryOrchestrator(
       options.redisPrefix || 'STANDALONE',
@@ -275,9 +243,7 @@ export class OrchestratorApi {
     try {
       return await Promise.all([
         ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
-        // Through the unwrapped factory: closing via the wrapper would set the
-        // flag again on the way out.
-        ...(this.externalDriverCreated ? [this.releaseDriver(this.untrackedExternalDriverFactory)] : []),
+        this.releaseDriver(this.options.externalDriverFactory),
         this.orchestrator.cleanup()
       ]);
     } catch (error) {

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -3,6 +3,7 @@ import * as stream from 'stream';
 import pt from 'promise-timeout';
 import {
   ContinueWaitError,
+  DriverFactory,
   DriverFactoryByDataSource,
   DriverType,
   QueryBody,
@@ -21,6 +22,19 @@ export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
 export class OrchestratorApi {
   private seenDataSources: Record<string, boolean> = {};
 
+  /**
+   * Whether anything has built the external (Cube Store) driver. The factory
+   * *creates* the connection on first call -- `server.ts` builds the driver and
+   * runs `testConnection()` inside it -- so releasing it unconditionally would
+   * have an orchestrator that never touched Cube Store open a connection on
+   * eviction purely to close it. `seenDataSources` guards the data-source loop
+   * the same way.
+   */
+  private externalDriverCreated: boolean = false;
+
+  /** The factory as provided, before the tracking wrapper below. */
+  private readonly untrackedExternalDriverFactory?: DriverFactory;
+
   protected orchestrator: QueryOrchestrator;
 
   protected readonly continueWaitTimeout: number;
@@ -31,6 +45,24 @@ export class OrchestratorApi {
     protected readonly options: OrchestratorApiOptions
   ) {
     this.continueWaitTimeout = this.options.continueWaitTimeout || 10;
+
+    const { externalDriverFactory } = this.options;
+
+    if (externalDriverFactory) {
+      this.untrackedExternalDriverFactory = externalDriverFactory;
+
+      // Wrapped before `QueryOrchestrator` captures it off `options`, so every
+      // caller that can build the driver goes through the flag, and marked on
+      // fulfilment: `server.ts` releases the driver and clears its memo when
+      // `testConnection()` fails, so a build that threw left nothing open.
+      this.options.externalDriverFactory = async () => {
+        const driver = await externalDriverFactory();
+
+        this.externalDriverCreated = true;
+
+        return driver;
+      };
+    }
 
     this.orchestrator = new QueryOrchestrator(
       options.redisPrefix || 'STANDALONE',
@@ -243,7 +275,9 @@ export class OrchestratorApi {
     try {
       return await Promise.all([
         ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
-        this.releaseDriver(this.options.externalDriverFactory),
+        // Through the unwrapped factory: closing via the wrapper would set the
+        // flag again on the way out.
+        ...(this.externalDriverCreated ? [this.releaseDriver(this.untrackedExternalDriverFactory)] : []),
         this.orchestrator.cleanup()
       ]);
     } catch (error) {

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -240,11 +240,23 @@ export class OrchestratorApi {
   }
 
   public async release() {
-    return Promise.all([
-      ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
-      this.releaseDriver(this.options.externalDriverFactory),
-      this.orchestrator.cleanup()
-    ]);
+    try {
+      return await Promise.all([
+        ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
+        this.releaseDriver(this.options.externalDriverFactory),
+        this.orchestrator.cleanup()
+      ]);
+    } catch (error) {
+      // `OrchestratorStorage` swallows this so that one orchestrator failing to
+      // close cannot fail shutdown, which leaves this as the only place an
+      // operator learns that a connection was not closed after all.
+      this.logger('Orchestrator Release Error', {
+        orchestratorId: this.options.redisPrefix,
+        error: (error as Error).stack || String(error),
+      });
+
+      throw error;
+    }
   }
 
   protected async releaseDriver(driverFn?: DriverFactoryByDataSource, dataSource: string = 'default') {

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -4,12 +4,33 @@ import type { OrchestratorApi } from './OrchestratorApi';
 export class OrchestratorStorage {
   protected readonly storage: LRUCache<string, OrchestratorApi>;
 
+  protected readonly pendingReleases: Set<Promise<void>> = new Set();
+
   public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean } = { compilerCacheSize: 100 }) {
     this.storage = new LRUCache<string, OrchestratorApi>({
       max: options.compilerCacheSize,
       ttl: options.maxCompilerCacheKeepAlive,
-      updateAgeOnGet: options.updateCompilerCacheKeepAlive
+      updateAgeOnGet: options.updateCompilerCacheKeepAlive,
+      // Any removal reason ('evict' | 'set' | 'delete' | 'expire') means the api is not
+      // reachable through the cache anymore, so its connections have to be closed.
+      // Without it an evicted api keeps its Cube Store web socket open forever: the heartbeat
+      // interval holds a reference to the socket, so it is never garbage collected either.
+      // disposeAfter, not dispose: release() is async and calls into the drivers, while
+      // dispose runs synchronously inside set()/delete().
+      disposeAfter: (api: OrchestratorApi) => {
+        this.release(api);
+      },
     });
+  }
+
+  protected release(api: OrchestratorApi) {
+    const pending: Promise<void> = api.release()
+      .then(() => undefined, () => undefined)
+      .then(() => {
+        this.pendingReleases.delete(pending);
+      });
+
+    this.pendingReleases.add(pending);
   }
 
   public has(orchestratorId: string) {
@@ -37,7 +58,9 @@ export class OrchestratorStorage {
   }
 
   public async releaseConnections() {
-    await Promise.all([...this.storage.values()].map(api => api.release()));
+    // clear() disposes every entry, which schedules release() for each of them.
     this.storage.clear();
+
+    await Promise.all([...this.pendingReleases]);
   }
 }

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -15,4 +15,49 @@ describe('OrchestratorApi', () => {
     await api.getPreAggregationQueueStates();
     expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith(undefined);
   });
+
+  describe('release', () => {
+    function createApi() {
+      const externalRelease = jest.fn(async () => undefined);
+      const externalDriver = { release: externalRelease };
+      const externalDriverFactory = jest.fn(async () => externalDriver as any);
+
+      const api = new OrchestratorApi(
+        async () => ({ release: jest.fn() }) as any,
+        jest.fn(),
+        {
+          cacheAndQueueDriver: 'memory',
+          contextToDbType: async () => 'postgres',
+          contextToExternalDbType: () => 'cubestore',
+          externalDriverFactory,
+        }
+      );
+
+      (api as any).orchestrator = { cleanup: async () => undefined };
+
+      return { api, externalDriverFactory, externalRelease };
+    }
+
+    test('does not build the external driver just to close it', async () => {
+      const { api, externalDriverFactory, externalRelease } = createApi();
+
+      await api.release();
+
+      // The factory creates the connection, so calling it here would have every
+      // eviction open a Cube Store connection purely to close it again.
+      expect(externalDriverFactory).not.toHaveBeenCalled();
+      expect(externalRelease).not.toHaveBeenCalled();
+    });
+
+    test('closes the external driver once something has built it', async () => {
+      const { api, externalRelease } = createApi();
+
+      // What the orchestrator does the first time it touches a pre-aggregation.
+      await (api as any).options.externalDriverFactory();
+
+      await api.release();
+
+      expect(externalRelease).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -15,49 +15,4 @@ describe('OrchestratorApi', () => {
     await api.getPreAggregationQueueStates();
     expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith(undefined);
   });
-
-  describe('release', () => {
-    function createApi() {
-      const externalRelease = jest.fn(async () => undefined);
-      const externalDriver = { release: externalRelease };
-      const externalDriverFactory = jest.fn(async () => externalDriver as any);
-
-      const api = new OrchestratorApi(
-        async () => ({ release: jest.fn() }) as any,
-        jest.fn(),
-        {
-          cacheAndQueueDriver: 'memory',
-          contextToDbType: async () => 'postgres',
-          contextToExternalDbType: () => 'cubestore',
-          externalDriverFactory,
-        }
-      );
-
-      (api as any).orchestrator = { cleanup: async () => undefined };
-
-      return { api, externalDriverFactory, externalRelease };
-    }
-
-    test('does not build the external driver just to close it', async () => {
-      const { api, externalDriverFactory, externalRelease } = createApi();
-
-      await api.release();
-
-      // The factory creates the connection, so calling it here would have every
-      // eviction open a Cube Store connection purely to close it again.
-      expect(externalDriverFactory).not.toHaveBeenCalled();
-      expect(externalRelease).not.toHaveBeenCalled();
-    });
-
-    test('closes the external driver once something has built it', async () => {
-      const { api, externalRelease } = createApi();
-
-      // What the orchestrator does the first time it touches a pre-aggregation.
-      await (api as any).options.externalDriverFactory();
-
-      await api.release();
-
-      expect(externalRelease).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -1,0 +1,113 @@
+import type { OrchestratorApi } from '../../src/core/OrchestratorApi';
+import { OrchestratorStorage } from '../../src/core/OrchestratorStorage';
+
+/**
+ * `OrchestratorStorage` only ever calls `release()` on what it holds, so the
+ * entry is stubbed down to that: the release lifecycle inside `OrchestratorApi`
+ * is its own unit.
+ */
+function createApi(release: () => Promise<unknown> = async () => undefined) {
+  const api = { release: jest.fn(release) };
+
+  return { api: api as unknown as OrchestratorApi, release: api.release };
+}
+
+// lru-cache runs `disposeAfter` once the operation that removed the entry has
+// finished, and the release it schedules is asynchronous.
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('OrchestratorStorage', () => {
+  test('releases an orchestrator the LRU evicts, and keeps the one still cached', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const evicted = createApi();
+    const kept = createApi();
+
+    storage.set('evicted', evicted.api);
+    storage.set('kept', kept.api);
+    await flush();
+
+    expect(storage.has('evicted')).toBe(false);
+    expect(evicted.release).toHaveBeenCalledTimes(1);
+
+    expect(storage.has('kept')).toBe(true);
+    expect(kept.release).not.toHaveBeenCalled();
+  });
+
+  test('releases an orchestrator replaced under the same id', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const first = createApi();
+    const second = createApi();
+
+    storage.set('same-id', first.api);
+    storage.set('same-id', second.api);
+    await flush();
+
+    expect(first.release).toHaveBeenCalledTimes(1);
+    expect(second.release).not.toHaveBeenCalled();
+  });
+
+  test('setting the same instance again does not release it', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const { api, release } = createApi();
+
+    storage.set('same-id', api);
+    storage.set('same-id', api);
+    await flush();
+
+    expect(storage.has('same-id')).toBe(true);
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  test('releaseConnections waits for the releases it schedules', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    let finishRelease: () => void = () => undefined;
+    const { api, release } = createApi(() => new Promise<void>(resolve => {
+      finishRelease = () => resolve();
+    }));
+
+    storage.set('a', api);
+
+    let settled = false;
+    const releasing = storage.releaseConnections().then(() => { settled = true; });
+    await flush();
+
+    // `clear()` only schedules the releases, so shutdown has to wait for them:
+    // returning here would let the process exit with the connections still open.
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    finishRelease();
+    await releasing;
+
+    expect(settled).toBe(true);
+    expect(storage.has('a')).toBe(false);
+  });
+
+  test('releaseConnections resolves and clears even when a release fails', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const failing = createApi(async () => { throw new Error('driver is gone'); });
+    const ok = createApi();
+
+    storage.set('failing', failing.api);
+    storage.set('ok', ok.api);
+
+    await expect(storage.releaseConnections()).resolves.toBeUndefined();
+
+    expect(ok.release).toHaveBeenCalledTimes(1);
+    expect(storage.has('failing')).toBe(false);
+    expect(storage.has('ok')).toBe(false);
+  });
+
+  test('forgets a release once it has finished', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+
+    storage.set('a', createApi().api);
+    storage.set('b', createApi().api);
+    await storage.releaseConnections();
+    await flush();
+
+    // Otherwise the set grows by one entry per eviction -- a smaller leak in
+    // place of the one being fixed.
+    expect((storage as any).pendingReleases.size).toBe(0);
+  });
+});

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -18,21 +18,24 @@ function createApi(release: () => Promise<unknown> = async () => undefined) {
  */
 function createRealApi(driverError: Error) {
   const logger = jest.fn();
-  const externalDriver = { release: async () => { throw driverError; } };
+  const driver = { release: async () => { throw driverError; } };
 
   const api = new OrchestratorApi(
-    async () => externalDriver as any,
+    async () => driver as any,
     logger,
     {
       cacheAndQueueDriver: 'memory',
       contextToDbType: async () => 'postgres',
       contextToExternalDbType: () => 'cubestore',
-      externalDriverFactory: async () => externalDriver as any,
       redisPrefix: 'tenant-1',
     }
   );
 
   (api as any).orchestrator = { cleanup: async () => undefined };
+
+  // A data source the orchestrator has touched, so the release has a driver to
+  // close -- and this one fails to close.
+  api.addDataSeenSource('default');
 
   return { api, logger };
 }

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -1,4 +1,4 @@
-import type { OrchestratorApi } from '../../src/core/OrchestratorApi';
+import { OrchestratorApi } from '../../src/core/OrchestratorApi';
 import { OrchestratorStorage } from '../../src/core/OrchestratorStorage';
 
 /**
@@ -10,6 +10,31 @@ function createApi(release: () => Promise<unknown> = async () => undefined) {
   const api = { release: jest.fn(release) };
 
   return { api: api as unknown as OrchestratorApi, release: api.release };
+}
+
+/**
+ * A real `OrchestratorApi` with a stubbed `QueryOrchestrator`, for the one case
+ * that is about what the api logs rather than what the storage does with it.
+ */
+function createRealApi(driverError: Error) {
+  const logger = jest.fn();
+  const externalDriver = { release: async () => { throw driverError; } };
+
+  const api = new OrchestratorApi(
+    async () => externalDriver as any,
+    logger,
+    {
+      cacheAndQueueDriver: 'memory',
+      contextToDbType: async () => 'postgres',
+      contextToExternalDbType: () => 'cubestore',
+      externalDriverFactory: async () => externalDriver as any,
+      redisPrefix: 'tenant-1',
+    }
+  );
+
+  (api as any).orchestrator = { cleanup: async () => undefined };
+
+  return { api, logger };
 }
 
 // lru-cache runs `disposeAfter` once the operation that removed the entry has
@@ -96,6 +121,25 @@ describe('OrchestratorStorage', () => {
     expect(ok.release).toHaveBeenCalledTimes(1);
     expect(storage.has('failing')).toBe(false);
     expect(storage.has('ok')).toBe(false);
+  });
+
+  test('a release that fails is logged rather than lost', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const { api, logger } = createRealApi(new Error('driver is gone'));
+
+    storage.set('failing', api);
+    storage.set('next', createApi().api);
+    await flush();
+
+    // The storage swallows the rejection so shutdown cannot fail on it, which
+    // leaves the log as the only signal that a connection stayed open.
+    expect(logger).toHaveBeenCalledWith(
+      'Orchestrator Release Error',
+      expect.objectContaining({
+        orchestratorId: 'tenant-1',
+        error: expect.stringContaining('driver is gone'),
+      })
+    );
   });
 
   test('forgets a release once it has finished', async () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

CORE-823

**Description of Changes Made**

Two halves of one leak: nothing asked the driver to close, and asking it to close did not close it.

**`OrchestratorStorage` never released an evicted orchestrator.** It keeps `OrchestratorApi` instances in an `LRUCache` with no `dispose` handler, so an entry pushed out by `max` — or replaced, deleted, expired — was dropped without `release()` ever being called. Only `releaseConnections()` at shutdown released anything.

Nothing else closes that socket: the driver pings it every 5s, so neither side times it out, and that live timer keeps the whole orchestrator reachable from a GC root. A collected socket would not be closed anyway — V8 runs no destructors and neither `ws` nor `net` registers a finalizer. In Node a socket is closed explicitly or never.

`disposeAfter` now covers every removal reason — `disposeAfter` rather than `dispose` because `release()` is async and calls into the drivers, while `dispose` runs synchronously inside `set()`/`delete()`. The scheduled releases are tracked in `pendingReleases` so `releaseConnections()` can await them; `clear()` only schedules them, so without that shutdown could return with the connections still open. A failing release is swallowed there so one orchestrator cannot fail shutdown, and logged by `OrchestratorApi.release()` before rethrowing, since that is otherwise the only signal an operator would have that this fix is not working in their deployment.

**`WebSocketConnection.close()` did not close the connection.** It called `webSocket.close()` and stopped there, so the `'close'` handler re-sent whatever was in flight over a fresh connection and the heartbeat on that one kept the socket alive again; a query arriving after the close re-opened it just as readily. Releasing the driver therefore freed nothing, which is why the dispose hook alone would not have been enough.

A single `closed` flag makes the close terminal. `initWebSocket()` refuses once it is set, which covers both a late query and the re-send path, whose `catch` then fails the messages that were in flight instead of re-opening for them. Messages already in flight are still given the chance to be answered — an eviction can land mid-query and Cube Store may already be working on the answer — so the socket goes away once the last of them settles, or immediately if there are none.

That wait is bounded, and the bound lives in the existing heartbeat interval rather than a timer of its own: that interval already owns "this socket has waited long enough" and is already the thing keeping the socket reachable. It cannot be left to the ordinary no-heartbeat check, because Cube Store keeps answering the pings of a connection whose query is simply never completed — so without an explicit bound a single wedged message would keep the socket, and the interval, for the life of the process. Pinging continues while a closed connection drains, so one draining legitimately is not dropped for inactivity. When the bound fires, whatever is left is rejected naming the count: a stuck message costs one query.

Two smaller things in the same file:

- The heartbeat interval is stopped through `teardown()` wherever the socket dies, not only in the `'close'` handler. It is the timer, not the socket, that keeps the graph reachable.
- The `'error'` handler returns early when the connection is closed — there is nothing to retry towards, and it stops arming a pointless timer per evicted connection — but rejects `readyPromise` first, since on a socket that never opened that is the only thing left which can settle it. The retry itself uses `.then(resolve, reject)` rather than `resolve(promise)`: on a socket whose `readyPromise` has settled, `resolve` returns without adopting what it was given, so a rejection handed to it was never observed, which is fatal under Node's default `--unhandled-rejections=throw`. The re-send also bails out when everything it was scheduled for has settled in the meantime.

**Measured in production before the fix**

~450 new sockets/minute per API pod (429 on a pod 43s after restart, 4,566 at 10 min, 5,198 at 16 min; a pod serving no traffic held 1), **65,551 established sockets on the Cube Store router** they pointed at, and that region's ingress OOM-killed 38–46 times in six hours. Reproduced on deployments pinned to v1.7.2 and v1.7.7, so it is not version-specific.

**Behaviour change worth a reviewer's attention**

`close()` is terminal, so a caller still holding a released driver gets `ConnectionError: Cube Store connection is closed` rather than a silently re-opened socket. That is the trade that makes the leak impossible, and it is what an eviction now costs: `release()` has no drain above the socket, so the next Cube Store round trip of a query still executing on an evicted orchestrator fails. Reachable through the cold-start race in `getOrchestratorApi()` (`has()` at `server.ts:575`, then several awaits before `set()`, so two concurrent requests for a cold id both `set()` and the loser is released while in use), through `RefreshScheduler` holding one api across a run, and through any request outliving the arrival of `max` distinct ids. Discussion and options are on [this thread](https://github.com/cube-js/cube/pull/11661#discussion_r3874622565).

**Tests**

`packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts` (new, 7 tests): eviction, replacement and same-instance re-set; `releaseConnections()` waits for the releases `clear()` schedules; it resolves and clears even when one release rejects; a failing release is logged; a finished release is forgotten rather than accumulating in the set.

`packages/cubejs-cubestore-driver/test/websocket-connection.test.ts` (+7 tests, in the existing suite that drives a mock Cube Store over real TCP): the socket closes when nothing is in flight; the connection stays OPEN until an in-flight query is answered and closes once drained; a query issued after close does not establish a new connection; a socket that dies while draining does not re-open; a message Cube Store never answers is given up on rather than holding the socket; a query still connecting when the close lands is rejected rather than hung; and a socket error on a closed connection leaves no unhandled rejection.

Each was verified to fail against the commit it guards — the connecting-close one by hanging to the jest timeout, the unhandled-rejection one via `process.on('unhandledRejection')`. All 15 pre-existing tests in that suite still pass, which is the check on the `teardown` and retry-path changes not regressing the re-send behaviour.

`cd packages/cubejs-cubestore-driver && yarn unit`: 22 passed.
`cd packages/cubejs-server-core && yarn unit`: 108 passed, 1 failed — `Refresh Scheduler › Exponential backoff`, which fails identically on `master` with this change reverted, so it is pre-existing and unrelated.

**Follow-ups, not in this PR**

- `server.ts` constructs `new OrchestratorStorage()` with no arguments, so the LRU always uses the default `max: 100` and silently ignores `compilerCacheSize` / `maxCompilerCacheKeepAlive` / `updateCompilerCacheKeepAlive`. Two things belong with that change rather than ahead of it: `ttlAutopurge` is unset, so an expired entry is only reaped when something touches the cache, and `new OrchestratorStorage({})` throws because `max` is then `undefined`. Both are latent while the storage is built with no arguments.
- `getOrchestratorApi()` is not de-duplicated by id, and `getQueryOrchestrator()` (`RefreshScheduler.ts:238, 621, 812, 831`) reaches the queues and cache driver without going through the api at all.
- `release()` calls the external driver factory unconditionally, and `CubeStoreDriver.testConnection()` runs `SELECT 1`, so releasing an orchestrator that never built that driver does a connect + query + close. Guarding it was tried and reverted as not worth the complexity — the wrapper it needs drew two defects in review. How often it applies depends on the config: under `cacheAndQueueDriver: 'cubestore'` the queue and cache go through the same factory (`QueryOrchestrator.ts:90`), so any orchestrator that served a query has already built the driver and the memo makes the release build a no-op; under `memory` with Cube Store still external, an orchestrator that served only non-pre-aggregated queries never touches the factory and every eviction does pay the round trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF1JQbLKkZ4XLd1hLXYVmA)_