### PR TITLE
docs: document the Parent dashboard control (CUB-3034)

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -124,6 +124,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
           - Controls 
             - Filter
             - Time granularity
+            - Parent
           - AI summary
           - Layout
             - Spacer

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -13,7 +13,7 @@ If the picker is empty, create the report first in a workbook tab — only publi
 
 ## Interaction with controls
 
-Charts respect [controls][ref-controls] — filters and time granularity switchers — placed on the same dashboard. A single control can drive multiple charts at once: its value is applied to every chart whose query references the targeted dimension.
+Charts respect the [controls][ref-controls] placed on the same dashboard — filters and time granularity switchers. A single control can drive multiple charts at once: its value is applied to every chart whose query references the targeted dimension.
 
 If some controls are incompatible with a chart's query, the chart skips them and shows a warning icon. See [Incompatible controls][ref-incompatible-controls] for details.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -1,12 +1,15 @@
 ---
 title: Controls
-description: Filter and time granularity switcher widgets that let dashboard viewers change what's shown on the dashboard.
+description: Filter, time granularity switcher, and parent widgets that let dashboard viewers change what's shown on the dashboard.
 ---
 
-Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers two control types — both target a dimension from your semantic model and apply the selected value to every [chart][ref-charts] on the dashboard whose query references that dimension.
+Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers three control types:
 
 - [Filter](#filter) — Narrow the data shown on the dashboard
 - [Time granularity switcher](#time-granularity-switcher) — Change the granularity of time-based dimensions
+- [Parent](#parent) — Re-point several other controls at once from a single dropdown
+
+Filters and time granularity switchers each target a dimension from your semantic model, and apply the selected value to every [chart][ref-charts] on the dashboard whose query references that dimension. A parent control works one level up: it targets no dimension of its own and drives *other controls* instead.
 
 ## Filter
 
@@ -92,19 +95,81 @@ Custom granularities defined in the [data model][ref-granularities] aren't offer
 
 You can configure a default granularity that's applied when the dashboard loads. If no default is set, charts use the granularity that was saved on the underlying report — viewers can still switch granularities, but the dashboard opens with each chart at its original granularity.
 
+## Parent
+
+A parent control is a dropdown of options you define. Picking one re-points a whole row of other controls at once — so a viewer makes a single choice instead of adjusting three or four filters by hand.
+
+Unlike the other two control types, a parent control targets no dimension and never touches a chart query directly. It applies values to the controls it *drives* — its **children** — and those children then apply themselves to charts exactly as if the viewer had operated each one. Filters and time granularity switchers can both be children; a parent control cannot be a child of another parent control.
+
+For example, an **Analysis** parent with the options `Retail`, `Wholesale` and `Promo` can set a **Channel** filter, a **Minimum order value** filter, and a **Date range** filter to a different combination for each option. Viewers see one dropdown; you can [hide](#visibility) the children if the individual values aren't worth showing.
+
+In the [dashboard builder][ref-workbooks], click **Parent** under **Add Controls** in the toolbar, then click **Configure Parent** to set it up. The editor has two tabs — **Options** and **Children**.
+
+<Info>
+Add the child controls to the dashboard *before* the parent control. The **Children** tab can only map controls that already exist, so a parent added to an empty dashboard has nothing to drive yet.
+</Info>
+
+### Options
+
+On the **Options** tab, type a label and click **Add** for each entry you want in the dropdown. Options appear as chips — remove one with its close button. A parent control can hold up to 50 options.
+
+Renaming an option later doesn't disturb the values you've mapped to it, so you can reword a label without redoing the mapping.
+
+### Children
+
+On the **Children** tab, pick a control from **Child control**, then give each of the parent's options a value for it. Each row renders *that child's own control* — a time granularity switcher's row shows its granularity picker, limited to the granularities that switcher allows; a filter's row shows that filter's operator and value inputs. So the values you can offer are exactly the ones a viewer could pick in the child itself.
+
+Repeat for each control you want the parent to drive. Every option/child pair can be in one of three states:
+
+| State | What happens when the viewer picks that option |
+|---|---|
+| **A value** | The child is set to that value. |
+| **Reset to default** | The child is cleared back to its own default. For a filter that means no filtering on that dimension. Turn on the row's **Reset to default** switch. |
+| **Left empty** | The child is left alone — it keeps whatever value the viewer already had. Use this deliberately when an option shouldn't have an opinion about a particular child. |
+
+While the parent's settings are open, the children it drives are highlighted on the canvas, so you can see the scope of the mapping at a glance.
+
+### One parent per child
+
+A control can be driven by only one parent control at a time. Mapping a child that another parent already drives **moves** it rather than sharing it — the editor warns you before you save, naming the parent that currently owns it.
+
+This is a deliberate restriction: if two parents drove the same child, both would write to it whenever either was used, and the result would depend on which happened to run last.
+
+### Mapping status on child controls
+
+Once a dashboard has at least one parent control, every filter and time granularity switcher on it shows a small indicator reporting how it's driven:
+
+| Status | Meaning |
+|---|---|
+| **Fully driven** | Every option of the owning parent sets this control. |
+| **Partly driven** | Only some of the owning parent's options set this control; the rest leave it alone. |
+| **Not driven** | No parent control maps this one. |
+
+Click the indicator to jump straight to the **Children** tab of the parent that owns that control, with it already selected. For a control nothing drives yet, the click opens the first parent control on the dashboard — topmost, then leftmost — so you can map it.
+
+The indicator only appears once a parent control exists — on a dashboard that doesn't use them, controls show no mapping status at all.
+
+### Default option
+
+Set **Default value** to the option that should be selected when the dashboard loads. Choosing a default in the builder also applies that option's values to the children, so their saved defaults line up with the parent's — meaning a published dashboard opens in a consistent state without the parent having to re-apply itself on every load.
+
+If you leave **Default value** empty, the parent opens with nothing selected and the children use their own defaults.
+
 ## Visibility
 
-Each control has a **Visibility** setting that determines how it appears on the published dashboard. The setting applies to both filters and time granularity switchers.
+Each control has a **Visibility** setting that determines how it appears on the published dashboard. The setting applies to all three control types.
 
 | Visibility | Behavior on the published dashboard |
 |---|---|
 | **Visible** (default) | Shown on the dashboard and viewers can change its value. |
-| **Hidden** | Not shown to viewers, but the control's value is still applied to the charts it targets. Use this to scope a dashboard with a fixed value — e.g., always filter to the current quarter — without exposing the control. |
+| **Hidden** | Not shown to viewers, but the control's value is still applied to the charts it targets. Use this to scope a dashboard with a fixed value — e.g., always filter to the current quarter — without exposing the control. Hiding the *children* of a [parent control](#parent) is the usual way to present one dropdown instead of the row of controls behind it. |
 | **Disabled** | Shown on the dashboard so viewers can see the active value, but they cannot change it. |
 
 Set the visibility from the **Visibility** dropdown when editing the control. **Hidden** controls remain visible in the dashboard builder so editors can reconfigure them, but disappear from the published view.
 
 ## Interaction with charts
+
+This section applies to filters and time granularity switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's Controls mapping — it acts only through the children it drives, and it's those children that show up here.
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -103,7 +103,7 @@ Unlike the other two control types, a parent control targets no dimension and ne
 
 For example, an **Analysis** parent with the options `Retail`, `Wholesale` and `Promo` can set a **Channel** filter, a **Minimum order value** filter, and a **Date range** filter to a different combination for each option. Viewers see one dropdown; you can [hide](#visibility) the children if the individual values aren't worth showing.
 
-In the [dashboard builder][ref-workbooks], click **Parent** under **Add Controls** in the toolbar, then click **Configure Parent** to set it up. The editor has two tabs — **Options** and **Children**.
+In the [dashboard builder][ref-workbooks], open the **Add Controls** menu in the toolbar and choose **Parent**, then click **Configure Parent** to set it up. The editor has two tabs — **Options** and **Children**.
 
 <Info>
 Add the child controls to the dashboard *before* the parent control. The **Children** tab can only map controls that already exist, so a parent added to an empty dashboard has nothing to drive yet.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -133,8 +133,6 @@ While the parent's settings are open, the children it drives are highlighted on 
 
 A control can be driven by only one parent control at a time. Mapping a child that another parent already drives **moves** it rather than sharing it — the editor warns you before you save, naming the parent that currently owns it.
 
-This is a deliberate restriction: if two parents drove the same child, both would write to it whenever either was used, and the result would depend on which happened to run last.
-
 ### Mapping status on child controls
 
 Once a dashboard has at least one parent control, every filter and time granularity switcher on it shows a small indicator reporting how it's driven:
@@ -147,11 +145,9 @@ Once a dashboard has at least one parent control, every filter and time granular
 
 Click the indicator to jump straight to the **Children** tab of the parent that owns that control, with it already selected. For a control nothing drives yet, the click opens the first parent control on the dashboard — topmost, then leftmost — so you can map it.
 
-The indicator only appears once a parent control exists — on a dashboard that doesn't use them, controls show no mapping status at all.
-
 ### Default option
 
-Set **Default value** to the option that should be selected when the dashboard loads. Choosing a default in the builder also applies that option's values to the children, so their saved defaults line up with the parent's — meaning a published dashboard opens in a consistent state without the parent having to re-apply itself on every load.
+Set **Default value** to the option that should be selected when the dashboard loads. Choosing a default in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
 
 If you leave **Default value** empty, the parent opens with nothing selected and the children use their own defaults.
 
@@ -169,13 +165,13 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 ## Interaction with charts
 
-This section applies to filters and time granularity switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's Controls mapping — it acts only through the children it drives, and it's those children that show up here.
+This section applies to filters and time granularity switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's [Controls mapping](#controls-mapping) — it acts only through the children it drives, and it's those children that show up here.
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
 ### Incompatible controls
 
-If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Controls of the other type still apply — for example, if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa.
+If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Filters and time granularity switchers are skipped independently — if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa.
 
 The chart displays a warning icon to indicate the problem:
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -11,13 +11,13 @@ The dashboard builder supports the following widget types:
 
 - [Charts](/docs/explore-analyze/dashboards/widgets/charts) — Visualize reports from your workbook
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
-- [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data or switch the time granularity
+- [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
 - [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks (in preview)
 
 ## Adding widgets
 
-Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter** and **Time Granularity** controls.
+Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter**, **Time Granularity** and **Parent** controls.
 
 Each item — a toolbar button, or an option inside the **Add Widgets** / **Add Controls** menus — can be added in two ways:
 


### PR DESCRIPTION
Companion docs for [cubedevinc/cubejs-enterprise#14425](https://github.com/cubedevinc/cubejs-enterprise/pull/14425) — the **Parent** dashboard control ([CUB-3034](https://linear.app/cube-d3/issue/CUB-3034/parent-control-widget-presets)).

> [!IMPORTANT]
> **Merge this after the feature ships**, not before. The product PR is approved and green but not yet merged, so until it lands this documents a control that isn't in the builder yet.

## What a parent control is

A dropdown of creator-defined options; picking one re-points a whole row of other controls (filters, time granularity switchers) at once. Viewers make one choice instead of adjusting several controls by hand.

## Why this isn't purely additive

The controls page opened by asserting there are **two** control types and that **both** target a dimension and apply to charts. A parent control does neither — it has no dimension and drives other controls, which then apply themselves. So three existing passages were stating something that a new section alone would have contradicted:

- **Intro** — "two control types — both target a dimension…" reworded so the dimension claim attaches to the two types it's true of.
- **Visibility** — "applies to both filters and time granularity switchers" → all three. The **Hidden** row also now notes that hiding a parent's *children* is the usual way to present one dropdown instead of the row behind it.
- **Interaction with charts** — a parent never appears in a chart's Controls mapping. Said outright, so a reader doesn't go hunting for it there.

## Also

- `charts.mdx` — "controls — filters and time granularity switchers —" read as a definition of the whole category. Reworded so it describes which controls charts respect, which is still exactly those two.
- `docs-mintlify/CLAUDE.md` — **Parent** added under Controls in the product taxonomy, since that tree is the canonical naming source.

## Notes

- `<Info>`, not `<Note>` — the conventions reserve `<Note>` for plan-availability callouts.
- Anchors and link refs verified by hand (every `(#…)` resolves to a real heading; every `[ref-…]` is defined and used). `yarn broken-links` needs a `mintlify` binary that isn't installed locally.
- No `docs.json` nav change — everything lands inside the existing Controls page.