### PR TITLE
docs: what a duplicated workbook or dashboard does with the original's sharing

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
@@ -132,6 +132,18 @@ You can duplicate a workbook by selecting **Duplicate** from the row
 actions menu on the workspace page. This creates a full copy of the
 workbook, including all its tabs, reports, and any published dashboard.
 
+A duplicate does not carry the original's sharing over by default. The
+copy is visible only to you, plus anyone with access to the folder it is
+created in.
+
+If the original is shared — with people, with groups, with your whole
+organization, or through signed embedding — Cube asks first. Select
+**Copy sharing and embedding settings** in the duplicate dialog to give
+the copy the same audience. The option appears only if you have
+**Full access** to the original, since copying its sharing means granting
+that access again. See [Share content][ref-sharing] for the access levels
+involved.
+
 ## Workbook versions
 
 When you [publish a dashboard][ref-dashboards] from a workbook, Cube
@@ -151,4 +163,5 @@ has not been published will be lost.
 </Warning>
 
 [ref-dashboards]: /docs/explore-analyze/dashboards
+[ref-sharing]: /docs/organize-content/sharing
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
@@ -129,20 +129,21 @@ and paste it as a new tab in any workbook using the same workflow.
 ## Duplicating workbooks
 
 You can duplicate a workbook by selecting **Duplicate** from the row
-actions menu on the workspace page. This creates a full copy of the
-workbook, including all its tabs, reports, and any published dashboard.
+actions menu on the workspace page, from the workbook menu while the
+workbook is open, or from a published dashboard's options menu. This
+creates a full copy of the workbook, including all its tabs, reports, and
+any published dashboard.
 
 A duplicate does not carry the original's sharing over by default. The
 copy is visible only to you, plus anyone with access to the folder it is
 created in.
 
 If the original is shared — with people, with groups, with your whole
-organization, or through signed embedding — Cube asks first. Select
-**Copy sharing and embedding settings** in the duplicate dialog to give
-the copy the same audience. The option appears only if you have
-**Full access** to the original, since copying its sharing means granting
-that access again. See [Share content][ref-sharing] for the access levels
-involved.
+organization, or through signed embedding — the duplicate dialog offers
+**Copy sharing and embedding settings**. Selecting it gives the copy the
+same audience. The option appears only if you have **Full access** to the
+original, since copying its sharing means granting that access again. See
+[Duplicates][ref-sharing-duplicates] for what does and doesn't carry over.
 
 ## Workbook versions
 
@@ -163,5 +164,5 @@ has not been published will be lost.
 </Warning>
 
 [ref-dashboards]: /docs/explore-analyze/dashboards
-[ref-sharing]: /docs/organize-content/sharing
+[ref-sharing-duplicates]: /docs/organize-content/sharing#duplicates
 

--- a/docs-mintlify/docs/organize-content/sharing.mdx
+++ b/docs-mintlify/docs/organize-content/sharing.mdx
@@ -141,23 +141,6 @@ This ensures users can always navigate to content they have permission to
 view, even if they don't have explicit access to every folder along the
 path.
 
-## Sharing folders
-
-Sharing a folder is the most efficient way to manage access for a
-collection of related content:
-
-1. Navigate to the folder in the **Workspace** page.
-2. Open the folder's action menu and select **Share** (or open the folder
-   and click the **Share** button).
-3. Add users, groups, or set organization-wide access as described above.
-
-{/* Screenshot: Workspace page showing a folder's action menu with the "Share"
-option highlighted. */}
-
-All current and future content added to the folder will inherit its
-permissions. This makes folders ideal for organizing content by team or
-project, where everyone on the team needs the same level of access.
-
 ### Duplicates
 
 Duplicating a workbook or dashboard does not carry its sharing over by
@@ -174,6 +157,23 @@ it from the folder it is created in, like any other new content there.
 The option requires **Full access** to the original, since copying its
 sharing means granting that access again. With **Can edit** or
 **Can view**, duplicating still works and the copy starts unshared.
+
+## Sharing folders
+
+Sharing a folder is the most efficient way to manage access for a
+collection of related content:
+
+1. Navigate to the folder in the **Workspace** page.
+2. Open the folder's action menu and select **Share** (or open the folder
+   and click the **Share** button).
+3. Add users, groups, or set organization-wide access as described above.
+
+{/* Screenshot: Workspace page showing a folder's action menu with the "Share"
+option highlighted. */}
+
+All current and future content added to the folder will inherit its
+permissions. This makes folders ideal for organizing content by team or
+project, where everyone on the team needs the same level of access.
 
 ## Sharing explorations for spreadsheet integrations
 

--- a/docs-mintlify/docs/organize-content/sharing.mdx
+++ b/docs-mintlify/docs/organize-content/sharing.mdx
@@ -158,6 +158,23 @@ All current and future content added to the folder will inherit its
 permissions. This makes folders ideal for organizing content by team or
 project, where everyone on the team needs the same level of access.
 
+### Duplicates
+
+Duplicating a workbook or dashboard does not carry its sharing over by
+default — the copy starts visible only to you, plus anyone with access to
+the folder it is created in.
+
+When the original is shared, the duplicate dialog offers **Copy sharing
+and embedding settings**. Selecting it re-grants the original's users,
+groups, and organization-wide access on the copy, and carries over
+[signed embedding][ref-signed-embedding] if it was enabled. Access that
+the original inherits from a folder is not copied — the duplicate derives
+it from the folder it is created in, like any other new content there.
+
+The option requires **Full access** to the original, since copying its
+sharing means granting that access again. With **Can edit** or
+**Can view**, duplicating still works and the copy starts unshared.
+
 ## Sharing explorations for spreadsheet integrations
 
 When you share an exploration with a user, that exploration becomes
@@ -175,3 +192,4 @@ interface.
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-google-sheets]: /docs/integrations/google-sheets
 [ref-excel]: /docs/integrations/microsoft-excel
+[ref-signed-embedding]: /embedding/iframe/auth/signed


### PR DESCRIPTION
Follows [cubedevinc/cubejs-enterprise#14416](https://github.com/cubedevinc/cubejs-enterprise/pull/14416) (CUB-3462), which adds a **Copy sharing and embedding settings** checkbox to the duplicate dialog.

The docs were already incomplete before that change and are now more so:

- **`explore-analyze/workbooks` → Duplicating workbooks** said a duplicate is "a full copy of the workbook, including all its tabs, reports, and any published dashboard" and nothing about sharing. Since CUB-3296 a copy has started **unshared**, which was never written down; CUB-3462 turns that into a choice, and the choice is only offered to someone with Full access to the original.
- **`organize-content/sharing` → Permission inheritance** covered folder inheritance only. Duplicates are the other way content acquires (or doesn't acquire) an audience, so they get a short subsection there, including the part people get wrong: folder-inherited access is *not* copied — the duplicate re-derives it from the folder it lands in.

Both sections state the default (unshared), what ticking the box carries over (users, groups, organization-wide access, signed embedding), and the Full-access requirement.