### PR TITLE
docs: the dashboard controls now live behind an Add Controls menu

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -10,7 +10,7 @@ Controls are widgets that let dashboard viewers change what's shown without leav
 
 ## Filter
 
-Filter widgets let viewers narrow down the data shown on the dashboard. In the [dashboard builder][ref-workbooks], open **Add Controls** in the toolbar and choose **Filter**. The new filter is added in an unconfigured state — click **Configure Filter** (or open the widget's settings menu) to pick a semantic view and a dimension.
+Filter widgets let viewers narrow down the data shown on the dashboard. In the [dashboard builder][ref-workbooks], open the **Add Controls** menu in the toolbar and choose **Filter**. The new filter is added in an unconfigured state — click **Configure Filter** (or open the widget's settings menu) to pick a semantic view and a dimension.
 
 ### Operators by dimension type
 
@@ -78,7 +78,7 @@ For example, on a sales dashboard with a **Country** filter and a **City** filte
 
 Time granularity switchers let viewers change the granularity of time-based dimensions on the dashboard — for example, switching a revenue chart from daily to weekly or monthly. The widget targets a single time dimension and applies the chosen [granularity][ref-granularities] to every chart that groups by that dimension.
 
-In the [dashboard builder][ref-workbooks], open **Add Controls** in the toolbar and choose **Time Granularity**. The new switcher is added in an unconfigured state — open its settings to pick a semantic view and a time dimension.
+In the [dashboard builder][ref-workbooks], open the **Add Controls** menu in the toolbar and choose **Time Granularity**. The new switcher is added in an unconfigured state — open its settings to pick a semantic view and a time dimension.
 
 ### Allowed granularities
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -10,7 +10,7 @@ Controls are widgets that let dashboard viewers change what's shown without leav
 
 ## Filter
 
-Filter widgets let viewers narrow down the data shown on the dashboard. In the [dashboard builder][ref-workbooks], click **Filter** under **Add Controls** in the toolbar. The new filter is added in an unconfigured state — click **Configure Filter** (or open the widget's settings menu) to pick a semantic view and a dimension.
+Filter widgets let viewers narrow down the data shown on the dashboard. In the [dashboard builder][ref-workbooks], open **Add Controls** in the toolbar and choose **Filter**. The new filter is added in an unconfigured state — click **Configure Filter** (or open the widget's settings menu) to pick a semantic view and a dimension.
 
 ### Operators by dimension type
 
@@ -78,7 +78,7 @@ For example, on a sales dashboard with a **Country** filter and a **City** filte
 
 Time granularity switchers let viewers change the granularity of time-based dimensions on the dashboard — for example, switching a revenue chart from daily to weekly or monthly. The widget targets a single time dimension and applies the chosen [granularity][ref-granularities] to every chart that groups by that dimension.
 
-In the [dashboard builder][ref-workbooks], click **Time Granularity** under **Add Controls** in the toolbar. The new switcher is added in an unconfigured state — open its settings to pick a semantic view and a time dimension.
+In the [dashboard builder][ref-workbooks], open **Add Controls** in the toolbar and choose **Time Granularity**. The new switcher is added in an unconfigured state — open its settings to pick a semantic view and a time dimension.
 
 ### Allowed granularities
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -17,12 +17,14 @@ The dashboard builder supports the following widget types:
 
 ## Adding widgets
 
-Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or add a **Filter** or **Time Granularity** control from the **Add Controls** group.
+Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter** and **Time Granularity** controls.
 
 Each toolbar item can be added in two ways:
 
 - **Click** it to drop the widget into the first open spot on the canvas.
 - **Drag** it from the toolbar onto the canvas to place it exactly where you want. As you drag, a full-size placeholder previews the widget's footprint and the surrounding widgets reflow to open a slot; release to drop it there. Dragging is especially handy on dense dashboards, where clicking would otherwise place the new widget far down the page.
+
+For anything that lives in a menu — every option under **Add Widgets** and **Add Controls** — open the menu first. The option itself is the item you click or drag, and starting a drag closes the menu so it doesn't cover the canvas.
 
 <Warning>
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -19,12 +19,12 @@ The dashboard builder supports the following widget types:
 
 Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter** and **Time Granularity** controls.
 
-Each toolbar item can be added in two ways:
+Each item — a toolbar button, or an option inside the **Add Widgets** / **Add Controls** menus — can be added in two ways:
 
 - **Click** it to drop the widget into the first open spot on the canvas.
 - **Drag** it from the toolbar onto the canvas to place it exactly where you want. As you drag, a full-size placeholder previews the widget's footprint and the surrounding widgets reflow to open a slot; release to drop it there. Dragging is especially handy on dense dashboards, where clicking would otherwise place the new widget far down the page.
 
-For anything that lives in a menu — every option under **Add Widgets** and **Add Controls** — open the menu first. The option itself is the item you click or drag, and starting a drag closes the menu so it doesn't cover the canvas.
+Starting a drag from a menu option closes the menu, so it doesn't cover the canvas while you place the widget.
 
 <Warning>
 


### PR DESCRIPTION
Follows [cubedevinc/cubejs-enterprise#14422](https://github.com/cubedevinc/cubejs-enterprise/pull/14422) ([CUB-2791](https://linear.app/cube-d3/issue/CUB-2791/group-buttons-to-add-controls)), which replaces the dashboard-builder toolbar's `Add Controls:` label and its two buttons with a single **Add Controls** dropdown — the same shape as the **Add Widgets** menu beside it.

⚠️ **Please hold this until #14422 has merged and shipped**, so the docs don't describe a UI that isn't live yet.

## What changes

Three sentences described clicking buttons that no longer exist:

**`widgets/controls.mdx`**
- "click **Filter** under **Add Controls** in the toolbar" → "open **Add Controls** in the toolbar and choose **Filter**"
- same for **Time Granularity**

**`widgets/index.mdx`**
- "add a **Filter** or **Time Granularity** control from the **Add Controls** group" → "the **Add Controls** menu for **Filter** and **Time Granularity** controls", so it reads as a sibling of the **Add Widgets** menu named in the same sentence.

## One addition

The "Adding widgets" section says each toolbar item can be **clicked** or **dragged**, which was written when most items were bare toolbar buttons. Now that both control inserts (and everything under **Add Widgets**) are menu options, that needs one clarifying line: open the menu first, the option itself is what you click or drag, and starting a drag closes the menu so it doesn't cover the canvas.

Both behaviours are verified against the deployed branch on `staging-mngr-4` — including dragging an option out of the open dropdown onto the board.