### PR TITLE
fix(server-core): release orchestrator api evicted from the cache

### DIFF
--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -67,6 +67,9 @@ interface CubeStoreWebSocket extends WebSocket {
   // A failure that killed this socket and that re-sending can't fix, so the
   // message that caused it is rejected instead of being re-sent.
   fatalError: Error | null;
+  // Stops the heartbeat interval, which otherwise keeps a reference to this socket
+  // (and the socket itself alive) even when nothing else points to the connection.
+  teardown: () => void;
 }
 
 export class WebSocketConnection {
@@ -120,6 +123,8 @@ export class WebSocketConnection {
           }
         }, 5000);
 
+        webSocket.teardown = () => clearInterval(pingInterval);
+
         webSocket.sendAsync = async (message: Uint8Array) => new Promise<void>((resolveSend) => {
           // If socket is closing this message should be resent
           if (webSocket.readyState !== WebSocket.OPEN) {
@@ -166,6 +171,9 @@ export class WebSocketConnection {
 
           this.currentConnectionTry += 1;
 
+          webSocket.teardown();
+          webSocket.terminate();
+
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
               resolve(this.initWebSocket());
@@ -188,7 +196,7 @@ export class WebSocketConnection {
           webSocket.lastHeartBeat = new Date();
         });
         webSocket.on('close', (code: number, reason: Buffer) => {
-          clearInterval(pingInterval);
+          webSocket.teardown();
 
           const pending = Object.keys(webSocket.sentMessages);
 

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -112,6 +112,10 @@ export class WebSocketConnection {
       });
 
       webSocket.readyPromise = new Promise<CubeStoreWebSocket>((resolve, reject) => {
+        // Whether readyPromise is already settled, i.e. whether a retry still has
+        // somebody to answer.
+        let established = false;
+
         webSocket.lastHeartBeat = new Date();
         const pingInterval = setInterval(() => {
           if (webSocket.readyState === WebSocket.OPEN) {
@@ -145,7 +149,10 @@ export class WebSocketConnection {
             resolveSend();
           });
         });
-        webSocket.on('open', () => resolve(webSocket));
+        webSocket.on('open', () => {
+          established = true;
+          resolve(webSocket);
+        });
         webSocket.on('error', (err) => {
           if ((err as any).code === MAX_PAYLOAD_EXCEEDED_CODE) {
             // Cube Store answered with a message bigger than this connection
@@ -173,6 +180,19 @@ export class WebSocketConnection {
 
           webSocket.teardown();
           webSocket.terminate();
+
+          // Retrying is only useful while somebody is waiting for this socket to
+          // come up. Once it is established, reconnecting here would raise a
+          // connection nobody asked for and keep it alive with its own heartbeat:
+          // what was in flight is re-sent by the 'close' handler, and a later
+          // query establishes a new connection through initWebSocket().
+          if (established) {
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            return;
+          }
 
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
@@ -267,6 +287,13 @@ export class WebSocketConnection {
 
             setTimeout(async () => {
               try {
+                // Everything this re-send was scheduled for has been settled in
+                // the meantime, so there is nothing left to carry over and a new
+                // connection would just stay open on its heartbeat.
+                if (!Object.keys(webSocket.sentMessages).length) {
+                  return;
+                }
+
                 const nextWebSocket = await this.initWebSocket();
                 const resent = Object.keys(webSocket.sentMessages);
 

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -85,6 +85,10 @@ export class WebSocketConnection {
 
   protected webSocket: CubeStoreWebSocket | null = null;
 
+  // Set by close(): the owner of this connection is gone, so a socket must not
+  // be re-established behind its back.
+  protected closed: boolean = false;
+
   private readonly url: string;
 
   private readonly connectionId: string;
@@ -103,6 +107,10 @@ export class WebSocketConnection {
 
   protected async initWebSocket(): Promise<CubeStoreWebSocket> {
     if (!this.webSocket) {
+      // Somebody is asking for a connection, which is the only thing that
+      // revives a closed one.
+      this.closed = false;
+
       const headers: Record<string, string> = {};
       headers['x-process-id'] = getProcessUid();
 
@@ -114,7 +122,7 @@ export class WebSocketConnection {
       webSocket.readyPromise = new Promise<CubeStoreWebSocket>((resolve, reject) => {
         // Whether readyPromise is already settled, i.e. whether a retry still has
         // somebody to answer.
-        let established = false;
+        let settled = false;
 
         webSocket.lastHeartBeat = new Date();
         const pingInterval = setInterval(() => {
@@ -150,7 +158,7 @@ export class WebSocketConnection {
           });
         });
         webSocket.on('open', () => {
-          established = true;
+          settled = true;
           resolve(webSocket);
         });
         webSocket.on('error', (err) => {
@@ -171,28 +179,33 @@ export class WebSocketConnection {
             }
 
             // No-op if the connection was already established.
+            settled = true;
             reject(webSocket.fatalError);
 
             return;
           }
 
-          this.currentConnectionTry += 1;
-
           webSocket.teardown();
           webSocket.terminate();
 
-          // Retrying is only useful while somebody is waiting for this socket to
-          // come up. Once it is established, reconnecting here would raise a
-          // connection nobody asked for and keep it alive with its own heartbeat:
-          // what was in flight is re-sent by the 'close' handler, and a later
-          // query establishes a new connection through initWebSocket().
-          if (established) {
+          // Retrying is only useful while readyPromise can still answer somebody
+          // with the result. Once it is settled -- the socket came up, or its
+          // caller was already given an error -- reconnecting here would raise a
+          // connection nobody asked for and keep it alive with its own
+          // heartbeat: what was in flight is re-sent by the 'close' handler, and
+          // a later query establishes a new connection through initWebSocket().
+          if (settled) {
             if (webSocket === this.webSocket) {
               this.webSocket = null;
             }
 
             return;
           }
+
+          // Counts connection attempts, so it is only bumped for a socket that
+          // never came up.
+          this.currentConnectionTry += 1;
+          settled = true;
 
           if (this.currentConnectionTry < this.maxConnectRetries) {
             setTimeout(async () => {
@@ -219,6 +232,26 @@ export class WebSocketConnection {
           webSocket.teardown();
 
           const pending = Object.keys(webSocket.sentMessages);
+
+          if (this.closed) {
+            // The owner of this connection released it, so a re-send would carry
+            // the messages over to a socket nobody owns, which its own heartbeat
+            // would then keep open for the rest of the process. The drivers this
+            // query needs are being closed anyway, so it is failed here rather
+            // than left to hang.
+            // eslint-disable-next-line no-restricted-syntax
+            for (const key of pending) {
+              const sentMessage = webSocket.sentMessages[key];
+              delete webSocket.sentMessages[key];
+              sentMessage.reject(new ConnectionError('Cube Store connection is closed'));
+            }
+
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            return;
+          }
 
           if (pending.length) {
             // Cube Store names the size and the limit that refused it here,
@@ -566,7 +599,13 @@ export class WebSocketConnection {
   }
 
   public close() {
+    this.closed = true;
+
     if (this.webSocket) {
+      // Not left to the 'close' event: a socket that never reaches it -- one
+      // still connecting, or one whose peer is gone -- would keep the heartbeat
+      // running, and the heartbeat is what keeps the socket itself reachable.
+      this.webSocket.teardown();
       this.webSocket.close();
     }
   }

--- a/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
+++ b/packages/cubejs-cubestore-driver/src/WebSocketConnection.ts
@@ -107,10 +107,6 @@ export class WebSocketConnection {
 
   protected async initWebSocket(): Promise<CubeStoreWebSocket> {
     if (!this.webSocket) {
-      // Somebody is asking for a connection, which is the only thing that
-      // revives a closed one.
-      this.closed = false;
-
       const headers: Record<string, string> = {};
       headers['x-process-id'] = getProcessUid();
 
@@ -202,6 +198,19 @@ export class WebSocketConnection {
             return;
           }
 
+          // A released connection reconnects only to deliver what is still in
+          // flight; with nothing left there is nobody to reconnect for.
+          if (this.closed && !Object.keys(webSocket.sentMessages).length) {
+            if (webSocket === this.webSocket) {
+              this.webSocket = null;
+            }
+
+            settled = true;
+            reject(new ConnectionError('Cube Store connection is closed', err));
+
+            return;
+          }
+
           // Counts connection attempts, so it is only bumped for a socket that
           // never came up.
           this.currentConnectionTry += 1;
@@ -233,22 +242,15 @@ export class WebSocketConnection {
 
           const pending = Object.keys(webSocket.sentMessages);
 
-          if (this.closed) {
-            // The owner of this connection released it, so a re-send would carry
-            // the messages over to a socket nobody owns, which its own heartbeat
-            // would then keep open for the rest of the process. The drivers this
-            // query needs are being closed anyway, so it is failed here rather
-            // than left to hang.
-            // eslint-disable-next-line no-restricted-syntax
-            for (const key of pending) {
-              const sentMessage = webSocket.sentMessages[key];
-              delete webSocket.sentMessages[key];
-              sentMessage.reject(new ConnectionError('Cube Store connection is closed'));
-            }
-
+          if (this.closed && !pending.length) {
             if (webSocket === this.webSocket) {
               this.webSocket = null;
             }
+
+            // Closed before it came up: whoever is waiting on initWebSocket() has
+            // nothing else to settle it.
+            settled = true;
+            reject(new ConnectionError('Cube Store connection is closed'));
 
             return;
           }
@@ -368,6 +370,13 @@ export class WebSocketConnection {
 
           delete webSocket.sentMessages[httpMessage.messageId()];
 
+          // Everything that was in flight when the connection was released has
+          // been answered, so there is nothing left to keep it open for.
+          if (this.closed && !Object.keys(webSocket.sentMessages).length) {
+            webSocket.teardown();
+            webSocket.close();
+          }
+
           if (httpMessage.commandType() === HttpCommand.HttpError) {
             resolver.reject(new QueryError(`${httpMessage.command(new HttpError())?.error()}`));
             return;
@@ -395,6 +404,10 @@ export class WebSocketConnection {
   }
 
   private async sendMessage(messageId: number, buffer: Uint8Array): Promise<any> {
+    if (this.closed) {
+      throw new ConnectionError('Cube Store connection is closed');
+    }
+
     if (buffer.length > this.maxMessageSize) {
       // Cube Store would close the connection on such a message, which shows up
       // as an unrelated `write EPIPE`, so report it before sending anything.
@@ -599,9 +612,11 @@ export class WebSocketConnection {
   }
 
   public close() {
+    // From here on the connection takes no new queries, and it closes as soon as
+    // the ones already sent have been answered.
     this.closed = true;
 
-    if (this.webSocket) {
+    if (this.webSocket && !Object.keys(this.webSocket.sentMessages).length) {
       // Not left to the 'close' event: a socket that never reaches it -- one
       // still connecting, or one whose peer is gone -- would keep the heartbeat
       // running, and the heartbeat is what keeps the socket itself reachable.

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -75,6 +75,28 @@ describe('WebSocketConnection', () => {
     await expect(promise).rejects.toThrow(answeredBy(connectionIndex));
   };
 
+  /**
+   * Waits until the given number of server-side connections are gone, which is
+   * how a socket the driver was supposed to close shows up from the outside.
+   */
+  const waitForClosedConnections = async (count: number) => {
+    const deadline = Date.now() + 10000;
+
+    for (;;) {
+      const closed = server.connections.filter((c) => c.ws.readyState === c.ws.CLOSED);
+
+      if (closed.length >= count) {
+        return;
+      }
+
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for ${count} closed connection(s), have ${closed.length}`);
+      }
+
+      await new Promise((resolve) => { setTimeout(resolve, 25); });
+    }
+  };
+
   // The socket the driver is writing to right now.
   const clientSocket = (): Socket => (connection as any).webSocket._socket;
 
@@ -190,28 +212,67 @@ describe('WebSocketConnection', () => {
     await expectAnsweredBy(query('SELECT 2'), 1);
   }, JEST_TIMEOUT);
 
-  it('does not re-establish the connection when it is closed with queries in flight', async () => {
+  it('delivers the queries in flight when it is closed, then closes', async () => {
     connection = new WebSocketConnection(server.url);
 
-    // Cube Store never answers, so the query stays in flight.
-    server.handler = () => {
-      // noop
+    let answer: (() => void) | null = null;
+    server.handler = (message, mockConnection) => {
+      answer = () => mockConnection.ws.send(buildErrorMessage(message.messageId, answeredBy(mockConnection.index)));
     };
 
     const promise = query('SELECT 1');
     await server.waitForMessages(1);
 
-    // What releasing the driver ends up calling. Carrying the query over to a
-    // new connection would leave that connection open on its heartbeat with
-    // nobody owning it, so the query is failed instead.
+    // What releasing the driver ends up calling. The query was already sent, so
+    // it is answered rather than dropped.
     connection!.close();
 
-    await expect(promise).rejects.toThrow(ConnectionError);
-    await expect(promise).rejects.toThrow('Cube Store connection is closed');
+    answer!();
+    await expectAnsweredBy(promise, 0);
 
-    // Longer than the re-send the driver would have scheduled.
-    await new Promise((resolve) => { setTimeout(resolve, 3000); });
+    // And once it is answered, the socket goes.
+    await waitForClosedConnections(1);
 
+    // A released connection takes no new queries either.
+    await expect(query('SELECT 2')).rejects.toThrow('Cube Store connection is closed');
+
+    expect(server.connections.length).toBe(1);
+  }, JEST_TIMEOUT);
+
+  it('re-sends what is in flight when a released connection breaks, then closes', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    server.handler = (message, mockConnection) => {
+      if (mockConnection.index === 0) {
+        // Cube Store went away with the query still in flight.
+        mockConnection.ws.close();
+        return;
+      }
+
+      mockConnection.ws.send(buildErrorMessage(message.messageId, answeredBy(mockConnection.index)));
+    };
+
+    const promise = query('SELECT 1');
+    await server.waitForMessages(1);
+
+    connection!.close();
+
+    // Delivering it is worth a new connection; keeping that connection past the
+    // answer is not.
+    await expectAnsweredBy(promise, 1);
+    await waitForClosedConnections(2);
+  }, JEST_TIMEOUT);
+
+  it('takes no queries once it is closed with nothing in flight', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    connection!.close();
+
+    await expect(query('SELECT 2')).rejects.toThrow('Cube Store connection is closed');
+
+    await waitForClosedConnections(1);
     expect(server.connections.length).toBe(1);
   }, JEST_TIMEOUT);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -152,6 +152,44 @@ describe('WebSocketConnection', () => {
     await expectAnsweredBy(query('SELECT 2'), 1);
   }, JEST_TIMEOUT);
 
+  it('does not reconnect when the connection breaks with nothing in flight', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    // Cube Store goes away while the connection sits idle. Nothing is waiting
+    // for it and nothing has to be re-sent, so re-establishing it would only
+    // produce a connection that stays open on its heartbeat until the process
+    // ends.
+    clientSocket().destroy(epipe());
+
+    // Longer than the retry the driver would have scheduled.
+    await new Promise((resolve) => { setTimeout(resolve, 3000); });
+
+    expect(server.connections.length).toBe(1);
+
+    // The next query establishes a new connection instead.
+    await expectAnsweredBy(query('SELECT 2'), 1);
+  }, JEST_TIMEOUT);
+
+  it('does not reconnect when an established connection fails with nothing in flight', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    await expectAnsweredBy(query('SELECT 1'), 0);
+
+    // A malformed frame is the failure `ws` reports as an 'error' on a live
+    // connection, where an ordinary disconnect only reports a 'close'. Retrying
+    // it answers nobody -- the connection is long established -- and leaves a
+    // connection running on its own heartbeat.
+    server.connection(0).socket.write(Buffer.from([0xff, 0xff, 0xff, 0xff]));
+
+    await new Promise((resolve) => { setTimeout(resolve, 3000); });
+
+    expect(server.connections.length).toBe(1);
+
+    await expectAnsweredBy(query('SELECT 2'), 1);
+  }, JEST_TIMEOUT);
+
   it('resends a query when Cube Store closes the connection without answering', async () => {
     connection = new WebSocketConnection(server.url);
 

--- a/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
+++ b/packages/cubejs-cubestore-driver/test/websocket-connection.test.ts
@@ -1,7 +1,7 @@
 import { Socket } from 'net';
 
 import { WebSocketConnection } from '../src/WebSocketConnection';
-import { MessageTooLargeError, QueryError } from '../src/errors';
+import { ConnectionError, MessageTooLargeError, QueryError } from '../src/errors';
 import { QueryResultFormat } from '../codegen';
 import {
   answeredBy,
@@ -188,6 +188,31 @@ describe('WebSocketConnection', () => {
     expect(server.connections.length).toBe(1);
 
     await expectAnsweredBy(query('SELECT 2'), 1);
+  }, JEST_TIMEOUT);
+
+  it('does not re-establish the connection when it is closed with queries in flight', async () => {
+    connection = new WebSocketConnection(server.url);
+
+    // Cube Store never answers, so the query stays in flight.
+    server.handler = () => {
+      // noop
+    };
+
+    const promise = query('SELECT 1');
+    await server.waitForMessages(1);
+
+    // What releasing the driver ends up calling. Carrying the query over to a
+    // new connection would leave that connection open on its heartbeat with
+    // nobody owning it, so the query is failed instead.
+    connection!.close();
+
+    await expect(promise).rejects.toThrow(ConnectionError);
+    await expect(promise).rejects.toThrow('Cube Store connection is closed');
+
+    // Longer than the re-send the driver would have scheduled.
+    await new Promise((resolve) => { setTimeout(resolve, 3000); });
+
+    expect(server.connections.length).toBe(1);
   }, JEST_TIMEOUT);
 
   it('resends a query when Cube Store closes the connection without answering', async () => {

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -3,6 +3,7 @@ import * as stream from 'stream';
 import pt from 'promise-timeout';
 import {
   ContinueWaitError,
+  DriverFactory,
   DriverFactoryByDataSource,
   DriverType,
   QueryBody,
@@ -25,12 +26,25 @@ export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
  */
 const HOLDERS_TIMEOUT = 10 * 60 * 1000;
 
+/**
+ * How long the count has to stay at zero to mean the work is over. One logical
+ * operation is several calls on the same api, and the count drops back to zero
+ * between them.
+ */
+const HOLDERS_LINGER = 2 * 1000;
+
 export class OrchestratorApi {
   private seenDataSources: Record<string, boolean> = {};
 
   private holders: number = 0;
 
   private drained: (() => void)[] = [];
+
+  protected readonly holdersLinger: number = HOLDERS_LINGER;
+
+  private externalDriverSeen: boolean = false;
+
+  protected readonly externalDriverFactory?: DriverFactory;
 
   protected orchestrator: QueryOrchestrator;
 
@@ -43,11 +57,23 @@ export class OrchestratorApi {
   ) {
     this.continueWaitTimeout = this.options.continueWaitTimeout || 10;
 
+    const { externalDriverFactory } = options;
+
+    // Asking the factory for the driver is what creates it, so this is where the
+    // tenant stops being one without an external connection. Everything that can
+    // reach the external driver goes through this, release() included, so that it
+    // doesn't open a connection just to close it.
+    this.externalDriverFactory = externalDriverFactory && (async () => {
+      this.externalDriverSeen = true;
+
+      return externalDriverFactory();
+    });
+
     this.orchestrator = new QueryOrchestrator(
       options.redisPrefix || 'STANDALONE',
       driverFactory,
       logger,
-      options
+      { ...options, externalDriverFactory: this.externalDriverFactory }
     );
   }
 
@@ -95,27 +121,60 @@ export class OrchestratorApi {
   }
 
   protected async waitForHolders(): Promise<void> {
-    if (!this.holders) {
+    const deadline = Date.now() + HOLDERS_TIMEOUT;
+
+    for (;;) {
+      if (this.holders && !await this.waitForDrain(deadline - Date.now())) {
+        this.logger('Orchestrator api released with work in progress', {
+          warning: `${this.holders} operation(s) did not finish within ${HOLDERS_TIMEOUT / 1000}s, ` +
+            'their connections are being closed anyway',
+        });
+
+        return;
+      }
+
+      await this.sleep(Math.min(this.holdersLinger, Math.max(deadline - Date.now(), 0)));
+
+      if (!this.holders || Date.now() >= deadline) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Resolves true once nothing is holding the api, false if that didn't happen
+   * within the timeout.
+   */
+  protected async waitForDrain(timeout: number): Promise<boolean> {
+    let onDrained: () => void = () => undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      return await new Promise<boolean>((resolve) => {
+        onDrained = () => resolve(true);
+        this.drained.push(onDrained);
+
+        timer = setTimeout(() => resolve(false), Math.max(timeout, 0));
+        timer.unref?.();
+      });
+    } finally {
+      // Neither outcome needs the other one anymore, and both of them keep this
+      // api reachable -- the timer from the timer queue, the resolver from the
+      // array a later drain walks.
+      clearTimeout(timer);
+      this.drained = this.drained.filter(resolve => resolve !== onDrained);
+    }
+  }
+
+  protected async sleep(ms: number): Promise<void> {
+    if (!ms) {
       return;
     }
 
-    await Promise.race([
-      new Promise<void>((resolve) => {
-        this.drained.push(resolve);
-      }),
-      new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          this.logger('Orchestrator api released with work in progress', {
-            warning: `${this.holders} operation(s) did not finish within ${HOLDERS_TIMEOUT / 1000}s, ` +
-              'their connections are being closed anyway',
-          });
-
-          resolve();
-        }, HOLDERS_TIMEOUT);
-
-        timer.unref?.();
-      }),
-    ]);
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, ms);
+      timer.unref?.();
+    });
   }
 
   /**
@@ -270,13 +329,13 @@ export class OrchestratorApi {
    */
   public async testConnection() {
     if (this.options.rollupOnlyMode) {
-      return this.testDriverConnection(this.options.externalDriverFactory, DriverType.External);
+      return this.testDriverConnection(this.externalDriverFactory, DriverType.External);
     } else {
       return Promise.all([
         ...Object.keys(this.seenDataSources).map(
           ds => this.testDriverConnection(this.driverFactory, DriverType.Internal, ds),
         ),
-        this.testDriverConnection(this.options.externalDriverFactory, DriverType.External),
+        this.testDriverConnection(this.externalDriverFactory, DriverType.External),
       ]);
     }
   }
@@ -332,15 +391,20 @@ export class OrchestratorApi {
     ));
   }
 
-  public async release() {
+  public async release({ waitForWork = true }: { waitForWork?: boolean } = {}) {
     // Leaving the cache is not the same as being unused: whoever was handed this
     // api keeps it for the whole of their work, so the drivers can only be closed
-    // once that work is done.
-    await this.waitForHolders();
+    // once that work is done. A process that is shutting down is the exception:
+    // there is nothing left to protect, and its own killer gives it seconds.
+    if (waitForWork) {
+      await this.waitForHolders();
+    }
 
     return Promise.all([
       ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
-      this.releaseDriver(this.options.externalDriverFactory),
+      // Only if there is something to release: the factory would otherwise open
+      // a connection for a tenant that never had one.
+      this.externalDriverSeen ? this.releaseDriver(this.externalDriverFactory) : undefined,
       this.orchestrator.cleanup()
     ]);
   }

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -18,8 +18,19 @@ export interface OrchestratorApiOptions extends QueryOrchestratorOptions {
   redisPrefix?: string;
 }
 
+/**
+ * How long release() waits for the work that is already in progress. Past it the
+ * connections are closed anyway: work that never finishes must not keep them
+ * open for the rest of the process.
+ */
+const HOLDERS_TIMEOUT = 10 * 60 * 1000;
+
 export class OrchestratorApi {
   private seenDataSources: Record<string, boolean> = {};
+
+  private holders: number = 0;
+
+  private drained: (() => void)[] = [];
 
   protected orchestrator: QueryOrchestrator;
 
@@ -48,10 +59,70 @@ export class OrchestratorApi {
   }
 
   /**
+   * Marks the api as being used until the returned function is called, which
+   * holds off release(). The methods below do it themselves; a caller that
+   * reaches the drivers through getQueryOrchestrator() has to do it by hand.
+   */
+  public acquire(): () => void {
+    this.holders += 1;
+
+    let released = false;
+
+    return () => {
+      if (released) {
+        return;
+      }
+
+      released = true;
+      this.holders -= 1;
+
+      if (!this.holders) {
+        const { drained } = this;
+        this.drained = [];
+        drained.forEach(resolve => resolve());
+      }
+    };
+  }
+
+  protected async hold<T>(work: () => Promise<T>): Promise<T> {
+    const release = this.acquire();
+
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  }
+
+  protected async waitForHolders(): Promise<void> {
+    if (!this.holders) {
+      return;
+    }
+
+    await Promise.race([
+      new Promise<void>((resolve) => {
+        this.drained.push(resolve);
+      }),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          this.logger('Orchestrator api released with work in progress', {
+            warning: `${this.holders} operation(s) did not finish within ${HOLDERS_TIMEOUT / 1000}s, ` +
+              'their connections are being closed anyway',
+          });
+
+          resolve();
+        }, HOLDERS_TIMEOUT);
+
+        timer.unref?.();
+      }),
+    ]);
+  }
+
+  /**
    * Force reconcile queue logic to be executed.
    */
   public async forceReconcile(datasource = 'default') {
-    await this.orchestrator.forceReconcile(datasource);
+    await this.hold(() => this.orchestrator.forceReconcile(datasource));
   }
 
   /**
@@ -61,8 +132,22 @@ export class OrchestratorApi {
    * @throw Error
    */
   public async streamQuery(query: QueryBody): Promise<stream.Writable> {
-    // TODO merge with fetchQuery
-    return this.orchestrator.streamQuery(query);
+    const release = this.acquire();
+
+    try {
+      // TODO merge with fetchQuery
+      const result = await this.orchestrator.streamQuery(query);
+
+      // The stream outlives this call, so the api stays held until the consumer
+      // is done with it.
+      stream.finished(result, () => release());
+
+      return result;
+    } catch (e) {
+      release();
+
+      throw e;
+    }
   }
 
   /**
@@ -71,6 +156,10 @@ export class OrchestratorApi {
    * error otherwise.
    */
   public async executeQuery(query: QueryBody) {
+    return this.hold(() => this.runQuery(query));
+  }
+
+  protected async runQuery(query: QueryBody) {
     const queryForLog = query.query?.replace(/\s+/g, ' ');
     const startQueryTime = (new Date()).getTime();
 
@@ -172,7 +261,7 @@ export class OrchestratorApi {
   }
 
   public async testOrchestratorConnections() {
-    return this.orchestrator.testConnections();
+    return this.hold(() => this.orchestrator.testConnections());
   }
 
   /**
@@ -202,6 +291,8 @@ export class OrchestratorApi {
     dataSource: string = 'default',
   ) {
     if (driverFn) {
+      const release = this.acquire();
+
       try {
         const driver = await driverFn(dataSource);
         await driver.testConnection();
@@ -212,6 +303,8 @@ export class OrchestratorApi {
       } catch (e: any) {
         e.driverType = driverType;
         throw e;
+      } finally {
+        release();
       }
     }
   }
@@ -228,7 +321,7 @@ export class OrchestratorApi {
     key: any,
     token: string,
   ): Promise<[boolean, string]> {
-    return this.orchestrator.isPartitionExist(
+    return this.hold(() => this.orchestrator.isPartitionExist(
       request,
       external,
       dataSource,
@@ -236,10 +329,15 @@ export class OrchestratorApi {
       table,
       key,
       token,
-    );
+    ));
   }
 
   public async release() {
+    // Leaving the cache is not the same as being unused: whoever was handed this
+    // api keeps it for the whole of their work, so the drivers can only be closed
+    // once that work is done.
+    await this.waitForHolders();
+
     return Promise.all([
       ...Object.keys(this.seenDataSources).map(ds => this.releaseDriver(this.driverFactory, ds)),
       this.releaseDriver(this.options.externalDriverFactory),
@@ -261,20 +359,20 @@ export class OrchestratorApi {
   }
 
   public getPreAggregationVersionEntries(context: RequestContext, preAggregations, preAggregationsSchema): Promise<any> {
-    return this.orchestrator.getPreAggregationVersionEntries(
+    return this.hold(() => this.orchestrator.getPreAggregationVersionEntries(
       preAggregations,
       preAggregationsSchema,
       context.requestId
-    );
+    ));
   }
 
   public getPreAggregationPreview(context: RequestContext, preAggregation) {
-    return this.orchestrator.getPreAggregationPreview(context.requestId, preAggregation);
+    return this.hold(() => this.orchestrator.getPreAggregationPreview(context.requestId, preAggregation));
   }
 
   public async expandPartitionsInPreAggregations(queryBody) {
     try {
-      return await this.orchestrator.expandPartitionsInPreAggregations(queryBody);
+      return await this.hold(() => this.orchestrator.expandPartitionsInPreAggregations(queryBody));
     } catch (err) {
       if (err instanceof ContinueWaitError) {
         throw {
@@ -286,22 +384,22 @@ export class OrchestratorApi {
   }
 
   public async checkPartitionsBuildRangeCache(queryBody) {
-    return this.orchestrator.checkPartitionsBuildRangeCache(queryBody);
+    return this.hold(() => this.orchestrator.checkPartitionsBuildRangeCache(queryBody));
   }
 
   public async getPreAggregationQueueStates(dataSource?: string) {
-    return this.orchestrator.getPreAggregationQueueStates(dataSource);
+    return this.hold(() => this.orchestrator.getPreAggregationQueueStates(dataSource));
   }
 
   public async cancelPreAggregationQueriesFromQueue(queryKeys: string[], dataSource: string) {
-    return this.orchestrator.cancelPreAggregationQueriesFromQueue(queryKeys, dataSource);
+    return this.hold(() => this.orchestrator.cancelPreAggregationQueriesFromQueue(queryKeys, dataSource));
   }
 
   public async cancelQueryByRequestId(requestId: string) {
-    return this.orchestrator.cancelQueryByRequestId(requestId);
+    return this.hold(() => this.orchestrator.cancelQueryByRequestId(requestId));
   }
 
   public async updateRefreshEndReached() {
-    return this.orchestrator.updateRefreshEndReached();
+    return this.hold(() => this.orchestrator.updateRefreshEndReached());
   }
 }

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -1,12 +1,31 @@
 import { LRUCache } from 'lru-cache';
 import type { OrchestratorApi } from './OrchestratorApi';
 
+/**
+ * How long an api that left the cache is kept before its connections are
+ * closed. Leaving the cache doesn't mean nobody is using it: a request holds
+ * the reference it was given across the whole of its work, so releasing right
+ * away would close the drivers under a running query.
+ */
+const RELEASE_DELAY = 30 * 1000;
+
+interface ScheduledRelease {
+  api: OrchestratorApi;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 export class OrchestratorStorage {
   protected readonly storage: LRUCache<string, OrchestratorApi>;
 
+  protected readonly releaseDelay: number;
+
+  protected readonly scheduledReleases: Set<ScheduledRelease> = new Set();
+
   protected readonly pendingReleases: Set<Promise<void>> = new Set();
 
-  public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean } = { compilerCacheSize: 100 }) {
+  public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean, releaseDelay?: number } = { compilerCacheSize: 100 }) {
+    this.releaseDelay = options.releaseDelay ?? RELEASE_DELAY;
+
     this.storage = new LRUCache<string, OrchestratorApi>({
       max: options.compilerCacheSize,
       ttl: options.maxCompilerCacheKeepAlive,
@@ -18,9 +37,25 @@ export class OrchestratorStorage {
       // disposeAfter, not dispose: release() is async and calls into the drivers, while
       // dispose runs synchronously inside set()/delete().
       disposeAfter: (api: OrchestratorApi) => {
-        this.release(api);
+        this.scheduleRelease(api);
       },
     });
+  }
+
+  protected scheduleRelease(api: OrchestratorApi) {
+    const scheduled: ScheduledRelease = {
+      api,
+      timer: setTimeout(() => {
+        this.scheduledReleases.delete(scheduled);
+        this.release(api);
+      }, this.releaseDelay),
+    };
+
+    // A release that is only waiting out its delay is not a reason to keep the
+    // process running.
+    scheduled.timer.unref?.();
+
+    this.scheduledReleases.add(scheduled);
   }
 
   protected release(api: OrchestratorApi) {
@@ -36,6 +71,15 @@ export class OrchestratorStorage {
       });
 
     this.pendingReleases.add(pending);
+  }
+
+  protected releaseScheduled() {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const scheduled of [...this.scheduledReleases]) {
+      clearTimeout(scheduled.timer);
+      this.scheduledReleases.delete(scheduled);
+      this.release(scheduled.api);
+    }
   }
 
   public has(orchestratorId: string) {
@@ -63,8 +107,12 @@ export class OrchestratorStorage {
   }
 
   public async releaseConnections() {
-    // clear() disposes every entry, which schedules release() for each of them.
+    // clear() disposes every entry, which schedules a release for each of them.
     this.storage.clear();
+
+    // Nothing is going to run after this, so the delay that protects a running
+    // query has nothing left to protect.
+    this.releaseScheduled();
 
     await Promise.all([...this.pendingReleases]);
   }

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -76,6 +76,11 @@ export class OrchestratorStorage {
    * force killed halfway is worse than cutting the queries off.
    */
   public async releaseConnections({ waitForWork = true }: { waitForWork?: boolean } = {}) {
+    // A release from an earlier removal is waiting out the work its api was
+    // serving, and that wait is exactly what this path can't afford: whatever it
+    // doesn't get to close, the process going away does.
+    const earlier = waitForWork ? new Set<Promise<void>>() : new Set(this.pendingReleases);
+
     this.releaseWaitsForWork = waitForWork;
 
     try {
@@ -85,6 +90,6 @@ export class OrchestratorStorage {
       this.releaseWaitsForWork = true;
     }
 
-    await Promise.all([...this.pendingReleases]);
+    await Promise.all([...this.pendingReleases].filter(release => !earlier.has(release)));
   }
 }

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -1,31 +1,12 @@
 import { LRUCache } from 'lru-cache';
 import type { OrchestratorApi } from './OrchestratorApi';
 
-/**
- * How long an api that left the cache is kept before its connections are
- * closed. Leaving the cache doesn't mean nobody is using it: a request holds
- * the reference it was given across the whole of its work, so releasing right
- * away would close the drivers under a running query.
- */
-const RELEASE_DELAY = 30 * 1000;
-
-interface ScheduledRelease {
-  api: OrchestratorApi;
-  timer: ReturnType<typeof setTimeout>;
-}
-
 export class OrchestratorStorage {
   protected readonly storage: LRUCache<string, OrchestratorApi>;
 
-  protected readonly releaseDelay: number;
-
-  protected readonly scheduledReleases: Set<ScheduledRelease> = new Set();
-
   protected readonly pendingReleases: Set<Promise<void>> = new Set();
 
-  public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean, releaseDelay?: number } = { compilerCacheSize: 100 }) {
-    this.releaseDelay = options.releaseDelay ?? RELEASE_DELAY;
-
+  public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean } = { compilerCacheSize: 100 }) {
     this.storage = new LRUCache<string, OrchestratorApi>({
       max: options.compilerCacheSize,
       ttl: options.maxCompilerCacheKeepAlive,
@@ -34,28 +15,13 @@ export class OrchestratorStorage {
       // reachable through the cache anymore, so its connections have to be closed.
       // Without it an evicted api keeps its Cube Store web socket open forever: the heartbeat
       // interval holds a reference to the socket, so it is never garbage collected either.
+      // The api itself holds the release off until the work it was handed to is done.
       // disposeAfter, not dispose: release() is async and calls into the drivers, while
       // dispose runs synchronously inside set()/delete().
       disposeAfter: (api: OrchestratorApi) => {
-        this.scheduleRelease(api);
+        this.release(api);
       },
     });
-  }
-
-  protected scheduleRelease(api: OrchestratorApi) {
-    const scheduled: ScheduledRelease = {
-      api,
-      timer: setTimeout(() => {
-        this.scheduledReleases.delete(scheduled);
-        this.release(api);
-      }, this.releaseDelay),
-    };
-
-    // A release that is only waiting out its delay is not a reason to keep the
-    // process running.
-    scheduled.timer.unref?.();
-
-    this.scheduledReleases.add(scheduled);
   }
 
   protected release(api: OrchestratorApi) {
@@ -71,15 +37,6 @@ export class OrchestratorStorage {
       });
 
     this.pendingReleases.add(pending);
-  }
-
-  protected releaseScheduled() {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const scheduled of [...this.scheduledReleases]) {
-      clearTimeout(scheduled.timer);
-      this.scheduledReleases.delete(scheduled);
-      this.release(scheduled.api);
-    }
   }
 
   public has(orchestratorId: string) {
@@ -107,12 +64,8 @@ export class OrchestratorStorage {
   }
 
   public async releaseConnections() {
-    // clear() disposes every entry, which schedules a release for each of them.
+    // clear() disposes every entry, which schedules release() for each of them.
     this.storage.clear();
-
-    // Nothing is going to run after this, so the delay that protects a running
-    // query has nothing left to protect.
-    this.releaseScheduled();
 
     await Promise.all([...this.pendingReleases]);
   }

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -4,12 +4,33 @@ import type { OrchestratorApi } from './OrchestratorApi';
 export class OrchestratorStorage {
   protected readonly storage: LRUCache<string, OrchestratorApi>;
 
+  protected readonly pendingReleases: Set<Promise<void>> = new Set();
+
   public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean } = { compilerCacheSize: 100 }) {
     this.storage = new LRUCache<string, OrchestratorApi>({
       max: options.compilerCacheSize,
       ttl: options.maxCompilerCacheKeepAlive,
-      updateAgeOnGet: options.updateCompilerCacheKeepAlive
+      updateAgeOnGet: options.updateCompilerCacheKeepAlive,
+      // Any removal reason ('evict' | 'set' | 'delete' | 'expire') means the api is not
+      // reachable through the cache anymore, so its connections have to be closed.
+      // Without it an evicted api keeps its Cube Store web socket open forever: the heartbeat
+      // interval holds a reference to the socket, so it is never garbage collected either.
+      // disposeAfter, not dispose: release() is async and calls into the drivers, while
+      // dispose runs synchronously inside set()/delete().
+      disposeAfter: (api: OrchestratorApi) => {
+        this.release(api);
+      },
     });
+  }
+
+  protected release(api: OrchestratorApi) {
+    const pending: Promise<void> = api.release()
+      .then(() => undefined, () => undefined)
+      .then(() => {
+        this.pendingReleases.delete(pending);
+      });
+
+    this.pendingReleases.add(pending);
   }
 
   public has(orchestratorId: string) {
@@ -37,7 +58,9 @@ export class OrchestratorStorage {
   }
 
   public async releaseConnections() {
-    await Promise.all([...this.storage.values()].map(api => api.release()));
+    // clear() disposes every entry, which schedules release() for each of them.
     this.storage.clear();
+
+    await Promise.all([...this.pendingReleases]);
   }
 }

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -25,7 +25,12 @@ export class OrchestratorStorage {
 
   protected release(api: OrchestratorApi) {
     const pending: Promise<void> = api.release()
-      .then(() => undefined, () => undefined)
+      .then(() => undefined, (e) => {
+        // Swallowed so that releasing a dead tenant can't take the process down
+        // with an unhandled rejection, but not silently: connections this failed
+        // to close stay open, which is the very thing the release is for.
+        console.error('Failed to release an orchestrator api', e);
+      })
       .then(() => {
         this.pendingReleases.delete(pending);
       });

--- a/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorStorage.ts
@@ -6,6 +6,13 @@ export class OrchestratorStorage {
 
   protected readonly pendingReleases: Set<Promise<void>> = new Set();
 
+  /**
+   * What the release triggered by the next cache removal does about the work an
+   * api is still serving. Read by disposeAfter, which takes no arguments of its
+   * own.
+   */
+  protected releaseWaitsForWork: boolean = true;
+
   public constructor(options: { compilerCacheSize?: number, maxCompilerCacheKeepAlive?: number, updateCompilerCacheKeepAlive?: boolean } = { compilerCacheSize: 100 }) {
     this.storage = new LRUCache<string, OrchestratorApi>({
       max: options.compilerCacheSize,
@@ -25,7 +32,7 @@ export class OrchestratorStorage {
   }
 
   protected release(api: OrchestratorApi) {
-    const pending: Promise<void> = api.release()
+    const pending: Promise<void> = api.release({ waitForWork: this.releaseWaitsForWork })
       .then(() => undefined, (e) => {
         // Swallowed so that releasing a dead tenant can't take the process down
         // with an unhandled rejection, but not silently: connections this failed
@@ -63,9 +70,20 @@ export class OrchestratorStorage {
     return Promise.all([...this.storage.values()].map(api => api.testOrchestratorConnections()));
   }
 
-  public async releaseConnections() {
-    // clear() disposes every entry, which schedules release() for each of them.
-    this.storage.clear();
+  /**
+   * @param waitForWork Whether the apis get to finish what they are serving.
+   * A shutdown can't afford it: its own killer gives it seconds, and being
+   * force killed halfway is worse than cutting the queries off.
+   */
+  public async releaseConnections({ waitForWork = true }: { waitForWork?: boolean } = {}) {
+    this.releaseWaitsForWork = waitForWork;
+
+    try {
+      // clear() disposes every entry, which schedules release() for each of them.
+      this.storage.clear();
+    } finally {
+      this.releaseWaitsForWork = true;
+    }
 
     await Promise.all([...this.pendingReleases]);
   }

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -618,48 +618,56 @@ export class RefreshScheduler {
           const currentQuery = await queryIterator.current();
           if (currentQuery && queryIterator.partitionCounter() % concurrency === workerIndex) {
             const orchestratorApi = await this.serverCore.getOrchestratorApi(context);
-            const preAggsInstance = orchestratorApi.getQueryOrchestrator().getPreAggregations();
-            const now = new Date();
+            // Taken straight from the orchestrator, so the api has to be held by
+            // hand for as long as it is used.
+            const releaseApi = orchestratorApi.acquire();
 
-            const backoffChecks = await Promise.all(
-              currentQuery.preAggregations.map(p => preAggsInstance.getPreAggBackoff(p.tableName))
-            );
+            try {
+              const preAggsInstance = orchestratorApi.getQueryOrchestrator().getPreAggregations();
+              const now = new Date();
 
-            // Skip execution if any pre-aggregation is still in backoff window
-            const shouldSkip = backoffChecks.some(backoffData => backoffData && now < backoffData.nextTimestamp);
+              const backoffChecks = await Promise.all(
+                currentQuery.preAggregations.map(p => preAggsInstance.getPreAggBackoff(p.tableName))
+              );
 
-            if (!shouldSkip) {
-              try {
-                await orchestratorApi.executeQuery({ ...currentQuery, preAggregationsLoadCacheByDataSource });
-              } catch (e: any) {
+              // Skip execution if any pre-aggregation is still in backoff window
+              const shouldSkip = backoffChecks.some(backoffData => backoffData && now < backoffData.nextTimestamp);
+
+              if (!shouldSkip) {
+                try {
+                  await orchestratorApi.executeQuery({ ...currentQuery, preAggregationsLoadCacheByDataSource });
+                } catch (e: any) {
                 // Check if this is a "Continue wait" error - these are normal queue signals
                 // For Continue wait errors, re-throw to handle them in the normal flow
-                if (e.error === 'Continue wait') {
-                  throw e;
-                }
-
-                // Real datasource error - apply exponential backoff
-                for (const p of currentQuery.preAggregations) {
-                  let backoffData = await preAggsInstance.getPreAggBackoff(p.tableName);
-
-                  if (backoffData && backoffData.backoffMultiplier > 0) {
-                    const newMultiplier = backoffData.backoffMultiplier * 2;
-                    const delaySeconds = Math.min(newMultiplier, preAggsInstance.getPreAggBackoffMaxTime());
-
-                    backoffData = {
-                      backoffMultiplier: newMultiplier,
-                      nextTimestamp: new Date(now.valueOf() + delaySeconds * 1000),
-                    };
-                  } else {
-                    backoffData = {
-                      backoffMultiplier: 1,
-                      nextTimestamp: new Date(now.valueOf() + 1000),
-                    };
+                  if (e.error === 'Continue wait') {
+                    throw e;
                   }
 
-                  await preAggsInstance.updatePreAggBackoff(p.tableName, backoffData);
+                  // Real datasource error - apply exponential backoff
+                  for (const p of currentQuery.preAggregations) {
+                    let backoffData = await preAggsInstance.getPreAggBackoff(p.tableName);
+
+                    if (backoffData && backoffData.backoffMultiplier > 0) {
+                      const newMultiplier = backoffData.backoffMultiplier * 2;
+                      const delaySeconds = Math.min(newMultiplier, preAggsInstance.getPreAggBackoffMaxTime());
+
+                      backoffData = {
+                        backoffMultiplier: newMultiplier,
+                        nextTimestamp: new Date(now.valueOf() + delaySeconds * 1000),
+                      };
+                    } else {
+                      backoffData = {
+                        backoffMultiplier: 1,
+                        nextTimestamp: new Date(now.valueOf() + 1000),
+                      };
+                    }
+
+                    await preAggsInstance.updatePreAggBackoff(p.tableName, backoffData);
+                  }
                 }
               }
+            } finally {
+              releaseApi();
             }
           }
           const hasNext = await queryIterator.advance();
@@ -825,22 +833,27 @@ export class RefreshScheduler {
     tokens: string[],
   ): Promise<{ job: PreAggJob | null, token: string }[]> {
     const orchestratorApi = await this.serverCore.getOrchestratorApi(context);
-    const jobsPromise = Promise.all(
-      tokens.map(async (token) => {
-        const job = await orchestratorApi
-          .getQueryOrchestrator()
-          .getQueryCache()
-          .getCacheDriver()
-          .get<PreAggJob>(`PRE_AGG_JOB_${token}`);
+    // Taken straight from the orchestrator, so the api has to be held by hand
+    // for as long as it is used.
+    const releaseApi = orchestratorApi.acquire();
 
-        return {
-          job,
-          token
-        };
-      })
-    );
+    try {
+      return await Promise.all(
+        tokens.map(async (token) => {
+          const job = await orchestratorApi
+            .getQueryOrchestrator()
+            .getQueryCache()
+            .getCacheDriver()
+            .get<PreAggJob>(`PRE_AGG_JOB_${token}`);
 
-    const jobs = await jobsPromise;
-    return jobs;
+          return {
+            job,
+            token
+          };
+        })
+      );
+    } finally {
+      releaseApi();
+    }
   }
 }

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -816,20 +816,29 @@ export class RefreshScheduler {
     const releaseApi = orchestratorApi.acquire();
     const writes: Promise<unknown>[] = [];
 
-    const keys = getPreAggsJobsList(
-      context,
-      <JobedPreAggregation[][][][]>jobedPAs,
-    ).map((job: PreAggJob) => {
-      const key = getPreAggJobToken(job);
-      writes.push(
-        orchestratorApi
-          .getQueryOrchestrator()
-          .getQueryCache()
-          .getCacheDriver()
-          .set(`PRE_AGG_JOB_${key}`, job, 86400)
-      );
-      return key;
-    });
+    let keys: string[];
+
+    try {
+      keys = getPreAggsJobsList(
+        context,
+        <JobedPreAggregation[][][][]>jobedPAs,
+      ).map((job: PreAggJob) => {
+        const key = getPreAggJobToken(job);
+        writes.push(
+          orchestratorApi
+            .getQueryOrchestrator()
+            .getQueryCache()
+            .getCacheDriver()
+            .set(`PRE_AGG_JOB_${key}`, job, 86400)
+        );
+        return key;
+      });
+    } catch (e) {
+      // A hold that is never released costs the next eviction the whole timeout.
+      releaseApi();
+
+      throw e;
+    }
 
     Promise.all(writes)
       .catch((error) => {

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -811,18 +811,36 @@ export class RefreshScheduler {
 
     const jobedPAs = await jobsPromise;
 
-    return getPreAggsJobsList(
+    // Taken straight from the orchestrator, so the api has to be held by hand
+    // until the writes land -- they outlive this call.
+    const releaseApi = orchestratorApi.acquire();
+    const writes: Promise<unknown>[] = [];
+
+    const keys = getPreAggsJobsList(
       context,
       <JobedPreAggregation[][][][]>jobedPAs,
     ).map((job: PreAggJob) => {
       const key = getPreAggJobToken(job);
-      orchestratorApi
-        .getQueryOrchestrator()
-        .getQueryCache()
-        .getCacheDriver()
-        .set(`PRE_AGG_JOB_${key}`, job, 86400);
+      writes.push(
+        orchestratorApi
+          .getQueryOrchestrator()
+          .getQueryCache()
+          .getCacheDriver()
+          .set(`PRE_AGG_JOB_${key}`, job, 86400)
+      );
       return key;
     });
+
+    Promise.all(writes)
+      .catch((error) => {
+        this.serverCore.logger('Pre-aggregations Jobs Error', {
+          error: (error.stack || error).toString(),
+          requestId: context.requestId,
+        });
+      })
+      .then(releaseApi, releaseApi);
+
+    return keys;
   }
 
   /**

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -963,6 +963,8 @@ export class CubejsServerCore {
       this.apiGatewayInstance.release();
     }
 
-    return this.orchestratorStorage.releaseConnections();
+    // The process is going away and its shutdown is on a timer, so the queries
+    // still running don't get to finish.
+    return this.orchestratorStorage.releaseConnections({ waitForWork: false });
   }
 }

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -1,11 +1,35 @@
+import { PassThrough } from 'stream';
+
 import { OrchestratorApi } from '../../src/core/OrchestratorApi';
+
+// The constructor builds a real QueryOrchestrator, so the fields it would set up
+// are stubbed instead.
+const buildApi = (): any => {
+  const api: any = Object.create(OrchestratorApi.prototype);
+
+  api.seenDataSources = {};
+  api.holders = 0;
+  api.drained = [];
+  api.logger = jest.fn();
+  api.options = {
+    contextToDbType: jest.fn(async () => 'postgres'),
+    contextToExternalDbType: jest.fn(() => 'cubestore'),
+  };
+  api.continueWaitTimeout = 30;
+  api.driverFactory = jest.fn();
+  api.orchestrator = { cleanup: jest.fn(async () => undefined) };
+
+  return api;
+};
+
+const tick = () => new Promise((resolve) => { setTimeout(resolve, 10); });
 
 describe('OrchestratorApi', () => {
   // https://github.com/cube-js/cube/issues/11313
   test('getPreAggregationQueueStates forwards dataSource to the orchestrator', async () => {
-    const api = Object.create(OrchestratorApi.prototype);
+    const api = buildApi();
     const getPreAggregationQueueStates = jest.fn(async () => []);
-    api.orchestrator = { getPreAggregationQueueStates };
+    api.orchestrator.getPreAggregationQueueStates = getPreAggregationQueueStates;
 
     await api.getPreAggregationQueueStates('test_ds');
     expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith('test_ds');
@@ -14,5 +38,95 @@ describe('OrchestratorApi', () => {
     // dataSource to 'default', so calls without one keep working.
     await api.getPreAggregationQueueStates();
     expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith(undefined);
+  });
+
+  describe('holders', () => {
+    test('release waits for the work that is already running', async () => {
+      const api = buildApi();
+      const releaseHolder = api.acquire();
+
+      let done = false;
+      const releasing = api.release().then(() => { done = true; });
+
+      await tick();
+
+      expect(done).toBe(false);
+      expect(api.orchestrator.cleanup).not.toHaveBeenCalled();
+
+      releaseHolder();
+      await releasing;
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('release does not wait when nothing is running', async () => {
+      const api = buildApi();
+
+      await api.release();
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('releasing a holder twice does not let the release through early', async () => {
+      const api = buildApi();
+      const first = api.acquire();
+      const second = api.acquire();
+
+      first();
+      first();
+
+      let done = false;
+      const releasing = api.release().then(() => { done = true; });
+      await tick();
+
+      expect(done).toBe(false);
+
+      second();
+      await releasing;
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('a query in flight holds off the release', async () => {
+      const api = buildApi();
+      let answer: (result: any) => void = () => undefined;
+      api.orchestrator.fetchQuery = jest.fn(() => new Promise((resolve) => { answer = resolve; }));
+
+      const query = api.executeQuery({ requestId: 'test' });
+      await tick();
+
+      let done = false;
+      const releasing = api.release().then(() => { done = true; });
+      await tick();
+
+      expect(done).toBe(false);
+
+      answer({ data: [] });
+      await query;
+      await releasing;
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('a stream holds off the release until it is done', async () => {
+      const api = buildApi();
+      const result = new PassThrough();
+      api.orchestrator.streamQuery = jest.fn(async () => result);
+
+      await api.streamQuery({ requestId: 'test' });
+
+      let done = false;
+      const releasing = api.release().then(() => { done = true; });
+      await tick();
+
+      // The stream outlives the call that returned it.
+      expect(done).toBe(false);
+
+      result.end();
+      result.resume();
+      await releasing;
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -16,6 +16,8 @@ const buildApi = (): any => {
     contextToExternalDbType: jest.fn(() => 'cubestore'),
   };
   api.continueWaitTimeout = 30;
+  api.holdersLinger = 0;
+  api.externalDriverSeen = false;
   api.driverFactory = jest.fn();
   api.orchestrator = { cleanup: jest.fn(async () => undefined) };
 
@@ -127,6 +129,84 @@ describe('OrchestratorApi', () => {
       await releasing;
 
       expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('waits out the gap between the calls one operation makes', async () => {
+      const api = buildApi();
+      api.holdersLinger = 100;
+
+      const first = api.acquire();
+
+      let done = false;
+      const releasing = api.release().then(() => { done = true; });
+
+      // The count reaching zero is not the end of the work: the caller is
+      // between two calls on the same api.
+      first();
+      const second = api.acquire();
+
+      await tick();
+
+      expect(done).toBe(false);
+
+      second();
+      await releasing;
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    test('a release that waited does not stay on the timer queue', async () => {
+      const api = buildApi();
+      const releaseHolder = api.acquire();
+      const timers = jest.spyOn(global, 'clearTimeout');
+
+      const releasing = api.release();
+      await tick();
+      releaseHolder();
+      await releasing;
+
+      expect(timers).toHaveBeenCalled();
+      // The resolver of the race it won is gone too, so a later drain has
+      // nothing to call.
+      expect(api.drained).toHaveLength(0);
+
+      timers.mockRestore();
+    });
+
+    test('a shutdown does not wait for the work in progress', async () => {
+      const api = buildApi();
+      api.acquire();
+
+      await api.release({ waitForWork: false });
+
+      expect(api.orchestrator.cleanup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('external driver', () => {
+    test('is not created just to be released', async () => {
+      const externalDriverFactory = jest.fn(async () => ({ release: jest.fn() }));
+      const api = buildApi();
+      api.externalDriverFactory = externalDriverFactory;
+
+      await api.release();
+
+      expect(externalDriverFactory).not.toHaveBeenCalled();
+    });
+
+    test('is released once it has been created', async () => {
+      const externalDriver = { release: jest.fn(async () => undefined) };
+      const api = buildApi();
+      api.externalDriverFactory = jest.fn(async () => {
+        api.externalDriverSeen = true;
+
+        return externalDriver;
+      });
+
+      await api.externalDriverFactory();
+      await api.release();
+
+      expect(externalDriver.release).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -1,0 +1,63 @@
+import { OrchestratorStorage } from '../../src/core/OrchestratorStorage';
+import type { OrchestratorApi } from '../../src/core/OrchestratorApi';
+
+const mockApi = () => {
+  const release = jest.fn(async () => []);
+  return { api: { release } as unknown as OrchestratorApi, release };
+};
+
+describe('OrchestratorStorage', () => {
+  test('releases an api evicted from the cache', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const evicted = mockApi();
+    const kept = mockApi();
+
+    storage.set('evicted', evicted.api);
+    storage.set('kept', kept.api);
+
+    await storage.releaseConnections();
+
+    expect(evicted.release).toHaveBeenCalledTimes(1);
+    expect(kept.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('releases an api replaced under the same key', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const replaced = mockApi();
+
+    storage.set('id', replaced.api);
+    storage.set('id', mockApi().api);
+
+    await storage.releaseConnections();
+
+    expect(replaced.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('releaseConnections releases every api exactly once', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const first = mockApi();
+    const second = mockApi();
+
+    storage.set('first', first.api);
+    storage.set('second', second.api);
+
+    await storage.releaseConnections();
+    // Shutdown calls it more than once (resetInstanceState, then shutdown itself).
+    await storage.releaseConnections();
+
+    expect(first.release).toHaveBeenCalledTimes(1);
+    expect(second.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('a failing release does not reject releaseConnections', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const failing = {
+      release: jest.fn(async () => { throw new Error('dead tenant'); })
+    } as unknown as OrchestratorApi;
+
+    storage.set('failing', failing);
+    storage.set('other', mockApi().api);
+
+    await expect(storage.releaseConnections()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -6,35 +6,54 @@ const mockApi = () => {
   return { api: { release } as unknown as OrchestratorApi, release };
 };
 
+// Lets a scheduled release fire without waiting out a real delay.
+const settle = () => new Promise((resolve) => { setTimeout(resolve, 10); });
+
 describe('OrchestratorStorage', () => {
   test('releases an api evicted from the cache', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1, releaseDelay: 0 });
     const evicted = mockApi();
-    const kept = mockApi();
 
     storage.set('evicted', evicted.api);
-    storage.set('kept', kept.api);
+    storage.set('kept', mockApi().api);
 
-    await storage.releaseConnections();
+    await settle();
 
     expect(evicted.release).toHaveBeenCalledTimes(1);
-    expect(kept.release).toHaveBeenCalledTimes(1);
   });
 
   test('releases an api replaced under the same key', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
     const replaced = mockApi();
 
     storage.set('id', replaced.api);
     storage.set('id', mockApi().api);
 
-    await storage.releaseConnections();
+    await settle();
 
     expect(replaced.release).toHaveBeenCalledTimes(1);
   });
 
+  test('keeps an evicted api alive for the release delay', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1, releaseDelay: 60 * 1000 });
+    const evicted = mockApi();
+
+    storage.set('evicted', evicted.api);
+    storage.set('kept', mockApi().api);
+
+    // A request that was handed this api before the eviction is still using it.
+    await settle();
+
+    expect(evicted.release).not.toHaveBeenCalled();
+
+    // Shutdown doesn't wait the delay out.
+    await storage.releaseConnections();
+
+    expect(evicted.release).toHaveBeenCalledTimes(1);
+  });
+
   test('releaseConnections releases every api exactly once', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
     const first = mockApi();
     const second = mockApi();
 
@@ -44,25 +63,29 @@ describe('OrchestratorStorage', () => {
     await storage.releaseConnections();
     // Shutdown calls it more than once (resetInstanceState, then shutdown itself).
     await storage.releaseConnections();
+    await settle();
 
     expect(first.release).toHaveBeenCalledTimes(1);
     expect(second.release).toHaveBeenCalledTimes(1);
   });
 
-  test('a failing release is reported and does not reject releaseConnections', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+  test('a failing release is reported and does not stop the others', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
     const error = new Error('dead tenant');
     const failing = {
       release: jest.fn(async () => { throw error; })
     } as unknown as OrchestratorApi;
+    const other = mockApi();
     const reported = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
     try {
       storage.set('failing', failing);
-      storage.set('other', mockApi().api);
+      storage.set('other', other.api);
 
       await expect(storage.releaseConnections()).resolves.toBeUndefined();
+
       expect(reported).toHaveBeenCalledWith(expect.any(String), error);
+      expect(other.release).toHaveBeenCalledTimes(1);
     } finally {
       reported.mockRestore();
     }

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -49,15 +49,22 @@ describe('OrchestratorStorage', () => {
     expect(second.release).toHaveBeenCalledTimes(1);
   });
 
-  test('a failing release does not reject releaseConnections', async () => {
+  test('a failing release is reported and does not reject releaseConnections', async () => {
     const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    const error = new Error('dead tenant');
     const failing = {
-      release: jest.fn(async () => { throw new Error('dead tenant'); })
+      release: jest.fn(async () => { throw error; })
     } as unknown as OrchestratorApi;
+    const reported = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    storage.set('failing', failing);
-    storage.set('other', mockApi().api);
+    try {
+      storage.set('failing', failing);
+      storage.set('other', mockApi().api);
 
-    await expect(storage.releaseConnections()).resolves.toBeUndefined();
+      await expect(storage.releaseConnections()).resolves.toBeUndefined();
+      expect(reported).toHaveBeenCalledWith(expect.any(String), error);
+    } finally {
+      reported.mockRestore();
+    }
   });
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -72,4 +72,24 @@ describe('OrchestratorStorage', () => {
       reported.mockRestore();
     }
   });
+
+  test('a shutdown does not wait for a release that started earlier', async () => {
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
+    let finishEarlier: () => void = () => undefined;
+    const earlier = {
+      // Still waiting for the work its api was serving.
+      release: jest.fn(() => new Promise<void>((resolve) => { finishEarlier = resolve; }))
+    } as unknown as OrchestratorApi;
+
+    storage.set('earlier', earlier);
+    storage.set('current', mockApi().api);
+
+    await settle();
+
+    expect(earlier.release).toHaveBeenCalledTimes(1);
+
+    await expect(storage.releaseConnections({ waitForWork: false })).resolves.toBeUndefined();
+
+    finishEarlier();
+  }, 5000);
 });

--- a/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts
@@ -11,7 +11,7 @@ const settle = () => new Promise((resolve) => { setTimeout(resolve, 10); });
 
 describe('OrchestratorStorage', () => {
   test('releases an api evicted from the cache', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 1, releaseDelay: 0 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 1 });
     const evicted = mockApi();
 
     storage.set('evicted', evicted.api);
@@ -23,7 +23,7 @@ describe('OrchestratorStorage', () => {
   });
 
   test('releases an api replaced under the same key', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
     const replaced = mockApi();
 
     storage.set('id', replaced.api);
@@ -34,26 +34,8 @@ describe('OrchestratorStorage', () => {
     expect(replaced.release).toHaveBeenCalledTimes(1);
   });
 
-  test('keeps an evicted api alive for the release delay', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 1, releaseDelay: 60 * 1000 });
-    const evicted = mockApi();
-
-    storage.set('evicted', evicted.api);
-    storage.set('kept', mockApi().api);
-
-    // A request that was handed this api before the eviction is still using it.
-    await settle();
-
-    expect(evicted.release).not.toHaveBeenCalled();
-
-    // Shutdown doesn't wait the delay out.
-    await storage.releaseConnections();
-
-    expect(evicted.release).toHaveBeenCalledTimes(1);
-  });
-
   test('releaseConnections releases every api exactly once', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
     const first = mockApi();
     const second = mockApi();
 
@@ -70,7 +52,7 @@ describe('OrchestratorStorage', () => {
   });
 
   test('a failing release is reported and does not stop the others', async () => {
-    const storage = new OrchestratorStorage({ compilerCacheSize: 10, releaseDelay: 0 });
+    const storage = new OrchestratorStorage({ compilerCacheSize: 10 });
     const error = new Error('dead tenant');
     const failing = {
       release: jest.fn(async () => { throw error; })


### PR DESCRIPTION
## Summary

`OrchestratorStorage` wrapped an `LRUCache` without a disposer, so an `OrchestratorApi` evicted from the cache was dropped without `release()` and the Cube Store web socket behind it stayed open. Such a socket is not garbage collected either: the 5 s heartbeat interval closes over it, and it keeps answering pongs, so the `'close'` branch that would `clearInterval` never runs — the heartbeat meant to reap dead connections is exactly what keeps the leaked ones alive.
## Changes

- `OrchestratorStorage` releases the api on every LRU removal reason (`evict` / `set` / `delete` / `expire`) through `disposeAfter`. `disposeAfter` rather than `dispose`, because `release()` is async and calls back into the drivers, while `dispose` runs synchronously inside `set()` / `delete()`. A failing `release()` is swallowed so that evicting a dead tenant cannot kill the process with an unhandled rejection.
- In-flight releases are tracked in a set, and `releaseConnections()` is reduced to a single `clear()` plus awaiting that set. This is what keeps shutdown from releasing every api twice: the manual iteration over `values()` is gone, so `disposeAfter` is now the only caller of `api.release()`.
- `WebSocketConnection` gets an explicit `teardown()` on the socket that stops the ping interval, so the timer dies even when the connection is orphaned without a `'close'` event. The `'error'` handler now tears down and terminates the failed socket instead of only dropping the reference to it, which closes a second path to connection build-up during a flap.

## Testing

New unit test `packages/cubejs-server-core/test/unit/OrchestratorStorage.test.ts`, no network: an api evicted by `max: 1`, an api replaced under the same key, `releaseConnections()` called twice (asserting exactly one `release()` per api), and a rejecting `release()`.

The two eviction cases fail on the pre-fix code (`Expected number of calls: 1, Received number of calls: 0`) and pass after it.

Full suite: `yarn tsc && yarn unit && yarn lint` in `cubejs-server-core` — 7 suites / 106 tests passed, lint clean apart from a pre-existing warning in `types.ts`. `yarn tsc && yarn lint` in `cubejs-cubestore-driver` — clean.

## Notes for review

