### PR TITLE
feat(cubestore): cap concurrent websocket connections per user

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1975,6 +1975,23 @@ The logging level for Cube Store.
 
 See also [`CUBEJS_LOG_LEVEL`](/reference/configuration/environment-variables#cubejs_log_level).
 
+## `CUBESTORE_MAX_WS_CONNECTIONS_PER_USER`
+
+The maximum number of concurrent WebSocket connections a single authenticated
+user may hold. At the limit, that user's oldest connection is closed to admit the
+new one: a client that still needs it reconnects, while one that had forgotten
+about it simply loses it. The limit is counted per Cube Store node, so a user
+connecting to several nodes may hold up to this many on each.
+
+Use it to keep one client that leaks connections from exhausting the node's file
+descriptors for everyone else. Set it comfortably above the number of connections
+a client legitimately keeps open at once, or working connections will be recycled.
+`0` disables the limit.
+
+| Possible Values           | Default in Development | Default in Production |
+| ------------------------- | ---------------------- | --------------------- |
+| A non-negative integer    | `0`                    | `0`                   |
+
 ## `CUBESTORE_META_ADDR`
 
 The address/port pair for the Cube Store **router** node in the cluster.

--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "parking_lot",
  "parquet-format",
  "parse-size",
  "paste",

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -94,6 +94,8 @@ opentelemetry-otlp = { version = "0.26.0", default-features = false, features = 
 opentelemetry-http = { version = "0.26.0", features = ["reqwest"] }
 lru = "0.18.2"
 moka = { version = "0.10.1", features = ["future"] }
+# Already in the tree transitively at this version; used for a timed lock.
+parking_lot = "0.12"
 ctor = "0.1.20"
 json = "0.12.4"
 futures-util = "0.3.17"

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -633,6 +633,10 @@ pub trait ConfigObj: DIService {
 
     fn check_ws_orphaned_messages_interval_secs(&self) -> u64;
 
+    /// Concurrent websocket connections allowed per authenticated user.
+    /// 0 disables the limit.
+    fn max_ws_connections_per_user(&self) -> usize;
+
     fn drop_ws_processing_messages_after_secs(&self) -> u64;
 
     fn drop_ws_complete_messages_after_secs(&self) -> u64;
@@ -785,6 +789,7 @@ pub struct ConfigObjImpl {
     pub metadata_cache_time_to_idle_secs: u64,
     pub stream_replay_check_interval_secs: u64,
     pub check_ws_orphaned_messages_interval_secs: u64,
+    pub max_ws_connections_per_user: usize,
     pub drop_ws_processing_messages_after_secs: u64,
     pub drop_ws_complete_messages_after_secs: u64,
     pub skip_kafka_parsing_errors: bool,
@@ -1176,6 +1181,10 @@ impl ConfigObj for ConfigObjImpl {
 
     fn check_ws_orphaned_messages_interval_secs(&self) -> u64 {
         self.check_ws_orphaned_messages_interval_secs
+    }
+
+    fn max_ws_connections_per_user(&self) -> usize {
+        self.max_ws_connections_per_user
     }
 
     fn drop_ws_processing_messages_after_secs(&self) -> u64 {
@@ -1960,6 +1969,10 @@ impl Config {
                     "CUBESTORE_CHECK_WS_ORPHANED_MESSAGES_INTERVAL",
                     30,
                 ),
+                max_ws_connections_per_user: env_parse(
+                    "CUBESTORE_MAX_WS_CONNECTIONS_PER_USER",
+                    0,
+                ),
                 drop_ws_processing_messages_after_secs: env_parse(
                     "CUBESTORE_DROP_WS_PROCESSING_MESSAGES_AFTER",
                     60 * 60,
@@ -2192,6 +2205,7 @@ impl Config {
                 gc_loop_interval: 60,
                 stream_replay_check_interval_secs: 60,
                 check_ws_orphaned_messages_interval_secs: 1,
+                max_ws_connections_per_user: 0,
                 drop_ws_processing_messages_after_secs: 60,
                 drop_ws_complete_messages_after_secs: 10,
                 skip_kafka_parsing_errors: false,
@@ -2974,6 +2988,7 @@ impl Config {
                         Duration::from_secs(config.drop_ws_complete_messages_after_secs()),
                         config.transport_max_message_size(),
                         config.transport_max_frame_size(),
+                        config.max_ws_connections_per_user(),
                     )
                 })
                 .await;

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -68,6 +68,17 @@ const CONNECTION_EVICTED_CLOSE_CODE: u16 = 1013;
 /// of bytes, so a peer that cannot take them within this long is not going to.
 const EVICTED_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// How long a caller waits for the connection counter's lock before giving up.
+///
+/// Nothing awaits inside the critical section — it is a map lookup and an
+/// insert — so waiting even this long is not reachable by the code as written;
+/// the bound is here so that no reasoning about the callers is needed to know
+/// this cannot stall a connection. It is not shorter because a thread holding
+/// the lock can be descheduled for milliseconds under CPU pressure, and giving
+/// up then would quietly stop counting connections exactly when the cap matters
+/// most. Both timeouts log, so a bound that is ever reached is visible.
+const COUNTER_LOCK_TIMEOUT: Duration = Duration::from_millis(100);
+
 /// How much room the transport is given above the configured sizes.
 ///
 /// The size limit is enforced here rather than by the transport, so that an
@@ -168,21 +179,24 @@ pub struct WsConnectionCounter {
     /// oldest, holding the token that asks the connection task to close.
     ///
     /// Synchronous on purpose, not a `tokio` lock behind `util::lock::acquire_lock`:
-    /// entries are removed from `WsConnectionGuard::drop` and a destructor cannot
+    /// entries are removed from `WsConnectionGuard::drop`, and a destructor cannot
     /// `.await`. Releasing anywhere else would leak the slot on a panic, a cancelled
     /// task, or a connection that dies before the upgrade completes. Nothing awaits
-    /// inside the critical section, which is what makes a sync lock correct here.
-    users: std::sync::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
+    /// inside the critical section either — `acquire` is not an `async fn`, so one
+    /// cannot be added — which is the shape the `tokio::sync::Mutex` docs point at a
+    /// standard-library lock for. Every caller still takes it with a bound, so the
+    /// property does not rest on that reasoning holding: see COUNTER_LOCK_TIMEOUT.
+    users: parking_lot::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
     next_id: AtomicU64,
 }
 
-/// Poisoning carries no meaning for a map of live connections, and a poisoned
-/// `unwrap` inside [`WsConnectionGuard::drop`] would abort the process instead
-/// of dropping one connection.
-fn lock_users(
-    users: &std::sync::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
-) -> std::sync::MutexGuard<'_, HashMap<String, BTreeMap<u64, CancellationToken>>> {
-    users.lock().unwrap_or_else(|e| e.into_inner())
+/// `None` when the lock could not be taken within [`COUNTER_LOCK_TIMEOUT`].
+/// Callers fail open: the cap is a safety net, so a counter that is briefly
+/// unavailable must not be what refuses or stalls a connection.
+fn try_lock_users(
+    users: &parking_lot::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
+) -> Option<parking_lot::MutexGuard<'_, HashMap<String, BTreeMap<u64, CancellationToken>>>> {
+    users.try_lock_for(COUNTER_LOCK_TIMEOUT)
 }
 
 /// Frees the slot taken by [`WsConnectionCounter::acquire`] when the connection
@@ -198,7 +212,7 @@ impl WsConnectionCounter {
     pub fn new(limit: usize) -> Arc<Self> {
         Arc::new(Self {
             limit,
-            users: std::sync::Mutex::new(HashMap::new()),
+            users: parking_lot::Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(0),
         })
     }
@@ -220,7 +234,21 @@ impl WsConnectionCounter {
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let evicted = {
-            let mut users = lock_users(&self.users);
+            let mut users = match try_lock_users(&self.users) {
+                Some(users) => users,
+                None => {
+                    log::error!(
+                        "Timed out locking the websocket connection counter; admitting an untracked connection (user: {})",
+                        user,
+                    );
+                    return WsConnectionGuard {
+                        counter: self.clone(),
+                        user: None,
+                        id: 0,
+                        cancel,
+                    };
+                }
+            };
             let entries = users.entry(user.to_string()).or_default();
             let evicted = if entries.len() >= self.limit {
                 let oldest = *entries.keys().next().expect("a full map has an entry");
@@ -249,7 +277,9 @@ impl WsConnectionCounter {
     }
 
     pub fn count(&self, user: &str) -> usize {
-        lock_users(&self.users).get(user).map_or(0, BTreeMap::len)
+        try_lock_users(&self.users)
+            .and_then(|users| users.get(user).map(BTreeMap::len))
+            .unwrap_or(0)
     }
 }
 
@@ -266,7 +296,19 @@ impl Drop for WsConnectionGuard {
             Some(user) => user,
             None => return,
         };
-        let mut users = lock_users(&self.counter.users);
+        let mut users = match try_lock_users(&self.counter.users) {
+            Some(users) => users,
+            None => {
+                // The entry stays behind, but it is the oldest one of that user by
+                // construction, so the next admission evicts it: cancelling an
+                // already finished connection's token is a no-op.
+                log::error!(
+                    "Timed out locking the websocket connection counter; leaving a finished connection's slot to be evicted (user: {})",
+                    user,
+                );
+                return;
+            }
+        };
         if let Some(entries) = users.get_mut(user) {
             // Idempotent: an evicting `acquire` may have removed this entry already.
             entries.remove(&self.id);
@@ -1560,7 +1602,9 @@ mod tests {
         drop(counter.acquire(Some("tenant-a")));
         assert_eq!(counter.count("tenant-a"), 0);
         assert!(
-            lock_users(&counter.users).is_empty(),
+            try_lock_users(&counter.users)
+                .expect("uncontended")
+                .is_empty(),
             "a churn of one-off users must not grow the map"
         );
 
@@ -1568,32 +1612,32 @@ mod tests {
         // its own statement and would free the slot it is meant to hold.
         let _b = counter.acquire(Some("tenant-b"));
         let _c = counter.acquire(Some("tenant-c"));
-        assert_eq!(lock_users(&counter.users).len(), 2);
+        assert_eq!(
+            try_lock_users(&counter.users).expect("uncontended").len(),
+            2
+        );
     }
 
     #[test]
-    fn ws_connection_counter_survives_a_poisoned_lock() {
+    fn acquire_gives_up_on_a_stuck_lock_instead_of_waiting_on_it() {
         let counter = WsConnectionCounter::new(1);
-        let held = counter.acquire(Some("tenant-a"));
+        let blocker = counter.users.lock();
 
-        let poisoner = Arc::clone(&counter);
-        let _ = std::thread::spawn(move || {
-            let _users = lock_users(&poisoner.users);
-            panic!("poison the users lock on purpose");
-        })
-        .join();
+        // From another thread: the lock is not reentrant, and the point is that a
+        // caller returns on its own schedule rather than the lock holder's.
+        let probe = Arc::clone(&counter);
+        let guard = std::thread::spawn(move || probe.acquire(Some("tenant-a")))
+            .join()
+            .expect("acquire must return rather than wait for the lock");
 
-        // Releasing a slot must not abort the process: a panicking destructor
-        // during unwinding is not recoverable, and every connection close runs
-        // this path.
-        drop(held);
-        assert_eq!(counter.count("tenant-a"), 0);
-
-        let after = counter.acquire(Some("tenant-a"));
         assert!(
-            !after.cancel.is_cancelled(),
-            "the cap must keep working after the lock was poisoned"
+            guard.user.is_none(),
+            "the cap is a safety net, so an unavailable counter admits the              connection untracked rather than refusing or stalling it"
         );
+        assert!(!guard.cancel.is_cancelled());
+
+        drop(blocker);
+        assert_eq!(counter.count("tenant-a"), 0);
     }
 
     #[test]

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -31,10 +31,11 @@ use log::error;
 use log::info;
 use log::trace;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 use tempfile::NamedTempFile;
 use tokio::fs::File;
@@ -132,9 +133,134 @@ pub struct HttpServer {
     cancel_token: CancellationToken,
     max_message_size: usize,
     max_frame_size: usize,
+    ws_connections: Arc<WsConnectionCounter>,
 }
 
 crate::di_service!(HttpServer, []);
+
+/// Caps how many concurrent websocket connections one authenticated user may
+/// hold. A client that leaks connections otherwise exhausts the process file
+/// descriptor table for every other user sharing the node.
+///
+/// At the limit the user's oldest connection is closed to admit the new one,
+/// rather than the new one being refused: a client that still needs the closed
+/// connection reconnects, while one that had forgotten about it simply loses it.
+/// A limit of 0 disables the cap.
+pub struct WsConnectionCounter {
+    limit: usize,
+    /// Live connections per user, keyed by a monotonic id so the first entry is the
+    /// oldest, holding the token that asks the connection task to close.
+    ///
+    /// Synchronous on purpose, not a `tokio` lock behind `util::lock::acquire_lock`:
+    /// entries are removed from `WsConnectionGuard::drop` and a destructor cannot
+    /// `.await`. Releasing anywhere else would leak the slot on a panic, a cancelled
+    /// task, or a connection that dies before the upgrade completes. Nothing awaits
+    /// inside the critical section, which is what makes a sync lock correct here.
+    users: std::sync::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
+    next_id: AtomicU64,
+}
+
+/// Poisoning carries no meaning for a map of live connections, and a poisoned
+/// `unwrap` inside [`WsConnectionGuard::drop`] would abort the process instead
+/// of dropping one connection.
+fn lock_users(
+    users: &std::sync::Mutex<HashMap<String, BTreeMap<u64, CancellationToken>>>,
+) -> std::sync::MutexGuard<'_, HashMap<String, BTreeMap<u64, CancellationToken>>> {
+    users.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Frees the slot taken by [`WsConnectionCounter::acquire`] when the connection
+/// task ends, however it ends, and carries the token that task waits on.
+pub struct WsConnectionGuard {
+    counter: Arc<WsConnectionCounter>,
+    user: Option<String>,
+    id: u64,
+    cancel: CancellationToken,
+}
+
+impl WsConnectionCounter {
+    pub fn new(limit: usize) -> Arc<Self> {
+        Arc::new(Self {
+            limit,
+            users: std::sync::Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(0),
+        })
+    }
+
+    /// Unauthenticated connections and a disabled cap stay untracked.
+    pub fn acquire(self: &Arc<Self>, user: Option<&str>) -> WsConnectionGuard {
+        let cancel = CancellationToken::new();
+        let user = match user {
+            Some(user) if self.limit > 0 => user,
+            _ => {
+                return WsConnectionGuard {
+                    counter: self.clone(),
+                    user: None,
+                    id: 0,
+                    cancel,
+                }
+            }
+        };
+
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let evicted = {
+            let mut users = lock_users(&self.users);
+            let entries = users.entry(user.to_string()).or_default();
+            let evicted = if entries.len() >= self.limit {
+                let oldest = *entries.keys().next().expect("a full map has an entry");
+                // Removed here rather than left to the victim's own `drop`, which
+                // runs later: otherwise this admission would overshoot the limit.
+                entries.remove(&oldest)
+            } else {
+                None
+            };
+            entries.insert(id, cancel.clone());
+            evicted
+        };
+
+        // Outside the lock. Cancelling only wakes the victim's task, so this cannot
+        // deadlock, but there is no reason to hold the lock across it.
+        if let Some(evicted) = evicted {
+            evicted.cancel();
+        }
+
+        WsConnectionGuard {
+            counter: self.clone(),
+            user: Some(user.to_string()),
+            id,
+            cancel,
+        }
+    }
+
+    pub fn count(&self, user: &str) -> usize {
+        lock_users(&self.users).get(user).map_or(0, BTreeMap::len)
+    }
+}
+
+impl WsConnectionGuard {
+    /// Resolves when this connection has been chosen to make room for a newer one.
+    pub async fn evicted(&self) {
+        self.cancel.cancelled().await
+    }
+}
+
+impl Drop for WsConnectionGuard {
+    fn drop(&mut self) {
+        let user = match &self.user {
+            Some(user) => user,
+            None => return,
+        };
+        let mut users = lock_users(&self.counter.users);
+        if let Some(entries) = users.get_mut(user) {
+            // Idempotent: an evicting `acquire` may have removed this entry already.
+            entries.remove(&self.id);
+            // Dropped when empty so a churn of one-off users can't grow the map.
+            if entries.is_empty() {
+                users.remove(user);
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum CubeRejection {
@@ -187,6 +313,7 @@ impl HttpServer {
         drop_complete_messages_after: Duration,
         max_message_size: usize,
         max_frame_size: usize,
+        max_ws_connections_per_user: usize,
     ) -> Arc<Self> {
         Arc::new(Self {
             bind_address,
@@ -197,6 +324,7 @@ impl HttpServer {
             drop_complete_messages_after,
             max_message_size,
             max_frame_size,
+            ws_connections: WsConnectionCounter::new(max_ws_connections_per_user),
             worker_loop: WorkerLoop::new("HttpServer message processing"),
             drop_orphaned_messages_loop: WorkerLoop::new("HttpServer drop orphaned messages"),
             cancel_token: CancellationToken::new(),
@@ -238,19 +366,35 @@ impl HttpServer {
         let context_filter_to_move = context_filter.clone();
         let max_frame_size = self.max_frame_size.clone();
         let max_message_size = self.max_message_size.clone();
+        let ws_connections = self.ws_connections.clone();
+        let ws_connections_filter = warp::any().map(move || ws_connections.clone());
 
         let query_route = warp::path!("ws")
             .and(context_filter_to_move)
+            .and(ws_connections_filter)
             .and(warp::ws::ws())
-            .and_then(move |tx: mpsc::Sender<(mpsc::Sender<Arc<HttpMessage>>, SqlQueryContext, HttpMessage)>, sql_query_context: SqlQueryContext, ws: Ws| async move {
+            .and_then(move |tx: mpsc::Sender<(mpsc::Sender<Arc<HttpMessage>>, SqlQueryContext, HttpMessage)>, sql_query_context: SqlQueryContext, ws_connections: Arc<WsConnectionCounter>, ws: Ws| async move {
                 let tx_to_move = tx.clone();
                 let sql_query_context = sql_query_context.clone();
+                let connection_guard = ws_connections.acquire(sql_query_context.user.as_deref());
                 let reply = ws.max_frame_size(max_frame_size.saturating_mul(TRANSPORT_SIZE_HEADROOM)).max_message_size(max_message_size.saturating_mul(TRANSPORT_SIZE_HEADROOM)).on_upgrade(async move |mut web_socket| {
+                    // Lives as long as the connection task; dropping it frees the slot.
+                    let connection_guard = connection_guard;
                     let process_id = sql_query_context.process_id.as_deref().unwrap_or("None");
                     trace!("WebSocket connection established (process_id: {})", process_id);
                     let (response_tx, mut response_rx) = mpsc::channel::<Arc<HttpMessage>>(10000);
                     loop {
                         tokio::select! {
+                            _ = connection_guard.evicted() => {
+                                log::warn!(
+                                    "Closing websocket connection to admit a newer one for the same user (process_id: {})",
+                                    process_id,
+                                );
+                                // A close frame rather than a bare drop, so the client
+                                // sees a clean close and can reconnect on its own terms.
+                                let _ = web_socket.close().await;
+                                break;
+                            }
                             Some(res) = response_rx.recv() => {
                                 trace!("Sending web socket response (process_id: {})", process_id);
                                 let send_res = web_socket.send(Message::binary(res.bytes())).await;
@@ -1323,6 +1467,129 @@ mod tests {
         }
     }
 
+    #[test]
+    fn acquire_evicts_the_oldest_connection_to_admit_a_new_one() {
+        let counter = WsConnectionCounter::new(2);
+        let oldest = counter.acquire(Some("tenant-a"));
+        let newer = counter.acquire(Some("tenant-a"));
+        assert_eq!(counter.count("tenant-a"), 2);
+
+        let newcomer = counter.acquire(Some("tenant-a"));
+
+        assert!(
+            oldest.cancel.is_cancelled(),
+            "the oldest connection is the one asked to close"
+        );
+        assert!(!newer.cancel.is_cancelled());
+        assert!(!newcomer.cancel.is_cancelled());
+        assert_eq!(
+            counter.count("tenant-a"),
+            2,
+            "the victim leaves before the newcomer is inserted, so the limit never overshoots"
+        );
+
+        // The victim's own drop runs later and must not take another entry with it,
+        // which is why entries are keyed by a monotonic id.
+        drop(oldest);
+        assert_eq!(counter.count("tenant-a"), 2);
+
+        // Eviction keeps following insertion order.
+        let latest = counter.acquire(Some("tenant-a"));
+        assert!(
+            newer.cancel.is_cancelled(),
+            "now the second connection is oldest"
+        );
+        assert!(!newcomer.cancel.is_cancelled());
+        assert!(!latest.cancel.is_cancelled());
+    }
+
+    #[test]
+    fn ws_connection_counter_caps_each_user_independently() {
+        let counter = WsConnectionCounter::new(1);
+        let a = counter.acquire(Some("tenant-a"));
+        let b = counter.acquire(Some("tenant-b"));
+
+        assert!(
+            !a.cancel.is_cancelled() && !b.cancel.is_cancelled(),
+            "one connection each is within the cap"
+        );
+
+        let a_again = counter.acquire(Some("tenant-a"));
+        assert!(a.cancel.is_cancelled(), "tenant-a is at its cap");
+        assert!(
+            !b.cancel.is_cancelled(),
+            "one user at its cap must not affect another"
+        );
+        assert!(!a_again.cancel.is_cancelled());
+        assert_eq!(counter.count("tenant-a"), 1);
+        assert_eq!(counter.count("tenant-b"), 1);
+    }
+
+    #[test]
+    fn ws_connection_counter_forgets_users_that_dropped_to_zero() {
+        let counter = WsConnectionCounter::new(1);
+
+        drop(counter.acquire(Some("tenant-a")));
+        assert_eq!(counter.count("tenant-a"), 0);
+        assert!(
+            lock_users(&counter.users).is_empty(),
+            "a churn of one-off users must not grow the map"
+        );
+
+        // Both guards are bound to names: one left as a temporary dies at the end of
+        // its own statement and would free the slot it is meant to hold.
+        let _b = counter.acquire(Some("tenant-b"));
+        let _c = counter.acquire(Some("tenant-c"));
+        assert_eq!(lock_users(&counter.users).len(), 2);
+    }
+
+    #[test]
+    fn ws_connection_counter_survives_a_poisoned_lock() {
+        let counter = WsConnectionCounter::new(1);
+        let held = counter.acquire(Some("tenant-a"));
+
+        let poisoner = Arc::clone(&counter);
+        let _ = std::thread::spawn(move || {
+            let _users = lock_users(&poisoner.users);
+            panic!("poison the users lock on purpose");
+        })
+        .join();
+
+        // Releasing a slot must not abort the process: a panicking destructor
+        // during unwinding is not recoverable, and every connection close runs
+        // this path.
+        drop(held);
+        assert_eq!(counter.count("tenant-a"), 0);
+
+        let after = counter.acquire(Some("tenant-a"));
+        assert!(
+            !after.cancel.is_cancelled(),
+            "the cap must keep working after the lock was poisoned"
+        );
+    }
+
+    #[test]
+    fn ws_connection_counter_leaves_untracked_what_it_cannot_attribute() {
+        let disabled = WsConnectionCounter::new(0);
+        let mut held = Vec::new();
+        for _ in 0..1000 {
+            held.push(disabled.acquire(Some("tenant-a")));
+        }
+        assert!(
+            held.iter().all(|guard| !guard.cancel.is_cancelled()),
+            "limit 0 disables the cap"
+        );
+        assert_eq!(disabled.count("tenant-a"), 0);
+
+        let counter = WsConnectionCounter::new(1);
+        let first = counter.acquire(None);
+        let second = counter.acquire(None);
+        assert!(
+            !first.cancel.is_cancelled() && !second.cancel.is_cancelled(),
+            "unauthenticated connections are not attributable and stay untracked"
+        );
+    }
+
     #[tokio::test]
     async fn upload_writes_the_whole_body_before_handing_off_the_path() -> Result<(), CubeError> {
         let dir = tempfile::tempdir()?;
@@ -1736,6 +2003,7 @@ mod tests {
             Duration::from_millis(1000),
             config.transport_max_message_size(),
             config.transport_max_frame_size(),
+            config.max_ws_connections_per_user(),
         ));
         {
             let http_server = http_server.clone();
@@ -1939,6 +2207,7 @@ mod tests {
             Duration::from_millis(1000),
             config.transport_max_message_size(),
             config.transport_max_frame_size(),
+            config.max_ws_connections_per_user(),
         ));
         {
             let http_server = http_server.clone();
@@ -1999,6 +2268,7 @@ mod tests {
             Duration::from_millis(1000),
             max_message_size,
             max_message_size,
+            0, // no websocket connection cap
         ));
         {
             let http_server = http_server.clone();
@@ -2077,6 +2347,7 @@ mod tests {
             Duration::from_millis(1000),
             max_message_size,
             max_frame_size,
+            0, // no websocket connection cap
         ));
         {
             let http_server = http_server.clone();
@@ -2151,6 +2422,7 @@ mod tests {
             Duration::from_millis(1000),
             max_message_size,
             max_message_size,
+            0, // no websocket connection cap
         ));
         {
             let http_server = http_server.clone();

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -71,13 +71,14 @@ const EVICTED_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 /// How long a caller waits for the connection counter's lock before giving up.
 ///
 /// Nothing awaits inside the critical section — it is a map lookup and an
-/// insert — so waiting even this long is not reachable by the code as written;
-/// the bound is here so that no reasoning about the callers is needed to know
-/// this cannot stall a connection. It is not shorter because a thread holding
-/// the lock can be descheduled for milliseconds under CPU pressure, and giving
-/// up then would quietly stop counting connections exactly when the cap matters
-/// most. Both timeouts log, so a bound that is ever reached is visible.
-const COUNTER_LOCK_TIMEOUT: Duration = Duration::from_millis(100);
+/// insert — so waiting at all is barely reachable by the code as written; the
+/// bound is here so that knowing this cannot stall a connection needs no
+/// reasoning about the callers. It is deliberately generous rather than tight:
+/// a thread holding the lock can be descheduled for a long time under CPU
+/// pressure, and giving up then would quietly stop counting connections
+/// exactly when the cap matters most. Both callers log when they give up, so a
+/// bound that is ever reached is visible rather than silent.
+const COUNTER_LOCK_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// How much room the transport is given above the configured sizes.
 ///

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -52,6 +52,22 @@ use warp::reject::Reject;
 /// process because it is too large (RFC 6455 section 7.4.1, "Message Too Big").
 const MESSAGE_TOO_BIG_CLOSE_CODE: u16 = 1009;
 
+/// Close code the WebSocket protocol reserves for a peer that should come back
+/// later (RFC 6455 section 7.4.1, "Try Again Later"). An evicted connection was
+/// recycled to make room for a newer one, not broken, and a client that still
+/// needs it should reconnect rather than report a transport failure.
+const CONNECTION_EVICTED_CLOSE_CODE: u16 = 1013;
+
+/// How long the server waits for an evicted connection's close frame to go out.
+///
+/// The connection's entry leaves the counter when it is evicted, not when its
+/// task ends, so this is also how long its descriptor can outlive the slot it
+/// accounted for: the steady-state overshoot is the eviction rate times this
+/// bound. Sending is what can block — a peer whose receive window is closed
+/// keeps the frame in our buffer indefinitely — and a close frame is a handful
+/// of bytes, so a peer that cannot take them within this long is not going to.
+const EVICTED_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// How much room the transport is given above the configured sizes.
 ///
 /// The size limit is enforced here rather than by the transport, so that an
@@ -390,9 +406,21 @@ impl HttpServer {
                                     "Closing websocket connection to admit a newer one for the same user (process_id: {})",
                                     process_id,
                                 );
-                                // A close frame rather than a bare drop, so the client
-                                // sees a clean close and can reconnect on its own terms.
-                                let _ = web_socket.close().await;
+                                // A close frame naming the reason rather than a bare drop,
+                                // so the client can tell being recycled from a network
+                                // blip. Bounded, because the descriptor is already
+                                // unaccounted for: see EVICTED_CLOSE_TIMEOUT.
+                                let close = web_socket.send(Message::close_with(
+                                    CONNECTION_EVICTED_CLOSE_CODE,
+                                    "connection evicted to admit a newer one for the same user",
+                                ));
+                                match tokio::time::timeout(EVICTED_CLOSE_TIMEOUT, close).await {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(e)) => error!("Websocket close send error: {:?}", e),
+                                    Err(_) => log::warn!(
+                                        "Timed out sending the close frame of an evicted websocket connection"
+                                    ),
+                                }
                                 break;
                             }
                             Some(res) = response_rx.recv() => {
@@ -2240,6 +2268,84 @@ mod tests {
                 .await
                 .expect("a header at the limit should be accepted");
         drop(socket);
+
+        http_server.stop_processing().await;
+        Ok(())
+    }
+
+    /// An evicted connection is told why it is going away, so a client can tell
+    /// being recycled from a network blip, and the cap actually reaches the
+    /// connection rather than only the counter.
+    #[tokio::test]
+    async fn ws_connection_evicted_test() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let mut auth = MockSqlAuthService::new();
+        auth.expect_authenticate().return_const(Ok(None));
+
+        let http_server = Arc::new(HttpServer::new(
+            "127.0.0.1:53036".to_string(),
+            Arc::new(auth),
+            Arc::new(SqlServiceMock {
+                message_counter: AtomicU64::new(0),
+            }),
+            Duration::from_millis(100),
+            Duration::from_millis(10000),
+            Duration::from_millis(1000),
+            64 * 1024,
+            64 * 1024,
+            // One connection per user, so the second one has to evict the first.
+            1,
+        ));
+        {
+            let http_server = http_server.clone();
+            cube_ext::spawn(async move { http_server.run_server().await });
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        fn connect_request(user: &str) -> Request {
+            let mut request = "ws://127.0.0.1:53036/ws".into_client_request().unwrap();
+            request.headers_mut().insert(
+                "authorization",
+                HeaderValue::from_str(&Credentials::new(user, "").as_http_header()).unwrap(),
+            );
+            request
+        }
+
+        let (mut first, _) = connect_async(connect_request("tenant-a"))
+            .await
+            .expect("the first connection is within the cap");
+        let (second, _) = connect_async(connect_request("tenant-a"))
+            .await
+            .expect("the second connection is admitted by evicting the first");
+
+        // Bounded, so a regression in the eviction path fails this test instead of
+        // hanging it: nothing else would ever wake this read.
+        let msg = tokio::time::timeout(Duration::from_secs(10), first.next())
+            .await
+            .expect("the evicted connection must be closed promptly")
+            .expect("the evicted connection is closed, not left open")
+            .unwrap();
+        match msg {
+            Message::Close(Some(frame)) => {
+                assert_eq!(u16::from(frame.code), CONNECTION_EVICTED_CLOSE_CODE);
+                assert!(
+                    frame.reason.contains("evicted"),
+                    "unexpected close reason: {}",
+                    frame.reason
+                );
+            }
+            msg => panic!("Close frame expected, got: {:?}", msg),
+        }
+
+        // Another user is unaffected by tenant-a having been at its cap.
+        let (other, _) = connect_async(connect_request("tenant-b"))
+            .await
+            .expect("a different user has its own slot");
+
+        drop(other);
+        drop(second);
 
         http_server.stop_processing().await;
         Ok(())


### PR DESCRIPTION
## Summary

Cube Store accepts an unbounded number of concurrent WebSocket connections per authenticated user. A client that opens connections faster than it closes them consumes the whole process file descriptor table, and once that is full the node cannot accept connections for any other user on it either. This adds an optional per-user cap.

At the limit the user's **oldest connection is closed to admit the new one**, rather than the new one being refused. A client that still needs the closed connection reconnects; one that had forgotten about it simply loses it. Refusing instead would leave a user whose slots are all held by forgotten connections unable to open a working one at all, since nothing would ever release them.

Disabled by default (`0`), so behaviour is unchanged unless a limit is set.

## Changes

- **`CUBESTORE_MAX_WS_CONNECTIONS_PER_USER`** — new config option, default `0` (disabled), documented in the environment variable reference.
- **`WsConnectionCounter`** — live connections per authenticated user, keyed by a monotonic id so the first entry is the oldest. Unauthenticated connections and a disabled cap stay untracked; users whose last connection goes away are removed from the map, so a churn of one-off users cannot grow it.
- **`WsConnectionGuard`** — taken at the `/ws` upgrade and released from `Drop`, so the slot comes back on every exit path: a close frame, a transport error, a panic, a cancelled task, or a connection that dies before the upgrade completes.
- Eviction goes through a `CancellationToken` the connection task selects on, next to the two branches it already had. The task sends a close frame before it leaves, so the client sees a clean close rather than a reset.
- The victim's entry is removed by the admitting call rather than left to the victim's own later `drop`, so the limit never overshoots; the monotonic id is what keeps those two removals from taking each other's entry.

The counter is per process, so a user connecting to several nodes may hold up to the limit on each. Called out in the docs, along with the advice to set the limit comfortably above what a client legitimately keeps open at once — below that, working connections get recycled.

## Changed behaviour at the limit

| | Before | After |
| --- | --- | --- |
| New connection over the limit | accepted, no limit exists | accepted |
| User's oldest connection | — | closed with a close frame |
| Descriptors held by one user | unbounded | at most the limit, per node |

## Testing

`cargo test -p cubestore --lib http::` — 16 passed. That includes the existing WebSocket tests (`ws_test`, `ws_process_id_header_test`, `query_test`, `inline_tables_query_test`, and the message-size tests), which run through the acquire/release path with the cap disabled, plus five new unit tests:

- eviction picks the oldest connection, leaves the newer ones alone, keeps following insertion order, and does not overshoot the limit;
- the victim's own later `drop` does not remove another connection's entry;
- one user at its cap does not affect another;
- users whose last connection goes away are forgotten, so the map does not grow;
- releasing a slot after the counter lock was poisoned does not abort the process. This one was verified to fail without the fix: a panicking destructor during unwinding is not recoverable, so `Drop` recovers a poisoned lock instead of unwrapping it.

`cargo check -p cubestore --all-targets` is clean, no new warnings.

## Design note

The counter lock is a `std::sync::Mutex` rather than a `tokio` one behind `util::lock::acquire_lock`, because entries are removed from a destructor and a destructor cannot `.await`. Releasing anywhere else — explicitly at the end of the connection loop, or from a spawned task — would leak the slot whenever the connection ends abnormally, and a cap whose slots only ever leak eventually admits nothing. Nothing awaits inside the critical section, which is what makes the synchronous lock correct here; that reasoning is recorded next to the field.
