### PR TITLE
docs: fix five stale documentation sections

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -105,7 +105,9 @@ above cannot express.
 ### Default filters
 
 A data model author can define default workbook filters on a semantic view with
-the [`meta.default_ui_filters`][ref-default-ui-filters] parameter:
+the [`meta.default_ui_filters`][ref-default-ui-filters] parameter. The same
+defaults are also seeded when a query on that view is started in the Google
+Sheets / Excel add-in.
 
 ```yaml
 views:

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -73,9 +73,14 @@ looks and feels like [Playground][ref-playground].
 
 <Info>
 
-Google Cloud for Sheets works only with [views][ref-views], not cubes.
+Cube Cloud for Sheets works only with [views][ref-views], not cubes.
 
 </Info>
+
+If the view defines [`default_ui_filters`][ref-default-ui-filters], those
+filters are pre-populated as soon as you select the view — the same way they
+are in workbooks. They are a starting point, not enforcement: you can change
+their values, switch operators, or remove them.
 
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
@@ -100,6 +105,31 @@ With every change to your query, Cube Cloud for Sheets will update the report on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
+### Measure position and order
+
+By default, measures nest under each value of the dimension they're paired
+with — every measure for the first column value, then every measure for the
+next. Open the **Display** tab to change **Measure position** to **Before
+columns** to get the opposite layout: each measure spans every column value,
+with all values of one measure together before moving to the next.
+
+For example, with `Forecast Sales Units` and `Forecast Net Sales` on Measures
+and a `season` dimension on Columns:
+
+- **After columns** (default): `Q1: [Sales Units, Net Sales] | Q2: [Sales
+  Units, Net Sales]`
+- **Before columns**: `Sales Units: [Q1, Q2] | Net Sales: [Q1, Q2]`
+
+{/* TODO: screenshot — side-by-side of the two output layouts (After columns vs Before columns) */}
+
+The same choice applies when measures are placed on **Rows** instead (set
+with **Measures on**, in the same tab) — there it's labeled **After rows** /
+**Before rows**.
+
+To change the order measures appear in within their group, drag them within
+the **Measures** pane on the **Pivot** tab. Position and order are saved with
+the report and survive **Refresh**.
+
 When your report is ready, you can optionally move it to [saved reports](#work-with-saved-reports)
 by clicking **Save**.
 
@@ -111,8 +141,18 @@ exploration by name across your whole deployment, not just the current
 folder — results are grouped by type and show each item's folder location,
 and selecting one navigates you straight to it.
 
-Click **Refresh** to manually refresh the data in the report's location.
-Click **Edit** to change the query or the location.
+An exploration can be placed more than once — on different sheets or at
+different anchors in the same spreadsheet, and in more than one document at
+once (a Google Sheets spreadsheet and an Excel workbook simultaneously).
+Hovering a row in this list shows every placement it has in the **current**
+document under **Location** / **Locations**. Click **Refresh** to update all
+of that exploration's placements in the current document at once; click its
+title to open it and change the query, which applies to every placement.
+
+A placement survives renaming the sheet it's on or the spreadsheet it's in —
+it's tracked by the sheet's and spreadsheet's own stable ids, not by name.
+It does **not** survive rows or columns inserted above its anchor cell; the
+anchor still shifts with the sheet.
 
 <Frame>
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />
@@ -133,5 +173,6 @@ in Cube Cloud.
 [ref-playground]: /docs/explore-analyze/playground
 [ref-views]: /docs/data-modeling/views
 [ref-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations
+[ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
 [ref-saved-reports]: /docs/workspace/saved-reports

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -150,9 +150,11 @@ of that exploration's placements in the current document at once; click its
 title to open it and change the query, which applies to every placement.
 
 A placement survives renaming the sheet it's on or the spreadsheet it's in —
-it's tracked by the sheet's and spreadsheet's own stable ids, not by name.
-It does **not** survive rows or columns inserted above its anchor cell; the
-anchor still shifts with the sheet.
+it's tracked by the sheet's and spreadsheet's own stable ids, not by name. A
+placement's anchor is a fixed cell reference, though, so it does **not**
+survive rows or columns inserted above it: the visible data shifts down with
+the insert, but the stored anchor doesn't move with it, so the next refresh
+targets the wrong cell.
 
 <Frame>
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -239,10 +239,16 @@ work together.
 | Tool | Description | Access |
 | --- | --- | --- |
 | `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
-| `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. | Read-only |
+| `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. Pass the dev `branchName` from `startDataModelEdit` to query that branch instead of the deployed model. | Read-only |
 
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
 guessing them.
+
+Omitting `branchName` queries the deployed model, exactly as before this parameter existed.
+Passing a `branchName` that isn't an active dev branch — for example the deploy branch's own
+name, or a feature branch with no dev worker running — fails with an error rather than
+silently answering from the deployed model, so a query aimed at the wrong branch never
+looks like a query that just returned no rows.
 
 ### Dashboard authoring
 
@@ -320,6 +326,9 @@ into the MCP server:
   model-editing tools, `getBranchDiff`, `getDeploymentEnv`, and both pre-aggregation
   tools — is offered only to users whose role allows editing the semantic model. A Viewer
   never sees them at all.
+- **Verification happens on the branch, before a merge, not after.** Pass the dev
+  `branchName` to `runQuery` to check that an edit returns the right data — `valid: true`
+  from `writeDataModelFile` only means the model compiles, not that it's correct.
 
 Review pending work with `getDataModelChanges` before you commit.
 
@@ -400,6 +409,8 @@ Call `startDataModelEdit` to enter development mode and get a dev `branchName`. 
 the current source with `listDataModelFiles` and `readDataModelFile`, then apply changes
 with `writeDataModelFile` or `deleteDataModelFile`, passing that `branchName`. Each write
 recompiles the model and reports validation errors, so you can iterate until it compiles.
+Before committing, verify the change returns the right data: call `runQuery` with the same
+`branchName` and check the numbers, since a compiling model can still return wrong results.
 Review the result with `getDataModelChanges`, then commit the branch from the Cube UI to
 publish it.
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -158,9 +158,11 @@ of that exploration's placements in the current document at once; click its
 title to open it and change the query, which applies to every placement.
 
 A placement survives renaming the sheet it's on or the workbook it's in —
-it's tracked by the sheet's and workbook's own stable ids, not by name. It
-does **not** survive rows or columns inserted above its anchor cell; the
-anchor still shifts with the sheet.
+it's tracked by the sheet's and workbook's own stable ids, not by name. A
+placement's anchor is a fixed cell reference, though, so it does **not**
+survive rows or columns inserted above it: the visible data shifts down with
+the insert, but the stored anchor doesn't move with it, so the next refresh
+targets the wrong cell.
 
 <Frame>
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -85,6 +85,11 @@ Cube Cloud for Excel works only with [views][ref-views], not cubes.
 
 </Info>
 
+If the view defines [`default_ui_filters`][ref-default-ui-filters], those
+filters are pre-populated as soon as you select the view — the same way they
+are in workbooks. They are a starting point, not enforcement: you can change
+their values, switch operators, or remove them.
+
 Click on members to add them to **Rows** and **Measures**.
 If needed, drag dimensions from **Rows** to **Columns**. Click on
 the funnel buttons to add members to **Filters**. Click on **×** to
@@ -108,6 +113,31 @@ With every change to your query, Cube Cloud for Excel will update the report on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
+### Measure position and order
+
+By default, measures nest under each value of the dimension they're paired
+with — every measure for the first column value, then every measure for the
+next. Open the **Display** tab to change **Measure position** to **Before
+columns** to get the opposite layout: each measure spans every column value,
+with all values of one measure together before moving to the next.
+
+For example, with `Forecast Sales Units` and `Forecast Net Sales` on Measures
+and a `season` dimension on Columns:
+
+- **After columns** (default): `Q1: [Sales Units, Net Sales] | Q2: [Sales
+  Units, Net Sales]`
+- **Before columns**: `Sales Units: [Q1, Q2] | Net Sales: [Q1, Q2]`
+
+{/* TODO: screenshot — side-by-side of the two output layouts (After columns vs Before columns) */}
+
+The same choice applies when measures are placed on **Rows** instead (set
+with **Measures on**, in the same tab) — there it's labeled **After rows** /
+**Before rows**.
+
+To change the order measures appear in within their group, drag them within
+the **Measures** pane on the **Pivot** tab. Position and order are saved with
+the report and survive **Refresh**.
+
 When your report is ready, you can optionally move it to [saved reports](#work-with-saved-reports)
 by clicking **Save**.
 
@@ -119,8 +149,18 @@ exploration by name across your whole deployment, not just the current
 folder — results are grouped by type and show each item's folder location,
 and selecting one navigates you straight to it.
 
-Click **Refresh** to manually refresh the data in the report's location.
-Click **Edit** to change the query or the location.
+An exploration can be placed more than once — on different sheets or at
+different anchors in the same workbook, and in more than one document at
+once (a Google Sheets spreadsheet and an Excel workbook simultaneously).
+Hovering a row in this list shows every placement it has in the **current**
+document under **Location** / **Locations**. Click **Refresh** to update all
+of that exploration's placements in the current document at once; click its
+title to open it and change the query, which applies to every placement.
+
+A placement survives renaming the sheet it's on or the workbook it's in —
+it's tracked by the sheet's and workbook's own stable ids, not by name. It
+does **not** survive rows or columns inserted above its anchor cell; the
+anchor still shifts with the sheet.
 
 <Frame>
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />
@@ -141,6 +181,7 @@ in Cube Cloud.
 [ref-playground]: /docs/explore-analyze/playground
 [ref-views]: /docs/data-modeling/views
 [ref-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations
+[ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
 [link-excel-addins]: https://support.microsoft.com/en-us/office/add-or-remove-add-ins-in-excel-0af570c4-5cf3-4fa9-9b88-403625a0b460
 [link-ms-appsource]: https://appsource.microsoft.com/en-us/product/office/WA200008486

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -77,20 +77,28 @@ This works on both regular and published (embedded) dashboards. The filter is
 only applied if a matching filter widget for that dimension already exists on the
 dashboard.
 
-## Allow CSV export
+## Allow chart export {#allow-csv-export}
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget's data as a CSV file, add the
-`allowExport=true` query parameter to the embed URL:
+widgets. To let viewers download a chart widget as a **CSV**, **PNG**, or
+**PDF** file, add the `allowExport=true` query parameter to the embed URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
-When enabled, each chart widget's ⋮ menu shows a **Download as CSV** action. The
-CSV is generated client-side from the data already loaded into the widget, so no
-additional query is issued. The parameter is opt-in — omit it (the default) to
-keep the download action hidden.
+When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
+as PNG**, and **Download as PDF** actions. `allowExport` is the single switch
+for all three formats — there is no way to allow one format while blocking
+another. Only the exact literal string `true` opts in; the parameter is
+otherwise opt-out — omit it (the default) to keep every download action
+hidden.
+
+The CSV is generated client-side from the data already loaded into the
+widget, so no additional query is issued. Screenshot mode suppresses export
+regardless of the parameter. Inside an embed, `allowExport` — not the
+viewer's own Cube role — is the authority on whether the download actions
+appear.
 
 ## Show or hide the AI chat
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -90,15 +90,14 @@ https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?sessi
 When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
 as PNG**, and **Download as PDF** actions. `allowExport` is the single switch
 for all three formats — there is no way to allow one format while blocking
-another. Only the exact literal string `true` opts in; the parameter is
-otherwise opt-out — omit it (the default) to keep every download action
-hidden.
+another. Only the exact literal string `true` opts in: `allowExport=1`,
+`allowExport=TRUE`, a bare `?allowExport`, and omitting the parameter (the
+default) all leave every download action hidden.
 
 The CSV is generated client-side from the data already loaded into the
-widget, so no additional query is issued. Screenshot mode suppresses export
-regardless of the parameter. Inside an embed, `allowExport` — not the
-viewer's own Cube role — is the authority on whether the download actions
-appear.
+widget, so no additional query is issued. Inside an embed, `allowExport` —
+not the viewer's own Cube role — is the authority on whether the download
+actions appear.
 
 ## Show or hide the AI chat
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -186,9 +186,9 @@ painted" signal (distinct from `ready`, which fires at mount, before data loads)
 
 #### `cube:event:download` {#cube-event-download}
 
-Emitted when a viewer exports something — a widget's data as CSV, or (in future)
-a dashboard image. Reports _that_ an export happened and its shape — never the
-exported rows themselves.
+Emitted when a viewer exports something — a widget's data as CSV, or a widget
+as a PNG or PDF image. Reports _that_ an export happened and its shape — never
+the exported rows themselves.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -209,10 +209,10 @@ exported rows themselves.
 ```
 
 <Note>
-  The CSV download action on a dashboard widget only appears when the embed URL
-  includes `allowExport=true` (see [Dashboards → Allow CSV
+  A dashboard widget's download actions (CSV, PNG, PDF) only appear when the
+  embed URL includes `allowExport=true` (see [Dashboards → Allow chart
   export](/embedding/iframe/dashboards#allow-csv-export)). The event fires when a
-  viewer uses it.
+  viewer uses one of them.
 </Note>
 
 #### `cube:event:drilldown` {#cube-event-drilldown}

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -287,10 +287,11 @@ over the view's default. When `auto_run` is not set, auto-run is on.
 #### `default_ui_filters`
 
 In the Cube cloud platform, you can use the `default_ui_filters` key in a
-view's `meta` to define default filters for [workbooks][ref-workbook-filtering]
-and views embedded via the React Embed SDK. When the view is selected, these
-filters are pre-populated as regular, fully editable filters — data consumers
-can change their values, switch operators, or remove them entirely.
+view's `meta` to define default filters for [workbooks][ref-workbook-filtering],
+views embedded via the React Embed SDK, and the Google Sheets / Excel add-in.
+When the view is selected, these filters are pre-populated as regular, fully
+editable filters — data consumers can change their values, switch operators,
+or remove them entirely.
 
 Each entry has a `member` (a dimension or measure exposed by the view), an
 `operator`, and a list of `values` — or a single `value`, which is natural for
@@ -418,11 +419,11 @@ bounds, drops that filter entry with a browser-console warning — the remaining
 entries still apply, and view selection never breaks.
 
 Unlike [`default_filters`](#default_filters), which are enforced on every query
-against the view, `default_ui_filters` only provide a starting point for the
-workbook UI: they don't apply to queries made through APIs or other
-visualization tools, and workbook users can freely modify or remove them.
-They also only apply to new queries — defining or changing them in the data
-model does not add them to existing queries.
+against the view, `default_ui_filters` only provide a starting point: they
+don't apply to queries made through APIs or other visualization tools, and
+data consumers can freely modify or remove them. They also only apply to new
+queries — defining or changing them in the data model does not add them to
+existing queries or saved explorations.
 
 ### `cubes`
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] N/A — Tests / linter (docs-only change)

Fixes five places where the docs described stale or incomplete behavior:

- **`default_ui_filters`** on a view now also seed queries in the Google Sheets / Excel add-in, not just workbooks and views embedded via the React Embed SDK. Updated the surface list in `reference/data-modeling/view.mdx`, added a pointer on the workbooks querying-data page, and a short note on both add-in pages.
- **Excel/Sheets add-in — saved reports.** An exploration can now be placed on multiple sheets/anchors and in multiple documents (a Google Sheets spreadsheet and an Excel workbook) at once. Rewrote "Work with saved reports" on both add-in pages to describe placements and what Refresh actually updates, instead of a single report location.
- **Excel/Sheets add-in — pivot builder.** The pivot builder's Display tab now has a Measure position control (before/after the paired dimension, on both the Columns and Rows axes) plus drag-to-reorder within the Measures pane. Added a "Measure position and order" subsection to both add-in pages with a worked before/after example.
- **Cube MCP server.** The `runQuery` tool now accepts an optional `branchName`, so an agent editing the data model can verify a change against its own dev branch before merging. Updated the tool table, the safety-constraints list, and the edit-the-data-model walkthrough in `docs/integrations/mcp-server.mdx`.
- **Embedded dashboards.** `allowExport=true` now also unlocks PNG/PDF widget export, not just CSV. Renamed and rewrote the "Allow CSV export" section in `embedding/iframe/dashboards.mdx` (kept the old anchor via explicit `{#allow-csv-export}` syntax so the existing inbound link from `events.mdx` keeps working), and updated the `cube:event:download` docs, which still said PNG was "in future."

Also fixed a small pre-existing typo while in the area ("Google Cloud for Sheets" → "Cube Cloud for Sheets" in `google-sheets.mdx`, matching the equivalent sentence on the Excel page).

Ran `npx mintlify broken-links --check-anchors` — no new broken links (one pre-existing broken anchor in `reference/control-plane-api.mdx` is unrelated to this change).
