### PR TITLE
refactor(query-orchestrator): Rework QueryCache.cacheQueryResult

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -931,8 +931,7 @@ export class QueryCache {
       return CacheAction.RefreshSameRequest;
     }
 
-    // Without a refreshKey there is nothing to refresh against, so an elapsed threshold alone
-    // never triggers a fetch — the entry keeps being served until it expires out of the cache.
+    // Without a refreshKey there is nothing to refresh against, so an elapsed threshold alone never triggers a fetch.
     if (!renewalKey) {
       return CacheAction.ServeCached;
     }
@@ -1082,7 +1081,6 @@ export class QueryCache {
   protected storeInMemoryCache(entry: CacheEntry, renewedAgo: number, ctx: CacheOperationContext): void {
     const { useInMemory, renewalThreshold } = ctx.options;
 
-    // No threshold means nothing bounds the in-memory window, so it stays off.
     if (useInMemory && !!renewalThreshold &&
       renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000) {
       this.memoryCache.set(ctx.redisKey, entry);

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -124,7 +124,7 @@ export type CacheKey =
 export type CacheEntry = {
   time: number;
   result: any;
-  renewalKey: string;
+  renewalKey?: string;
   requestId?: string;
 };
 
@@ -907,11 +907,6 @@ export class QueryCache {
     callback: () => MaybeCancelablePromise<T>,
   ) => this.cacheDriver.withLock(`lock:${key}`, callback, ttl, true);
 
-  /**
-   * A client polling through continue-wait re-enters with the same requestId, so rejecting
-   * the result it just wrote would restart the fetch on every poll and never converge while
-   * the refreshKey keeps moving. Background renew opts out: fresh data is all it exists for.
-   */
   protected static decideCacheAction(
     entry: CacheEntry,
     renewedAgo: number,
@@ -929,10 +924,15 @@ export class QueryCache {
     const isSameRequest = options.requestId && entry.requestId &&
       QueryCache.extractRequestUUID(entry.requestId) === QueryCache.extractRequestUUID(options.requestId);
 
+    // A client polling through continue-wait re-enters with the same requestId, so rejecting
+    // the result it just wrote would restart the fetch on every poll and never converge while
+    // the refreshKey keeps moving. Background renew opts out: fresh data is all it exists for.
     if (isSameRequest && !options.renewCycle) {
       return CacheAction.RefreshSameRequest;
     }
 
+    // Without a refreshKey there is nothing to refresh against, so an elapsed threshold alone
+    // never triggers a fetch — the entry keeps being served until it expires out of the cache.
     if (!renewalKey) {
       return CacheAction.ServeCached;
     }
@@ -1082,7 +1082,9 @@ export class QueryCache {
   protected storeInMemoryCache(entry: CacheEntry, renewedAgo: number, ctx: CacheOperationContext): void {
     const { useInMemory, renewalThreshold } = ctx.options;
 
-    if (useInMemory && renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000) {
+    // No threshold means nothing bounds the in-memory window, so it stays off.
+    if (useInMemory && !!renewalThreshold &&
+      renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000) {
       this.memoryCache.set(ctx.redisKey, entry);
     }
   }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -128,6 +128,22 @@ type CacheEntry = {
   requestId?: string;
 };
 
+type CacheAction =
+  | 'serve-cached'
+  | 'refresh-same-request'
+  | 'refresh-background'
+  | 'wait-for-renew';
+
+type CacheOperationContext = {
+  cacheKey: CacheKey;
+  redisKey: string;
+  renewalKey?: string;
+  expiration: number;
+  spanId: string;
+  options: CacheQueryResultOptions;
+  log: (message: string, extra?: Record<string, any>) => void;
+};
+
 export interface QueryCacheOptions {
   refreshKeyRenewalThreshold?: number;
   externalQueueOptions?: any;
@@ -155,6 +171,8 @@ export class QueryCache {
   protected externalQueue: QueryQueue | null = null;
 
   protected memoryCache: LRUCache<string, CacheEntry>;
+
+  private static readonly IN_MEMORY_CACHE_DISABLE_PERIOD = 5 * 60 * 1000;
 
   public constructor(
     protected readonly cachePrefix: string,
@@ -888,6 +906,186 @@ export class QueryCache {
     callback: () => MaybeCancelablePromise<T>,
   ) => this.cacheDriver.withLock(`lock:${key}`, callback, ttl, true);
 
+  /**
+   * A client polling through continue-wait re-enters with the same requestId, so rejecting
+   * the result it just wrote would restart the fetch on every poll and never converge while
+   * the refreshKey keeps moving. Background renew opts out: fresh data is all it exists for.
+   */
+  private static decideCacheAction(
+    entry: CacheEntry,
+    renewedAgo: number,
+    options: CacheQueryResultOptions,
+    renewalKey?: string,
+  ): CacheAction {
+    const { renewalThreshold } = options;
+    const isExpired = !renewalThreshold || !entry.time || renewedAgo > renewalThreshold * 1000;
+    const isKeyMismatch = !!renewalKey && entry.renewalKey !== renewalKey;
+
+    if (!isExpired && !isKeyMismatch) {
+      return 'serve-cached';
+    }
+
+    const isSameRequest = options.requestId && entry.requestId &&
+      QueryCache.extractRequestUUID(entry.requestId) === QueryCache.extractRequestUUID(options.requestId);
+
+    if (isSameRequest && !options.renewCycle) {
+      return 'refresh-same-request';
+    }
+
+    if (!renewalKey) {
+      return 'serve-cached';
+    }
+
+    return options.waitForRenew ? 'wait-for-renew' : 'refresh-background';
+  }
+
+  private static isMemoryEntryUsable(
+    entry: CacheEntry,
+    renewedAgo: number,
+    expiration: number,
+    renewalThreshold?: number,
+    renewalKey?: string,
+  ): boolean {
+    if (renewedAgo > expiration * 1000 || renewedAgo > QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD) {
+      return false;
+    }
+
+    if (!renewalKey) {
+      return true;
+    }
+
+    // Near expiry an in-memory entry races with refreshes carrying a different refreshKey value.
+    return !!renewalThreshold &&
+      !!entry.time &&
+      renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000 &&
+      entry.renewalKey === renewalKey;
+  }
+
+  private cacheOperationContext(
+    cacheKey: CacheKey,
+    expiration: number,
+    options: CacheQueryResultOptions,
+  ): CacheOperationContext {
+    const spanId = crypto.randomBytes(16).toString('hex');
+    const logContext = {
+      cacheKey,
+      requestId: options.requestId,
+      spanId,
+      primaryQuery: options.primaryQuery,
+      renewCycle: options.renewCycle,
+    };
+
+    return {
+      cacheKey,
+      redisKey: this.queryRedisKey(cacheKey),
+      renewalKey: options.renewalKey && this.queryRedisKey(options.renewalKey),
+      expiration,
+      spanId,
+      options,
+      log: (message, extra) => this.logger(message, extra ? { ...logContext, ...extra } : logContext),
+    };
+  }
+
+  private fetchAndCacheQuery(
+    query: string | QueryWithParams,
+    values: string[],
+    ctx: CacheOperationContext,
+  ) {
+    const { cacheKey, redisKey, renewalKey, expiration, spanId, options } = ctx;
+
+    return this.queryWithRetryAndRelease(query, values, {
+      cacheKey,
+      priority: options.priority,
+      external: options.external,
+      requestId: options.requestId,
+      spanId,
+      persistent: options.persistent,
+      dataSource: options.dataSource,
+      useCsvQuery: options.useCsvQuery,
+      lambdaTypes: options.lambdaTypes,
+    }).then(res => {
+      const entry = {
+        time: (new Date()).getTime(),
+        result: res,
+        renewalKey,
+        requestId: options.requestId,
+      };
+
+      return this
+        .cacheDriver
+        .set(redisKey, entry, expiration)
+        .then(({ bytes }) => {
+          ctx.log('Renewed');
+          this.logger('Outgoing network usage', {
+            service: 'cache',
+            requestId: options.requestId,
+            spanId,
+            bytes,
+            cacheKey,
+          });
+          return res;
+        });
+    }).catch(e => {
+      if (!(e instanceof ContinueWaitError)) {
+        ctx.log('Dropping Cache', { error: e.stack || e });
+        this.cacheDriver.remove(redisKey)
+          .catch(err => this.logger('Error removing key', {
+            cacheKey,
+            spanId,
+            error: err.stack || err,
+            requestId: options.requestId
+          }));
+      }
+      throw e;
+    });
+  }
+
+  private fetchAndCacheQueryInBackground(
+    query: string | QueryWithParams,
+    values: string[],
+    ctx: CacheOperationContext,
+  ): void {
+    this.fetchAndCacheQuery(query, values, ctx).catch(e => {
+      if (!(e instanceof ContinueWaitError)) {
+        ctx.log('Error renewing', { error: e.stack || e });
+      }
+    });
+  }
+
+  private getFromMemoryCache(ctx: CacheOperationContext): CacheEntry | null {
+    const { redisKey, renewalKey, expiration, options } = ctx;
+    const entry = this.memoryCache.get(redisKey);
+
+    if (!entry) {
+      return null;
+    }
+
+    const renewedAgo = (new Date()).getTime() - entry.time;
+
+    if (!QueryCache.isMemoryEntryUsable(entry, renewedAgo, expiration, options.renewalThreshold, renewalKey)) {
+      this.memoryCache.delete(redisKey);
+      return null;
+    }
+
+    ctx.log('Found in memory cache entry', {
+      time: entry.time,
+      renewedAgo,
+      renewalKey: entry.renewalKey,
+      newRenewalKey: renewalKey,
+      renewalThreshold: options.renewalThreshold,
+    });
+
+    return entry;
+  }
+
+  private storeInMemoryCache(entry: CacheEntry, renewedAgo: number, ctx: CacheOperationContext): void {
+    const { useInMemory, renewalThreshold } = ctx.options;
+
+    if (useInMemory && renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000) {
+      this.memoryCache.set(ctx.redisKey, entry);
+    }
+  }
+
   public async cacheQueryResult(
     query: string | QueryWithParams,
     values: string[],
@@ -895,167 +1093,57 @@ export class QueryCache {
     expiration: number,
     options: CacheQueryResultOptions,
   ) {
-    const spanId = crypto.randomBytes(16).toString('hex');
     options = options || { dataSource: 'default' };
-    const { renewalThreshold, primaryQuery, renewCycle } = options;
-    const renewalKey = options.renewalKey && this.queryRedisKey(options.renewalKey);
-    const redisKey = this.queryRedisKey(cacheKey);
-    const fetchNew = () => (
-      this.queryWithRetryAndRelease(query, values, {
-        cacheKey,
-        priority: options.priority,
-        external: options.external,
-        requestId: options.requestId,
-        spanId,
-        persistent: options.persistent,
-        dataSource: options.dataSource,
-        useCsvQuery: options.useCsvQuery,
-        lambdaTypes: options.lambdaTypes,
-      }).then(res => {
-        const result = {
-          time: (new Date()).getTime(),
-          result: res,
-          renewalKey,
-          requestId: options.requestId,
-        };
-        return this
-          .cacheDriver
-          .set(redisKey, result, expiration)
-          .then(({ bytes }) => {
-            this.logger('Renewed', { cacheKey, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-            this.logger('Outgoing network usage', {
-              service: 'cache',
-              requestId: options.requestId,
-              spanId,
-              bytes,
-              cacheKey,
-            });
-            return res;
-          });
-      }).catch(e => {
-        if (!(e instanceof ContinueWaitError)) {
-          this.logger('Dropping Cache', {
-            cacheKey,
-            error: e.stack || e,
-            requestId: options.requestId,
-            spanId,
-            primaryQuery,
-            renewCycle
-          });
-          this.cacheDriver.remove(redisKey)
-            .catch(err => this.logger('Error removing key', {
-              cacheKey,
-              spanId,
-              error: err.stack || err,
-              requestId: options.requestId
-            }));
-        }
-        throw e;
-      })
-    );
+
+    const ctx = this.cacheOperationContext(cacheKey, expiration, options);
+    const { renewalThreshold } = options;
 
     if (options.forceNoCache) {
-      this.logger('Force no cache for', { cacheKey, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-      return fetchNew();
+      ctx.log('Force no cache for');
+      return this.fetchAndCacheQuery(query, values, ctx);
     }
 
-    let res;
+    let entry: CacheEntry | null = options.useInMemory ? this.getFromMemoryCache(ctx) : null;
 
-    const inMemoryCacheDisablePeriod = 5 * 60 * 1000;
-
-    if (options.useInMemory) {
-      const inMemoryValue = this.memoryCache.get(redisKey);
-      if (inMemoryValue) {
-        const renewedAgo = (new Date()).getTime() - inMemoryValue.time;
-
-        if (
-          renewalKey && (
-            !renewalThreshold ||
-            !inMemoryValue.time ||
-            // Do not cache in memory in last 5 minutes of expiry.
-            // Most likely it'll cause race condition of refreshing data with different refreshKey values.
-            renewedAgo + inMemoryCacheDisablePeriod > renewalThreshold * 1000 ||
-            inMemoryValue.renewalKey !== renewalKey
-          ) || renewedAgo > expiration * 1000 || renewedAgo > inMemoryCacheDisablePeriod
-        ) {
-          this.memoryCache.delete(redisKey);
-        } else {
-          this.logger('Found in memory cache entry', {
-            cacheKey,
-            time: inMemoryValue.time,
-            renewedAgo,
-            renewalKey: inMemoryValue.renewalKey,
-            newRenewalKey: renewalKey,
-            renewalThreshold,
-            requestId: options.requestId,
-            spanId,
-            primaryQuery,
-            renewCycle
-          });
-          res = inMemoryValue;
-        }
-      }
+    if (!entry) {
+      entry = await this.cacheDriver.get(ctx.redisKey);
     }
 
-    if (!res) {
-      res = await this.cacheDriver.get(redisKey);
+    if (!entry) {
+      ctx.log('Missing cache for');
+      return this.fetchAndCacheQuery(query, values, ctx);
     }
 
-    if (res) {
-      const parsedResult = res;
-      const renewedAgo = (new Date()).getTime() - parsedResult.time;
-      this.logger('Found cache entry', {
-        cacheKey,
-        time: parsedResult.time,
-        renewedAgo,
-        renewalKey: parsedResult.renewalKey,
-        newRenewalKey: renewalKey,
-        renewalThreshold,
-        requestId: options.requestId,
-        spanId,
-        primaryQuery,
-        renewCycle
-      });
+    const renewedAgo = (new Date()).getTime() - entry.time;
 
-      const isExpired = !renewalThreshold || !parsedResult.time || renewedAgo > renewalThreshold * 1000;
-      const isKeyMismatch = renewalKey && parsedResult.renewalKey !== renewalKey;
-      const isSameRequest = options.requestId && parsedResult.requestId &&
-        QueryCache.extractRequestUUID(parsedResult.requestId) === QueryCache.extractRequestUUID(options.requestId);
+    ctx.log('Found cache entry', {
+      time: entry.time,
+      renewedAgo,
+      renewalKey: entry.renewalKey,
+      newRenewalKey: ctx.renewalKey,
+      renewalThreshold,
+    });
 
-      // Continue-wait cycle: result was produced by our request,
-      // refreshKey changed during execution — return cached, refresh in background.
-      // Skip for renewCycle — it must always fetch fresh data to keep cache up-to-date.
-      if (isSameRequest && !renewCycle && (isExpired || isKeyMismatch)) {
-        this.logger('Same request cache hit (background refresh)', { cacheKey, renewalThreshold, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-        fetchNew().catch(e => {
-          if (!(e instanceof ContinueWaitError)) {
-            this.logger('Error renewing', { cacheKey, error: e.stack || e, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-          }
-        });
-      } else if (renewalKey && (isExpired || isKeyMismatch)) {
-        // Cache expired or refreshKey changed — need to refresh
-        if (options.waitForRenew) {
-          this.logger('Waiting for renew', { cacheKey, renewalThreshold, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-          return fetchNew();
-        } else {
-          this.logger('Renewing existing key', { cacheKey, renewalThreshold, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-          fetchNew().catch(e => {
-            if (!(e instanceof ContinueWaitError)) {
-              this.logger('Error renewing', { cacheKey, error: e.stack || e, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-            }
-          });
-        }
-      }
-
-      this.logger('Using cache for', { cacheKey, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-      if (options.useInMemory && renewedAgo + inMemoryCacheDisablePeriod <= renewalThreshold * 1000) {
-        this.memoryCache.set(redisKey, parsedResult);
-      }
-      return parsedResult.result;
-    } else {
-      this.logger('Missing cache for', { cacheKey, requestId: options.requestId, spanId, primaryQuery, renewCycle });
-      return fetchNew();
+    switch (QueryCache.decideCacheAction(entry, renewedAgo, options, ctx.renewalKey)) {
+      case 'wait-for-renew':
+        ctx.log('Waiting for renew', { renewalThreshold });
+        return this.fetchAndCacheQuery(query, values, ctx);
+      case 'refresh-same-request':
+        ctx.log('Same request cache hit (background refresh)', { renewalThreshold });
+        this.fetchAndCacheQueryInBackground(query, values, ctx);
+        break;
+      case 'refresh-background':
+        ctx.log('Renewing existing key', { renewalThreshold });
+        this.fetchAndCacheQueryInBackground(query, values, ctx);
+        break;
+      default:
+        break;
     }
+
+    ctx.log('Using cache for');
+    this.storeInMemoryCache(entry, renewedAgo, ctx);
+
+    return entry.result;
   }
 
   protected async lastRefreshTime(cacheKey) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -128,11 +128,12 @@ export type CacheEntry = {
   requestId?: string;
 };
 
-export type CacheAction =
-  | 'serve-cached'
-  | 'refresh-same-request'
-  | 'refresh-background'
-  | 'wait-for-renew';
+export enum CacheAction {
+  ServeCached = 'serve-cached',
+  RefreshSameRequest = 'refresh-same-request',
+  RefreshBackground = 'refresh-background',
+  WaitForRenew = 'wait-for-renew',
+}
 
 type CacheOperationContext = {
   cacheKey: CacheKey;
@@ -922,21 +923,21 @@ export class QueryCache {
     const isKeyMismatch = !!renewalKey && entry.renewalKey !== renewalKey;
 
     if (!isExpired && !isKeyMismatch) {
-      return 'serve-cached';
+      return CacheAction.ServeCached;
     }
 
     const isSameRequest = options.requestId && entry.requestId &&
       QueryCache.extractRequestUUID(entry.requestId) === QueryCache.extractRequestUUID(options.requestId);
 
     if (isSameRequest && !options.renewCycle) {
-      return 'refresh-same-request';
+      return CacheAction.RefreshSameRequest;
     }
 
     if (!renewalKey) {
-      return 'serve-cached';
+      return CacheAction.ServeCached;
     }
 
-    return options.waitForRenew ? 'wait-for-renew' : 'refresh-background';
+    return options.waitForRenew ? CacheAction.WaitForRenew : CacheAction.RefreshBackground;
   }
 
   protected static isMemoryEntryUsable(
@@ -1125,14 +1126,14 @@ export class QueryCache {
     });
 
     switch (QueryCache.decideCacheAction(entry, renewedAgo, options, ctx.renewalKey)) {
-      case 'wait-for-renew':
+      case CacheAction.WaitForRenew:
         ctx.log('Waiting for renew', { renewalThreshold });
         return this.fetchAndCacheQuery(query, values, ctx);
-      case 'refresh-same-request':
+      case CacheAction.RefreshSameRequest:
         ctx.log('Same request cache hit (background refresh)', { renewalThreshold });
         this.fetchAndCacheQueryInBackground(query, values, ctx);
         break;
-      case 'refresh-background':
+      case CacheAction.RefreshBackground:
         ctx.log('Renewing existing key', { renewalThreshold });
         this.fetchAndCacheQueryInBackground(query, values, ctx);
         break;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -121,14 +121,14 @@ export type CacheKey =
   [CacheKeyItem, CacheKeyItem, CacheKeyItem] |
   [CacheKeyItem, CacheKeyItem, CacheKeyItem, CacheKeyItem];
 
-type CacheEntry = {
+export type CacheEntry = {
   time: number;
   result: any;
   renewalKey: string;
   requestId?: string;
 };
 
-type CacheAction =
+export type CacheAction =
   | 'serve-cached'
   | 'refresh-same-request'
   | 'refresh-background'
@@ -172,7 +172,7 @@ export class QueryCache {
 
   protected memoryCache: LRUCache<string, CacheEntry>;
 
-  private static readonly IN_MEMORY_CACHE_DISABLE_PERIOD = 5 * 60 * 1000;
+  protected static readonly IN_MEMORY_CACHE_DISABLE_PERIOD = 5 * 60 * 1000;
 
   public constructor(
     protected readonly cachePrefix: string,
@@ -911,7 +911,7 @@ export class QueryCache {
    * the result it just wrote would restart the fetch on every poll and never converge while
    * the refreshKey keeps moving. Background renew opts out: fresh data is all it exists for.
    */
-  private static decideCacheAction(
+  protected static decideCacheAction(
     entry: CacheEntry,
     renewedAgo: number,
     options: CacheQueryResultOptions,
@@ -939,7 +939,7 @@ export class QueryCache {
     return options.waitForRenew ? 'wait-for-renew' : 'refresh-background';
   }
 
-  private static isMemoryEntryUsable(
+  protected static isMemoryEntryUsable(
     entry: CacheEntry,
     renewedAgo: number,
     expiration: number,
@@ -961,7 +961,7 @@ export class QueryCache {
       entry.renewalKey === renewalKey;
   }
 
-  private cacheOperationContext(
+  protected cacheOperationContext(
     cacheKey: CacheKey,
     expiration: number,
     options: CacheQueryResultOptions,
@@ -986,7 +986,7 @@ export class QueryCache {
     };
   }
 
-  private fetchAndCacheQuery(
+  protected fetchAndCacheQuery(
     query: string | QueryWithParams,
     values: string[],
     ctx: CacheOperationContext,
@@ -1040,7 +1040,7 @@ export class QueryCache {
     });
   }
 
-  private fetchAndCacheQueryInBackground(
+  protected fetchAndCacheQueryInBackground(
     query: string | QueryWithParams,
     values: string[],
     ctx: CacheOperationContext,
@@ -1052,7 +1052,7 @@ export class QueryCache {
     });
   }
 
-  private getFromMemoryCache(ctx: CacheOperationContext): CacheEntry | null {
+  protected getFromMemoryCache(ctx: CacheOperationContext): CacheEntry | null {
     const { redisKey, renewalKey, expiration, options } = ctx;
     const entry = this.memoryCache.get(redisKey);
 
@@ -1078,7 +1078,7 @@ export class QueryCache {
     return entry;
   }
 
-  private storeInMemoryCache(entry: CacheEntry, renewedAgo: number, ctx: CacheOperationContext): void {
+  protected storeInMemoryCache(entry: CacheEntry, renewedAgo: number, ctx: CacheOperationContext): void {
     const { useInMemory, renewalThreshold } = ctx.options;
 
     if (useInMemory && renewedAgo + QueryCache.IN_MEMORY_CACHE_DISABLE_PERIOD <= renewalThreshold * 1000) {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -6,6 +6,10 @@ QueryCacheTest('Local', {
 });
 
 class QueryCacheOpened extends QueryCache {
+  public static get disablePeriod(): number {
+    return this.IN_MEMORY_CACHE_DISABLE_PERIOD;
+  }
+
   public static decideCacheAction(
     entry: Partial<CacheEntry>,
     renewedAgo: number,
@@ -16,6 +20,22 @@ class QueryCacheOpened extends QueryCache {
       entry as CacheEntry,
       renewedAgo,
       options as CacheQueryResultOptions,
+      renewalKey,
+    );
+  }
+
+  public static isMemoryEntryUsable(
+    entry: Partial<CacheEntry>,
+    renewedAgo: number,
+    expiration: number,
+    renewalThreshold?: number,
+    renewalKey?: string,
+  ): boolean {
+    return super.isMemoryEntryUsable(
+      entry as CacheEntry,
+      renewedAgo,
+      expiration,
+      renewalThreshold,
       renewalKey,
     );
   }
@@ -151,6 +171,121 @@ describe('QueryCache.decideCacheAction', () => {
   cases.forEach(({ name, entry, renewedAgo, options, renewalKey, expected }) => {
     it(name, () => {
       expect(QueryCacheOpened.decideCacheAction(entry, renewedAgo, options, renewalKey)).toEqual(expected);
+    });
+  });
+});
+
+describe('QueryCache.isMemoryEntryUsable', () => {
+  // In-memory window. `expiration` and `renewalThreshold` are seconds, `renewedAgo` is ms.
+  const WINDOW = QueryCacheOpened.disablePeriod;
+  const HOUR = 3600;
+
+  type Case = {
+    name: string,
+    entry: Partial<CacheEntry>,
+    renewedAgo: number,
+    expiration: number,
+    renewalThreshold?: number,
+    renewalKey?: string,
+    expected: boolean,
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'past expiration but still inside the in-memory window: unusable',
+      entry: { time: 1 },
+      renewedAgo: 61 * 1000,
+      expiration: 60,
+      expected: false,
+    },
+    {
+      name: 'past the in-memory window but nowhere near expiration: unusable',
+      entry: { time: 1 },
+      renewedAgo: WINDOW + 1,
+      expiration: HOUR,
+      expected: false,
+    },
+    {
+      name: 'exactly at the in-memory window: usable',
+      entry: { time: 1 },
+      renewedAgo: WINDOW,
+      expiration: HOUR,
+      expected: true,
+    },
+    {
+      name: 'exactly at expiration: usable',
+      entry: { time: 1 },
+      renewedAgo: 60 * 1000,
+      expiration: 60,
+      expected: true,
+    },
+    {
+      name: 'without a renewal key the renewal checks are skipped: no threshold and no timestamp still usable',
+      entry: { time: 0 },
+      renewedAgo: 1000,
+      expiration: HOUR,
+      expected: true,
+    },
+    {
+      name: 'renewal key without a renewal threshold: unusable',
+      entry: { time: 1, renewalKey: 'rk' },
+      renewedAgo: 1000,
+      expiration: HOUR,
+      renewalKey: 'rk',
+      expected: false,
+    },
+    {
+      name: 'renewal key with an entry that has no timestamp: unusable',
+      entry: { time: 0, renewalKey: 'rk' },
+      renewedAgo: 1000,
+      expiration: HOUR,
+      renewalThreshold: HOUR,
+      renewalKey: 'rk',
+      expected: false,
+    },
+    {
+      name: 'threshold below twice the window, entry inside the last window before expiry: unusable',
+      entry: { time: 1, renewalKey: 'rk' },
+      renewedAgo: 100 * 1000,
+      expiration: HOUR,
+      renewalThreshold: 300,
+      renewalKey: 'rk',
+      expected: false,
+    },
+    {
+      name: 'threshold below twice the window, entry exactly at the last window before expiry: usable',
+      entry: { time: 1, renewalKey: 'rk' },
+      renewedAgo: 100 * 1000,
+      expiration: HOUR,
+      renewalThreshold: 400,
+      renewalKey: 'rk',
+      expected: true,
+    },
+    {
+      name: 'renewal key mismatch: unusable',
+      entry: { time: 1, renewalKey: 'old' },
+      renewedAgo: 1000,
+      expiration: HOUR,
+      renewalThreshold: HOUR,
+      renewalKey: 'new',
+      expected: false,
+    },
+    {
+      name: 'every check satisfied: usable',
+      entry: { time: 1, renewalKey: 'rk' },
+      renewedAgo: 1000,
+      expiration: HOUR,
+      renewalThreshold: HOUR,
+      renewalKey: 'rk',
+      expected: true,
+    },
+  ];
+
+  cases.forEach(({ name, entry, renewedAgo, expiration, renewalThreshold, renewalKey, expected }) => {
+    it(name, () => {
+      expect(
+        QueryCacheOpened.isMemoryEntryUsable(entry, renewedAgo, expiration, renewalThreshold, renewalKey)
+      ).toEqual(expected);
     });
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -1,5 +1,143 @@
+import { QueryCache } from '../../src';
 import { QueryCacheTest } from './QueryCache.abstract';
 
 QueryCacheTest('Local', {
   cacheAndQueueDriver: 'memory',
+});
+
+describe('QueryCache.decideCacheAction', () => {
+  // Cast past `private` so the decision table can be covered without seeding a cache driver.
+  const decideCacheAction = (QueryCache as any).decideCacheAction.bind(QueryCache);
+
+  const THRESHOLD = 600;
+  const NOT_EXPIRED = 100 * 1000;
+  const EXPIRED = 700 * 1000;
+
+  type Case = {
+    name: string,
+    entry: { time: number, renewalKey?: string, requestId?: string },
+    renewedAgo: number,
+    options: Record<string, any>,
+    renewalKey?: string,
+    expected: string,
+  };
+
+  const cases: Case[] = [
+    {
+      name: 'not expired and renewal key matches: serves cache even for the same request',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1-span-1' },
+      renewedAgo: NOT_EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-2', waitForRenew: true },
+      renewalKey: 'rk',
+      expected: 'serve-cached',
+    },
+    {
+      name: 'expired with renewal key and waitForRenew: blocks on fetch',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
+      renewalKey: 'rk',
+      expected: 'wait-for-renew',
+    },
+    {
+      name: 'expired with renewal key without waitForRenew: refreshes in background',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
+      renewalKey: 'rk',
+      expected: 'refresh-background',
+    },
+    {
+      name: 'renewal key mismatch while not expired and waitForRenew: blocks on fetch',
+      entry: { time: 1, renewalKey: 'old', requestId: 'req-1' },
+      renewedAgo: NOT_EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
+      renewalKey: 'new',
+      expected: 'wait-for-renew',
+    },
+    {
+      name: 'renewal key mismatch while not expired without waitForRenew: refreshes in background',
+      entry: { time: 1, renewalKey: 'old', requestId: 'req-1' },
+      renewedAgo: NOT_EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
+      renewalKey: 'new',
+      expected: 'refresh-background',
+    },
+    {
+      name: 'same request (different span) and expired: serves stale, refreshes in background',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1-span-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
+      renewalKey: 'rk',
+      expected: 'refresh-same-request',
+    },
+    {
+      name: 'same request and renewal key mismatch: serves stale, refreshes in background',
+      entry: { time: 1, renewalKey: 'old', requestId: 'req-1-span-1' },
+      renewedAgo: NOT_EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
+      renewalKey: 'new',
+      expected: 'refresh-same-request',
+    },
+    {
+      name: 'renew cycle never serves stale: expired same request blocks on fetch',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1-span-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true, renewCycle: true },
+      renewalKey: 'rk',
+      expected: 'wait-for-renew',
+    },
+    {
+      name: 'renew cycle never serves stale: key mismatch without waitForRenew refreshes in background',
+      entry: { time: 1, renewalKey: 'old', requestId: 'req-1-span-1' },
+      renewedAgo: NOT_EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: false, renewCycle: true },
+      renewalKey: 'new',
+      expected: 'refresh-background',
+    },
+    {
+      name: 'expired without a renewal key: keeps serving cache',
+      entry: { time: 1, requestId: 'req-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
+      expected: 'serve-cached',
+    },
+    {
+      name: 'expired without a renewal key but same request: refreshes in background',
+      entry: { time: 1, requestId: 'req-1-span-1' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
+      expected: 'refresh-same-request',
+    },
+    {
+      name: 'missing renewal threshold counts as expired',
+      entry: { time: 1, renewalKey: 'rk', requestId: 'req-1' },
+      renewedAgo: 0,
+      options: { requestId: 'req-2', waitForRenew: true },
+      renewalKey: 'rk',
+      expected: 'wait-for-renew',
+    },
+    {
+      name: 'entry without a timestamp counts as expired',
+      entry: { time: 0, renewalKey: 'rk', requestId: 'req-1' },
+      renewedAgo: 0,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
+      renewalKey: 'rk',
+      expected: 'refresh-background',
+    },
+    {
+      name: 'entry without a request id is never treated as the same request',
+      entry: { time: 1, renewalKey: 'rk' },
+      renewedAgo: EXPIRED,
+      options: { renewalThreshold: THRESHOLD, requestId: 'req-1', waitForRenew: true },
+      renewalKey: 'rk',
+      expected: 'wait-for-renew',
+    },
+  ];
+
+  cases.forEach(({ name, entry, renewedAgo, options, renewalKey, expected }) => {
+    it(name, () => {
+      expect(decideCacheAction(entry, renewedAgo, options, renewalKey)).toEqual(expected);
+    });
+  });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -1,25 +1,42 @@
-import { QueryCache } from '../../src';
+import { CacheAction, CacheEntry, CacheQueryResultOptions, QueryCache } from '../../src';
 import { QueryCacheTest } from './QueryCache.abstract';
 
 QueryCacheTest('Local', {
   cacheAndQueueDriver: 'memory',
 });
 
-describe('QueryCache.decideCacheAction', () => {
-  // Cast past `private` so the decision table can be covered without seeding a cache driver.
-  const decideCacheAction = (QueryCache as any).decideCacheAction.bind(QueryCache);
+/**
+ * Opens up the protected decision helper and accepts partial fixtures, so the decision
+ * table can be covered without seeding a cache driver.
+ */
+class QueryCacheOpened extends QueryCache {
+  public static decideCacheAction(
+    entry: Partial<CacheEntry>,
+    renewedAgo: number,
+    options: Partial<CacheQueryResultOptions>,
+    renewalKey?: string,
+  ): CacheAction {
+    return super.decideCacheAction(
+      entry as CacheEntry,
+      renewedAgo,
+      options as CacheQueryResultOptions,
+      renewalKey,
+    );
+  }
+}
 
+describe('QueryCache.decideCacheAction', () => {
   const THRESHOLD = 600;
   const NOT_EXPIRED = 100 * 1000;
   const EXPIRED = 700 * 1000;
 
   type Case = {
     name: string,
-    entry: { time: number, renewalKey?: string, requestId?: string },
+    entry: Partial<CacheEntry>,
     renewedAgo: number,
-    options: Record<string, any>,
+    options: Partial<CacheQueryResultOptions>,
     renewalKey?: string,
-    expected: string,
+    expected: CacheAction,
   };
 
   const cases: Case[] = [
@@ -137,7 +154,7 @@ describe('QueryCache.decideCacheAction', () => {
 
   cases.forEach(({ name, entry, renewedAgo, options, renewalKey, expected }) => {
     it(name, () => {
-      expect(decideCacheAction(entry, renewedAgo, options, renewalKey)).toEqual(expected);
+      expect(QueryCacheOpened.decideCacheAction(entry, renewedAgo, options, renewalKey)).toEqual(expected);
     });
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -176,7 +176,6 @@ describe('QueryCache.decideCacheAction', () => {
 });
 
 describe('QueryCache.isMemoryEntryUsable', () => {
-  // In-memory window. `expiration` and `renewalThreshold` are seconds, `renewedAgo` is ms.
   const WINDOW = QueryCacheOpened.disablePeriod;
   const HOUR = 3600;
 

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -5,10 +5,6 @@ QueryCacheTest('Local', {
   cacheAndQueueDriver: 'memory',
 });
 
-/**
- * Opens up the protected decision helper and accepts partial fixtures, so the decision
- * table can be covered without seeding a cache driver.
- */
 class QueryCacheOpened extends QueryCache {
   public static decideCacheAction(
     entry: Partial<CacheEntry>,
@@ -46,7 +42,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: NOT_EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-2', waitForRenew: true },
       renewalKey: 'rk',
-      expected: 'serve-cached',
+      expected: CacheAction.ServeCached,
     },
     {
       name: 'expired with renewal key and waitForRenew: blocks on fetch',
@@ -54,7 +50,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
       renewalKey: 'rk',
-      expected: 'wait-for-renew',
+      expected: CacheAction.WaitForRenew,
     },
     {
       name: 'expired with renewal key without waitForRenew: refreshes in background',
@@ -62,7 +58,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
       renewalKey: 'rk',
-      expected: 'refresh-background',
+      expected: CacheAction.RefreshBackground,
     },
     {
       name: 'renewal key mismatch while not expired and waitForRenew: blocks on fetch',
@@ -70,7 +66,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: NOT_EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
       renewalKey: 'new',
-      expected: 'wait-for-renew',
+      expected: CacheAction.WaitForRenew,
     },
     {
       name: 'renewal key mismatch while not expired without waitForRenew: refreshes in background',
@@ -78,7 +74,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: NOT_EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
       renewalKey: 'new',
-      expected: 'refresh-background',
+      expected: CacheAction.RefreshBackground,
     },
     {
       name: 'same request (different span) and expired: serves stale, refreshes in background',
@@ -86,7 +82,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
       renewalKey: 'rk',
-      expected: 'refresh-same-request',
+      expected: CacheAction.RefreshSameRequest,
     },
     {
       name: 'same request and renewal key mismatch: serves stale, refreshes in background',
@@ -94,7 +90,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: NOT_EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
       renewalKey: 'new',
-      expected: 'refresh-same-request',
+      expected: CacheAction.RefreshSameRequest,
     },
     {
       name: 'renew cycle never serves stale: expired same request blocks on fetch',
@@ -102,7 +98,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true, renewCycle: true },
       renewalKey: 'rk',
-      expected: 'wait-for-renew',
+      expected: CacheAction.WaitForRenew,
     },
     {
       name: 'renew cycle never serves stale: key mismatch without waitForRenew refreshes in background',
@@ -110,21 +106,21 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: NOT_EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: false, renewCycle: true },
       renewalKey: 'new',
-      expected: 'refresh-background',
+      expected: CacheAction.RefreshBackground,
     },
     {
       name: 'expired without a renewal key: keeps serving cache',
       entry: { time: 1, requestId: 'req-1' },
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: true },
-      expected: 'serve-cached',
+      expected: CacheAction.ServeCached,
     },
     {
       name: 'expired without a renewal key but same request: refreshes in background',
       entry: { time: 1, requestId: 'req-1-span-1' },
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1-span-7', waitForRenew: true },
-      expected: 'refresh-same-request',
+      expected: CacheAction.RefreshSameRequest,
     },
     {
       name: 'missing renewal threshold counts as expired',
@@ -132,7 +128,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: 0,
       options: { requestId: 'req-2', waitForRenew: true },
       renewalKey: 'rk',
-      expected: 'wait-for-renew',
+      expected: CacheAction.WaitForRenew,
     },
     {
       name: 'entry without a timestamp counts as expired',
@@ -140,7 +136,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: 0,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-2', waitForRenew: false },
       renewalKey: 'rk',
-      expected: 'refresh-background',
+      expected: CacheAction.RefreshBackground,
     },
     {
       name: 'entry without a request id is never treated as the same request',
@@ -148,7 +144,7 @@ describe('QueryCache.decideCacheAction', () => {
       renewedAgo: EXPIRED,
       options: { renewalThreshold: THRESHOLD, requestId: 'req-1', waitForRenew: true },
       renewalKey: 'rk',
-      expected: 'wait-for-renew',
+      expected: CacheAction.WaitForRenew,
     },
   ];
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`QueryCache.cacheQueryResult` was a 168-line method holding the fetch-and-store closure, the in-memory LRU handling, the four-way refresh decision and 14 logger calls that each repeated the same context object; this splits it into `decideCacheAction` (a pure static returning one of `serve-cached` / `refresh-same-request` / `refresh-background` / `wait-for-renew`), `fetchAndCacheQuery`, `fetchAndCacheQueryInBackground`, `getFromMemoryCache` / `isMemoryEntryUsable`, `storeInMemoryCache` and `cacheOperationContext`, leaving `cacheQueryResult` at 58 lines of linear code. Behaviour, the public `cacheQueryResult` signature and every logger message are unchanged — the 12 existing `cacheQueryResult renewal logic` tests pass without touching a single assertion. Adds 14 table-driven tests that exercise the decision table directly instead of seeding a cache driver and spying on the queue, including the pre-existing quirk where an expired entry with no renewal key keeps being served, which was previously buried in the branch ordering. Verified with `yarn tsc`, `yarn lint` (0 errors) and the full unit suite (91 passed) in `packages/cubejs-query-orchestrator`.