### PR TITLE
docs: document embed header controls and standalone explorations

### DIFF
--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -16,7 +16,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 - **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it to a workbook as a re-runnable report (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
-- **Save your results** – Ask the agent to save a result as a [report](/docs/explore-analyze/workbooks) inside a workbook, or as a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) — say "save this as an exploration I can open in Excel" to get one without creating a workbook
+- **Save your results** – Ask the agent to save a result as a [report](/docs/explore-analyze/workbooks) inside a workbook, or as a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) when you don't want to create a workbook
 
 ## Discover available fields
 

--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -16,7 +16,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 - **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it to a workbook as a re-runnable report (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
-- **Save to Workbook** – Export insights to [Workbooks](/docs/explore-analyze/workbooks) for further analysis
+- **Save your results** – Ask the agent to save a result as a [report](/docs/explore-analyze/workbooks) inside a workbook, or as a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) — say "save this as an exploration I can open in Excel" to get one without creating a workbook
 
 ## Discover available fields
 

--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -13,7 +13,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 
 - **Natural language queries** – Ask questions in plain language without knowing SQL
 - **Multi-query reasoning** – The AI creates and synthesizes multiple queries for complex questions
-- **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it to a workbook as a re-runnable report (in preview)
+- **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it as a re-runnable report or exploration (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
 - **Save your results** – Ask the agent to save a result as a [report](/docs/explore-analyze/workbooks) inside a workbook, or as a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) when you don't want to create a workbook

--- a/docs-mintlify/docs/explore-analyze/explore.mdx
+++ b/docs-mintlify/docs/explore-analyze/explore.mdx
@@ -50,7 +50,11 @@ Explore results carry the same [freshness and pre-aggregation indicators](/docs/
 ## Saving explorations
 
 You can save an exploration so you can return to it later without
-re-building your query.
+re-building your query. An exploration is the same kind of object as a
+workbook [report](/docs/explore-analyze/workbooks) — the only difference is
+whether it belongs to a workbook. [Analytics Chat](/docs/explore-analyze/analytics-chat)
+and the Cube MCP `createReport` tool save a standalone exploration the same
+way: by leaving the workbook unset.
 
 - **Save** — For an unsaved exploration, click **Save** to open the
   **Save Exploration** dialog. Give your exploration a name and click

--- a/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
@@ -6,6 +6,9 @@ title: Workbooks
 Workbooks allow you to build reports and explore data with AI agents, organize the results of your
 analysis, and share trusted insights with your team.
 
+A report inside a workbook and a standalone [exploration](/docs/explore-analyze/explore#saving-explorations)
+are the same kind of object — the only difference is whether it's filed inside a workbook.
+
 ## Tabs
 
 Workbooks can contain one or more tabs, each providing a different way to query and analyze your data. Tabs enable you to organize multiple analyses within a single workbook, making it easy to explore different aspects of your data or combine insights from different sources.

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -33,10 +33,9 @@ result inline in the [chat thread](/docs/explore-analyze/analytics-chat). This
 result is ephemeral by default.
 
 Ask to **save it** — to a workbook, or as a standalone
-[exploration](/docs/explore-analyze/explore#saving-explorations) you can open in Excel
-or Google Sheets — and Cube persists both the code and the run result onto a report,
-which then renders the saved output without re-running. Saving re-executes the
-analysis.
+[exploration](/docs/explore-analyze/explore#saving-explorations) — and Cube persists
+both the code and the run result, which then renders the saved output without
+re-running. Saving re-executes the analysis.
 
 <Info>
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -32,9 +32,11 @@ Ask for the analysis in natural language — "forecast next quarter's revenue",
 result inline in the [chat thread](/docs/explore-analyze/analytics-chat). This
 result is ephemeral by default.
 
-Ask to **save it to a workbook** and Cube persists both the code and the run result
-onto a report, which then renders the saved output without re-running. Saving
-re-executes the analysis.
+Ask to **save it** — to a workbook, or as a standalone
+[exploration](/docs/explore-analyze/explore#saving-explorations) you can open in Excel
+or Google Sheets — and Cube persists both the code and the run result onto a report,
+which then renders the saved output without re-running. Saving re-executes the
+analysis.
 
 <Info>
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -34,8 +34,8 @@ result is ephemeral by default.
 
 Ask to **save it** — to a workbook, or as a standalone
 [exploration](/docs/explore-analyze/explore#saving-explorations) — and Cube persists
-both the code and the run result, which then renders the saved output without
-re-running. Saving re-executes the analysis.
+both the code and the run result. Opening the saved copy renders that output without
+re-running; saving re-executes the analysis.
 
 <Info>
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -259,7 +259,7 @@ programmatically. Creating and editing workbooks requires the Explorer role or h
 | --- | --- | --- |
 | `readWorkbook` | Reads a workbook — its name and its current dashboard draft and published configs. | Read-only |
 | `createWorkbook` | Creates a new empty workbook, the container that holds reports and a dashboard. | Write |
-| `createReport` | Saves a query plus its visualization as a report inside a workbook, and returns the `reportId` a chart widget references. | Write |
+| `createReport` | Saves a query plus its visualization as a report. Pass `workbookId` to file it inside a workbook and get the `reportId` a chart widget references; omit `workbookId` to save a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) instead. | Write |
 | `readReport` | Reads one saved report by id — its title, SQL, chart spec, placement, and a shareable URL. | Read-only |
 | `updateReport` | Edits an existing report in place, keeping its `reportId`. Send only the fields you want to change. | Destructive — prompts |
 | `deleteReport` | Deletes a report. | Destructive — prompts |

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -15,6 +15,13 @@ To enable it, pass `creatorMode: true` to the [Generate Session API][ref-generat
   Creator Mode requires [Signed embedding](/embedding/iframe/auth/signed). Private embedding is not supported.
 </Note>
 
+## Dashboard header controls
+
+When a user opens a dashboard inside Creator Mode, its header renders the
+same as in a standalone dashboard embed. To hide any of its controls (title,
+back button, Edit, Duplicate) for your embed, see
+[Show or hide header controls](/embedding/iframe/dashboards#show-or-hide-header-controls).
+
 ## Embed tenant scoping
 
 In Creator Mode, content (workbooks, dashboards) and the groups/user attributes referenced by the session are scoped to an **embed tenant**. Pass `embedTenantName` to isolate content per customer; omit it to use the current tenant.

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -149,14 +149,17 @@ https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?sessi
 
 Every one of these defaults to shown. Only the exact literal string `false`
 hides a control — `=0`, `=False`, `=FALSE`, and a bare `?showDashboardTitle`
-(no value) all leave it visible. This is the opposite polarity from
-`allowExport` above, which fails closed: these parameters remove a control,
-so a typo must not silently strip the viewer's only way back out of the
-embed.
+(no value) all leave it visible. Note this is the inverse of `allowExport`
+above, where only the literal string `true` opts in.
 
-Hiding controls one at a time collapses the header cleanly — there's no
-empty row or stray border left behind, the same as setting
-`showDashboardHeader=false` directly. `showDashboardEditButton` can only
+<Note>
+These parameters are URL-only — they aren't accepted in the [Generate
+Session](/reference/embed-apis/generate-session#session-settings) `settings`
+object, unlike `showDashboardChat`.
+</Note>
+
+Setting `showDashboardHeader=false` overrides the other four: the whole bar
+disappears regardless of their values. `showDashboardEditButton` can only
 hide the Edit action; it can never show one to a viewer who lacks edit
 permission.
 
@@ -168,8 +171,8 @@ draft).
 <Note>
 These controls apply to the dashboard header only — the workbook header
 (which carries Publish and Share) is unaffected. Unlike [showDashboardChat](#show-or-hide-the-ai-chat),
-there's no account-wide default for these five parameters; they're URL-only,
-and not exposed under **Embed → Settings**.
+there's no account-wide default for these five parameters, and they're not
+exposed under **Embed → Settings**.
 </Note>
 
 ## Set the language

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -159,11 +159,13 @@ object, unlike `showDashboardChat`, and they have no account-wide default
 under **Embed → Settings**.
 </Note>
 
+These parameters apply to the dashboard header only — the workbook header
+(which carries Publish and Share) is unaffected.
+
 Setting `showDashboardHeader=false` overrides the other four: the whole bar
 disappears regardless of their values. `showDashboardEditButton` can only
 hide the Edit action; it can never show one to a viewer who lacks edit
-permission. They apply to the dashboard header only — the workbook header
-(which carries Publish and Share) is unaffected.
+permission.
 
 These parameters are read from the URL the host loaded the iframe with and
 stay pinned for the life of the embed, so they survive in-app navigation

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -155,25 +155,20 @@ above, where only the literal string `true` opts in.
 <Note>
 These parameters are URL-only — they aren't accepted in the [Generate
 Session](/reference/embed-apis/generate-session#session-settings) `settings`
-object, unlike `showDashboardChat`.
+object, unlike `showDashboardChat`, and they have no account-wide default
+under **Embed → Settings**.
 </Note>
 
 Setting `showDashboardHeader=false` overrides the other four: the whole bar
 disappears regardless of their values. `showDashboardEditButton` can only
 hide the Edit action; it can never show one to a viewer who lacks edit
-permission.
+permission. They apply to the dashboard header only — the workbook header
+(which carries Publish and Share) is unaffected.
 
 These parameters are read from the URL the host loaded the iframe with and
 stay pinned for the life of the embed, so they survive in-app navigation
 (for example, from the home-page dashboard card, or after publishing a
 draft).
-
-<Note>
-These controls apply to the dashboard header only — the workbook header
-(which carries Publish and Share) is unaffected. Unlike [showDashboardChat](#show-or-hide-the-ai-chat),
-there's no account-wide default for these five parameters, and they're not
-exposed under **Embed → Settings**.
-</Note>
 
 ## Set the language
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -129,6 +129,49 @@ This applies to embedded published dashboards; it does not affect the standalone
 [Analytics Chat](/embedding/iframe/analytics-chat) surface, where embedding the
 chat is itself the opt-in.
 
+## Show or hide header controls
+
+By default, an embedded dashboard's header shows its title, back button, and
+— when the viewer has permission — the Edit and Duplicate actions. Hide any
+of them individually with URL parameters on the embed iframe `src`:
+
+| Parameter | Hides |
+| --- | --- |
+| `showDashboardHeader=false` | The entire header bar |
+| `showDashboardBackButton=false` | The back button |
+| `showDashboardTitle=false` | The dashboard title |
+| `showDashboardEditButton=false` | The Edit action |
+| `showDashboardDuplicateButton=false` | The Duplicate action |
+
+```text
+https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&showDashboardBackButton=false&showDashboardTitle=false
+```
+
+Every one of these defaults to shown. Only the exact literal string `false`
+hides a control — `=0`, `=False`, `=FALSE`, and a bare `?showDashboardTitle`
+(no value) all leave it visible. This is the opposite polarity from
+`allowExport` above, which fails closed: these parameters remove a control,
+so a typo must not silently strip the viewer's only way back out of the
+embed.
+
+Hiding controls one at a time collapses the header cleanly — there's no
+empty row or stray border left behind, the same as setting
+`showDashboardHeader=false` directly. `showDashboardEditButton` can only
+hide the Edit action; it can never show one to a viewer who lacks edit
+permission.
+
+These parameters are read from the URL the host loaded the iframe with and
+stay pinned for the life of the embed, so they survive in-app navigation
+(for example, from the home-page dashboard card, or after publishing a
+draft).
+
+<Note>
+These controls apply to the dashboard header only — the workbook header
+(which carries Publish and Share) is unaffected. Unlike [showDashboardChat](#show-or-hide-the-ai-chat),
+there's no account-wide default for these five parameters; they're URL-only,
+and not exposed under **Embed → Settings**.
+</Note>
+
 ## Set the language
 
 Embedded dashboards render their UI in the account's default language, which you can

--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -79,6 +79,10 @@ over the account-wide setting.
 |----------|------|----------|-------|
 | `showDashboardChat` | boolean | No | Show or hide the AI chat (agent panel and launcher bubble) on embedded dashboards for this session. Omit to inherit the account-wide **Show dashboard chat** toggle (**Embed → Settings**; shown by default); `false` hides it even if enabled account-wide, `true` shows it even if disabled. Affects embedded **published dashboards** only — not the standalone [embedded chat][ref-analytics-chat] surface. See [Hiding the AI chat][ref-signed-embedding]. |
 
+<Note>
+The dashboard header's title, back button, Edit, and Duplicate controls are hidden with URL parameters on the embed iframe instead — they aren't part of this `settings` object. See [Show or hide header controls](/embedding/iframe/dashboards#show-or-hide-header-controls).
+</Note>
+
 ## User profile
 
 `userProfile` lets you attach a human-readable display name and avatar to an external user so they render with a recognizable identity inside embedded surfaces (workbook owners, dashboard headers, etc.) instead of the raw `externalId`.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

**Description of changes**

Two independent documentation updates:

1. **Embedded dashboards** can now hide individual header controls (the whole bar, back button, title, edit action, or duplicate action) via five new URL parameters on the embed iframe. Documents the parameters, their defaults, and the precedence rule for the edit action, on the Dashboards embedding page, with a short pointer from the Creator Mode page.
2. **Saving a query or analysis without attaching it to a workbook** creates a standalone exploration — the same kind of object as a workbook report, just not filed inside one. This is what the workspace browser and the Excel/Google Sheets add-ins list. Clarifies the report/exploration relationship once (on the Explore page) and links to it from Analytics Chat, Workbooks, Python analysis, and the MCP server's `createReport` tool docs, instead of leaving the two terms used inconsistently.

Both changes are surgical edits to existing sections — no new pages or navigation entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPT3ZA5DNJaHP47aVLg6vP)_