### PR TITLE
fix(query-orchestrator): serialize cold-cache renewal paths

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -335,6 +335,8 @@ export class QueryCache {
         }
       );
 
+      // Keep the cycle after the foreground renewal: concurrent passes race on a cold cache.
+      // It remains necessary when skipRefreshKeyWaitForRenew serves a stale key from a warm cache.
       this.startRenewCycle(
         query,
         values,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -318,7 +318,7 @@ export class QueryCache {
     }
 
     if (!this.options.backgroundRenew && queryBody.cacheMode !== 'stale-while-revalidate') {
-      const resultPromise = this.renewQuery(
+      const result = await this.renewQuery(
         query,
         values,
         cacheKeyQueries,
@@ -350,7 +350,7 @@ export class QueryCache {
         }
       );
 
-      return resultPromise;
+      return result;
     }
 
     this.logger('Background fetch', { cacheKey, requestId: queryBody.requestId });

--- a/packages/cubejs-query-orchestrator/test/integration/cubestore/QueryCacheCubestore.test.ts
+++ b/packages/cubejs-query-orchestrator/test/integration/cubestore/QueryCacheCubestore.test.ts
@@ -41,6 +41,7 @@ QueryCacheTest(
   'CubeStore Cache Driver',
   {
     cacheAndQueueDriver: 'cubestore',
+    backgroundRenew: false,
     cubeStoreDriverFactory,
     beforeAll,
     afterAll

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -377,6 +377,44 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       });
     });
 
+    describe('cachedQueryResult cold cache (backgroundRenew: false)', () => {
+      it('executes the main query only once instead of racing two fetches for the same key', async () => {
+        const mainQuery = `SELECT cold-cache-main-${crypto.randomBytes(8).toString('hex')}`;
+        const cacheKeyQuery = `SELECT cold-cache-refresh-key-${crypto.randomBytes(8).toString('hex')}`;
+
+        const mainQueryCalls: string[] = [];
+
+        const spy = jest.spyOn(cache, 'queryWithRetryAndRelease').mockImplementation(async (query) => {
+          if (query === mainQuery) {
+            mainQueryCalls.push(query as string);
+            return [{ result: 'ok' }];
+          }
+          return [{ refresh_key: '1' }];
+        });
+
+        try {
+          await cache.cachedQueryResult(
+            {
+              query: mainQuery,
+              values: [],
+              cacheKeyQueries: [[cacheKeyQuery, []]],
+              requestId: 'cold-cache-req',
+              dataSource: 'default',
+            },
+            [],
+          );
+
+          // Give the fire-and-forget renew cycle a chance to also hit the queue
+          // for the same (still cold) cache key before asserting.
+          await pausePromise(50);
+
+          expect(mainQueryCalls.length).toBe(1);
+        } finally {
+          spy.mockRestore();
+        }
+      });
+    });
+
     it('queryCacheKey format', () => {
       const key1 = QueryCache.queryCacheKey({
         query: 'select data',

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { createCancelablePromise, pausePromise } from '@cubejs-backend/shared';
 
-import { CacheKey, CacheKeyItem, QueryCache, QueryCacheOptions } from '../../src';
+import { CacheKey, CacheKeyItem, ContinueWaitError, QueryCache, QueryCacheOptions } from '../../src';
 
 export type QueryCacheTestOptions = QueryCacheOptions & {
   beforeAll?: () => Promise<void>,
@@ -384,13 +384,14 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
 
         const mainQueryCalls: string[] = [];
 
-        const spy = jest.spyOn(cache, 'queryWithRetryAndRelease').mockImplementation(async (query) => {
+        const querySpy = jest.spyOn(cache, 'queryWithRetryAndRelease').mockImplementation(async (query) => {
           if (query === mainQuery) {
             mainQueryCalls.push(query as string);
             return [{ result: 'ok' }];
           }
           return [{ refresh_key: '1' }];
         });
+        const renewCycleSpy = jest.spyOn(cache, 'startRenewCycle');
 
         try {
           await cache.cachedQueryResult(
@@ -409,8 +410,34 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
           await pausePromise(50);
 
           expect(mainQueryCalls.length).toBe(1);
+          expect(renewCycleSpy).toHaveBeenCalledTimes(1);
         } finally {
-          spy.mockRestore();
+          renewCycleSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+      it('does not start a renew cycle when the foreground renewal continues waiting', async () => {
+        const continueWaitError = new ContinueWaitError();
+        const renewQuerySpy = jest.spyOn(cache, 'renewQuery').mockRejectedValue(continueWaitError);
+        const renewCycleSpy = jest.spyOn(cache, 'startRenewCycle');
+
+        try {
+          await expect(cache.cachedQueryResult(
+            {
+              query: 'SELECT continue-wait-main',
+              values: [],
+              cacheKeyQueries: [['SELECT continue-wait-refresh-key', []]],
+              requestId: 'continue-wait-req',
+              dataSource: 'default',
+            },
+            [],
+          )).rejects.toBe(continueWaitError);
+
+          expect(renewCycleSpy).not.toHaveBeenCalled();
+        } finally {
+          renewCycleSpy.mockRestore();
+          renewQuerySpy.mockRestore();
         }
       });
     });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -378,23 +378,39 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
     });
 
     describe('cachedQueryResult cold cache (backgroundRenew: false)', () => {
+      beforeAll(() => {
+        expect(cache.options.backgroundRenew).toBe(false);
+      });
+
       it('executes the main query only once instead of racing two fetches for the same key', async () => {
         const mainQuery = `SELECT cold-cache-main-${crypto.randomBytes(8).toString('hex')}`;
         const cacheKeyQuery = `SELECT cold-cache-refresh-key-${crypto.randomBytes(8).toString('hex')}`;
 
-        const mainQueryCalls: string[] = [];
-
+        // Mock below QueryCache and above QueryQueue so duplicate cache submissions remain observable.
         const querySpy = jest.spyOn(cache, 'queryWithRetryAndRelease').mockImplementation(async (query) => {
           if (query === mainQuery) {
-            mainQueryCalls.push(query as string);
             return [{ result: 'ok' }];
           }
-          return [{ refresh_key: '1' }];
+
+          if (query === cacheKeyQuery) {
+            return [{ refresh_key: '1' }];
+          }
+
+          throw new Error(`Unexpected query: ${JSON.stringify(query)}`);
         });
-        const renewCycleSpy = jest.spyOn(cache, 'startRenewCycle');
+        const queryCallCount = (targetQuery: string) => querySpy.mock.calls
+          .filter(([query]) => query === targetQuery).length;
+        const renewQuerySpy = jest.spyOn(cache, 'renewQuery');
+        const startRenewCycle = cache.startRenewCycle.bind(cache);
+        let mainQueryCallsAtRenewCycleStart: number | undefined;
+        const renewCycleSpy = jest.spyOn(cache, 'startRenewCycle').mockImplementation((...args) => {
+          mainQueryCallsAtRenewCycleStart = queryCallCount(mainQuery);
+          return startRenewCycle(...args);
+        });
+        let renewCyclePromise: Promise<unknown> | undefined;
 
         try {
-          await cache.cachedQueryResult(
+          const result = await cache.cachedQueryResult(
             {
               query: mainQuery,
               values: [],
@@ -405,21 +421,33 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
             [],
           );
 
-          // Give the fire-and-forget renew cycle a chance to also hit the queue
-          // for the same (still cold) cache key before asserting.
-          await pausePromise(50);
+          const renewCycleCallIndex = renewQuerySpy.mock.calls.findIndex(
+            ([, , , , , , renewOptions]) => renewOptions.renewCycle
+          );
+          if (renewCycleCallIndex !== -1) {
+            renewCyclePromise = renewQuerySpy.mock.results[renewCycleCallIndex].value;
+            await renewCyclePromise;
+          }
 
-          expect(mainQueryCalls.length).toBe(1);
+          expect(renewCycleCallIndex).not.toBe(-1);
+          expect(result.data).toEqual([{ result: 'ok' }]);
+          expect(mainQueryCallsAtRenewCycleStart).toBe(1);
+          expect(queryCallCount(cacheKeyQuery)).toBe(1);
+          expect(queryCallCount(mainQuery)).toBe(1);
           expect(renewCycleSpy).toHaveBeenCalledTimes(1);
         } finally {
+          await renewCyclePromise?.catch(() => undefined);
           renewCycleSpy.mockRestore();
+          renewQuerySpy.mockRestore();
           querySpy.mockRestore();
         }
       });
 
-      it('does not start a renew cycle when the foreground renewal continues waiting', async () => {
-        const continueWaitError = new ContinueWaitError();
-        const renewQuerySpy = jest.spyOn(cache, 'renewQuery').mockRejectedValue(continueWaitError);
+      it.each([
+        { type: 'ContinueWaitError', error: new ContinueWaitError() },
+        { type: 'a generic error', error: new Error('driver failed') },
+      ])('does not start a renew cycle when the foreground renewal fails with $type', async ({ error }) => {
+        const renewQuerySpy = jest.spyOn(cache, 'renewQuery').mockRejectedValue(error);
         const renewCycleSpy = jest.spyOn(cache, 'startRenewCycle');
 
         try {
@@ -432,7 +460,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
               dataSource: 'default',
             },
             [],
-          )).rejects.toBe(continueWaitError);
+          )).rejects.toBe(error);
 
           expect(renewCycleSpy).not.toHaveBeenCalled();
         } finally {

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.test.ts
@@ -3,6 +3,7 @@ import { QueryCacheTest } from './QueryCache.abstract';
 
 QueryCacheTest('Local', {
   cacheAndQueueDriver: 'memory',
+  backgroundRenew: false,
 });
 
 class QueryCacheOpened extends QueryCache {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required (not required)

**Issue Reference this PR resolves**

Fixes #11499

**Description of Changes Made**

When `backgroundRenew` is disabled, await the foreground renewal before starting the follow-up renewal cycle so both paths cannot compete for the same cold-cache query; if the foreground renewal rejects, propagate the error without starting the cycle.
The request still waits for the same refresh-key and main-query chain as before; the follow-up cycle starts afterward and reuses the populated caches.
Adds deterministic shared memory and CubeStore coverage for one refresh-key and main-query execution, post-success cycle ordering, and both `ContinueWaitError` and generic error propagation.
Verified with the query-orchestrator unit suite, TypeScript compilation, ESLint, and the `test-postgres` deployment via `yarn dev`.
