### PR TITLE
ci: drop the push trigger from the Cube Store workflow

### DIFF
--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -1,12 +1,6 @@
 name: Rust
 
 on:
-  push:
-    paths:
-      - '.github/workflows/rust-cubestore.yml'
-      - 'rust/cubestore/**'
-    branches-ignore:
-      - master
   pull_request:
     paths:
       - '.github/workflows/rust-cubestore.yml'


### PR DESCRIPTION
## Problem

The `Rust` workflow builds all 8 Cube Store jobs on pull requests that don't touch `rust/cubestore/**` at all. It fires whenever a branch is rebased across a commit that touched those paths — a release commit, most often.

Seen on #11669, a docs-only change: 6 files, all under `docs-mintlify/`. After a rebase, the workflow started the Debian build, 4 `cubestore` target builds, 2 `cubestore_linux` builds and 2 Docker image builds.

## Cause

The workflow declared two triggers with identical path filters. The two events compare those paths against different things:

- `pull_request` compares against the **pull request diff** (merge base to head). This is correct, and it did not fire on the docs-only change.
- `push` compares against the **push range** (previous head to new head). A rebase moves the branch head across every commit that landed on master in between, so the files those commits touched enter the range.

In that case the rebase crossed the `v1.7.29` release commit, which touched 6 files under `rust/cubestore/**` — `Cargo.lock`, `Cargo.toml`, `package.json`, `CHANGELOG.md`, `src/config/mod.rs` and `src/http/mod.rs`. That is what the push trigger matched.

This is a property of the two events, not a mistake in the filter. Push path filters cannot be made to measure against the merge base.

## Fix

Remove the `push` block, leaving `pull_request` alone.

## Why this is safe

- The removed trigger was `branches-ignore: master`, so it never ran on master.
- Master is already covered by `rust-cubestore-master.yml`, which has the same path filter and runs the same `debian` and `cubestore` jobs, plus the `:dev` image push.
- `rust-cubestore.yml` was the only path-filtered workflow in the repo with this shape. The others pair `pull_request` with a `push` scoped to `branches: master`.

## Trade-off

A branch pushed with no open pull request no longer builds Cube Store. Opening a draft pull request restores it. Since changes reach master through a pull request, the push trigger could not gate anything the `pull_request` trigger doesn't already gate.

## Check

`actionlint` passes on the changed file and repo-wide.
