### PR TITLE
docs: recipe for cross-data-source UNION ALL queries via the SQL API

### DIFF
--- a/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
+++ b/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
@@ -64,6 +64,10 @@ Cubes that don't set `data_source` use the default source — there's no
 need to write `data_source: default` explicitly, though you can if you
 prefer to be explicit.
 
+A single query can also span sources: see [querying across data
+sources](/recipes/data-modeling/cross-data-source-queries) for appending rows
+from cubes in different databases into one result set.
+
 For multitenancy scenarios where the data source is selected dynamically
 per request, see [`driver_factory`](/reference/configuration/config#driver_factory)
 and the [multitenancy guide][ref-config-multitenancy].

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -675,6 +675,7 @@
                   "recipes/data-modeling/dbt",
                   "recipes/data-modeling/using-dynamic-measures",
                   "recipes/data-modeling/dynamic-union-tables",
+                  "recipes/data-modeling/cross-data-source-queries",
                   "recipes/data-modeling/polymorphic-cubes",
                   "recipes/data-modeling/custom-order"
                 ]

--- a/docs-mintlify/docs/data-modeling/concepts/data-blending.mdx
+++ b/docs-mintlify/docs/data-modeling/concepts/data-blending.mdx
@@ -18,6 +18,11 @@ efficient for large volumes of data.
 The other situation in which data blending could be a better approach than joining 
 on date is when the two tables have mostly the same columns, such as in the example below.
 
+This pattern builds one cube over a union of the underlying cubes' SQL, so all of
+them must live in the same data source. To append rows from cubes in *different*
+databases, see [querying across data
+sources](/recipes/data-modeling/cross-data-source-queries).
+
 For an example, consider an omnichannel store which has both online and offline sales. Let's
 calculate summary metrics for revenue, customer count, etc. We have a
 `retail_orders` cube for offline sales:

--- a/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
+++ b/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
@@ -1,0 +1,356 @@
+---
+title: Querying across data sources
+description: Append rows from cubes that live in different databases into one result set with a UNION ALL query through the SQL API.
+---
+
+## Use case
+
+Some datasets are spread across more than one database. Product events, for
+example, are often split by age: the last few months stay in a fast analytical
+database that serves live dashboards, while everything older is moved to
+cheaper storage. Both tables describe the same events and carry the same
+columns.
+
+The goal is to report on them together — one result set with the rows of both
+databases appended, plus a dimension that says which database each row came
+from.
+
+This is a *union*: it adds rows. It is a different problem from a
+[`rollup_join`](/reference/data-modeling/pre-aggregations#rollup_join), which
+adds columns by relating entities that live in different databases. It is also
+different from [data blending](/docs/data-modeling/concepts/data-blending),
+which unions cubes inside a single database.
+
+The [SQL API](/reference/core-data-apis/sql-api) can do this at query time,
+against live data and without pre-aggregations. Each cube is queried on its own
+data source, and Cube appends the results.
+
+## Configuration
+
+Define the two connections as [multiple data
+sources](/admin/connect-to-data/multiple-data-sources). The default source needs
+no name; every other source gets one, and the full list goes in
+`CUBEJS_DATASOURCES`:
+
+```dotenv
+CUBEJS_DATASOURCES=default,recent
+
+CUBEJS_DB_TYPE=postgres
+CUBEJS_DB_HOST=archive.example.com
+CUBEJS_DB_NAME=analytics
+# ...
+
+CUBEJS_DS_RECENT_DB_TYPE=clickhouse
+CUBEJS_DS_RECENT_DB_HOST=clickhouse.example.com
+CUBEJS_DS_RECENT_DB_NAME=analytics
+# ...
+```
+
+## Data modeling
+
+Model each table as its own cube, and point one of them at the named data source
+with [`data_source`](/reference/data-modeling/cube#data_source). The cube without
+a `data_source` uses the default one.
+
+Give both cubes a matching set of members, and add a constant dimension that
+identifies the origin of each row. That dimension is what makes the two halves
+of the union distinguishable once they sit in the same result set:
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: archived_events
+    sql_table: events
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: created_at
+        sql: created_at
+        type: time
+
+      - name: tier
+        sql: tier
+        type: string
+
+      - name: storage
+        sql: "'archive'"
+        type: string
+
+    measures:
+      - name: event_count
+        type: count
+
+  - name: recent_events
+    sql_table: events
+    data_source: recent
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: created_at
+        sql: created_at
+        type: time
+
+      - name: tier
+        sql: tier
+        type: string
+
+      - name: storage
+        sql: "'recent'"
+        type: string
+
+    measures:
+      - name: event_count
+        type: count
+```
+
+```javascript title="JavaScript"
+cube(`archived_events`, {
+  sql_table: `events`,
+
+  dimensions: {
+    id: {
+      sql: `id`,
+      type: `number`,
+      primary_key: true
+    },
+
+    created_at: {
+      sql: `created_at`,
+      type: `time`
+    },
+
+    tier: {
+      sql: `tier`,
+      type: `string`
+    },
+
+    storage: {
+      sql: `'archive'`,
+      type: `string`
+    }
+  },
+
+  measures: {
+    event_count: {
+      type: `count`
+    }
+  }
+})
+
+cube(`recent_events`, {
+  sql_table: `events`,
+  data_source: `recent`,
+
+  dimensions: {
+    id: {
+      sql: `id`,
+      type: `number`,
+      primary_key: true
+    },
+
+    created_at: {
+      sql: `created_at`,
+      type: `time`
+    },
+
+    tier: {
+      sql: `tier`,
+      type: `string`
+    },
+
+    storage: {
+      sql: `'recent'`,
+      type: `string`
+    }
+  },
+
+  measures: {
+    event_count: {
+      type: `count`
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+## Querying
+
+Connect to the [SQL API](/reference/core-data-apis/sql-api) and append the two
+cubes with `UNION ALL`:
+
+```sql
+SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.archived_events
+GROUP BY 1, 2
+UNION ALL
+SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.recent_events
+GROUP BY 1, 2
+```
+
+```
+ storage |    tier    | events
+---------+------------+--------
+ archive | free       | 412508
+ archive | enterprise |  95012
+ recent  | free       |  38471
+ recent  | enterprise |   9930
+```
+
+Each half of the union is evaluated against its own database, in that database's
+own dialect, and Cube appends the two results. Filters reach the databases
+rather than being applied afterwards, so a `WHERE` clause on either side limits
+what that database scans:
+
+```sql
+SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.archived_events
+WHERE tier = 'enterprise'
+GROUP BY 1, 2
+UNION ALL
+SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.recent_events
+WHERE tier = 'enterprise'
+GROUP BY 1, 2
+```
+
+Add a time dimension to both halves to line the databases up on a common grain:
+
+```sql
+SELECT storage, tier, DATE_TRUNC('day', created_at) AS date, MEASURE(event_count) AS events
+FROM public.archived_events
+GROUP BY 1, 2, 3
+UNION ALL
+SELECT storage, tier, DATE_TRUNC('day', created_at) AS date, MEASURE(event_count) AS events
+FROM public.recent_events
+GROUP BY 1, 2, 3
+ORDER BY 3, 1
+```
+
+<Note>
+
+Qualifying cube names with the `public` schema, as above, is the reliable form.
+An unqualified cube name whose name also matches a table in the underlying
+database fails to resolve.
+
+</Note>
+
+### Aggregating across the union
+
+Wrap the union in a CTE to aggregate over both databases at once. Here the
+per-tier totals combine events from both databases:
+
+```sql
+WITH blended AS (
+  SELECT storage, tier, MEASURE(event_count) AS events
+  FROM public.archived_events
+  GROUP BY 1, 2
+  UNION ALL
+  SELECT storage, tier, MEASURE(event_count) AS events
+  FROM public.recent_events
+  GROUP BY 1, 2
+)
+SELECT tier, SUM(events) AS total, COUNT(DISTINCT storage) AS databases
+FROM blended
+GROUP BY 1
+ORDER BY 2 DESC
+```
+
+```
+    tier    | total  | databases
+------------+--------+-----------
+ free       | 450979 |         2
+ enterprise | 104942 |         2
+```
+
+`UNION` also works where duplicate rows should collapse, as do an outer
+`ORDER BY` and `LIMIT` over the union.
+
+### Inspecting how a query is split
+
+Run `EXPLAIN` on any of these queries to see the plan. It puts a `Union` over one
+`CubeScan` per cube, and each scan carries its own filter — the `WHERE` clause is
+part of the request sent for that cube, not a step applied after the results are
+appended:
+
+```sql
+EXPLAIN SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.archived_events
+WHERE tier = 'enterprise'
+GROUP BY 1, 2
+UNION ALL
+SELECT storage, tier, MEASURE(event_count) AS events
+FROM public.recent_events
+WHERE tier = 'enterprise'
+GROUP BY 1, 2
+```
+
+```
+Union
+  CubeScan: request={
+  "measures": [
+    "archived_events.event_count"
+  ],
+  "dimensions": [
+    "archived_events.storage",
+    "archived_events.tier"
+  ],
+  "segments": [],
+  "order": [],
+  "filters": [
+    {
+      "member": "archived_events.tier",
+      "operator": "equals",
+      "values": [
+        "enterprise"
+      ]
+    }
+  ]
+}
+  CubeScan: request={
+  "measures": [
+    "recent_events.event_count"
+  ],
+  "dimensions": [
+    "recent_events.storage",
+    "recent_events.tier"
+  ],
+  "segments": [],
+  "order": [],
+  "filters": [
+    {
+      "member": "recent_events.tier",
+      "operator": "equals",
+      "values": [
+        "enterprise"
+      ]
+    }
+  ]
+}
+```
+
+The plan identifies each scan by cube, not by data source, so read it together
+with the `data_source` of each cube to see which database serves which half.
+
+## Limitations
+
+Unions combine rows across data sources; joins do not. A query that joins two
+cubes on different data sources is rejected, and relating entities across
+databases needs a
+[`rollup_join`](/reference/data-modeling/pre-aggregations#rollup_join) instead.
+
+Each half of the union is subject to the [maximum row
+limit](/docs/data-modeling/configuration#maximum-row-limit) on its own, and the
+cap applies before the results are appended. Aggregate inside each half of the
+union, as in the examples above, rather than unioning raw rows and aggregating
+afterwards.

--- a/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
+++ b/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
@@ -190,11 +190,11 @@ cubes with `UNION ALL`:
 
 ```sql
 SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.archived_events
+FROM archived_events
 GROUP BY 1, 2
 UNION ALL
 SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.recent_events
+FROM recent_events
 GROUP BY 1, 2
 ```
 
@@ -214,12 +214,12 @@ what that database scans:
 
 ```sql
 SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.archived_events
+FROM archived_events
 WHERE tier = 'enterprise'
 GROUP BY 1, 2
 UNION ALL
 SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.recent_events
+FROM recent_events
 WHERE tier = 'enterprise'
 GROUP BY 1, 2
 ```
@@ -228,20 +228,21 @@ Add a time dimension to both halves to line the databases up on a common grain:
 
 ```sql
 SELECT storage, tier, DATE_TRUNC('day', created_at) AS date, MEASURE(event_count) AS events
-FROM public.archived_events
+FROM archived_events
 GROUP BY 1, 2, 3
 UNION ALL
 SELECT storage, tier, DATE_TRUNC('day', created_at) AS date, MEASURE(event_count) AS events
-FROM public.recent_events
+FROM recent_events
 GROUP BY 1, 2, 3
 ORDER BY 3, 1
 ```
 
 <Note>
 
-Qualifying cube names with the `public` schema, as above, is the reliable form.
-An unqualified cube name whose name also matches a table in the underlying
-database fails to resolve.
+A cube whose name starts with `pg_` cannot be referenced by that name alone: the
+SQL API routes such names to `pg_catalog` and reports `Table or CTE with name
+'pg_...' not found`. Qualify it with the schema that holds cubes — `FROM
+public.pg_costs` — or avoid the prefix.
 
 </Note>
 
@@ -253,11 +254,11 @@ per-tier totals combine events from both databases:
 ```sql
 WITH blended AS (
   SELECT storage, tier, MEASURE(event_count) AS events
-  FROM public.archived_events
+  FROM archived_events
   GROUP BY 1, 2
   UNION ALL
   SELECT storage, tier, MEASURE(event_count) AS events
-  FROM public.recent_events
+  FROM recent_events
   GROUP BY 1, 2
 )
 SELECT tier, SUM(events) AS total, COUNT(DISTINCT storage) AS databases
@@ -276,6 +277,17 @@ ORDER BY 2 DESC
 `UNION` also works where duplicate rows should collapse, as do an outer
 `ORDER BY` and `LIMIT` over the union.
 
+<Warning>
+
+Aggregating over the union like this is only correct for additive measures such
+as `count` and `sum`. Non-additive measures — `count_distinct`, `avg`,
+percentiles — cannot be combined from per-source results: summing distinct
+counts double-counts anything present in both databases, and averaging averages
+ignores how many rows each database contributed. No error is raised, so report
+these measures per data source instead.
+
+</Warning>
+
 ### Inspecting how a query is split
 
 Run `EXPLAIN` on any of these queries to see the plan. It puts a `Union` over one
@@ -285,12 +297,12 @@ appended:
 
 ```sql
 EXPLAIN SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.archived_events
+FROM archived_events
 WHERE tier = 'enterprise'
 GROUP BY 1, 2
 UNION ALL
 SELECT storage, tier, MEASURE(event_count) AS events
-FROM public.recent_events
+FROM recent_events
 WHERE tier = 'enterprise'
 GROUP BY 1, 2
 ```

--- a/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
+++ b/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
@@ -239,10 +239,10 @@ ORDER BY 3, 1
 
 <Note>
 
-A cube whose name starts with `pg_` cannot be referenced by that name alone: the
-SQL API routes such names to `pg_catalog` and reports `Table or CTE with name
-'pg_...' not found`. Qualify it with the schema that holds cubes — `FROM
-public.pg_costs` — or avoid the prefix.
+A cube whose name starts with `pg_` cannot be referenced by that name alone. The
+SQL API routes such a name to `pg_catalog`, where no cube is ever found, and the
+query fails with `Table or CTE with name 'pg_...' not found`. Qualify it with the
+schema that holds cubes, as in `FROM public.pg_costs`, or avoid the prefix.
 
 </Note>
 

--- a/docs-mintlify/recipes/index.mdx
+++ b/docs-mintlify/recipes/index.mdx
@@ -4,7 +4,7 @@ description: Step-by-step tutorials and best practices for getting the most out 
 mode: wide
 ---
 
-Explore **40 recipes** across data modeling, calculations, analytics patterns,
+Explore **41 recipes** across data modeling, calculations, analytics patterns,
 pre-aggregations, configuration, APIs, and AI.
 
 ## Data Modeling

--- a/docs-mintlify/recipes/index.mdx
+++ b/docs-mintlify/recipes/index.mdx
@@ -4,7 +4,7 @@ description: Step-by-step tutorials and best practices for getting the most out 
 mode: wide
 ---
 
-Explore **39 recipes** across data modeling, calculations, analytics patterns,
+Explore **40 recipes** across data modeling, calculations, analytics patterns,
 pre-aggregations, configuration, APIs, and AI.
 
 ## Data Modeling
@@ -27,6 +27,9 @@ pre-aggregations, configuration, APIs, and AI.
   </Card>
   <Card title="Dynamic union tables" icon="stack-2" href="/recipes/data-modeling/dynamic-union-tables">
     Combine multiple database tables that relate to the same entity into a single cube.
+  </Card>
+  <Card title="Querying across data sources" icon="arrow-merge" href="/recipes/data-modeling/cross-data-source-queries">
+    Append rows from cubes in different databases into one result set with a UNION ALL query.
   </Card>
   <Card title="Custom ordering" icon="sort-ascending-shapes" href="/recipes/data-modeling/custom-order">
     Define a custom sort order for categorical values like pipeline stages that don't sort alphabetically.


### PR DESCRIPTION
## Summary

Adds a recipe showing how to append rows from cubes on different data sources into one result set, using a live `UNION ALL` through the SQL API.

The docs had no page covering this. `data-blending.mdx` shows the same `UNION ALL` shape but builds it from `{cube.sql()}` refs inside one `sql:` block, so it compiles to a single statement on a single connection — and it never mentions data sources. `joining-multiple-data-sources.mdx` is `rollup_join`, which adds columns rather than rows. A reader with two databases had nowhere to go.

The recipe covers:

- Configuring two sources with `CUBEJS_DATASOURCES` and `CUBEJS_DS_<NAME>_*`
- Two cubes with matching members and a constant dimension identifying each row's origin
- The `UNION ALL` query, filtering, a shared time grain, and aggregating over the union in a CTE
- `EXPLAIN` output showing the `Union` over one `CubeScan` per cube, with each scan carrying its own filter
- Limitations: joins across data sources are rejected, and the maximum row limit applies to each half of the union before the results are appended

Also adds a scoping sentence to `data-blending.mdx` (the pattern requires a single data source) and a pointer from `multiple-data-sources.mdx`, so both pages lead to the new recipe.

## Test plan

- Verified the behavior on a local Docker rig — Cube with two data sources (Postgres and DuckDB), two cubes with the same member shape, no pre-aggregations. Every query form in the recipe was run against it: `UNION ALL`, filtering, a shared time grain, `UNION` distinct, an outer `ORDER BY`/`LIMIT`, and the CTE aggregate. Blended totals matched the sums computed directly against each database.
- Confirmed the filter reaches each database: the generated SQL carries `WHERE` in each source's own dialect, and the `EXPLAIN` output in the recipe is the real plan from that rig.
- Confirmed both documented limitations reproduce: a cross-source join is rejected at rewrite time, and an unqualified cube name colliding with an underlying table name fails to resolve.
- All four touched pages render without MDX errors under `mint dev` (HTTP 200).
- `mint broken-links --check-anchors` reports no broken links in any page touched here; every anchor linked from the recipe was checked against the repo's existing cross-links.
