### PR TITLE
docs: document undocumented customer-facing changes from the last week

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -75,12 +75,13 @@ allowance resets at the start of each calendar month.
 
 ## Tracking usage
 
-Administrators can monitor token consumption through the **AI Tokens Usage**
-tab in the billing settings page. The dashboard shows:
+Administrators can monitor token consumption on the billing settings page,
+under two tabs:
 
-- Total token usage over time
-- Remaining allocation from per-seat grants and token packages
-- Breakdown by usage dimension
+- **AI Usage** — aggregate spend per user or per role over a billing period,
+  with a chart and a table. Covers the full period, not just recent activity.
+- **AI Requests** — the raw request log, on a rolling window of hours with a
+  live tail of new requests as they come in.
 
 ## When limits are reached
 

--- a/docs-mintlify/admin/ai/bring-your-own-model.mdx
+++ b/docs-mintlify/admin/ai/bring-your-own-model.mdx
@@ -84,7 +84,7 @@ directly by your model provider based on their pricing.
 This means:
 
 - No Cube token quota is deducted for BYOM chat requests
-- No token usage is tracked in the AI Tokens Usage dashboard for BYOM requests
+- No token usage is tracked in the AI Usage / AI Requests tabs for BYOM requests
 - Per-seat token grants and token packages do not apply
 
 See [AI Tokens][ref-ai-tokens] for details on how token billing works with

--- a/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
+++ b/docs-mintlify/docs/pre-aggregations/cube-store-architecture.mdx
@@ -1045,6 +1045,15 @@ Self-hosted deployments can raise the ceiling instead, but
 `CUBESTORE_TRANSPORT_MAX_MESSAGE_SIZE` and `CUBESTORE_TRANSPORT_MAX_FRAME_SIZE`
 have to go up together, since a message is sent as a single frame.
 
+### Connection limits
+
+Alongside message size, a node can also cap how many of these WebSocket
+connections one authenticated user holds at once, via
+[`CUBESTORE_MAX_WS_CONNECTIONS_PER_USER`](/reference/configuration/environment-variables#cubestore_max_ws_connections_per_user).
+At the limit, the user's oldest connection is closed to admit the new one; a
+client that still needs it reconnects. The limit is counted per node and
+disabled (`0`) by default.
+
 ### Why it lives in Cube Store
 
 Folding the cache and queue into Cube Store is itself a design decision in

--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -281,6 +281,37 @@ DELETE /api/v1/embed-tenants/{embedTenantName}/user-attributes/{id}
 
 These endpoints use the same `Api-Key` authentication as Generate Session and require admin access. List endpoints return cursor-paginated results (`?first=`, `?after=`).
 
+### Provisioning users
+
+An embed user otherwise only exists in Cube once they generate their first
+session, which means a workbook or dashboard can't be shared with a teammate
+who hasn't opened the embed yet. To provision a user ahead of time — from
+your own user directory, before their first session — use:
+
+```text
+POST /api/v1/embed-tenants/{embedTenantName}/user
+POST /api/v1/embed-tenants/{embedTenantName}/users
+```
+
+The single-user endpoint takes one body with the same fields `generate-session`
+accepts for an external user — `externalId`, `email`, `userProfile`, `groups`,
+`tenantGroups` — so an integration uses one vocabulary whether it pushes its
+directory ahead of time or lets a session provision the user. Session-only
+fields (`userAttributes`, `securityContext`) aren't accepted here: a later
+session re-applies them anyway, so provisioning can't be a second source of
+truth for row-level security. `groups` and `tenantGroups` follow the same
+replace-when-supplied, clear-with-`[]`, preserve-when-omitted rules as
+[Groups](#groups).
+
+The bulk endpoint takes `{ "users": [...] }` (up to the account's bulk-action
+limit) and is partially successful: it always returns `200`, with each entry
+reported in `succeeded` or `failed` (with an `error.status`/`error.message`),
+in the order requested.
+
+Provisioning is idempotent — an existing `externalId` is updated, not
+rejected — and the embed tenant itself is created on demand if it doesn't
+exist yet.
+
 ### Response
 
 The API returns a session object:


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Weekly documentation audit against recent `cube-js/cube` and `cubedevinc/cubejs-enterprise`
commits, filtered against the customer-facing criteria. Three shipped features were
missing docs (or had gone stale):

- **Provisioning embed users ahead of a session** — new `POST
  /embed-tenants/{embedTenantName}/user` and `.../users` admin endpoints let an
  integration create/update embed users from its own directory before they ever
  open the embed. Documented under the existing "Embed-tenant admin API" section
  of the Generate Session reference.
- **Cube Store per-user WebSocket connection cap** — `CUBESTORE_MAX_WS_CONNECTIONS_PER_USER`
  was already in the environment variables reference but not cross-linked from the
  Cube Store architecture page's connection/transport docs. Added a short
  "Connection limits" subsection next to the existing "Message size limits" one.
- **AI Tokens Usage tab split into AI Usage / AI Requests** — the billing docs still
  referenced the old single "AI Tokens Usage" tab, which was split into two tabs
  with different scopes (aggregate spend vs. raw request log). Updated the
  "Tracking usage" section and a stale cross-reference in the BYOM docs.

All other candidate changes from the last week were checked and found already
documented (e.g. `COPY ... FROM STDIN`, the queue fast-track flag, `cube dbt sync`,
multi-sheet placements in the Sheets/Excel add-on) or not customer-facing
(internal instrumentation/analytics events).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXRUZPJVXV86gLZWJ5xsiB)_