### PR TITLE
docs: signed embedding session renewal

### DIFF
--- a/docs-mintlify/embedding/iframe/auth/signed.mdx
+++ b/docs-mintlify/embedding/iframe/auth/signed.mdx
@@ -31,7 +31,7 @@ Signed embedding works through a two-step authentication flow:
 
 **Session lifecycle:**
 - **Sessions** are valid for **5 minutes** and must be exchanged within this window
-- **Tokens** are minted with a **24-hour** expiry, but the iframe stops trusting one an hour early so an in-flight request can't expire mid-call — usable life is closer to **23 hours**
+- **Tokens** are usable for about **23 hours** after exchange — they're minted with a 24-hour expiry, but the iframe stops trusting one an hour early so an in-flight request can't lapse mid-call
 - Sessions are single-use and expire after being exchanged
 - A long-lived tab can renew its token **in place**, without reloading the iframe — see [Events & actions → Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive)
 

--- a/docs-mintlify/embedding/iframe/auth/signed.mdx
+++ b/docs-mintlify/embedding/iframe/auth/signed.mdx
@@ -31,8 +31,9 @@ Signed embedding works through a two-step authentication flow:
 
 **Session lifecycle:**
 - **Sessions** are valid for **5 minutes** and must be exchanged within this window
-- **Tokens** are valid for **24 hours** after exchange
+- **Tokens** are minted with a **24-hour** expiry, but the iframe stops trusting one an hour early so an in-flight request can't expire mid-call — usable life is closer to **23 hours**
 - Sessions are single-use and expire after being exchanged
+- A long-lived tab can renew its token **in place**, without reloading the iframe — see [Events & actions → Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive)
 
 This ensures secure authentication while maintaining a smooth user experience.
 

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -60,15 +60,10 @@ Keep the following behavior in mind:
 
 ## Organizing content with folders
 
-Embed users in Creator Mode can create, rename, and delete folders in their
-workspace, the same way they organize workbooks and dashboards — useful once a
-tenant has enough creators that a flat workspace stops being manageable.
+Embed users in Creator Mode can create, rename, and delete folders in their workspace, the same way they organize workbooks and dashboards — useful once a tenant has enough creators that a flat workspace stops being manageable.
 
-- **Create Folder** is disabled, with a tooltip, while viewing a folder shared
-  from your main workspace (see [Default dashboards](#default-dashboards)) — a
-  shared folder can't hold new content created by embed users.
-- Deleting a folder moves its contents to the workspace root; it doesn't
-  delete what was inside it.
+- **Create Folder** is disabled while viewing a folder shared from your main workspace (see [Default dashboards](#default-dashboards)) — a shared folder can't hold new content created by embed users.
+- Deleting a folder moves its contents to the workspace root; it doesn't delete what was inside it.
 
 ## Sharing workbooks and dashboards
 

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -58,6 +58,18 @@ Keep the following behavior in mind:
 - Embed users can't edit content shared from the main workspace. Opening a shared workbook shows its published dashboard, so a workbook must have a published dashboard for users to open it.
 - Removing the share from the **All embed users** group removes those items from embed users' workspaces immediately.
 
+## Organizing content with folders
+
+Embed users in Creator Mode can create, rename, and delete folders in their
+workspace, the same way they organize workbooks and dashboards — useful once a
+tenant has enough creators that a flat workspace stops being manageable.
+
+- **Create Folder** is disabled, with a tooltip, while viewing a folder shared
+  from your main workspace (see [Default dashboards](#default-dashboards)) — a
+  shared folder can't hold new content created by embed users.
+- Deleting a folder moves its contents to the workspace root; it doesn't
+  delete what was inside it.
+
 ## Sharing workbooks and dashboards
 
 Embed users in Creator Mode can share the workbooks and dashboards they build with other users, the same way they would in the full Cube app.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -58,13 +58,6 @@ Keep the following behavior in mind:
 - Embed users can't edit content shared from the main workspace. Opening a shared workbook shows its published dashboard, so a workbook must have a published dashboard for users to open it.
 - Removing the share from the **All embed users** group removes those items from embed users' workspaces immediately.
 
-## Organizing content with folders
-
-Embed users in Creator Mode can create, rename, and delete folders in their workspace, the same way they organize workbooks and dashboards — useful once a tenant has enough creators that a flat workspace stops being manageable.
-
-- **Create Folder** is disabled while viewing a folder shared from your main workspace (see [Default dashboards](#default-dashboards)) — a shared folder can't hold new content created by embed users.
-- Deleting a folder moves its contents to the workspace root; it doesn't delete what was inside it.
-
 ## Sharing workbooks and dashboards
 
 Embed users in Creator Mode can share the workbooks and dashboards they build with other users, the same way they would in the full Cube app.

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -309,7 +309,7 @@ down from a recoverable one.
 | --- | --- | --- |
 | `message` | `string` | Human-readable message. |
 | `name` | `string` _(optional)_ | Error name/class, e.g. `"TypeError"`. |
-| `context` | `string` _(optional)_ | Where it originated, e.g. `"embed-render"`. |
+| `context` | `string` _(optional)_ | Where it originated, e.g. `"embed-render"`, `"session-renewal"`. |
 | `fatal` | `boolean` _(optional)_ | `true` when the error took down the whole surface. |
 
 ```json

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -475,24 +475,37 @@ sendAction("cube:action:set-session", { sessionId: newSessionId });
 ```
 
 A rejected id (unknown, already redeemed, or expired) doesn't tear down a
-working embed — it's reported via `cube:event:error` so you can retry.
+working embed. It's reported via `cube:event:error` with `context:
+"session-renewal"` and `name: "EmbedSessionExchangeError"`, so you can filter
+for it and retry.
 
 ## Keeping a signed session alive
 
-A signed embed's token is minted with a 24-hour expiry and can't refresh
+A signed embed's token is usable for about 23 hours (see [Session
+lifecycle](/embedding/iframe/auth/signed#how-it-works)) and can't refresh
 itself — left alone, a tab open that long drops to a "Session expired"
 message. Renew it in place instead, using the events and action above:
 
 ```js
+let renewing = false;
+
 window.addEventListener("message", (event) => {
   if (event.origin !== CUBE_ORIGIN) return;
   const data = event.data;
   if (!data || data.source !== "cube-embed" || data.direction !== "event") return;
 
   if (data.type === "cube:event:session-expiring" || data.type === "cube:event:session-expired") {
+    // Both events can fire for one session — renew only once.
+    if (renewing) return;
+    renewing = true;
+
     fetch("/api/cube-embed-session", { method: "POST" }) // your backend, calling Generate Session
       .then((r) => r.json())
-      .then(({ sessionId }) => sendAction("cube:action:set-session", { sessionId }));
+      .then(({ sessionId }) => sendAction("cube:action:set-session", { sessionId }))
+      .catch((error) => console.error("Session renewal failed", error))
+      .finally(() => {
+        renewing = false;
+      });
   }
 });
 ```

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -503,13 +503,6 @@ never reach the browser. Each id is single-use and expires 5 minutes after
 minting, so mint it in response to the event rather than caching one ahead of
 time.
 
-<Tip>
-  Already using `@cube-dev/embed-sdk`'s `connectCubeEmbed`? Its
-  `autoRenewSession({ mintSession })` method wires up this exact renewal —
-  including retrying a failed mint once the tab returns to the foreground —
-  so you don't have to hand-roll the listener above.
-</Tip>
-
 ## Surfaces
 
 Events come from one of three customer-facing surfaces, reported in the envelope's

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -97,6 +97,8 @@ window.addEventListener("message", (event) => {
 | [`cube:event:download`](#cube-event-download) | The viewer exports data or an image | dashboard |
 | [`cube:event:drilldown`](#cube-event-drilldown) | The viewer drills into a measure | dashboard |
 | [`cube:event:ai-query`](#cube-event-ai-query) | The viewer runs an AI / natural-language query | all |
+| [`cube:event:session-expiring`](#cube-event-session-expiring) | A signed session is close to expiring (~30 min out) | all |
+| [`cube:event:session-expired`](#cube-event-session-expired) | A signed session has expired | all |
 | [`cube:event:error`](#cube-event-error) | The embed surfaces an error | all |
 
 <Note>
@@ -255,6 +257,48 @@ surface, the dashboard agent, and the embedded app.
 }
 ```
 
+#### `cube:event:session-expiring` {#cube-event-session-expiring}
+
+Emitted once per [signed embedding](/embedding/iframe/auth/signed) session, ~30
+minutes before it stops working. This is the moment to mint a replacement
+session and push it in with `cube:action:set-session` — see [Keeping a signed
+session alive](#keeping-a-signed-session-alive) below.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `expiresAt` | `number` | Epoch ms when the session actually stops working — earlier than the token's nominal 24-hour expiry, see [Session lifecycle](/embedding/iframe/auth/signed#how-it-works). |
+| `expiresInMs` | `number` | Milliseconds from this event to `expiresAt`. `0` if already past it. |
+
+```json
+{
+  "expiresAt": 1735689600000,
+  "expiresInMs": 1800000
+}
+```
+
+<Note>
+  Only fires for signed embedding sessions — a private-embedding iframe has no
+  expiring session to renew. It's a best-effort timer inside the iframe: a
+  hidden or suspended tab can throttle it, so it may arrive late (immediately
+  on wake) or after `cube:event:session-expired`.
+</Note>
+
+#### `cube:event:session-expired` {#cube-event-session-expired}
+
+Emitted when a signed session has actually lapsed. The embed can't recover on
+its own — there's no refresh token or re-exchange endpoint — so nothing happens
+until you push a fresh session in with `cube:action:set-session`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `expiredAt` | `number` | Epoch ms when the session was observed to have lapsed. |
+
+```json
+{
+  "expiredAt": 1735689600000
+}
+```
+
 #### `cube:event:error` {#cube-event-error}
 
 Emitted when the embed surfaces an error (a render error, a query failure, an
@@ -318,6 +362,7 @@ sendAction("cube:action:refresh");
 | [`cube:action:set-filter`](#cube-action-set-filter) | Push a filter into a dashboard | `{ filterUrlParameter }` |
 | [`cube:action:navigate`](#cube-action-navigate) | Navigate the embed to a path | `{ path }` |
 | [`cube:action:refresh`](#cube-action-refresh) | Re-run the embed's queries | _none_ |
+| [`cube:action:set-session`](#cube-action-set-session) | Swap in a fresh signed session, in place (no iframe reload) | `{ sessionId }` |
 
 #### `cube:action:set-color-scheme` {#cube-action-set-color-scheme}
 
@@ -410,6 +455,60 @@ Re-run the embed's queries and refresh its data. No payload.
 ```js
 sendAction("cube:action:refresh");
 ```
+
+#### `cube:action:set-session` {#cube-action-set-session}
+
+Hand the embed a fresh [signed embedding](/embedding/iframe/auth/signed)
+session id, replacing the one it's running on **without reloading the
+iframe**. Sent before the current session lapses, the swap is invisible —
+nothing unmounts, so the viewer keeps their place, filters, and any unsaved
+editing state. Sent after it has already lapsed, it still recovers the embed
+without a reload, but the surface has been torn down by then and transient
+state is gone.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `sessionId` | `string` | A single-use session id from the [Generate Session API](/reference/embed-apis/generate-session). Expires 5 minutes after it's minted, so mint it at the moment you send it rather than ahead of time. |
+
+```js
+sendAction("cube:action:set-session", { sessionId: newSessionId });
+```
+
+A rejected id (unknown, already redeemed, or expired) doesn't tear down a
+working embed — it's reported via `cube:event:error` so you can retry.
+
+## Keeping a signed session alive
+
+A signed embed's token is minted with a 24-hour expiry and can't refresh
+itself — left alone, a tab open that long drops to a "Session expired"
+message. Renew it in place instead, using the events and action above:
+
+```js
+window.addEventListener("message", (event) => {
+  if (event.origin !== CUBE_ORIGIN) return;
+  const data = event.data;
+  if (!data || data.source !== "cube-embed" || data.direction !== "event") return;
+
+  if (data.type === "cube:event:session-expiring" || data.type === "cube:event:session-expired") {
+    fetch("/api/cube-embed-session", { method: "POST" }) // your backend, calling Generate Session
+      .then((r) => r.json())
+      .then(({ sessionId }) => sendAction("cube:action:set-session", { sessionId }));
+  }
+});
+```
+
+Mint the replacement session on your own backend — [Generate
+Session](/reference/embed-apis/generate-session) needs an API key that must
+never reach the browser. Each id is single-use and expires 5 minutes after
+minting, so mint it in response to the event rather than caching one ahead of
+time.
+
+<Tip>
+  Already using `@cube-dev/embed-sdk`'s `connectCubeEmbed`? Its
+  `autoRenewSession({ mintSession })` method wires up this exact renewal —
+  including retrying a failed mint once the tab returns to the foreground —
+  so you don't have to hand-roll the listener above.
+</Tip>
 
 ## Surfaces
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

**Description of changes**

A signed embed's token is minted with a 24-hour expiry, but usable life is
really closer to 23 hours (the iframe stops trusting the token an hour
before its nominal expiry so an in-flight request can't lapse mid-call). A
long-lived tab can now renew its session without an iframe reload. Documents:

- The updated session lifecycle on the [Signed embedding](https://github.com/cube-js/cube/blob/master/docs-mintlify/embedding/iframe/auth/signed.mdx) page.
- Two new events (`cube:event:session-expiring`, `cube:event:session-expired`)
  and a new action (`cube:action:set-session`) on the
  [Events & actions](https://github.com/cube-js/cube/blob/master/docs-mintlify/embedding/iframe/events.mdx)
  page, with a worked renewal example.

This is a surgical edit to existing sections — no new pages or navigation entries.

**Verification**
- Every fact (the ~23h effective token life, the event/action names, and payload shapes) was checked directly against the shipped implementation rather than taken from a changelog.
- `scripts/check_links.py .` reports no new broken links introduced by this change (pre-existing failures elsewhere in the repo are unrelated).
- `docs.json` untouched — no navigation changes needed.
