### PR TITLE
docs: a parent control's default is the option picked on the dashboard

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -147,9 +147,11 @@ Click the indicator to jump straight to the **Children** tab of the parent that 
 
 ### Default option
 
-Set **Default value** to the option that should be selected when the dashboard loads. Choosing a default in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
+The option a parent control opens on is the one you last picked **in the control itself on the dashboard**, not a field in its settings — the same way a filter's static default and a time granularity switcher's default are set. Pick an option in the dashboard builder and it's saved on the widget and applied to every viewer when the dashboard loads.
 
-If you leave **Default value** empty, the parent opens with nothing selected and the children use their own defaults.
+Picking in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
+
+If you never pick an option, the parent opens with nothing selected and the children use their own defaults. Deleting the option that was serving as the default clears it, and the parent goes back to opening on nothing.
 
 ## Visibility
 


### PR DESCRIPTION
Companion to [cubedevinc/cubejs-enterprise#14501](https://github.com/cubedevinc/cubejs-enterprise/pull/14501) (CUB-4201).

The **Parent** section's `### Default option` told readers to *"Set **Default value** to the option that should be selected when the dashboard loads"*. That field is removed in the product: no other control has one, and a second writer for the same value could disagree with what the dashboard itself says.

A parent control's default is now what a filter's static default and a time granularity switcher's default already were — **the option you last picked in the control on the dashboard**, saved on the widget and applied to every viewer on load. This page already describes filter defaults that way ("Static defaults are configured by interacting with the filter in the dashboard builder — the value you select is saved on the widget"), so the parent now reads consistently with its siblings.

What follows from the pick is unchanged, so the paragraph about the children's saved defaults lining up stays as it was. The change also states what happens when the option serving as the default is deleted: it's cleared, and the parent goes back to opening on nothing.

**Timing:** the product change is green but not yet merged. Hold this until #14501 lands, or merge it knowing docs will describe the new behaviour slightly ahead of it.
