### PR TITLE
docs: per-member exclusions for user-group notification recipients

### DIFF
--- a/docs-mintlify/docs/explore-analyze/notifications.mdx
+++ b/docs-mintlify/docs/explore-analyze/notifications.mdx
@@ -31,12 +31,11 @@ scratch — the copy carries over the source schedule's notification settings.
 
 ### Delivery channel
 
-Toggle between two delivery channels:
+A schedule delivers to one channel, not both. Pick it with the **Send via**
+radio buttons:
 
-- **Email** — select recipients using a searchable picker with checkboxes. The
-  picker is grouped into **Users** and **User groups** sections, so you can add
-  individual workspace users, entire [user groups][ref-user-groups], or a mix of
-  both.
+- **Email** — sends to the [recipients](#recipients) you choose: individual
+  workspace users, [user groups][ref-user-groups], or a mix of both.
 - **Slack** — select a Slack channel to post to. Requires connecting your Slack
   workspace first (one-time OAuth flow via **Connect to Slack**). Once
   connected, select a channel from a searchable picker.
@@ -75,16 +74,42 @@ from the published dashboard.
 
 ### Recipients
 
-The recipient picker is split into two sections:
+Under the **Recipients** heading there are two separate controls:
 
-- **Users** — individual workspace users.
-- **User groups** — [user groups][ref-user-groups]. A group is expanded to its
-  current members each time the notification is sent, so adding or removing
-  members takes effect on the next run without editing the schedule. The **User
-  groups** section only appears when your workspace has at least one user group.
+- **Users** — a searchable picker for individual workspace users.
+- **User groups** — a dropdown holding an expandable checklist of
+  [user groups][ref-user-groups] and their members. It appears only when your
+  workspace has at least one user group.
+
+A group is expanded to its current members each time the notification is sent,
+so adding or removing members takes effect on the next run without editing the
+schedule. The number beside a group's name is how many members it can currently
+email; a member with no email address is not listed and is never counted.
 
 A recipient who is selected individually and also belongs to a selected group is
 emailed only once.
+
+#### Excluding individual group members
+
+Tick a group to notify everyone in it, then expand it and untick anyone who
+should be skipped. Those people are stored as exceptions to that group on this
+schedule — the group stays selected and keeps picking up new members, but the
+excluded members are left out of every run.
+
+One search box filters both levels at once, so typing a person's name narrows
+the list to the groups that would notify them, with that person shown under
+each.
+
+Exceptions are saved with the rest of the form, not applied as you click. A few
+details worth knowing:
+
+- Unticking a group's **last** remaining member unticks the whole group.
+- Exceptions belong to one schedule and one group. Excluding someone from a
+  group here does not affect the group anywhere else, or any other schedule.
+- An exception is not a block on the person. If they are **also** selected under
+  **Users**, or have [subscribed themselves][ref-subscribe], they still get the
+  email — a direct recipient row and group membership are independent, and
+  either one alone delivers.
 
 ## Slack notifications
 

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -48,7 +48,7 @@ The dashboard must be published before schedules can be created.
 Click **New scheduled refresh** in the sidebar footer. A dialog opens
 with the following configuration options.
 
-### Frequency
+### Schedule {#frequency}
 
 | Option | Description |
 | --- | --- |
@@ -122,20 +122,37 @@ If a schedule sends [email notifications][ref-notifications], anyone who can vie
 the dashboard can subscribe to it themselves — an editor does not have to add
 them as a recipient. Open the scheduled refreshes sidebar from the published
 dashboard and use the toggle on a schedule to subscribe or unsubscribe.
-Subscribing adds you to the schedule's email recipients; unsubscribing removes
-you. The change takes effect on the next run.
+
+The toggle covers **every** way that schedule could reach you, in one click. If
+you were added individually, unsubscribing removes you from its recipients. If
+you are reached through a [user group][ref-user-groups] — or several — it also
+records you as an exception to each of those groups on this schedule, so the
+group keeps notifying everyone else but stops emailing you. Subscribing reverses
+both: it clears those exceptions and adds you back as a recipient in your own
+right. The change takes effect on the next run.
+
+<Note>
+
+Unsubscribing affects only this schedule. It does not remove you from the user
+group, and it does not change any other schedule that group receives.
+
+</Note>
 
 The toggle appears only for schedules that email individual recipients — those
 with notifications enabled and the email delivery channel. A schedule delivers to
 either individual inboxes or a Slack channel, not both, so a schedule that posts
 to Slack (or that has notifications turned off) has nothing to subscribe to. If an
-editor switches a schedule to Slack, its existing subscriptions are cancelled;
-you can subscribe again if it is later switched back to email.
+editor switches a schedule to Slack, its individual subscriptions are cancelled
+and any group exceptions it held are cleared; if it is later switched back to
+email, everyone starts from the group's full membership again and can subscribe
+or unsubscribe afresh.
 
 Every notification email also includes a one-click **Unsubscribe** link in its
 footer, so a recipient can stop receiving a schedule's emails without signing in
-to Cube. This works for any recipient, including those added directly by an
-editor and embed users who have no Cube account of their own.
+to Cube. It behaves exactly like the toggle, covering both a direct recipient row
+and any [user group][ref-user-groups] delivering to you. This works for any
+recipient, including those added directly by an editor and embed users who have
+no Cube account of their own.
 
 ## Run phases
 
@@ -151,3 +168,4 @@ The sidebar shows real-time status updates during execution.
 
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-notifications]: /docs/explore-analyze/notifications
+[ref-user-groups]: /admin/users-and-permissions/user-groups


### PR DESCRIPTION
Companion docs for [cubedevinc/cubejs-enterprise#14418](https://github.com/cubedevinc/cubejs-enterprise/pull/14418) (CUB-3302), which reworked how a scheduled refresh picks its notification recipients. Both pages described the previous UI, so this is mostly a correction rather than an addition.

## What was wrong

**`notifications.mdx`** claimed recipients were *"a searchable picker with checkboxes… grouped into **Users** and **User groups** sections"*. They are now two separate controls, and the second is a dropdown holding an expandable checklist of groups and their members.

**`scheduled-refreshes.mdx`** claimed that *"subscribing adds you to the schedule's email recipients; unsubscribing removes you"*. That was the exact hole the ticket fixed: someone reached only through a user group had no recipient row to remove, so the toggle could never turn itself off.

## What this documents

- **Excluding individual group members** — the new checklist. Tick a group, expand it, untick anyone who should be skipped; they are stored as exceptions to that group on that schedule, so the group keeps picking up new members while the excluded ones stay out.
- **What the viewer's toggle now covers** — one click stops every route the schedule could reach you by, direct row and each group; subscribing reverses both.
- **The exception is not a block on the person** — a direct recipient row and group membership are independent, so someone excluded at group level who is also selected under **Users** still gets the email. Easy to assume otherwise.
- The email footer's **Unsubscribe** link runs through the same path, so it covers group delivery too.

## Smaller drifts corrected on the same surfaces

- The delivery channel is **radio buttons** (**Send via**), not a toggle — it was previously ambiguous whether both channels could be used at once. They cannot.
- The frequency select is now labelled **Schedule**. The heading follows it; its anchor is preserved as `{#frequency}` so any external deep links keep working.
- Switching a schedule to Slack clears **group exceptions** as well as individual subscriptions — the page previously mentioned only the latter.

## Verification

Every claim was checked against the shipped implementation rather than inferred from the diff, including the two the pages already had right, which are preserved:

- *"emailed only once"* if selected both individually and via a group — confirmed, `pushRecipient` de-dupes.
- The **User groups** control appears only when the workspace has at least one group — confirmed, it renders behind `userGroups.length > 0`.

Link references resolve in both files with none unused, and `/admin/users-and-permissions/user-groups` (newly referenced from `scheduled-refreshes.mdx`) exists.

Not done here, as it is a separate concern: both pages use `<Info>` for the plan-availability callout where `docs-mintlify/CLAUDE.md` asks for `<Note>`. Pre-existing on both, and worth its own sweep across the docs rather than a drive-by on two files.