### PR TITLE
docs(dashboards): document control values in the dashboard URL

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -153,6 +153,50 @@ Picking in the builder also applies that option's values to the children, so the
 
 If you never pick an option, the parent opens with nothing selected and the children use their own defaults. Deleting the option that was serving as the default clears it, and the parent goes back to opening on nothing.
 
+## Sharing the current selection
+
+On a published dashboard, the values a viewer picks in the controls are reflected
+in the URL, so the view they are looking at is bookmarkable and shareable. Copy
+the address bar, send it on, and the recipient opens the dashboard with the same
+filters and granularities applied.
+
+Each control type has its own parameter:
+
+| Control | Parameter | Example |
+|---|---|---|
+| [Filter](#filter) | `f_<semantic_view>.<dimension>=<JSON>` | `f_orders.status={"value":"shipped"}` |
+| [Time granularity switcher](#time-granularity-switcher) | `tg_<semantic_view>.<dimension>=<granularity>` | `tg_orders.created_at=week` |
+
+The semantic view and dimension are the **internal names** configured on the
+control — not the display titles you see in the picker. A view shown as `Orders`
+is usually `orders` in the parameter. Granularities are lowercase: `day`, `week`,
+`month`, `quarter`, `year`.
+
+You can also write these parameters by hand to open a dashboard in a particular
+state — see [Pre-set dashboard filters via URL][ref-embed-url-filters] for the
+embedded case, which uses the same format.
+
+What does and doesn't travel in the link:
+
+- **Only what the viewer chose.** Values that came from the control's own
+  configuration — a static default, a [default granularity](#default-granularity)
+  — are not written into the URL. Every viewer already gets those from the
+  dashboard itself, and leaving them out means a link stays correct after the
+  dashboard's defaults change.
+- **Never a personalized default.** A filter resolved from a
+  [user attribute](#user-attribute-default) stays out of the link, so sharing a
+  dashboard never pins your own attribute value onto the recipient. They see the
+  dashboard through their own attributes.
+- **Filters and granularities together.** Picking both puts both in the link,
+  including when a [parent control](#parent) sets several children at once.
+- **Published dashboards only.** In the dashboard builder the URL is left to
+  the editing session, so editing a control there doesn't rewrite it.
+
+When a dashboard opens with these parameters, they are applied on top of whatever
+defaults the controls carry. A parameter is ignored when nothing on the dashboard
+can honor it — there is no matching control for that dimension, or the requested
+granularity isn't in the switcher's [allowed granularities](#allowed-granularities).
+
 ## Visibility
 
 Each control has a **Visibility** setting that determines how it appears on the published dashboard. The setting applies to all three control types.
@@ -206,6 +250,7 @@ For [time granularity switchers][ref-time-grain], the dimension picker is restri
 Mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire controls across charts that use different semantic views without you needing to revisit each chart manually.
 
 [ref-time-grain]: #time-granularity-switcher
+[ref-embed-url-filters]: /embedding/iframe/dashboards#pre-set-dashboard-filters-via-url
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-charts]: /docs/explore-analyze/dashboards/widgets/charts

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -59,23 +59,35 @@ To embed a dashboard for external/customer-facing applications, generate a sessi
 
 See [Signed embedding](/embedding/iframe/auth/signed) for the full session generation flow, API key setup, and a complete working example.
 
-## Pre-set dashboard filters via URL
+## Pre-set dashboard filters and granularities via URL {#pre-set-dashboard-filters-via-url}
 
-You can pre-set dashboard filter values by adding URL parameters in the format
-`?f_<semantic_view>.<dimension>=<JSON>`. The `<semantic_view>` and `<dimension>`
-must match the internal names (not display titles) of the semantic view and
-dimension configured on the filter widget. If the filter type is omitted, it
-defaults to `equals`.
+You can pre-set the values of a dashboard's [controls](/docs/explore-analyze/dashboards/widgets/controls) by adding
+URL parameters:
+
+| Control | Parameter | Example |
+|---|---|---|
+| Filter | `f_<semantic_view>.<dimension>=<JSON>` | `f_orders_transactions.users_country={"value":"USA"}` |
+| Time granularity switcher | `tg_<semantic_view>.<dimension>=<granularity>` | `tg_orders_transactions.created_at=week` |
+
+The `<semantic_view>` and `<dimension>` must match the internal names (not
+display titles) of the semantic view and dimension configured on the widget. For
+filters, an omitted filter type defaults to `equals`; granularities are lowercase
+(`day`, `week`, `month`, `quarter`, `year`).
 
 Example:
 
 ```text
-https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&f_orders_transactions.users_country={"value":"USA"}
+https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&f_orders_transactions.users_country={"value":"USA"}&tg_orders_transactions.created_at=week
 ```
 
-This works on both regular and published (embedded) dashboards. The filter is
-only applied if a matching filter widget for that dimension already exists on the
-dashboard.
+This works on both regular and published (embedded) dashboards. A parameter is
+applied only if a matching control for that dimension already exists on the
+dashboard, and a granularity outside the switcher's allowed list is ignored.
+
+The reverse direction works too: when a viewer changes a control, the new value
+is written back into the dashboard's own URL, so the state a link carries and the
+state a viewer reaches by clicking are the same format. See [Controls → Sharing the
+current selection](/docs/explore-analyze/dashboards/widgets/controls#sharing-the-current-selection).
 
 ## Allow chart export {#allow-csv-export}
 


### PR DESCRIPTION
## What

Documents that a published dashboard's URL carries the viewer's control values — the user-facing half of [cubedevinc/cubejs-enterprise#14497](https://github.com/cubedevinc/cubejs-enterprise/pull/14497) (CUB-4198), which added outbound URL sync for the time granularity switcher.

Two gaps:

**`docs/explore-analyze/dashboards/widgets/controls.mdx`** never mentioned the URL at all, so the page described three controls whose selections read as living only in the viewer's browser tab. New **Sharing the current selection** section covers:

- both parameters (`f_<view>.<dimension>=<JSON>`, `tg_<view>.<dimension>=<granularity>`), with the internal-name and lowercase-granularity gotchas;
- what deliberately does *not* travel — a static default or a user-attribute default, so a shared link neither pins a default that has since changed nor leaks the sharer's own attribute value onto the recipient;
- when an inbound parameter is ignored (no matching control; granularity outside the switcher's allowed list).

**`embedding/iframe/dashboards.mdx`** documented only `?f_…`, though `?tg_…` has worked inbound for as long. Its section now covers both in a table and notes the values travel back out too.

## Note on the anchor

The embed heading became "Pre-set dashboard filters **and granularities** via URL" but keeps its old anchor explicitly (`{#pre-set-dashboard-filters-via-url}`), so the existing link from `embedding/iframe/events.mdx` keeps resolving.

## Verification

Every claim was checked against the shipped code rather than inferred: the parameter formats and the internal-name/lowercase requirements, the defaults-excluded rules (`buildUrlFilterParamsFromState` / `buildUrlTimeGrainParamsFromState` serialize only viewer-overridden widgets), the `allowedGrains` gate on inbound, and published-only scope. The behavior itself was driven end-to-end on a real published dashboard.
