### PR TITLE
docs: a parent control can take its default from a user attribute

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -36,7 +36,7 @@ You can set a default value that's applied when the dashboard loads. Defaults ar
 There are two ways to set a default:
 
 - **Static default** — pick a value (or values) directly in the filter. Every viewer sees the same default.
-- **User attribute default** — resolve the default from the viewer's [user attribute][ref-user-attributes] at load time, so each viewer sees their own personalized default.
+- **User attribute default** — resolve the default from the viewer's [user attribute][ref-user-attributes] at load time, so each viewer sees their own personalized default. [Parent controls](#default-option) support this too.
 
 Static defaults are configured by interacting with the filter in the dashboard builder — the value you select is saved on the widget and applied to every viewer when the dashboard loads.
 
@@ -153,6 +153,41 @@ Picking in the builder also applies that option's values to the children, so the
 
 If you never pick an option, the parent opens with nothing selected and the children use their own defaults. Deleting the option that was serving as the default clears it, and the parent goes back to opening on nothing.
 
+#### User attribute default
+
+The default above is one arrangement for everyone. To give each viewer their own, turn on **User attribute default** in the parent control's settings and pick a [user attribute][ref-user-attributes]. When the dashboard loads, Cube reads that attribute for the current viewer and opens the control on the option it names — and drives the children with it, exactly as if the viewer had picked that option themselves.
+
+This is how you ship one dashboard that opens differently per audience: a **Reporting period** parent whose options are `Month` and `Quarter`, opening on whichever one the viewer's `reporting_period` attribute says, with every filter and time granularity switcher behind it already set to match.
+
+To configure it:
+
+<Steps>
+ <Step title="Open the parent control's settings">
+   In the dashboard builder, click **Configure Parent** on the control, or open its settings menu.
+ </Step>
+ <Step title="Enable User attribute default">
+   Scroll to the **User attribute default** switch and turn it on.
+ </Step>
+ <Step title="Pick the attribute">
+   Select the [user attribute][ref-user-attributes] to resolve. Only attributes defined in your account appear in the picker.
+ </Step>
+</Steps>
+
+The attribute value is matched against the **option labels**, ignoring case and surrounding spaces — an attribute reading `quarter` selects the option labelled `Quarter`. Give the options the labels your attribute already uses, or adjust the attribute values to match; renaming an option later doesn't disturb the child mappings, so labels are safe to align after the fact.
+
+| Attribute type | How it's applied |
+|---|---|
+| **String**, **Number** | Matched against the option labels as a single value. |
+| **String array**, **Number array** | The first entry that names an option wins. A parent control is single-select, so the rest are ignored. |
+
+If the value matches no option — or is empty, `null`, or unresolvable — the control falls back to the [default option](#default-option) you picked, and the children keep the arrangement that goes with it.
+
+<Note>
+The attribute is resolved for the viewer, not baked into the dashboard. Editing the attribute's value changes what that viewer opens on the next time the dashboard loads; it never rewrites the published dashboard, so the default you picked in the builder stays intact for everyone else.
+</Note>
+
+Viewers can still switch to another option unless the control's [visibility](#visibility) is set to **Disabled**, and their own pick outranks the attribute for the rest of the session. Values passed [in the URL](#sharing-the-current-selection) outrank both, so a shared link opens on the values it names rather than on the recipient's attribute.
+
 ## Sharing the current selection
 
 On a published dashboard, the values a viewer picks in the controls are reflected
@@ -183,10 +218,11 @@ What does and doesn't travel in the link:
   — are not written into the URL. Every viewer already gets those from the
   dashboard itself, and leaving them out means a link stays correct after the
   dashboard's defaults change.
-- **Never a personalized default.** A filter resolved from a
-  [user attribute](#user-attribute-default) stays out of the link, so sharing a
-  dashboard never pins your own attribute value onto the recipient. They see the
-  dashboard through their own attributes.
+- **Never a personalized default.** A value resolved from a
+  [user attribute](#user-attribute-default) stays out of the link — whether it
+  seeded a filter directly or reached one through a [parent control](#parent)
+  opening on the viewer's own option. Sharing a dashboard never pins your
+  attribute value onto the recipient; they see it through their own attributes.
 - **Filters and granularities together.** Picking both puts both in the link,
   including when a [parent control](#parent) sets several children at once.
 - **Published dashboards only.** In the dashboard builder the URL is left to


### PR DESCRIPTION
## What

A filter can resolve its default from the viewer's [user attribute](https://cube.dev/docs/admin/users-and-permissions/user-attributes); a **parent control** could not — so a dashboard that groups its controls behind one had no way to open differently per viewer. That setting now exists, and this documents it.

Companion to cubedevinc/cubejs-enterprise#14502 (CUB-4200).

## Where it goes

A `#### User attribute default` subsection under the parent control's **Default option**, mirroring the filter's own section one screen up — the fixed default first, then the per-viewer one that overrides it.

The parts a reader can't guess, and that cost review rounds to get right in the implementation:

- **Matching is against the option LABELS**, case- and space-insensitively. There is no mapping UI, so an attribute reading `quarter` selects the option labelled `Quarter`. The docs say to align the labels with the attribute values, and point out that renaming an option later doesn't disturb the child mappings — so aligning after the fact is safe.
- **An array attribute uses its first entry that names an option**, because a parent control is single-select. Left undocumented, the natural guess is "all of them", as with a multi-select filter.
- **No match falls back to the picked default** — control and children together, not the control alone.
- **Precedence**: a viewer's own pick outranks the attribute for the session, and `?f_…` parameters outrank both, so deep links keep working.

A `<Note>` covers the question the feature reliably raises: the attribute is resolved per viewer and never rewrites the published dashboard, so the default picked in the builder stays intact for everyone else.

The filter's summary line at the top of the page now points at the parent section, so someone reading about the filter's version learns the parent has one.

## Checks

`#### User attribute default` appears twice on the page now (filter and parent), so the cross-link deliberately targets `#default-option` rather than Mintlify's `-2` dedup suffix — I verified every same-page anchor on the page resolves against the headings it defines, rather than assuming the suffix. MDX component tags balance. `mintlify broken-links` needs a package this checkout can't install offline, so CI's run of it is the authority.

## Not covered here

cubedevinc/cubejs-enterprise#14499 made a parent's displayed label re-derive from its children, which is user-visible (edit a child by hand and the parent can fall back to the placeholder). That's the author's change to describe, not mine — flagging it so it isn't assumed covered by this PR.
