### PR TITLE
docs: say the parent default is set in the builder, not on any dashboard

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -147,7 +147,7 @@ Click the indicator to jump straight to the **Children** tab of the parent that 
 
 ### Default option
 
-The option a parent control opens on is the one you last picked **in the control itself on the dashboard**, not a field in its settings — the same way a filter's static default and a time granularity switcher's default are set. Pick an option in the dashboard builder and it's saved on the widget and applied to every viewer when the dashboard loads.
+A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no **Default value** field in the parent's settings.
 
 Picking in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -147,7 +147,7 @@ Click the indicator to jump straight to the **Children** tab of the parent that 
 
 ### Default option
 
-A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no **Default value** field in the parent's settings.
+A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no default field in the parent's settings.
 
 Picking in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -147,7 +147,7 @@ Click the indicator to jump straight to the **Children** tab of the parent that 
 
 ### Default option
 
-A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no default field in the parent's settings.
+A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no static default field in the parent's settings.
 
 Picking in the builder also applies that option's values to the children, so their saved defaults line up with the parent's and a published dashboard opens in a consistent state.
 


### PR DESCRIPTION
Applies the review comment on #11685 that I merged past — my mistake, so this lands as a follow-up rather than an edit to that PR.

The finding was right. #11685 opened the **Default option** paragraph with:

> The option a parent control opens on is the one you last picked **in the control itself on the dashboard** …

which is ambiguous about *which* dashboard. A viewer changing a parent control on a **published** dashboard does not change the saved default — only a pick in the builder does. The following sentence said so, but the lead sentence is the one people skim, and on its own it reads as "whatever was last selected wins."

This uses the reviewer's suggested wording, which mirrors the phrasing the filter section already uses one screen up ("configured by interacting with the filter in the dashboard builder — the value you select is saved on the widget") and collapses two sentences into one:

> A parent control's default is set the same way a filter's static default is — by interacting with the control in the dashboard builder. The option you select is saved on the widget and applied to every viewer when the dashboard loads; there's no **Default value** field in the parent's settings.

Product change: [cubedevinc/cubejs-enterprise#14501](https://github.com/cubedevinc/cubejs-enterprise/pull/14501) (CUB-4201), merged.
