### PR TITLE
docs(dashboards): address the review on the control-URL section

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -190,10 +190,7 @@ Viewers can still switch to another option unless the control's [visibility](#vi
 
 ## Sharing the current selection
 
-On a published dashboard, the values a viewer picks in the controls are reflected
-in the URL, so the view they are looking at is bookmarkable and shareable. Copy
-the address bar, send it on, and the recipient opens the dashboard with the same
-filters and granularities applied.
+On a published dashboard, the values a viewer picks in the controls are reflected in the URL, so the view they are looking at is bookmarkable and shareable. Copy the address bar, send it on, and the recipient opens the dashboard with the same filters and granularities applied.
 
 Each control type has its own parameter:
 
@@ -202,36 +199,18 @@ Each control type has its own parameter:
 | [Filter](#filter) | `f_<semantic_view>.<dimension>=<JSON>` | `f_orders.status={"value":"shipped"}` |
 | [Time granularity switcher](#time-granularity-switcher) | `tg_<semantic_view>.<dimension>=<granularity>` | `tg_orders.created_at=week` |
 
-The semantic view and dimension are the **internal names** configured on the
-control — not the display titles you see in the picker. A view shown as `Orders`
-is usually `orders` in the parameter. Granularities are lowercase: `day`, `week`,
-`month`, `quarter`, `year`.
+The semantic view and dimension are the **internal names** configured on the control — not the display titles you see in the picker. A view shown as `Orders` is usually `orders` in the parameter. Granularities are lowercase and must be one of the switcher's [allowed granularities](#allowed-granularities) — `day`, `week`, `month`, `quarter`, `year`, plus `second`, `minute`, and `hour` for time dimensions that expose them.
 
-You can also write these parameters by hand to open a dashboard in a particular
-state — see [Pre-set dashboard filters via URL][ref-embed-url-filters] for the
-embedded case, which uses the same format.
+You can also write these parameters by hand to open a dashboard in a particular state — see [Pre-set dashboard filters and granularities via URL][ref-embed-url-filters] for the embedded case, which uses the same format.
 
 What does and doesn't travel in the link:
 
-- **Only what the viewer chose.** Values that came from the control's own
-  configuration — a static default, a [default granularity](#default-granularity)
-  — are not written into the URL. Every viewer already gets those from the
-  dashboard itself, and leaving them out means a link stays correct after the
-  dashboard's defaults change.
-- **Never a personalized default.** A value resolved from a
-  [user attribute](#user-attribute-default) stays out of the link — whether it
-  seeded a filter directly or reached one through a [parent control](#parent)
-  opening on the viewer's own option. Sharing a dashboard never pins your
-  attribute value onto the recipient; they see it through their own attributes.
-- **Filters and granularities together.** Picking both puts both in the link,
-  including when a [parent control](#parent) sets several children at once.
-- **Published dashboards only.** In the dashboard builder the URL is left to
-  the editing session, so editing a control there doesn't rewrite it.
+- **Only what the viewer chose.** Values that came from the control's own configuration — a static default, a [default granularity](#default-granularity) — are not written into the URL. Every viewer already gets those from the dashboard itself, and leaving them out means a link stays correct after the dashboard's defaults change.
+- **Never a personalized default.** A value resolved from a [user attribute](#user-attribute-default) stays out of the link — whether it seeded a filter directly or reached one through a [parent control](#parent) opening on the viewer's own option. Sharing a dashboard never pins your attribute value onto the recipient; they see it through their own attributes.
+- **Filters and granularities together.** Picking both puts both in the link, including when a [parent control](#parent) sets several children at once. A parent control isn't serialized itself — the link carries the values its children ended up with, so the recipient sees the same data while the parent dropdown opens on whatever default it resolves for them, which may not be the option the sharer picked.
+- **Written out on published dashboards only.** Reading these parameters works anywhere, including [embedded][ref-embed-url-filters] dashboards; it's the writing that is published-only. In the dashboard builder the URL is left to the editing session, so changing a control there doesn't rewrite it.
 
-When a dashboard opens with these parameters, they are applied on top of whatever
-defaults the controls carry. A parameter is ignored when nothing on the dashboard
-can honor it — there is no matching control for that dimension, or the requested
-granularity isn't in the switcher's [allowed granularities](#allowed-granularities).
+When a dashboard opens with these parameters, they are applied on top of whatever defaults the controls carry. A parameter is ignored when nothing on the dashboard can honor it — there is no matching control for that dimension, or the requested granularity isn't in the switcher's [allowed granularities](#allowed-granularities).
 
 ## Visibility
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -71,14 +71,19 @@ URL parameters:
 
 The `<semantic_view>` and `<dimension>` must match the internal names (not
 display titles) of the semantic view and dimension configured on the widget. For
-filters, an omitted filter type defaults to `equals`; granularities are lowercase
-(`day`, `week`, `month`, `quarter`, `year`).
+filters, an omitted filter type defaults to `equals`. Granularities are lowercase
+and must be one of the switcher's allowed granularities — `day`, `week`, `month`,
+`quarter`, `year`, plus `second`, `minute`, and `hour` for time dimensions that
+expose them.
 
 Example:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&f_orders_transactions.users_country={"value":"USA"}&tg_orders_transactions.created_at=week
 ```
+
+The filter's JSON value is shown unencoded for readability — percent-encode it
+when constructing the URL programmatically.
 
 This works on both regular and published (embedded) dashboards. A parameter is
 applied only if a matching control for that dimension already exists on the

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -72,9 +72,10 @@ URL parameters:
 The `<semantic_view>` and `<dimension>` must match the internal names (not
 display titles) of the semantic view and dimension configured on the widget. For
 filters, an omitted filter type defaults to `equals`. Granularities are lowercase
-and must be one of the switcher's allowed granularities — `day`, `week`, `month`,
-`quarter`, `year`, plus `second`, `minute`, and `hour` for time dimensions that
-expose them.
+and must be one of the switcher's [allowed
+granularities](/docs/explore-analyze/dashboards/widgets/controls#allowed-granularities) —
+`day`, `week`, `month`, `quarter`, `year`, plus `second`, `minute`, and `hour`
+for time dimensions that expose them.
 
 Example:
 
@@ -82,17 +83,20 @@ Example:
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&f_orders_transactions.users_country={"value":"USA"}&tg_orders_transactions.created_at=week
 ```
 
-The filter's JSON value is shown unencoded for readability — percent-encode it
-when constructing the URL programmatically.
+The filter's JSON value is shown unencoded for readability. Percent-encode it
+before the URL goes anywhere real — pasted as-is into the `src="…"` of the iframe
+snippet above, its raw `"` closes the attribute and truncates the URL.
 
 This works on both regular and published (embedded) dashboards. A parameter is
 applied only if a matching control for that dimension already exists on the
 dashboard, and a granularity outside the switcher's allowed list is ignored.
 
-The reverse direction works too: when a viewer changes a control, the new value
-is written back into the dashboard's own URL, so the state a link carries and the
-state a viewer reaches by clicking are the same format. See [Controls → Sharing the
-current selection](/docs/explore-analyze/dashboards/widgets/controls#sharing-the-current-selection).
+The reverse direction works on published dashboards: when a viewer changes a
+control there, the new value is written back into the dashboard's own URL, so the
+state a link carries and the state a viewer reaches by clicking are the same
+format. Reading the parameters works anywhere; it's the writing that is
+published-only. See [Controls → Sharing the current
+selection](/docs/explore-analyze/dashboards/widgets/controls#sharing-the-current-selection).
 
 ## Allow chart export {#allow-csv-export}
 


### PR DESCRIPTION
## What

Follow-up to [#11687](https://github.com/cube-js/cube/pull/11687), which I merged on green checks two minutes after the review landed — before reading it. All five findings hold, so this fixes them. Four are mine; one is pre-existing.

| # | Sev | Fix |
|---|---|---|
| 1 | Medium | Granularity list said `day`…`year`, contradicting **Allowed granularities** on the same page — `second`, `minute`, `hour` are offered for `TIMESTAMP`/`DATETIME` dimensions. Both pages now name the sub-day grains and point at the switcher's allowed list as the authority. |
| 2 | Medium | "Published dashboards only" read as scoping the whole feature, contradicting the embed page's "works on both regular and published dashboards". Both true — the restriction is on the *outbound write*, not the inbound read — so the bullet now names the direction. |
| 3 | Low | The section said the children's values travel but not what the recipient's **parent** dropdown shows. Now documented. |
| 4 | Low | Link text still said "Pre-set dashboard filters via URL" after #11687 renamed that heading to include granularities. |
| 5 | Low | The embed example carries raw `{`, `"`, `}` — pre-existing, but that section is now the canonical hand-written-URL reference, so it says to percent-encode when building programmatically. |

Plus the wrap nit: the new prose is unwrapped to one paragraph per line, matching the rest of `controls.mdx`.

## On finding 3

The reviewer flagged its own suggested wording as unverified ("worth confirming against the implementation"). I checked: a parent control's selection is runtime-only `useState` in `useDashboardParents`, never serialized, and `resolveParentSelection` falls back to the widget's saved `defaultOptionId`. So the recipient does see the children's shared values while the parent dropdown reads the dashboard's own default — which is exactly why it's worth stating, since it otherwise looks like a bug.
