### PR TITLE
docs: address review feedback on #11686

### DIFF
--- a/docs-mintlify/docs/explore-analyze/notifications.mdx
+++ b/docs-mintlify/docs/explore-analyze/notifications.mdx
@@ -83,8 +83,9 @@ Under the **Recipients** heading there are two separate controls:
 
 A group is expanded to its current members each time the notification is sent,
 so adding or removing members takes effect on the next run without editing the
-schedule. The number beside a group's name is how many members it can currently
-email; a member with no email address is not listed and is never counted.
+schedule. The number beside a group's name counts the members it can currently
+email, so a group can show fewer than its full membership — anyone without an
+email address is left out of both the count and the list.
 
 A recipient who is selected individually and also belongs to a selected group is
 emailed only once.

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -104,11 +104,11 @@ The sidebar lists all existing schedules with the following information:
 
 To create a new schedule based on an existing one — for example, to send the
 same dashboard to another Slack channel or a different set of recipients without
-re-entering the schedule, timezone, and notification settings — you can
+re-entering the **Schedule**, timezone, and notification settings — you can
 duplicate it. There are two ways:
 
 - **From the sidebar** — click the duplicate (copy) icon on a schedule card. The
-  form dialog opens pre-filled with that schedule's cadence, timezone, and
+  form dialog opens pre-filled with its **Schedule**, timezone, and
   notification configuration. Adjust anything you need, then click **Save** to
   create the new schedule.
 - **From the edit dialog** — while editing a schedule, click **Save as copy** in

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -50,6 +50,8 @@ with the following configuration options.
 
 ### Schedule {#frequency}
 
+Pick how often the refresh runs with the **Schedule** select:
+
 | Option | Description |
 | --- | --- |
 | Hourly | Runs every hour at the specified minute |
@@ -102,11 +104,11 @@ The sidebar lists all existing schedules with the following information:
 
 To create a new schedule based on an existing one — for example, to send the
 same dashboard to another Slack channel or a different set of recipients without
-re-entering the frequency, timezone, and notification settings — you can
+re-entering the schedule, timezone, and notification settings — you can
 duplicate it. There are two ways:
 
 - **From the sidebar** — click the duplicate (copy) icon on a schedule card. The
-  form dialog opens pre-filled with that schedule's frequency, timezone, and
+  form dialog opens pre-filled with that schedule's cadence, timezone, and
   notification configuration. Adjust anything you need, then click **Save** to
   create the new schedule.
 - **From the edit dialog** — while editing a schedule, click **Save as copy** in
@@ -131,15 +133,15 @@ group keeps notifying everyone else but stops emailing you. Subscribing reverses
 both: it clears those exceptions and adds you back as a recipient in your own
 right. The change takes effect on the next run.
 
-<Note>
+<Info>
 
 Unsubscribing affects only this schedule. It does not remove you from the user
 group, and it does not change any other schedule that group receives.
 
-</Note>
+</Info>
 
-The toggle appears only for schedules that email individual recipients — those
-with notifications enabled and the email delivery channel. A schedule delivers to
+The toggle appears only for schedules that send email — those with
+notifications enabled and the email delivery channel. A schedule delivers to
 either individual inboxes or a Slack channel, not both, so a schedule that posts
 to Slack (or that has notifications turned off) has nothing to subscribe to. If an
 editor switches a schedule to Slack, its individual subscriptions are cancelled


### PR DESCRIPTION
Follow-up to [#11686](https://github.com/cube-js/cube/pull/11686), which I merged about a minute after the review landed and before reading it. All five comments are addressed here; the review was right on every one.

| Comment | Change |
| --- | --- |
| `<Note>` is reserved for plan availability | The new "affects only this schedule" callout is a general note → `<Info>` |
| "schedules that email **individual** recipients" | → "schedules that send email" |
| Stale "frequency" prose + a heading with nothing naming the control | Both fixed |
| Member-count claim unverified in the description | Verified; sentence tightened |
| Missing trailing newline | Added |

## Notes on two of them

**The `<Note>`/`<Info>` inversion was mine.** The reviewer's sharper point was that #11686 left the page with the convention exactly backwards — `<Info>` on the plan gate, `<Note>` on a general note — because it deferred the plan-callout sweep while adding a new callout on the wrong side of it. Deferring the sweep is still right; landing a new callout on the wrong side of it was not. Fixed here; the plan callout is untouched.

**The member count is correct as documented.** `UserGroupsService.getUsersByGroupIds` filters on `user.email`, matching the `email IS NOT NULL` in both the send-time expansion and the coverage check, and it's pinned by an integration test ("leaves a member the run could never email out of the tree"). To the reviewer's second question — a workspace user genuinely can lack an email (`User.email` is `?: string | null`), and it is reachable enough that an unfiltered query *errors*, which is why the filter exists at all. So the clause stays, but reworded around what a reader would actually notice: a count lower than the group's membership.

**The "individual recipients" phrase is the interesting failure.** It was correct before #11686 and only became misleading because the paragraph I added directly above it changed what the reader knows by that point. Editing a paragraph can falsify its neighbours.