### PR TITLE
docs: close the gaps review found in the parent user-attribute default

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -36,7 +36,7 @@ You can set a default value that's applied when the dashboard loads. Defaults ar
 There are two ways to set a default:
 
 - **Static default** — pick a value (or values) directly in the filter. Every viewer sees the same default.
-- **User attribute default** — resolve the default from the viewer's [user attribute][ref-user-attributes] at load time, so each viewer sees their own personalized default. [Parent controls](#default-option) support this too.
+- **User attribute default** — resolve the default from the viewer's [user attribute][ref-user-attributes] at load time, so each viewer sees their own personalized default. [Parent controls](#parent-user-attribute-default) support this too.
 
 Static defaults are configured by interacting with the filter in the dashboard builder — the value you select is saved on the widget and applied to every viewer when the dashboard loads.
 
@@ -153,7 +153,7 @@ Picking in the builder also applies that option's values to the children, so the
 
 If you never pick an option, the parent opens with nothing selected and the children use their own defaults. Deleting the option that was serving as the default clears it, and the parent goes back to opening on nothing.
 
-#### User attribute default
+#### User attribute default {#parent-user-attribute-default}
 
 The default above is one arrangement for everyone. To give each viewer their own, turn on **User attribute default** in the parent control's settings and pick a [user attribute][ref-user-attributes]. When the dashboard loads, Cube reads that attribute for the current viewer and opens the control on the option it names — and drives the children with it, exactly as if the viewer had picked that option themselves.
 
@@ -163,17 +163,21 @@ To configure it:
 
 <Steps>
  <Step title="Open the parent control's settings">
-   In the dashboard builder, click **Configure Parent** on the control, or open its settings menu.
+   In the dashboard builder, click **Configure Parent** on the control.
  </Step>
  <Step title="Enable User attribute default">
-   Scroll to the **User attribute default** switch and turn it on.
+   Below the **Options** and **Children** tabs — next to **Visibility** — turn on the **User attribute default** switch.
  </Step>
  <Step title="Pick the attribute">
    Select the [user attribute][ref-user-attributes] to resolve. Only attributes defined in your account appear in the picker.
  </Step>
 </Steps>
 
-The attribute value is matched against the **option labels**, ignoring case and surrounding spaces — an attribute reading `quarter` selects the option labelled `Quarter`. Give the options the labels your attribute already uses, or adjust the attribute values to match; renaming an option later doesn't disturb the child mappings, so labels are safe to align after the fact.
+The attribute value is matched against the **option labels**, ignoring case and surrounding spaces — an attribute reading `quarter` selects the option labelled `Quarter`. Give the options the labels your attribute already uses, or adjust the attribute values to match.
+
+<Warning>
+Renaming an option leaves its child mappings intact, but the attribute match is by label — so a rename that moves a label away from the values your attribute holds silently stops it resolving, with no error. The control falls back to the option you picked as the default. Rename labels and attribute values together.
+</Warning>
 
 | Attribute type | How it's applied |
 |---|---|
@@ -186,7 +190,7 @@ If the value matches no option — or is empty, `null`, or unresolvable — the 
 The attribute is resolved for the viewer, not baked into the dashboard. Editing the attribute's value changes what that viewer opens on the next time the dashboard loads; it never rewrites the published dashboard, so the default you picked in the builder stays intact for everyone else.
 </Note>
 
-Viewers can still switch to another option unless the control's [visibility](#visibility) is set to **Disabled**, and their own pick outranks the attribute for the rest of the session. Values passed [in the URL](#sharing-the-current-selection) outrank both, so a shared link opens on the values it names rather than on the recipient's attribute.
+Viewers can still switch to another option unless the control's [visibility](#visibility) is set to **Disabled**, and their own pick outranks the attribute for the rest of the session. Values passed [in the URL](#sharing-the-current-selection) outrank both. A parent control has no parameter of its own there — a shared link carries its *children's* values, and the dropdown follows those children, so the recipient opens on the arrangement the link names rather than on the one their own attribute would have chosen.
 
 ## Sharing the current selection
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -113,7 +113,7 @@ Add the child controls to the dashboard *before* the parent control. The **Child
 
 On the **Options** tab, type a label and click **Add** for each entry you want in the dropdown. Options appear as chips — remove one with its close button. A parent control can hold up to 50 options.
 
-Renaming an option later doesn't disturb the values you've mapped to it, so you can reword a label without redoing the mapping.
+Renaming an option later doesn't disturb the values you've mapped to it, so you can reword a label without redoing the mapping — but if the control has a [user attribute default](#parent-user-attribute-default), that match is by label, so rename the attribute's values with it.
 
 ### Children
 
@@ -190,7 +190,7 @@ If the value matches no option — or is empty, `null`, or unresolvable — the 
 The attribute is resolved for the viewer, not baked into the dashboard. Editing the attribute's value changes what that viewer opens on the next time the dashboard loads; it never rewrites the published dashboard, so the default you picked in the builder stays intact for everyone else.
 </Note>
 
-Viewers can still switch to another option unless the control's [visibility](#visibility) is set to **Disabled**, and their own pick outranks the attribute for the rest of the session. Values passed [in the URL](#sharing-the-current-selection) outrank both. A parent control has no parameter of its own there — a shared link carries its *children's* values, and the dropdown follows those children, so the recipient opens on the arrangement the link names rather than on the one their own attribute would have chosen.
+Viewers can still switch to another option unless the control's [visibility](#visibility) is set to **Disabled**, and their own pick outranks the attribute for the rest of the session. Values passed [in the URL](#sharing-the-current-selection) outrank both — but only what the sharer actually picked travels: a parent control has no parameter of its own, and an untouched, attribute-resolved one puts nothing in the link, so the recipient still opens on their own attribute. When the sharer did pick an option, the link carries that option's *children's* values and the recipient opens on those.
 
 ## Sharing the current selection
 


### PR DESCRIPTION
## Why this exists

Follow-up to #11689. I merged that PR on green checks without reading its review comments — a passing `review-with-tracking` job means the reviewer *ran*, not that it found nothing. Four findings were waiting; all four are addressed here.

## What changed

**A rename silently breaks the attribute match.** The original text told the reader renaming an option is safe, borrowing that reassurance from the Options section — where it's true, because child mappings key off the option *id*. The attribute match keys off the *label*. Renaming `Quarter` → `Quarterly` after wiring up an attribute keeps every child value intact and quietly stops the per-viewer default resolving, with no error: the control just falls back to the picked default. That now has a `<Warning>` of its own instead of an implied all-clear.

**The setup step pointed two ways at once.** It offered "click **Configure Parent**, or open its settings menu", while the page says that editor has two tabs — so a reader could land somewhere the switch isn't and then be told to scroll to it. Checked against the implementation: the switch renders after the tabs, beside **Visibility**. The step now names one path and says where to look.

**The cross-link landed a section short of its subject.** #11689 pointed it at `#default-option` to avoid depending on Mintlify's `-2` suffix for the second `User attribute default` heading. Sound, but it dropped the reader above the thing they clicked for. The heading now carries an explicit `{#parent-user-attribute-default}` id — the syntax `docs-mintlify/CLAUDE.md` sanctions for pinning anchors — which fixes both the guesswork and the landing position.

**The link-plus-attribute case was left open.** The parameter table has rows for filters and time granularity switchers only, so "a shared link opens on the values it names" quietly meant the *children's* values, leaving unsaid what the recipient's dropdown shows when they also have an attribute of their own. Now stated: a parent has no parameter of its own, the link carries its children's values, and the dropdown follows those children.

## Checks

All same-page anchors resolve against the headings the file defines, including the new explicit id; MDX component tags balance. `mintlify broken-links` needs a package this checkout can't install offline, so CI's run is the authority — and this time I'll read the review threads before merging, not just the check list.
