### PR TITLE
Update security report email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 
 ## Reporting a Vulnerability
 
-Please email security reports to info@cube.dev or reach out to maintainers directly in https://slack.cube.dev.
+Please email security reports to security@cube.dev or reach out to maintainers directly in https://slack.cube.dev.
 Please do not create issues or public conversations for discovered security issues until patch is shipped.


### PR DESCRIPTION
Update the security contact email listed to the new address:

https://cube.dev/security

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

Related #11670 