### PR TITLE
docs: pre-provisioning embed users via the embed-tenant admin API

### DIFF
--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -281,6 +281,20 @@ DELETE /api/v1/embed-tenants/{embedTenantName}/user-attributes/{id}
 
 These endpoints use the same `Api-Key` authentication as Generate Session and require admin access. List endpoints return cursor-paginated results (`?first=`, `?after=`).
 
+### Provisioning users ahead of a session
+
+An embed user is normally created the first time they generate a session. To put your directory into Cube up front — for example, so a creator can share a workbook with a teammate who hasn't opened the embed yet — provision users directly:
+
+```text
+GET  /api/v1/embed-tenants/{embedTenantName}/users
+POST /api/v1/embed-tenants/{embedTenantName}/user
+POST /api/v1/embed-tenants/{embedTenantName}/users
+```
+
+The single-user endpoint takes the same identity fields as `generate-session` — `externalId`, `email`, `userProfile`, `groups`, `tenantGroups` — and is idempotent: provisioning an `externalId` that already exists updates it rather than failing. Each `groups`/`tenantGroups` lane is replaced when supplied, left untouched when omitted, and cleared with `[]`. A later session for the same `externalId` still applies whatever it carries, so provisioning only changes who a user is, never what their session grants.
+
+The bulk endpoint accepts a `users` array (up to the account's bulk-action limit) and is partially successful: it returns `200` with a `succeeded` list and a `failed` list (each entry carrying the `externalId` and the error the single-user call would have returned), rather than failing the whole batch over one bad entry.
+
 ### Response
 
 The API returns a session object:


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

`cubejs-enterprise#14458` added two new admin endpoints for provisioning embed users ahead of their first session:

```text
POST /api/v1/embed-tenants/{embedTenantName}/user
POST /api/v1/embed-tenants/{embedTenantName}/users
```

These were never documented — the Generate Session reference page only listed the groups/user-attributes admin endpoints in its "Embed-tenant admin API" section. This adds a short "Provisioning users ahead of a session" subsection describing the request fields, idempotent/desired-state semantics, and the bulk endpoint's partial-success response shape, following the existing style on the page.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Jukk3iZbfmQp6BbUWvyDj)_