### PR TITLE
docs: fix typo chnage -> change

### DIFF
--- a/docs/content/product/apis-integrations/google-sheets.mdx
+++ b/docs/content/product/apis-integrations/google-sheets.mdx
@@ -109,7 +109,7 @@ Go to the add-on menu and click <Btn>View saved reports</Btn> to see a list of
 reports.
 
 Click <Btn>Refresh</Btn> to manually refresh the data in the report's location.
-Click <Btn>Edit</Btn> to chnage the query or the location.
+Click <Btn>Edit</Btn> to change the query or the location.
 
 <Screenshot
   src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/"


### PR DESCRIPTION
Corrects the misspelling `chnage` -> `change` in `docs/content/product/apis-integrations/google-sheets.mdx`.

Documentation only, no behaviour change.