### PR TITLE
docs(dashboards): Board editing is GA — remove preview callouts

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks (in preview)
+- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
 
 ## Adding widgets
 
@@ -26,21 +26,9 @@ Each item — a toolbar button, or an option inside the **Add Widgets** / **Add 
 
 Starting a drag from a menu option closes the menu, so it doesn't cover the canvas while you place the widget.
 
-<Warning>
-
-Dragging a toolbar item to place it exactly (drag-to-place) is currently in preview, and the behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate it for your account. Clicking to add a widget is available to everyone.
-
-</Warning>
-
 ## Arranging widgets
 
 Drag any widget to move it, and use the handle in its bottom-right corner to resize it — the surrounding widgets shift to make room.
-
-<Warning>
-
-Selecting multiple widgets and moving or deleting them as a group is currently in preview, and the behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate it for your account.
-
-</Warning>
 
 To work with several widgets at once, select them first:
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -3,12 +3,6 @@ title: Spacer & Divider
 description: Non-data layout elements — a spacer for whitespace and a divider line — that help you structure a dashboard.
 ---
 
-<Warning>
-
-Spacer and divider widgets are currently in preview, and their behavior may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate them for your account.
-
-</Warning>
-
 Spacer and divider are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace and visual structure to a dashboard.
 
 ## Spacer


### PR DESCRIPTION
`useBoardDashboards` has been rolled out to all tenants, so the dashboard-editing features that were behind it are now GA. This removes the "in preview → reach out to Cube support" callouts from the three shipped capabilities:

- **Multi-select & group-move** (was CUB-2124 / #11558)
- **Drag-to-place** (was CUB-3179 / #11555)
- **Spacer & Divider** (was CUB-3039 / #11557)

Changes:
- `widgets/index.mdx` — remove the drag-to-place and multi-select `<Warning>` blocks; drop the "(in preview)" tag on the Spacer & Divider list item.
- `widgets/layout.mdx` — remove the Spacer & Divider `<Warning>` block.

**Not touched:** the **Grid container** widget stays in preview — its feature (cubejs-enterprise#13919) hasn't merged yet, and its docs (#11556) remain held with their preview callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)