### PR TITLE
docs: fill gaps from recent SQL API, dbt push, and deployment changes

### DIFF
--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -18,6 +18,17 @@ the&nbsp;**Cube Cloud** logo in the top left corner.
   <img src="https://ucarecdn.com/cdd5831a-a8f8-4342-bc3e-25aab2c04a5b/" />
 </Frame>
 
+## Default deployment {#default-deployment}
+
+On an account with more than one deployment, opening Cube without a deployment in the URL
+resolves to a default, in this order: the user's own pin, the last deployment they switched
+to, the account-wide default, then the most recently created deployment.
+
+Admins set the account-wide default from the **⋮** menu on a deployment's row in
+[the list of deployments](#list-of-deployments) — **Set as default** (or **Remove as
+default** on the current one). Everyone lands there unless they've picked their own; see
+[Preferences](/docs/preferences#default-deployment) for the per-user setting.
+
 ## Creating a new deployment
 
 Creating a new deployment is an essential prerequisite to running a Cube

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -612,7 +612,7 @@ credential can write to the repository — a `git-receive-pack` probe for a PAT,
 | --- | --- |
 | **Models path** | Directory in the dbt project where generated model files are written. Defaults to `models/marts/cube/`. |
 | **Validation level** | The dbt check a pushed model must pass before Cube opens the change. **Parse only** just parses the project. **Compile (recommended)** — the default — opens the warehouse connection but doesn't materialize anything. **Build in a validation schema** (**Build**) actually builds the model in a schema you provide, catching errors the other two levels can't. |
-| **Validation schema** | Required by the form whenever **Validation level** is **Build**, on every adapter. An existing schema you create and grant access to yourself — Cube only creates and drops the temporary validation relation inside it, never the schema. |
+| **Validation schema** | Required whenever **Validation level** is **Build**, including on adapters that fall back to **Parse only** (see below). An existing schema you create and grant access to yourself — Cube only creates and drops the temporary validation relation inside it, never the schema. |
 | **Delivery mode** | **Open a pull request** (default) pushes to a `cube/dbt-push/*` branch and opens a PR/MR. **Commit directly to a branch** commits straight to a branch you name — validation still runs. |
 
 Then **Save dbt settings**.

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -611,8 +611,8 @@ credential can write to the repository — a `git-receive-pack` probe for a PAT,
 | Setting | Description |
 | --- | --- |
 | **Models path** | Directory in the dbt project where generated model files are written. Defaults to `models/marts/cube/`. |
-| **Validation level** | The dbt check a pushed model must pass before Cube opens the change. **Parse only** just parses the project. **Compile (recommended)** — the default — opens the warehouse connection but doesn't materialize anything. **Build in a validation schema** actually builds the model in a schema you provide, catching errors the other two levels can't. |
-| **Validation schema** | Required when **Validation level** is **Build**. An existing schema you create and grant access to yourself — Cube only creates and drops the temporary validation relation inside it, never the schema. |
+| **Validation level** | The dbt check a pushed model must pass before Cube opens the change. **Parse only** just parses the project. **Compile (recommended)** — the default — opens the warehouse connection but doesn't materialize anything. **Build in a validation schema** (**Build**) actually builds the model in a schema you provide, catching errors the other two levels can't. |
+| **Validation schema** | Required by the form whenever **Validation level** is **Build**, on every adapter. An existing schema you create and grant access to yourself — Cube only creates and drops the temporary validation relation inside it, never the schema. |
 | **Delivery mode** | **Open a pull request** (default) pushes to a `cube/dbt-push/*` branch and opens a PR/MR. **Commit directly to a branch** commits straight to a branch you name — validation still runs. |
 
 Then **Save dbt settings**.
@@ -624,7 +624,9 @@ validation schema, in addition to its existing read access to production so dbt 
 resolve `ref()` calls. Grant `CREATE`/`DROP` (or the warehouse's equivalent, e.g. BigQuery
 Data Editor) on that one schema only, and keep the principal read-only everywhere else.
 BigQuery, Databricks, and Athena don't yet support **Compile** or **Build** and fall
-back to **Parse only** regardless of what's selected.
+back to **Parse only** regardless of what's selected — you can still pick **Build** and
+fill in a schema there, since the form requires one, but the run itself only parses and
+the schema goes unused.
 
 </Note>
 
@@ -663,10 +665,10 @@ to.
 <Step title="Push">
 
 Confirm. Cube clones the repo, writes the files (**create-only** — it never overwrites an
-existing model and never force-pushes), and runs `dbt deps` plus the configured
-**Validation level**. If validation fails, the push stops with dbt's own output and **no
-pull request is opened**. On success, a progress toast ends with a link to the pull
-request — or, for SSH or non-GitHub/GitLab hosts, a prefilled compare link to open it
+existing model and never force-pushes), and runs `dbt deps` followed by the check your
+**Validation level** selects. If validation fails, the push stops with dbt's own output
+and **no pull request is opened**. On success, a progress toast ends with a link to the
+pull request — or, for SSH or non-GitHub/GitLab hosts, a prefilled compare link to open it
 yourself.
 
 </Step>

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -611,9 +611,22 @@ credential can write to the repository — a `git-receive-pack` probe for a PAT,
 | Setting | Description |
 | --- | --- |
 | **Models path** | Directory in the dbt project where generated model files are written. Defaults to `models/marts/cube/`. |
+| **Validation level** | The dbt check a pushed model must pass before Cube opens the change. **Parse only** just parses the project. **Compile (recommended)** — the default — opens the warehouse connection but doesn't materialize anything. **Build in a validation schema** actually builds the model in a schema you provide, catching errors the other two levels can't. |
+| **Validation schema** | Required when **Validation level** is **Build**. An existing schema you create and grant access to yourself — Cube only creates and drops the temporary validation relation inside it, never the schema. |
 | **Delivery mode** | **Open a pull request** (default) pushes to a `cube/dbt-push/*` branch and opens a PR/MR. **Commit directly to a branch** commits straight to a branch you name — validation still runs. |
 
 Then **Save dbt settings**.
+
+<Note>
+
+**Build** needs a warehouse principal that can create and drop relations in the
+validation schema, in addition to its existing read access to production so dbt can
+resolve `ref()` calls. Grant `CREATE`/`DROP` (or the warehouse's equivalent, e.g. BigQuery
+Data Editor) on that one schema only, and keep the principal read-only everywhere else.
+BigQuery, Databricks, and Athena don't yet support **Compile** or **Build** and fall
+back to **Parse only** regardless of what's selected.
+
+</Note>
 
 </Step>
 
@@ -650,10 +663,11 @@ to.
 <Step title="Push">
 
 Confirm. Cube clones the repo, writes the files (**create-only** — it never overwrites an
-existing model and never force-pushes), and runs `dbt deps` + `dbt parse`. If parse fails,
-the push stops with dbt's own output and **no pull request is opened**. On success, a
-progress toast ends with a link to the pull request — or, for SSH or non-GitHub/GitLab
-hosts, a prefilled compare link to open it yourself.
+existing model and never force-pushes), and runs `dbt deps` plus the configured
+**Validation level**. If validation fails, the push stops with dbt's own output and **no
+pull request is opened**. On success, a progress toast ends with a link to the pull
+request — or, for SSH or non-GitHub/GitLab hosts, a prefilled compare link to open it
+yourself.
 
 </Step>
 

--- a/docs-mintlify/docs/preferences.mdx
+++ b/docs-mintlify/docs/preferences.mdx
@@ -75,7 +75,7 @@ own.
 ## Default deployment
 
 If your account has more than one deployment, pick which one you land on when you open
-Cube without a deployment in the URL. Leaving it as **Account default** follows the
-deployment your admin pinned (see [Default deployment](/admin/deployment#default-deployment)),
-or the most recently created deployment if nothing is pinned. The control is hidden on
-single-deployment accounts.
+Cube without a deployment in the URL. Leaving it as **Account default** falls back to the
+rest of the [resolution order](/admin/deployment#default-deployment) — the deployment you
+last switched to, then the deployment your admin pinned, then the most recently created
+one. The control is hidden on single-deployment accounts.

--- a/docs-mintlify/docs/preferences.mdx
+++ b/docs-mintlify/docs/preferences.mdx
@@ -17,6 +17,7 @@ account, apply across all devices, and don't affect other users in the account.
 | Code editor | Switch to the new CodeMirror-based code editor for data models | Off |
 | New message scrolling | Automatically scroll to new messages in chat | On |
 | Alternating row colors | Highlight alternating rows in data tables | Off |
+| Default deployment | Choose which deployment you land on when you open Cube without one in the URL | Account default |
 
 ## Language
 
@@ -70,3 +71,11 @@ everyone queries in the account-wide zone.
 
 See [Time zones](/admin/time-zones) for what a zone changes and how dashboards carry their
 own.
+
+## Default deployment
+
+If your account has more than one deployment, pick which one you land on when you open
+Cube without a deployment in the URL. Leaving it as **Account default** follows the
+deployment your admin pinned (see [Default deployment](/admin/deployment#default-deployment)),
+or the most recently created deployment if nothing is pinned. The control is hidden on
+single-deployment accounts.

--- a/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
+++ b/docs-mintlify/recipes/data-modeling/cross-data-source-queries.mdx
@@ -365,4 +365,7 @@ Each half of the union is subject to the [maximum row
 limit](/docs/data-modeling/configuration#maximum-row-limit) on its own, and the
 cap applies before the results are appended. Aggregate inside each half of the
 union, as in the examples above, rather than unioning raw rows and aggregating
-afterwards.
+afterwards. This per-half limit applies specifically because the two halves reach
+different data sources; a union whose branches share one data source is pushed
+down as a single statement and the limit applies once, to the combined result (see
+[query pushdown](/reference/core-data-apis/sql-api/query-format#query-pushdown)).

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -204,6 +204,12 @@ If direct conversion is not possible, different SQL transformation rewrite rules
 Please refer to the [SQL API reference][ref-ref-sql-api] for the list of supported SQL functions and clauses.
 Support varies based on the target database.
 
+A `UNION` or `UNION ALL` of queries that all target the same data source is pushed
+down as a single statement, so the [row limit][ref-query-default-limit] applies once,
+to the combined result, rather than separately to each branch. A union whose branches
+reach different data sources still evaluates each branch on its own; see [querying
+across data sources][ref-cross-data-source-queries] for that case.
+
 ## Top-down and bottom-up evaluation
 
 Fundamentally, every SQL operation results in a tabular data set.
@@ -447,6 +453,7 @@ If a query of yours has that shape, you can:
 [ref-query-default-limit]: /reference/core-data-apis/queries#row-limit
 [ref-env-db-query-limit]: /reference/configuration/environment-variables#cubejs_db_query_limit
 [ref-env-cubesql-stream-mode]: /reference/configuration/environment-variables#cubesql_stream_mode
+[ref-cross-data-source-queries]: /recipes/data-modeling/cross-data-source-queries
 [ref-env-non-streaming-limit]: /reference/configuration/environment-variables#cubesql_non_streaming_query_max_row_limit
 [ref-ref-sql-api]: /reference/core-data-apis/sql-api/reference
 [link-postgres-boolean]: https://www.postgresql.org/docs/current/datatype-boolean.html

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -205,8 +205,9 @@ Please refer to the [SQL API reference][ref-ref-sql-api] for the list of support
 Support varies based on the target database.
 
 A `UNION` or `UNION ALL` of queries that all target the same data source is pushed
-down as a single statement, so the [row limit][ref-query-default-limit] applies once,
-to the combined result, rather than separately to each branch. A union whose branches
+down as a single statement, so the [maximum row
+limit](/docs/data-modeling/configuration#maximum-row-limit) applies once, to the
+combined result, rather than separately to each branch. A union whose branches
 reach different data sources still evaluates each branch on its own; see [querying
 across data sources][ref-cross-data-source-queries] for that case.
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -562,8 +562,8 @@ of the PostgreSQL documentation.
 </Info>
 
 Window functions are supported via [query pushdown][ref-qpd] only; they are not
-available in [query post-processing][ref-qpp]. Two kinds are supported, including
-over a grouped subquery, CTE, or join:
+available in [query post-processing][ref-qpp]. The window can be evaluated over a grouped
+subquery, a CTE, or a join. Two kinds are supported:
 
 - **Aggregate functions used as window functions** — any supported aggregate
   function (such as `SUM`, `AVG`, `COUNT`, `MIN`, or `MAX`) combined with an

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -513,8 +513,10 @@ of the PostgreSQL documentation.
 | `STRING_AGG` | Concatenates the input values into a string, separated by a delimiter (supports `DISTINCT`) | ✅ Yes | ❌ No |
 | `PERCENTILE_CONT` | Computes a continuous percentile, used with `WITHIN GROUP (ORDER BY ...)` | ✅ Yes | ❌ No |
 
-Aggregate functions that take more than one argument (for example, `PERCENTILE_CONT`
-combined with other arguments in the same call) are supported in pushdown.
+An aggregate function that takes more than one argument (for example,
+`APPROX_PERCENTILE_CONT(expr, 0.5)`) is no longer excluded from pushdown by its argument
+count; whether it can be pushed down still depends on the target data source supporting
+that function.
 
 In projections in inner parts of post-processing queries:
 * `AVG`, `COUNT`, `MAX`, `MIN`, and `SUM` can only be used with measures of

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -513,6 +513,9 @@ of the PostgreSQL documentation.
 | `STRING_AGG` | Concatenates the input values into a string, separated by a delimiter (supports `DISTINCT`) | ✅ Yes | ❌ No |
 | `PERCENTILE_CONT` | Computes a continuous percentile, used with `WITHIN GROUP (ORDER BY ...)` | ✅ Yes | ❌ No |
 
+Aggregate functions that take more than one argument (for example, `PERCENTILE_CONT`
+combined with other arguments in the same call) are supported in pushdown.
+
 In projections in inner parts of post-processing queries:
 * `AVG`, `COUNT`, `MAX`, `MIN`, and `SUM` can only be used with measures of
 [compatible types][ref-sql-api-aggregate-functions].
@@ -557,7 +560,8 @@ of the PostgreSQL documentation.
 </Info>
 
 Window functions are supported via [query pushdown][ref-qpd] only; they are not
-available in [query post-processing][ref-qpp]. Two kinds are supported:
+available in [query post-processing][ref-qpp]. Two kinds are supported, including
+over a grouped subquery, CTE, or join:
 
 - **Aggregate functions used as window functions** — any supported aggregate
   function (such as `SUM`, `AVG`, `COUNT`, `MIN`, or `MAX`) combined with an

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -514,9 +514,8 @@ of the PostgreSQL documentation.
 | `PERCENTILE_CONT` | Computes a continuous percentile, used with `WITHIN GROUP (ORDER BY ...)` | ✅ Yes | ❌ No |
 
 An aggregate function that takes more than one argument (for example,
-`APPROX_PERCENTILE_CONT(expr, 0.5)`) is no longer excluded from pushdown by its argument
-count; whether it can be pushed down still depends on the target data source supporting
-that function.
+`APPROX_PERCENTILE_CONT(expr, 0.5)`) can be pushed down, provided the target data source
+supports that function.
 
 In projections in inner parts of post-processing queries:
 * `AVG`, `COUNT`, `MAX`, `MIN`, and `SUM` can only be used with measures of


### PR DESCRIPTION
## Summary

Routine scan of recent merges in `cube-js/cube` and `cubedevinc/cubejs-enterprise` for customer-facing changes missing from docs-mintlify. Four small gaps found and closed with surgical edits to existing pages (no new pages needed):

- **SQL API pushdown** (`reference/core-data-apis/sql-api/query-format.mdx`, `reference.mdx`, `recipes/data-modeling/cross-data-source-queries.mdx`):
  - A `UNION`/`UNION ALL` of queries that all reach the same data source is now pushed down as a single statement, so the row limit applies once to the combined result rather than per branch (cube-js/cube#11651). Cross-referenced from the existing cross-data-source-queries recipe, which documents the still-unaffected per-branch case.
  - Aggregate functions taking more than one argument, and window functions over grouped subqueries/CTEs/joins, are now supported in pushdown (cube-js/cube#11684).
- **dbt push** (`docs/integrations/dbt.mdx`): new **Validation level** setting (Parse only / Compile (recommended, default) / Build in a validation schema) and **Validation schema** field, plus the per-warehouse grant requirements and the three adapters (BigQuery, Databricks, Athena) that currently fall back to parse-only (cubedevinc/cubejs-enterprise#14392).
- **Default landing deployment** (`admin/deployment/index.mdx`, `docs/preferences.mdx`): accounts with multiple deployments can now set an account-wide default (admin) and/or a personal default (per user), with the resolution order documented (cubedevinc/cubejs-enterprise#14519).

All four were verified against the actual diff/PR body (not just the commit subject) and confirmed absent from docs-mintlify before writing. No changes qualified as a "big" new-page-worthy feature in this pass, so no Linear ticket was needed.

One additional gap was found but intentionally **not** addressed here: the funnel chart type has no docs-mintlify page at all (missing from `chart-types/index.mdx`), which predates the PR that added its horizontal-orientation option (cubedevinc/cubejs-enterprise#14510). Flagging for a separate pass rather than folding a new page into this change.

## Test plan

- [x] Verified each change against `git show`/PR body, not just the commit subject
- [x] Searched docs-mintlify to confirm no existing coverage before editing
- [ ] Docs maintainer review for tone/placement

---
_Generated by [Claude Code](https://claude.ai/code/session_0111WWjfNRcHAa8HP7uXAKm7)_