### PR TITLE
docs: fill gaps found in a routine doc-coverage audit (SQL API, embedding, billing, usage analytics)

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -71,16 +71,25 @@ Contact your account executive for details on purchasing token packages.
 ## Free tier
 
 Each user on a free plan receives an individual monthly token allowance. This
-allowance resets at the start of each calendar month.
+allowance resets at the start of each calendar month, and usage is tracked
+against it in real time — once a user's spend for the month reaches the
+allowance, further AI requests are blocked until the next reset (see
+[When limits are reached](#when-limits-are-reached)).
+
+If an account downgrades to the free plan mid-month, that month's already
+recorded spend is drawn against the new free allowance immediately, rather
+than resetting.
 
 ## Tracking usage
 
-Administrators can monitor token consumption through the **AI Tokens Usage**
-tab in the billing settings page. The dashboard shows:
+Administrators can monitor token consumption through the **AI** tab in the
+billing settings page, split into two views:
 
-- Total token usage over time
-- Remaining allocation from per-seat grants and token packages
-- Breakdown by usage dimension
+- **AI Usage** — aggregate token consumption over time, remaining allocation
+  from per-seat grants and token packages, and a breakdown by user, role, and
+  usage dimension.
+- **AI Requests** — a raw, per-request log (with a live tail) for inspecting
+  individual AI calls as they happen.
 
 ## When limits are reached
 

--- a/docs-mintlify/admin/monitoring/usage-analytics.mdx
+++ b/docs-mintlify/admin/monitoring/usage-analytics.mdx
@@ -64,6 +64,22 @@ The API Requests view includes the security context behind each request, so
 embedded analytics customers can slice usage by tenant — for example, to find
 the heaviest tenants or compare per-tenant latency and cache efficiency.
 
+## Querying usage data from your own tools
+
+To pull your account's usage and billing data into an external BI tool instead
+of (or in addition to) using the console, request a scoped Cube API token:
+
+```bash
+curl -X POST https://your-account.cubecloud.dev/api/v1/usage-analytics/token \
+  -H "Authorization: Api-Key ${API_KEY}"
+```
+
+The returned token is scoped to your account's Usage Analytics views (the same
+ones described in [Build your own dashboards](#build-your-own-dashboards)) and
+can be used to authenticate [Core Data API][ref-core-data-apis] requests
+against those views from tools like Power BI. Only account administrators can
+request this token.
+
 ## Data freshness and isolation
 
 Usage Analytics data is available on a slight delay compared to live activity.
@@ -73,3 +89,5 @@ For real-time inspection of individual queries, use
 Usage Analytics content is isolated from your own deployments' content: the
 views and dashboards described above don't appear in your data model, and your
 end users can't access them.
+
+[ref-core-data-apis]: /reference/core-data-apis

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -7,7 +7,7 @@ description: Embed the full Cube application so users can build and modify their
   Creator Mode is available on the [Enterprise plan](https://cube.dev/pricing).
 </Info>
 
-Creator Mode embeds the full Cube application instead of an individual dashboard or chat. Users can create and modify workbooks, dashboards, and reports inside the iframe.
+Creator Mode embeds the full Cube application instead of an individual dashboard or chat. Users can create and modify workbooks, dashboards, folders, and reports inside the iframe.
 
 To enable it, pass `creatorMode: true` to the [Generate Session API][ref-generate-session].
 

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -62,6 +62,10 @@ or [GraphQL API][ref-ref-graphql-api-args] to specify the time zone for a query.
 Also, you can use the [`SQL_UTILS` context variable][ref-sql-utils] to apply the
 time zone conversion to dimensions that are not used as time dimensions in a query.
 
+The `timezone` value must be a valid [IANA time zone name][wiki-tz-database]
+(e.g., `America/Los_Angeles`, `Europe/Rome`). A value that is not a valid IANA
+time zone name is rejected with an error rather than being silently ignored.
+
 Additionally, note that time zones have impact on [pre-aggregation
 matching][ref-matching-preaggs-time-dimensions].
 
@@ -400,6 +404,7 @@ called `count` to be defined in the cube or view. Please add one to resolve this
 
 
 [wiki-utc-time-zone]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[wiki-tz-database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [ref-data-model]: /docs/data-modeling/overview
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -62,6 +62,36 @@ FROM orders
 ORDER BY status, id DESC;
 ```
 
+### `UNION`
+
+Synopsis:
+
+```sql
+query UNION [ ALL ] query
+```
+
+`UNION` combines the result sets of two or more `SELECT` statements. `UNION ALL`
+keeps duplicate rows in the combined result; plain `UNION` removes them.
+
+When every unioned query targets the same [data source][ref-data-sources],
+`UNION`/`UNION ALL` is pushed down as a single query to that data source. A
+`UNION`/`UNION ALL` spanning multiple data sources still runs as
+[post-processing][ref-qpp] on top of the individual queries.
+
+Example:
+
+```sql
+SELECT status, COUNT(*) AS count
+FROM orders
+WHERE created_at >= '2024-01-01'
+GROUP BY 1
+UNION ALL
+SELECT status, COUNT(*) AS count
+FROM orders
+WHERE created_at < '2024-01-01'
+GROUP BY 1;
+```
+
 ### `EXPLAIN`
 
 Synopsis:
@@ -512,6 +542,7 @@ of the PostgreSQL documentation.
 | `MEASURE` | Works with measures of [any type][ref-sql-api-aggregate-functions] | ✅ Yes | <nobr>❌ Outer</nobr><br/><nobr>✅ Inner (selections)</nobr><br/><nobr>✅ Inner (projections)</nobr> |
 | `STRING_AGG` | Concatenates the input values into a string, separated by a delimiter (supports `DISTINCT`) | ✅ Yes | ❌ No |
 | `PERCENTILE_CONT` | Computes a continuous percentile, used with `WITHIN GROUP (ORDER BY ...)` | ✅ Yes | ❌ No |
+| `APPROX_PERCENTILE_CONT` | Computes an approximate continuous percentile, used with `WITHIN GROUP (ORDER BY ...)`. Also how `APPROX_MEDIAN` is expressed (as `APPROX_PERCENTILE_CONT(expr, 0.5)`), which is useful for computing a median on data sources with no exact median function, such as Athena, Trino, and Presto | ✅ Yes | ❌ No |
 
 In projections in inner parts of post-processing queries:
 * `AVG`, `COUNT`, `MAX`, `MIN`, and `SUM` can only be used with measures of
@@ -557,17 +588,26 @@ of the PostgreSQL documentation.
 </Info>
 
 Window functions are supported via [query pushdown][ref-qpd] only; they are not
-available in [query post-processing][ref-qpp]. Two kinds are supported:
+available in [query post-processing][ref-qpp]. Three kinds are supported:
 
 - **Aggregate functions used as window functions** — any supported aggregate
   function (such as `SUM`, `AVG`, `COUNT`, `MIN`, or `MAX`) combined with an
   `OVER (...)` clause.
-- **The `LAG` and `LEAD` window functions:**
+- **The `LAG` and `LEAD` window functions.**
+- **Ranking and value window functions:**
 
 | Function | Description | [Pushdown][ref-qpd] | <nobr>[Post-processing][ref-qpp]</nobr> |
 | --- | --- | --- | --- |
 | `LAG` | Returns the value from a row at a given offset before the current row within its partition | ✅ Yes | ❌ No |
 | `LEAD` | Returns the value from a row at a given offset after the current row within its partition | ✅ Yes | ❌ No |
+| `ROW_NUMBER` | Returns the number of the current row within its partition, counting from 1 | ✅ Yes | ❌ No |
+| `RANK` | Returns the rank of the current row within its partition, with gaps after ties | ✅ Yes | ❌ No |
+| `DENSE_RANK` | Returns the rank of the current row within its partition, without gaps after ties | ✅ Yes | ❌ No |
+| `PERCENT_RANK` | Returns the relative rank of the current row: `(rank - 1) / (total rows - 1)` | ✅ Yes | ❌ No |
+| `CUME_DIST` | Returns the cumulative distribution: the number of partition rows preceding or peer with the current row, divided by total rows in the partition | ✅ Yes | ❌ No |
+| `FIRST_VALUE` | Returns the value evaluated at the first row of the window frame | ✅ Yes | ❌ No |
+| `LAST_VALUE` | Returns the value evaluated at the last row of the window frame | ✅ Yes | ❌ No |
+| `NTH_VALUE` | Returns the value evaluated at the `n`-th row of the window frame, counting from 1 | ✅ Yes | ❌ No |
 
 ### Row and array comparisons
 
@@ -607,6 +647,7 @@ See the [XIRR recipe](/recipes/data-modeling/xirr) for more details.
 [ref-meta-api]: /reference/core-data-apis/rest-api/reference#metadata-api
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-graphql-api]: /reference/core-data-apis/graphql-api
+[ref-data-sources]: /admin/connect-to-data/data-sources
 [link-postgres-funcs]: https://www.postgresql.org/docs/current/functions.html
 [link-postgres-copy]: https://www.postgresql.org/docs/current/sql-copy.html
 [link-github-sql-api]: https://github.com/cube-js/cube/issues?q=is%3Aopen+is%3Aissue+label%3Aapi%3Asql


### PR DESCRIPTION
## Summary

Routine audit cross-checking recent merged PRs in `cube-js/cube` and `cubedevinc/cubejs-enterprise` against `docs-mintlify`, filtered through the customer-facing criteria in cubejs-enterprise's `.claude/shared/customer-facing-criteria.md`. These are small, surgical additions to existing pages for shipped (not flagged-off) behavior that had no documentation at all.

- **SQL API reference** (`reference/core-data-apis/sql-api/reference.mdx`):
  - Document `UNION`/`UNION ALL` pushdown to the data source (previously ran only as post-processing; could silently drop rows before this shipped)
  - Document the ranking/value window functions (`ROW_NUMBER`, `RANK`, `DENSE_RANK`, `PERCENT_RANK`, `CUME_DIST`, `FIRST_VALUE`, `LAST_VALUE`, `NTH_VALUE`) — only `LAG`/`LEAD` were previously documented
  - Document `APPROX_PERCENTILE_CONT`, including its use for `APPROX_MEDIAN` on data sources with no exact median function (Athena, Trino, Presto)
- **Querying data APIs** (`reference/core-data-apis/queries.mdx`): note that the `timezone` query option is now validated against real IANA time zone names and rejected early if invalid
- **Creator Mode embedding** (`embedding/iframe/creator-mode.mdx`): mention that embed users can now create folders, not just workbooks/dashboards/reports
- **AI Tokens** (`admin/account-billing/ai-tokens.mdx`): document the AI Usage / AI Requests tab split, and free-tier token enforcement + the mid-month-downgrade drawdown behavior
- **Usage Analytics** (`admin/monitoring/usage-analytics.mdx`): document the new `POST /api/v1/usage-analytics/token` endpoint for pulling usage data into external BI tools

## Not included here

A few larger, genuinely undocumented features surfaced by the same audit (Funnel chart, Dashboard comments, the Alerts feature, and the dbt chat-driven workspace-authoring capability) are tracked as separate GitHub issues rather than bundled into this docs PR, since they likely need their own new page(s)/sections rather than a small edit.

## Test plan

- [ ] Docs build (`cd docs-mintlify && yarn dev`) renders each changed page without MDX/broken-link errors
- [ ] Spot-check the new SQL API tables and the UNION example render correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01C51CFWY8FHD7RZdzHWXBKD)_