### PR TITLE
docs: explain editable SAML audience (CUB-2546)

### DIFF
--- a/docs-mintlify/admin/sso/google-workspace.mdx
+++ b/docs-mintlify/admin/sso/google-workspace.mdx
@@ -20,19 +20,14 @@ Available on [Enterprise plan](https://cube.dev/pricing).
 First, we'll enable SAML authentication in Cube Cloud. To do this, log in to
 Cube Cloud and
 
-1. Click your username from the top-right corner, then click **Team &
-   Security**.
+1. Navigate to **Admin → Settings**.
+2. On the **Authentication & SSO** tab, enable **SAML**.
+3. Set **Audience (SP Entity ID)** to the **Single Sign-On URL** shown
+   directly above it.
 
-2. On the **Authentication & SSO** tab, ensure **SAML** is
-   enabled:
-
-<Frame>
-  <img src="https://ucarecdn.com/f5ff1413-f37c-4476-afcc-0ff29e87e80a/" alt="Cube Cloud Team Authentication and SSO tab" />
-</Frame>
-
-Take note of the **Single Sign On URL** and **Service Provider Entity
-ID** values here, as we will need them in the next step when we configure
-the SAML integration in Google Workspace.
+Take note of the **Single Sign-On URL** and **Audience (SP Entity ID)**
+values. You will need them when you configure the SAML integration in Google
+Workspace.
 
 ## Create a SAML Integration in Google Workspace
 
@@ -69,10 +64,10 @@ Workspace][google-docs-create-saml-app].
 5. Enter the following values for the **Service provider details**
    section and click **Continue**.
 
-| Name      | Description                                                         |
-| --------- | ------------------------------------------------------------------- |
-| ACS URL   | Use the **Single Sign On URL** value from Cube Cloud         |
-| Entity ID | Use the **Service Provider Entity ID** value from Cube Cloud |
+| Name      | Description |
+| --------- | ----------- |
+| ACS URL   | Use the **Single Sign-On URL** value from Cube Cloud. |
+| Entity ID | Use the **Audience (SP Entity ID)** value from Cube Cloud. |
 
 5. On the final screen, click **Finish**.
 
@@ -83,34 +78,39 @@ Workspace][google-docs-create-saml-app].
   <img src="https://ucarecdn.com/8e1696fa-828c-4be5-a1d8-81c7b054dadb/" />
 </Frame>
 
-## Enable SAML in Cube Cloud
+## Complete SAML configuration in Cube Cloud
 
 In this step, we'll finalise the configuration by entering the values from our
 SAML integration in Google into Cube Cloud.
 
-1. From the same **Authentication & SSO > SAML** tab, click the
-   **Advanced Settings** tab:
+1. Return to **Admin → Settings → Authentication & SSO → SAML**.
+2. Confirm that **Audience (SP Entity ID)** still matches the **Single
+   Sign-On URL** exactly.
+3. Enter the following values in the **SAML Settings** section:
 
-<Frame>
-  <img src="https://ucarecdn.com/5359c52e-69c1-45fa-baf2-d3bb07d72634/" />
-</Frame>
+| Name | Description |
+| --- | --- |
+| Entity ID / Issuer | Use the **Entity ID** value from Google Workspace. |
+| SSO (Sign on) URL | Use the **SSO URL** value from Google Workspace. |
+| Certificate | Use the **Certificate** value from Google Workspace. |
 
-2. Enter the following values in the **SAML Settings** section:
-
-| Name                        | Description                                                        |
-| --------------------------- | ------------------------------------------------------------------ |
-| Audience (SP Entity ID)     | Delete the prefilled value and leave empty                         |
-| IdP Issuer (IdP Entity ID)  | Use the **Issuer** value from Google Workspace              |
-| Identity Provider Login URL | Use the **Sign on URL** value from Google Workspace         |
-| Certificate                 | Use the **Signing Certificate** value from Google Workspace |
-
-3. Enable **Auto-provision new users** if you want users to be automatically
+4. Enable **Auto-provision new users** if you want users to be automatically
    created in Cube on their first login via this SAML provider. New users
    are assigned the Viewer role by default — see
    [Default role for new users](#default-role-for-new-users) to choose a
    different role. Enable this if you are not using SCIM provisioning.
 
-4. Scroll down and click **Save SAML Settings** to save the changes.
+5. Click **Apply** to save the changes.
+
+<Note>
+
+Existing working Google Workspace integrations with a blank Audience do not
+need to change immediately. A blank Audience disables audience validation. To
+enable validation, update the Google **Entity ID** and Cube **Audience (SP
+Entity ID)** together, keep another authentication method enabled, and test
+SAML sign-in before you disable the fallback method.
+
+</Note>
 
 ## Default role for new users
 

--- a/docs-mintlify/admin/sso/google-workspace.mdx
+++ b/docs-mintlify/admin/sso/google-workspace.mdx
@@ -22,8 +22,8 @@ Cube Cloud and
 
 1. Navigate to **Admin → Settings**.
 2. On the **Authentication & SSO** tab, enable **SAML**.
-3. Set **Audience (SP Entity ID)** to the **Single Sign-On URL** shown
-   directly above it.
+3. For a new integration, replace any prefilled **Audience (SP Entity ID)**
+   value with the **Single Sign-On URL** shown directly above it.
 
 Take note of the **Single Sign-On URL** and **Audience (SP Entity ID)**
 values. You will need them when you configure the SAML integration in Google
@@ -69,9 +69,9 @@ Workspace][google-docs-create-saml-app].
 | ACS URL   | Use the **Single Sign-On URL** value from Cube Cloud. |
 | Entity ID | Use the **Audience (SP Entity ID)** value from Cube Cloud. |
 
-5. On the final screen, click **Finish**.
+6. On the final screen, click **Finish**.
 
-6. From the app details page, click **User access** and ensure the app is
+7. From the app details page, click **User access** and ensure the app is
    **ON for everyone**:
 
 <Frame>

--- a/docs-mintlify/admin/sso/index.mdx
+++ b/docs-mintlify/admin/sso/index.mdx
@@ -32,6 +32,17 @@ Use the toggle in the **SAML** section to enable or disable the authentication
 via an identity provider supporting the [SAML protocol][wiki-saml].
 Once it's enabled, you'll see the **SAML Settings** section directly below.
 
+Check the following guides to get tool-specific instructions on configuration:
+
+<CardGroup cols={2}>
+  <Card title="Google Workspace" img="https://static.cube.dev/icons/google-cloud.svg" href="/admin/sso/google-workspace">
+  </Card>
+  <Card title="Microsoft Entra ID" img="https://static.cube.dev/icons/azure.svg" href="/admin/sso/microsoft-entra-id">
+  </Card>
+  <Card title="Okta" img="https://static.cube.dev/icons/okta.svg" href="/admin/sso/okta">
+  </Card>
+</CardGroup>
+
 #### Match SAML service provider identifiers
 
 Cube shows two service provider values in the SAML settings:
@@ -59,17 +70,6 @@ you change an existing configuration, keep another authentication method
 enabled until you have tested SAML sign-in in a separate browser session.
 
 </Note>
-
-Check the following guides to get tool-specific instructions on configuration:
-
-<CardGroup cols={2}>
-  <Card title="Google Workspace" img="https://static.cube.dev/icons/google-cloud.svg" href="/admin/sso/google-workspace">
-  </Card>
-  <Card title="Microsoft Entra ID" img="https://static.cube.dev/icons/azure.svg" href="/admin/sso/microsoft-entra-id">
-  </Card>
-  <Card title="Okta" img="https://static.cube.dev/icons/okta.svg" href="/admin/sso/okta">
-  </Card>
-</CardGroup>
 
 [wiki-saml]: https://en.wikipedia.org/wiki/SAML_2.0
 [ref-apis]: /reference

--- a/docs-mintlify/admin/sso/index.mdx
+++ b/docs-mintlify/admin/sso/index.mdx
@@ -18,10 +18,6 @@ Cube Cloud also provides single sign-on (SSO) via identity providers supporting
 
 </Info>
 
-<Frame>
-  <img src="https://ucarecdn.com/e3b3bce2-117e-4cbc-b516-c71b51b98888/" />
-</Frame>
-
 ## Configuration
 
 To manage authentication settings, navigate to **Admin → Settings**
@@ -35,6 +31,34 @@ sections to enable or disable these authentication options.
 Use the toggle in the **SAML** section to enable or disable the authentication
 via an identity provider supporting the [SAML protocol][wiki-saml].
 Once it's enabled, you'll see the **SAML Settings** section directly below.
+
+#### Match SAML service provider identifiers
+
+Cube shows two service provider values in the SAML settings:
+
+| Cube setting | Identity provider setting |
+| --- | --- |
+| **Single Sign-On URL** | ACS URL or Reply URL |
+| **Audience (SP Entity ID)** | Audience, Entity ID, or SP Entity ID |
+
+The **Audience (SP Entity ID)** value validates the audience in SAML responses.
+It must exactly match the value configured in your identity provider. Leaving
+the field blank disables audience validation and is supported only for
+compatibility with existing configurations.
+
+Some identity providers, including Amazon Federate, use one service provider
+identifier for both the AuthnRequest issuer and the response audience. For
+these providers, set **Audience (SP Entity ID)** in Cube to the **Single
+Sign-On URL**, then use that same value as the identity provider's Entity ID
+or Audience.
+
+<Note>
+
+Existing working SAML integrations do not need to change their Audience. When
+you change an existing configuration, keep another authentication method
+enabled until you have tested SAML sign-in in a separate browser session.
+
+</Note>
 
 Check the following guides to get tool-specific instructions on configuration:
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
@@ -59,9 +59,10 @@ update both sides of the integration.
 2. In the **Basic SAML Configuration** section, enter the following:
    - **Entity ID** — Use the **Single Sign-On URL** value from Cube.
    - **Reply URL** — Use the **Single Sign-On URL** value from Cube.
-3. Go to **Attributes & Claims → Edit → Advanced settings** and
-   set the audience claim override to the **Audience (SP Entity ID)** value
-   from Cube. It must match exactly.
+3. If the **Audience (SP Entity ID)** value from Cube differs from the
+   **Entity ID** configured in the previous step, go to **Attributes & Claims
+   → Edit → Advanced settings** and set the audience claim override to the
+   Cube value. If the values match, no audience claim override is required.
 4. Go to **SAML Certificates → Edit** and select **Sign SAML
    response and assertion** for the **Signing Option**.
 5. Download the **Federation Metadata XML** file — you'll need it

--- a/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
@@ -29,9 +29,19 @@ First, enable SAML authentication in Cube:
 1. In Cube, navigate to **Admin → Settings**.
 2. On the **Authentication & SSO** tab, enable the **SAML**
    toggle.
-3. Take note of the **Single Sign-On URL** and **Audience**
-   values — you'll need them when configuring the Enterprise Application
-   in Entra.
+3. For a new integration, set **Audience (SP Entity ID)** to the
+   **Single Sign-On URL** shown directly above it.
+4. Take note of the **Single Sign-On URL** and **Audience (SP Entity ID)**
+   values — you'll need them when configuring the Enterprise Application in
+   Entra.
+
+<Note>
+
+Existing working Entra integrations with a different Audience do not need to
+change. Keep the existing audience claim override unless you intentionally
+update both sides of the integration.
+
+</Note>
 
 ## Create an Enterprise Application in Entra
 
@@ -50,7 +60,8 @@ First, enable SAML authentication in Cube:
    - **Entity ID** — Use the **Single Sign-On URL** value from Cube.
    - **Reply URL** — Use the **Single Sign-On URL** value from Cube.
 3. Go to **Attributes & Claims → Edit → Advanced settings** and
-   set the audience claim override to the **Audience** value from Cube.
+   set the audience claim override to the **Audience (SP Entity ID)** value
+   from Cube. It must match exactly.
 4. Go to **SAML Certificates → Edit** and select **Sign SAML
    response and assertion** for the **Signing Option**.
 5. Download the **Federation Metadata XML** file — you'll need it

--- a/docs-mintlify/admin/sso/okta/saml.mdx
+++ b/docs-mintlify/admin/sso/okta/saml.mdx
@@ -29,8 +29,19 @@ First, enable SAML authentication in Cube Cloud:
 1. In Cube Cloud, navigate to **Admin → Settings**.
 2. On the **Authentication & SSO** tab, enable the **SAML**
    toggle.
-3. Take note of the **Single Sign-On URL** and **Audience**
+3. For a new integration, set **Audience (SP Entity ID)** to the
+   **Single Sign-On URL** shown directly above it. This gives the AuthnRequest
+   issuer and response audience one matching service provider identifier.
+4. Take note of the **Single Sign-On URL** and **Audience (SP Entity ID)**
    values — you'll need them when configuring the SAML integration in Okta.
+
+<Note>
+
+Existing working Okta integrations with a different Audience do not need to
+change. If you update the value, change it in Cube and Okta together and test
+SAML sign-in before disabling another authentication method.
+
+</Note>
 
 ## Create a SAML integration in Okta
 
@@ -43,8 +54,8 @@ First, enable SAML authentication in Cube Cloud:
 5. Enter the following values in the **SAML Settings** section:
    - **Single sign on URL** — Use the **Single Sign-On URL**
      value from Cube Cloud.
-   - **Audience URI (SP Entity ID)** — Use the **Audience**
-     value from Cube Cloud.
+   - **Audience URI (SP Entity ID)** — Use the **Audience (SP Entity ID)**
+     value from Cube Cloud. It must match exactly.
 6. Click **Next** to go to the **Feedback** screen, fill in
    any necessary details and click **Finish**.
 


### PR DESCRIPTION
## Summary

- document the mapping between Cube's Single Sign-On URL, Audience, and IdP service-provider identifiers
- add explicit Amazon Federate guidance for its single Entity ID/Audience field
- correct Google Workspace guidance that previously instructed users to clear Audience
- update Okta and Microsoft Entra setup instructions and add migration-safe notes
- remove stale Cube settings screenshots instead of documenting obsolete UI

## Compatibility

Existing working integrations are told not to change. Blank Audience remains documented as a compatibility mode that disables validation; enabling validation requires changing both sides and testing with a fallback authentication method enabled.

Ticket: https://linear.app/cube-d3/issue/CUB-2546/support-aws-federate-for-sso-setup

## Validation

- git diff --check
- Mintlify dependency installation was attempted twice, but the registry timed out while fetching optional sharp platform packages; CI should run the docs build and link checker.