### PR TITLE
fix(tesseract): keep expression measures out of nested group merging

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/has_expression_or_calculated_members.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/has_expression_or_calculated_members.rs
@@ -24,9 +24,13 @@ impl TraversalVisitor for HasExpressionOrCalculatedMembersCollector {
         _: &Self::State,
     ) -> Result<Option<Self::State>, CubeError> {
         match node.as_ref() {
-            MemberSymbol::MemberExpression(_) => self.found = true,
+            MemberSymbol::MemberExpression(s) => {
+                if !s.is_reference() {
+                    self.found = true;
+                }
+            }
             MemberSymbol::Measure(s) => {
-                if s.is_calculated() {
+                if s.is_calculated() && !s.is_reference() {
                     self.found = true;
                 }
             }
@@ -40,11 +44,14 @@ impl TraversalVisitor for HasExpressionOrCalculatedMembersCollector {
     }
 }
 
-/// Whether the dependency tree of `node` contains a member whose own body
-/// writes SQL around the members it references - a member expression or a
-/// measure of a calculated kind. What such a body computes is not a function
-/// of the members it references: an aggregate written in it is not a member of
+/// Whether the dependency tree of `node` contains a member that writes SQL of
+/// its own around the members it references - a member expression or a measure
+/// of a calculated kind. What such a body computes is not a function of the
+/// members it references: an aggregate written in it is not a member of
 /// anything and appears nowhere in the tree.
+///
+/// A bare reference writes nothing of its own - every measure of a view is one
+/// - so it is followed into the member it references instead.
 pub fn has_expression_or_calculated_members(node: &Rc<MemberSymbol>) -> Result<bool, CubeError> {
     let mut visitor = HasExpressionOrCalculatedMembersCollector::new();
     visitor.apply(node, &())?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/has_expression_or_calculated_members.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/has_expression_or_calculated_members.rs
@@ -1,0 +1,52 @@
+use crate::planner::{MemberSymbol, TraversalVisitor};
+use cubenativeutils::CubeError;
+use std::rc::Rc;
+
+struct HasExpressionOrCalculatedMembersCollector {
+    found: bool,
+}
+
+impl HasExpressionOrCalculatedMembersCollector {
+    fn new() -> Self {
+        Self { found: false }
+    }
+
+    fn extract_result(self) -> bool {
+        self.found
+    }
+}
+
+impl TraversalVisitor for HasExpressionOrCalculatedMembersCollector {
+    type State = ();
+    fn on_node_traverse(
+        &mut self,
+        node: &Rc<MemberSymbol>,
+        _: &Self::State,
+    ) -> Result<Option<Self::State>, CubeError> {
+        match node.as_ref() {
+            MemberSymbol::MemberExpression(_) => self.found = true,
+            MemberSymbol::Measure(s) => {
+                if s.is_calculated() {
+                    self.found = true;
+                }
+            }
+            _ => {}
+        };
+        if self.found {
+            Ok(None)
+        } else {
+            Ok(Some(()))
+        }
+    }
+}
+
+/// Whether the dependency tree of `node` contains a member whose own body
+/// writes SQL around the members it references - a member expression or a
+/// measure of a calculated kind. What such a body computes is not a function
+/// of the members it references: an aggregate written in it is not a member of
+/// anything and appears nowhere in the tree.
+pub fn has_expression_or_calculated_members(node: &Rc<MemberSymbol>) -> Result<bool, CubeError> {
+    let mut visitor = HasExpressionOrCalculatedMembersCollector::new();
+    visitor.apply(node, &())?;
+    Ok(visitor.extract_result())
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/mod.rs
@@ -2,6 +2,7 @@ mod calc_group_dims_collector;
 mod cube_names_collector;
 mod find_owned_by_cube;
 mod has_cumulative_members;
+mod has_expression_or_calculated_members;
 mod has_multi_stage_members;
 mod join_hints_collector;
 mod member_childs_collector;
@@ -13,6 +14,7 @@ pub use find_owned_by_cube::*;
 
 pub use calc_group_dims_collector::{collect_calc_group_dims, collect_calc_group_dims_from_nodes};
 pub use has_cumulative_members::{has_cumulative_members, HasCumulativeMembersCollector};
+pub use has_expression_or_calculated_members::has_expression_or_calculated_members;
 pub use has_multi_stage_members::{has_multi_stage_members, HasMultiStageMembersCollector};
 pub use join_hints_collector::{
     collect_join_hints, collect_join_hints_for_measures, JoinHintsCollector,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -460,9 +460,11 @@ impl MultiFactJoinGroups {
     /// elsewhere.
     ///
     /// Multi-stage measures plan through their own CTE pipeline, not as a leaf
-    /// of this join. Member expressions and calculated measures write SQL around
-    /// their references, so an aggregate written there is a member of nothing
-    /// and no leaf accounts for it.
+    /// of this join. A member expression or a calculated measure that writes SQL
+    /// of its own around its references is out too: an aggregate written there
+    /// is a member of nothing, so no leaf accounts for it. A bare reference -
+    /// every measure of a view is one - writes nothing, and is followed into the
+    /// member it references.
     fn group_survives_join(
         measures: &[Rc<MemberSymbol>],
         join: &Rc<JoinTree>,
@@ -1148,6 +1150,37 @@ mod tests {
             nested_trees_groups_of(&ctx, vec![expression, checkouts_unique], true);
 
         assert_eq!(num_groups, 2);
+    }
+
+    #[test]
+    fn test_nested_trees_calculated_measure_does_not_merge() {
+        // The measure writes its own `COUNT(*)` around the reference, and that
+        // count is a member of nothing - the referenced distinct count is the
+        // only leaf, and it says nothing about the count beside it.
+        let (num_groups, _) =
+            nested_trees_groups(&["carts.repeated_msid", "checkouts.unique_msid"], true);
+
+        assert_eq!(num_groups, 2);
+    }
+
+    #[test]
+    fn test_nested_trees_view_measures_merge() {
+        // A measure of a view is a bare reference to the cube measure, so the
+        // referenced distinct counts are what decides - the same merge the cube
+        // paths get.
+        let (num_groups, measures) = nested_trees_groups(
+            &["funnel.unique_msid", "funnel.checkouts_unique_msid"],
+            true,
+        );
+
+        assert_eq!(num_groups, 1);
+        assert_eq!(
+            measures,
+            vec![vec![
+                "funnel.checkouts_unique_msid".to_string(),
+                "funnel.unique_msid".to_string()
+            ]]
+        );
     }
 
     #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -1,6 +1,7 @@
 use crate::cube_bridge::join_hints::JoinHintItem;
 use crate::planner::collectors::{
-    collect_join_hints, collect_multiplied_measures, has_multi_stage_members,
+    collect_join_hints, collect_multiplied_measures, has_expression_or_calculated_members,
+    has_multi_stage_members,
 };
 use crate::planner::filter::FilterItem;
 use crate::planner::join_hints::JoinHints;
@@ -451,24 +452,32 @@ impl MultiFactJoinGroups {
     /// Whether every measure of a group computes the same value, by the same
     /// SQL, when evaluated over `join` instead of its own tree.
     ///
-    /// A measure whose cube `join` does not multiply reads exactly its own
-    /// rows, so nothing changes. A multiplied one only qualifies if its value
-    /// is immune to replication; a key-based count is deliberately not
-    /// accepted, because staying correct would mean switching it to the
-    /// distinct `MultipliedCount` form, and the render form a measure is
-    /// classified into is decided from its own join tree elsewhere.
+    /// Only a measure built entirely out of plain aggregated measures qualifies,
+    /// and then one leaf at a time: a leaf whose cube `join` does not multiply
+    /// reads exactly its own rows, and a multiplied one has to be immune to
+    /// replication. A key-based count is deliberately not accepted, because
+    /// staying correct would mean switching it to the distinct
+    /// `MultipliedCount` form, and the render form a measure is classified into
+    /// is decided from its own join tree elsewhere.
     ///
     /// Multi-stage measures are planned through their own CTE pipeline rather
-    /// than as a leaf of this join, so they are never moved. Neither is a
-    /// member expression: it names no member to anchor it to a cube, so what it
-    /// reads is whatever rows the join it lands on produces - `COUNT(*)` over a
-    /// wider tree counts the fanned-out rows and answers a different question.
+    /// than as a leaf of this join, so they are never moved. Neither are member
+    /// expressions and calculated measures: their bodies write SQL around the
+    /// members they reference, and an aggregate written there is a member of
+    /// nothing, so no leaf accounts for it. Reading the leaves of
+    /// `COUNT(*) - {cube.unique_id}` says the value cannot move while the
+    /// `COUNT(*)` beside it counts whatever rows the join it lands on produces.
+    /// Groups carrying such a measure keep their own tree whatever their leaves
+    /// say, which gives up the merge for every composite and expression-based
+    /// measure - the shapes whose value the leaves do not determine.
     fn group_survives_join(
         measures: &[Rc<MemberSymbol>],
         join: &Rc<JoinTree>,
     ) -> Result<bool, CubeError> {
         for measure in measures.iter() {
-            if has_multi_stage_members(measure, false)? {
+            if has_multi_stage_members(measure, false)?
+                || has_expression_or_calculated_members(measure)?
+            {
                 return Ok(false);
             }
             // `join` is only a candidate here, not the tree the query will
@@ -749,7 +758,8 @@ impl MultiFactJoinGroups {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::cube_bridge::MockSchema;
+    use crate::planner::{MemberExpressionExpression, MemberExpressionSymbol};
+    use crate::test_fixtures::cube_bridge::{MockMemberSql, MockSchema};
     use crate::test_fixtures::test_utils::TestContext;
 
     #[test]
@@ -1024,18 +1034,30 @@ mod tests {
         assert!(groups.resolve_join_path_for_measure(&unknown).is_none());
     }
 
+    fn nested_trees_context() -> TestContext {
+        let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees.yaml");
+        TestContext::new(schema).unwrap()
+    }
+
     fn nested_trees_groups(
         measure_paths: &[&str],
         merge_nested: bool,
     ) -> (usize, Vec<Vec<String>>) {
-        let schema = MockSchema::from_yaml_file("common/integration_nested_join_trees.yaml");
-        let ctx = TestContext::new(schema).unwrap();
-
-        let country = ctx.create_symbol("sites.country").unwrap();
+        let ctx = nested_trees_context();
         let measures = measure_paths
             .iter()
             .map(|path| ctx.create_symbol(path).unwrap())
             .collect_vec();
+
+        nested_trees_groups_of(&ctx, measures, merge_nested)
+    }
+
+    fn nested_trees_groups_of(
+        ctx: &TestContext,
+        measures: Vec<Rc<MemberSymbol>>,
+        merge_nested: bool,
+    ) -> (usize, Vec<Vec<String>>) {
+        let country = ctx.create_symbol("sites.country").unwrap();
 
         let hints = MeasuresJoinHints::builder(&JoinHints::new())
             .add_dimensions(&[country])
@@ -1088,6 +1110,49 @@ mod tests {
         // The wider tree splits every `carts` row into one row per checkout, so
         // a plain count over it would answer the number of checkouts.
         let (num_groups, _) = nested_trees_groups(&["carts.count", "checkouts.unique_msid"], true);
+
+        assert_eq!(num_groups, 2);
+    }
+
+    fn make_expression_measure(
+        ctx: &TestContext,
+        name: &str,
+        cube_name: &str,
+        sql: &str,
+    ) -> Rc<MemberSymbol> {
+        let member_sql = Rc::new(MockMemberSql::new(sql).unwrap());
+        let mut compiler = ctx.query_tools().compiler().borrow_mut();
+        let sql_call = compiler
+            .compile_sql_call(&cube_name.to_string(), member_sql)
+            .unwrap();
+        let cube_symbol = compiler
+            .add_cube_table_evaluator(cube_name.to_string(), vec![])
+            .unwrap();
+        drop(compiler);
+        let symbol = MemberExpressionSymbol::try_new(
+            cube_symbol,
+            name.to_string(),
+            MemberExpressionExpression::SqlCall(sql_call),
+            None,
+            None,
+            vec![cube_name.to_string()],
+        )
+        .unwrap();
+        MemberSymbol::new_member_expression(symbol)
+    }
+
+    #[test]
+    fn test_nested_trees_expression_around_distinct_measure_does_not_merge() {
+        // The `COUNT(*)` written in the expression is a member of nothing, so
+        // the distinct count beside it is the only leaf there is to check - and
+        // it says nothing about the count that would read the fanned-out rows.
+        let ctx = nested_trees_context();
+        let expression =
+            make_expression_measure(&ctx, "net_carts", "carts", "COUNT(*) - {carts.unique_msid}");
+        let checkouts_unique = ctx.create_symbol("checkouts.unique_msid").unwrap();
+
+        let (num_groups, _) =
+            nested_trees_groups_of(&ctx, vec![expression, checkouts_unique], true);
 
         assert_eq!(num_groups, 2);
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -452,24 +452,17 @@ impl MultiFactJoinGroups {
     /// Whether every measure of a group computes the same value, by the same
     /// SQL, when evaluated over `join` instead of its own tree.
     ///
-    /// Only a measure built entirely out of plain aggregated measures qualifies,
-    /// and then one leaf at a time: a leaf whose cube `join` does not multiply
-    /// reads exactly its own rows, and a multiplied one has to be immune to
-    /// replication. A key-based count is deliberately not accepted, because
-    /// staying correct would mean switching it to the distinct
-    /// `MultipliedCount` form, and the render form a measure is classified into
-    /// is decided from its own join tree elsewhere.
+    /// Only measures built out of plain aggregated measures qualify, leaf by
+    /// leaf: a leaf whose cube `join` does not multiply reads its own rows
+    /// anyway, a multiplied one has to be immune to replication. A key-based
+    /// count is not accepted - staying correct would mean switching it to the
+    /// distinct `MultipliedCount` form, decided from the measure's own tree
+    /// elsewhere.
     ///
-    /// Multi-stage measures are planned through their own CTE pipeline rather
-    /// than as a leaf of this join, so they are never moved. Neither are member
-    /// expressions and calculated measures: their bodies write SQL around the
-    /// members they reference, and an aggregate written there is a member of
-    /// nothing, so no leaf accounts for it. Reading the leaves of
-    /// `COUNT(*) - {cube.unique_id}` says the value cannot move while the
-    /// `COUNT(*)` beside it counts whatever rows the join it lands on produces.
-    /// Groups carrying such a measure keep their own tree whatever their leaves
-    /// say, which gives up the merge for every composite and expression-based
-    /// measure - the shapes whose value the leaves do not determine.
+    /// Multi-stage measures plan through their own CTE pipeline, not as a leaf
+    /// of this join. Member expressions and calculated measures write SQL around
+    /// their references, so an aggregate written there is a member of nothing
+    /// and no leaf accounts for it.
     fn group_survives_join(
         measures: &[Rc<MemberSymbol>],
         join: &Rc<JoinTree>,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_nested_join_trees.yaml
@@ -52,6 +52,9 @@ cubes:
       - name: avg_value
         type: avg
         sql: value
+      - name: repeated_msid
+        type: number
+        sql: "COUNT(*) - {carts.unique_msid}"
 
   - name: checkouts
     sql: "SELECT * FROM checkouts"
@@ -73,3 +76,18 @@ cubes:
       - name: total_amount
         type: sum
         sql: amount
+
+views:
+  - name: funnel
+    cubes:
+      - join_path: sites
+        includes:
+          - country
+      - join_path: sites.carts
+        includes:
+          - unique_msid
+          - min_value
+      - join_path: sites.carts.checkouts
+        includes:
+          - unique_msid
+        prefix: true

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -245,6 +245,50 @@ async fn test_nested_trees_expression_around_distinct_measure_alone() {
     }
 }
 
+/// Every measure of a view is a bare reference to the cube measure, so the same
+/// two nested trees fold into one scan when the query is written on the view -
+/// and answer what the cube paths answer.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_view_measures_share_one_base_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - funnel.unique_msid
+          - funnel.checkouts_unique_msid
+        dimensions:
+          - funnel.country
+        order:
+          - id: funnel.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+/// A calculated measure that writes a raw aggregate of its own around a
+/// reference keeps its tree: the referenced distinct count is the only leaf, and
+/// the count beside it would read the fanned-out rows.
+#[test]
+fn test_nested_trees_calculated_measure_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - carts.repeated_msid
+          - checkouts.unique_msid
+        dimensions:
+          - sites.country
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+}
+
 /// Each cube has its own rollup keyed by the shared dimension. Folding the
 /// groups leaves one query that no single rollup covers, so the merge has to
 /// stand down where per-leg rollups are available.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
@@ -186,6 +186,65 @@ async fn test_nested_trees_count_star_expression_keeps_its_own_scan() {
     }
 }
 
+/// The `COUNT(*)` of an expression is a member of nothing, so the reference
+/// beside it is the only leaf the fan-out check can read - and a distinct count
+/// answering "cannot move" says nothing about the raw count next to it.
+///
+/// Only the grouping is asserted: a raw aggregate written inside an expression
+/// that also references a member is rendered above the per-group CTEs, where it
+/// has no rows of the join left to read, so the split query is not executable.
+#[test]
+fn test_nested_trees_expression_around_distinct_measure_keeps_its_own_scan() {
+    let ctx = create_context();
+
+    let net_carts = make_measure_expression("net_carts", "carts", "COUNT(*) - {carts.unique_msid}");
+    let mut measures = vec![net_carts];
+    measures.extend(members_from_strings(vec!["checkouts.unique_msid"]));
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(measures))
+            .dimensions(Some(members_from_strings(vec!["sites.country"])))
+            .build(),
+    );
+
+    let sql = ctx.build_sql_from_options(options).unwrap();
+    assert_eq!(base_scan_count(&sql), 2, "sql: {sql}");
+}
+
+/// The same expression on its own, over the `carts` tree it belongs to: one
+/// repeated cart in the US, none in DE. The `checkouts` tree carries four US
+/// rows for the same three carts, so evaluating the expression there would
+/// answer 2 instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_trees_expression_around_distinct_measure_alone() {
+    let ctx = create_context();
+
+    let net_carts = make_measure_expression("net_carts", "carts", "COUNT(*) - {carts.unique_msid}");
+
+    let options = Rc::new(
+        MockBaseQueryOptions::builder()
+            .cube_evaluator(ctx.query_tools().cube_evaluator().clone())
+            .base_tools(ctx.query_tools().base_tools().clone())
+            .join_graph(ctx.query_tools().join_graph().clone())
+            .security_context(ctx.security_context().clone())
+            .measures(Some(vec![net_carts]))
+            .dimensions(Some(members_from_strings(vec!["sites.country"])))
+            .build(),
+    );
+
+    let sql = ctx.build_sql_from_options(options.clone()).unwrap();
+    assert_eq!(base_scan_count(&sql), 1, "sql: {sql}");
+
+    if let Some(result) = ctx.try_execute_pg_from_options(options, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 /// Each cube has its own rollup keyed by the shared dimension. Folding the
 /// groups leaves one query that no single rollup covers, so the merge has to
 /// stand down where per-leg rollups are available.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_expression_around_distinct_measure_alone.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_expression_around_distinct_measure_alone.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+sites__country | net_carts
+---------------+----------
+US             | 1        
+DE             | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_view_measures_share_one_base_scan.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__nested_join_trees__nested_trees_view_measures_share_one_base_scan.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/nested_join_trees.rs
+expression: result
+---
+funnel__country | funnel__unique_msid | funnel__checkouts_unique_msid
+----------------+---------------------+------------------------------
+DE              | 1                   | 0                            
+US              | 2                   | 2


### PR DESCRIPTION
## Summary

Folding a nested multi-fact group into the wider join tree is decided from the leaf measures the group carries, and a member expression or a calculated measure is not a leaf: an aggregate written directly in its body is a member of nothing, so no leaf of the dependency tree accounts for it. `COUNT(*) - {cube.unique_msid}` passed the check on its distinct-count leaf alone, and the raw count beside it was then computed over the fanned-out join — a wrong number on a perfectly valid data model. The most reachable path is SQL API push-down, which packs an arbitrary expression into a single member.

A group now moves only when every measure it carries is built entirely out of plain aggregated measures whose kind survives row multiplication. This gives up the merge for composite and expression-based measures: those are exactly the shapes whose value is not a function of the checked leaves.

## Changes

- New collector `has_expression_or_calculated_members` (`planner/collectors/`), a `TraversalVisitor` predicate that reports a `MemberSymbol::MemberExpression` or a measure of a `Calculated` kind anywhere in a measure's dependency tree.
- `group_survives_join` refuses the move for such a measure, keeping every existing refusal in place (multi-stage members, `as_measure()` failure, `multiplied && !survives_row_multiplication()`, and the "a shape the candidate tree rejects means no merge" fallbacks). The check only looks at the measures of the group being folded in, so an expression sitting in the wider group still lets the narrower one merge.
- Unit test over the existing `integration_nested_join_trees.yaml` fixture: an expression mixing a raw `COUNT(*)` with a reference to a duplicate-insensitive measure leaves two groups.
- Integration tests: the same query keeps two base scans, plus the expression alone with its Postgres result snapshot (`US | 1`, `DE | 0` — the merged plan answered `2`).

## Testing

- `cargo test -p cubesqlplanner multi_fact_join_groups` — 17 passed.
- `cargo test -p cubesqlplanner --features integration-postgres` — whole crate 1299 passed, executed against a testcontainers Postgres (not skipped).
- Confirmed the new unit test fails with the guard removed, so it does pin the hole.
- The merges that must keep working stay merged: `distinct_measures_share_one_base_scan`, `min_max_share_one_base_scan`, `merge_with_filter_on_shallower_cube`, `filter_on_deeper_cube_leaves_one_tree`, `separate_pre_aggs_still_match`, `pre_aggregation_query_keeps_separate_scans`.

One note for reviewers: for an expression that mixes a raw aggregate with a *measure* reference, the two-group plan renders that aggregate above the per-group CTEs, where Postgres rejects it (`42803`). That is independent of this change — it reproduces on sibling groups, which never merge, and on the commit before nested merging was introduced. So this restores the pre-merge outcome for that shape and removes the window where it silently answered a wrong number instead; the rendering gap itself is left for separate work. Only the grouping is asserted in that integration test, with the executable snapshot on the single-group query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
