### PR TITLE
docs(dashboards): document the Field switcher control

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -124,6 +124,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
           - Controls 
             - Filter
             - Time granularity
+            - Field switcher
             - Parent
           - AI summary
           - Layout

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -151,6 +151,10 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
   applies to your session only — it is never saved to the dashboard. If you ask
   it to change something with no control on the dashboard, it explains the
   current state instead of applying a change.
+- **Field switchers aren't driven by the agent.** The agent can read and change
+  [filters and time granularities][ref-controls]; a
+  [field switcher][ref-field-switcher] is not among the controls it operates, so
+  ask it about the data instead and change the field yourself in the control.
 - **No authoring on published dashboards.** The published Dashboard Agent
   cannot create reports or build dashboards, edit the saved dashboard, or change
   the data model. Those live in the [Workbook Agent][ref-workbook-agent].
@@ -161,5 +165,6 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-workbook-agent]: /docs/explore-analyze/workbooks/workbook-agent
 [ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
+[ref-field-switcher]: /docs/explore-analyze/dashboards/widgets/controls#field-switcher
 [ref-control-visibility]: /docs/explore-analyze/dashboards/widgets/controls#visibility
 [ref-embedding]: /embedding/iframe/dashboards

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -1,15 +1,16 @@
 ---
 title: Controls
-description: Filter, time granularity switcher, and parent widgets that let dashboard viewers change what's shown on the dashboard.
+description: Filter, time granularity switcher, field switcher, and parent widgets that let dashboard viewers change what's shown on the dashboard.
 ---
 
-Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers three control types:
+Controls are widgets that let dashboard viewers change what's shown without leaving the dashboard. The dashboard builder offers four control types:
 
 - [Filter](#filter) — Narrow the data shown on the dashboard
 - [Time granularity switcher](#time-granularity-switcher) — Change the granularity of time-based dimensions
+- [Field switcher](#field-switcher) — Swap which dimension or measure the charts are built on
 - [Parent](#parent) — Re-point several other controls at once from a single dropdown
 
-Filters and time granularity switchers each target a dimension from your semantic model, and apply the selected value to every [chart][ref-charts] on the dashboard whose query references that dimension. A parent control works one level up: it targets no dimension of its own and drives *other controls* instead.
+The first three each target a member from your semantic model, and apply the viewer's choice to every [chart][ref-charts] on the dashboard whose query references that member. Filters and time granularity switchers change *how a member is queried* — which rows come back, which buckets they fall into. A field switcher goes further and changes *which member is queried at all*. A parent control works one level up: it targets no member of its own and drives *other controls* instead.
 
 ## Filter
 
@@ -95,11 +96,73 @@ Custom granularities defined in the [data model][ref-granularities] aren't offer
 
 You can configure a default granularity that's applied when the dashboard loads. If no default is set, charts use the granularity that was saved on the underlying report — viewers can still switch granularities, but the dashboard opens with each chart at its original granularity.
 
+## Field switcher
+
+A field switcher lets viewers change *which* dimension or measure the charts are built on — swapping a revenue chart's breakdown from **Status** to **City**, or its measure from **Order count** to **Total revenue** — without leaving the dashboard or opening the report.
+
+Where a [filter](#filter) narrows the rows and a [time granularity switcher](#time-granularity-switcher) rebuckets them, a field switcher replaces the member itself in the chart's query. One dashboard can then answer several questions that would otherwise need a chart each.
+
+In the [dashboard builder][ref-workbooks], open the **Add Controls** menu in the toolbar and choose **Field Switcher**, then click **Configure Field Switcher** to set it up.
+
+### Choosing what it switches
+
+A field switcher works on one member kind at a time — set **Field Type** to either **Dimension** or **Measure**. The rest of the settings follow from that choice:
+
+| Setting | What it does |
+|---|---|
+| **Field Type** | Whether this control swaps a dimension or a measure. Switching the type resets the settings below it, since the two draw from different pools. |
+| **Dimension to Replace** / **Measure to Replace** | The member the charts are currently built on — the one this control stands in for. |
+| **Alternatives** | The members viewers may switch to. The replaced member is always offered as well, so a viewer can get back to the original view. |
+
+Alternatives come from the control's own semantic view, and must be the same kind as the replaced member — a dimension switcher offers dimensions, a measure switcher offers measures.
+
+### Default option
+
+The member a viewer starts on is set the same way a filter's static default is: by picking it in the control while you're in the dashboard builder. The selection is saved on the widget and applied to every viewer when the dashboard loads. If you never pick one, the dashboard opens on the replaced member.
+
+Removing a member from **Alternatives** after it was serving as the default clears the default, so viewers can't start on a member the control no longer offers.
+
+### Default granularity per option
+
+When a dimension switcher offers **time** dimensions, each of them can carry its own granularity, set under **Default granularity per option**.
+
+This exists because a swap otherwise inherits whatever granularity the chart already had. A viewer moving from **Created at** to a **Completed at** that only makes sense monthly would get the replaced dimension's daily buckets, and the author would have no way to say otherwise.
+
+Each time option is either pinned to a granularity or left at **Inherit from the chart**, which is the default and the behavior of every control configured before this setting existed. Non-time options don't have the setting, and a measure switcher has no granularities to speak of.
+
+If the dashboard also has a [time granularity switcher](#time-granularity-switcher) pointed at the swapped-in dimension, the viewer's own pick wins over the per-option granularity — a granularity a viewer actively chose outranks one the author set as a starting point. A granularity control nobody has touched does not.
+
+### User attribute default {#field-switcher-user-attribute-default}
+
+Like [filters](#user-attribute-default) and [parent controls](#parent-user-attribute-default), a field switcher can start each viewer on their own member. Turn on **User attribute default** in the control's settings and pick a [user attribute][ref-user-attributes]; when the dashboard loads, Cube reads that attribute for the current viewer and opens the control on the member it names.
+
+This is how one dashboard opens on the breakdown each audience cares about — a **Breakdown** switcher opening on `region` for one team and `channel` for another, from a single published dashboard.
+
+The attribute seeds the *selection*, exactly as the [default option](#default-option) does, and loses to a pick the viewer has already made. A value that isn't among the **Alternatives** is ignored rather than forced: the attribute is set per user and the options are set per dashboard, so the two can drift apart without anyone editing either, and the safe reading of an unusable value is "no opinion" — the control falls back to the default option.
+
+### What the swap preserves
+
+The swapped-in member is queried under the replaced member's output name, so everything the chart configured against that column keeps working across a switch — column formatting, sorting, pivots, and conditional formatting rules all survive, rather than resetting each time the viewer picks a different member.
+
+### When a chart can't take the switch {#when-a-chart-cant-take-the-switch}
+
+Cube applies the switch in two places: to the SQL that runs, and to the query description the chart formats its results with. It applies the switch only if **both** take it — otherwise the chart would be labelled and formatted as one member while showing another's numbers, which nothing on screen would reveal.
+
+When only one half can take it, the chart keeps rendering the member it was built on and shows a notice reading **"The Field switcher could not be applied to this chart"**. The usual reason is a query Cube can't read back as semantic members — a hand-written one, or one built with a `JOIN` or `UNION`. The rest of the dashboard still switches.
+
+A chart whose query doesn't use the replaced member at all is a different case: it is simply out of the control's scope, exactly as it would be for a filter, and shows no notice.
+
+A chart with a [period comparison][ref-charts] is a narrower case: the comparison can't follow a member switch, so the chart applies the switch and drops the comparison, saying so in its own notice rather than silently showing a comparison that no longer matches the data.
+
+<Note>
+A field switcher can't be a [parent control's](#parent) child, and a viewer's choice in one isn't carried in the [shared URL](#sharing-the-current-selection). Both are current limitations rather than deliberate design.
+</Note>
+
 ## Parent
 
 A parent control is a dropdown of options you define. Picking one re-points a whole row of other controls at once — so a viewer makes a single choice instead of adjusting three or four filters by hand.
 
-Unlike the other two control types, a parent control targets no dimension and never touches a chart query directly. It applies values to the controls it *drives* — its **children** — and those children then apply themselves to charts exactly as if the viewer had operated each one. Filters and time granularity switchers can both be children; a parent control cannot be a child of another parent control.
+Unlike the other control types, a parent control targets no dimension and never touches a chart query directly. It applies values to the controls it *drives* — its **children** — and those children then apply themselves to charts exactly as if the viewer had operated each one. Filters and time granularity switchers can both be children; a [field switcher](#field-switcher) cannot yet, and a parent control cannot be a child of another parent control.
 
 For example, an **Analysis** parent with the options `Retail`, `Wholesale` and `Promo` can set a **Channel** filter, a **Minimum order value** filter, and a **Date range** filter to a different combination for each option. Viewers see one dropdown; you can [hide](#visibility) the children if the individual values aren't worth showing.
 
@@ -135,7 +198,7 @@ A control can be driven by only one parent control at a time. Mapping a child th
 
 ### Mapping status on child controls
 
-Once a dashboard has at least one parent control, every filter and time granularity switcher on it shows a small indicator reporting how it's driven:
+Once a dashboard has at least one parent control, every filter and time granularity switcher on it shows a small indicator reporting how it's driven. [Field switchers](#field-switcher) don't, since a parent can't drive one:
 
 | Status | Meaning |
 |---|---|
@@ -202,6 +265,7 @@ Each control type has its own parameter:
 |---|---|---|
 | [Filter](#filter) | `f_<semantic_view>.<dimension>=<JSON>` | `f_orders.status={"value":"shipped"}` |
 | [Time granularity switcher](#time-granularity-switcher) | `tg_<semantic_view>.<dimension>=<granularity>` | `tg_orders.created_at=week` |
+| [Field switcher](#field-switcher) | *(none yet)* | — |
 
 The semantic view and dimension are the **internal names** configured on the control — not the display titles you see in the picker. A view shown as `Orders` is usually `orders` in the parameter. Granularities are lowercase and must be one of the switcher's [allowed granularities](#allowed-granularities) — `day`, `week`, `month`, `quarter`, `year`, plus `second`, `minute`, and `hour` for time dimensions that expose them.
 
@@ -212,13 +276,14 @@ What does and doesn't travel in the link:
 - **Only what the viewer chose.** Values that came from the control's own configuration — a static default, a [default granularity](#default-granularity) — are not written into the URL. Every viewer already gets those from the dashboard itself, and leaving them out means a link stays correct after the dashboard's defaults change.
 - **Never a personalized default.** A value resolved from a [user attribute](#user-attribute-default) stays out of the link — whether it seeded a filter directly or reached one through a [parent control](#parent) opening on the viewer's own option. Sharing a dashboard never pins your attribute value onto the recipient; they see it through their own attributes.
 - **Filters and granularities together.** Picking both puts both in the link, including when a [parent control](#parent) sets several children at once. A parent control isn't serialized itself — the link carries the values its children ended up with, so the recipient sees the same data while the parent dropdown opens on whatever default it resolves for them, which may not be the option the sharer picked.
+- **Not the field switcher, yet.** A [field switcher](#field-switcher) has no parameter of its own, so a viewer's member choice doesn't travel in the link. The recipient opens on the control's [default option](#default-option), or on their own [user attribute](#field-switcher-user-attribute-default) where one is set — and on the charts the sharer was looking at, built on a different member than the sharer saw.
 - **Written out on published dashboards only.** Reading these parameters works anywhere, including [embedded][ref-embed-url-filters] dashboards; it's the writing that is published-only. In the dashboard builder the URL is left to the editing session, so changing a control there doesn't rewrite it.
 
 When a dashboard opens with these parameters, they are applied on top of whatever defaults the controls carry. A parameter is ignored when nothing on the dashboard can honor it — there is no matching control for that dimension, or the requested granularity isn't in the switcher's [allowed granularities](#allowed-granularities).
 
 ## Visibility
 
-Each control has a **Visibility** setting that determines how it appears on the published dashboard. The setting applies to all three control types.
+Each control has a **Visibility** setting that determines how it appears on the published dashboard. The setting applies to all four control types.
 
 | Visibility | Behavior on the published dashboard |
 |---|---|
@@ -230,13 +295,13 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 ## Interaction with charts
 
-This section applies to filters and time granularity switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's [Controls mapping](#controls-mapping) — it acts only through the children it drives, and it's those children that show up here.
+This section applies to filters, time granularity switchers and field switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's [Controls mapping](#controls-mapping) — it acts only through the children it drives, and it's those children that show up here.
 
 When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
 
 ### Incompatible controls
 
-If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Filters and time granularity switchers are skipped independently — if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa.
+If controls of a certain type are incompatible with a particular chart's query, the chart skips all controls of that type and renders the data without them. Each type is skipped independently — if filters fail but a time granularity switcher works, the chart shows the granularity-adjusted data without filtering, and vice versa. A [field switcher](#field-switcher) that can't be applied says so [on the chart itself](#when-a-chart-cant-take-the-switch) rather than through the icons below.
 
 The chart displays a warning icon to indicate the problem:
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -162,7 +162,7 @@ A field switcher can't be a [parent control's](#parent) child, and a viewer's ch
 
 A parent control is a dropdown of options you define. Picking one re-points a whole row of other controls at once — so a viewer makes a single choice instead of adjusting three or four filters by hand.
 
-Unlike the other control types, a parent control targets no dimension and never touches a chart query directly. It applies values to the controls it *drives* — its **children** — and those children then apply themselves to charts exactly as if the viewer had operated each one. Filters and time granularity switchers can both be children; a [field switcher](#field-switcher) cannot yet, and a parent control cannot be a child of another parent control.
+Unlike the other control types, a parent control targets no member and never touches a chart query directly. It applies values to the controls it *drives* — its **children** — and those children then apply themselves to charts exactly as if the viewer had operated each one. Filters and time granularity switchers can both be children; a [field switcher](#field-switcher) cannot yet, and a parent control cannot be a child of another parent control.
 
 For example, an **Analysis** parent with the options `Retail`, `Wholesale` and `Promo` can set a **Channel** filter, a **Minimum order value** filter, and a **Date range** filter to a different combination for each option. Viewers see one dropdown; you can [hide](#visibility) the children if the individual values aren't worth showing.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -116,7 +116,7 @@ A field switcher works on one member kind at a time — set **Field Type** to ei
 
 Alternatives come from the control's own semantic view, and must be the same kind as the replaced member — a dimension switcher offers dimensions, a measure switcher offers measures.
 
-### Default option
+### Default option {#field-switcher-default-option}
 
 The member a viewer starts on is set the same way a filter's static default is: by picking it in the control while you're in the dashboard builder. The selection is saved on the widget and applied to every viewer when the dashboard loads. If you never pick one, the dashboard opens on the replaced member.
 
@@ -138,7 +138,7 @@ Like [filters](#user-attribute-default) and [parent controls](#parent-user-attri
 
 This is how one dashboard opens on the breakdown each audience cares about — a **Breakdown** switcher opening on `region` for one team and `channel` for another, from a single published dashboard.
 
-The attribute seeds the *selection*, exactly as the [default option](#default-option) does, and loses to a pick the viewer has already made. A value that isn't among the **Alternatives** is ignored rather than forced: the attribute is set per user and the options are set per dashboard, so the two can drift apart without anyone editing either, and the safe reading of an unusable value is "no opinion" — the control falls back to the default option.
+The attribute seeds the *selection*, exactly as the [default option](#field-switcher-default-option) does, and loses to a pick the viewer has already made. A value that isn't among the **Alternatives** is ignored rather than forced: the attribute is set per user and the options are set per dashboard, so the two can drift apart without anyone editing either, and the safe reading of an unusable value is "no opinion" — the control falls back to the default option.
 
 ### What the swap preserves
 
@@ -265,7 +265,6 @@ Each control type has its own parameter:
 |---|---|---|
 | [Filter](#filter) | `f_<semantic_view>.<dimension>=<JSON>` | `f_orders.status={"value":"shipped"}` |
 | [Time granularity switcher](#time-granularity-switcher) | `tg_<semantic_view>.<dimension>=<granularity>` | `tg_orders.created_at=week` |
-| [Field switcher](#field-switcher) | *(none yet)* | — |
 
 The semantic view and dimension are the **internal names** configured on the control — not the display titles you see in the picker. A view shown as `Orders` is usually `orders` in the parameter. Granularities are lowercase and must be one of the switcher's [allowed granularities](#allowed-granularities) — `day`, `week`, `month`, `quarter`, `year`, plus `second`, `minute`, and `hour` for time dimensions that expose them.
 
@@ -276,7 +275,7 @@ What does and doesn't travel in the link:
 - **Only what the viewer chose.** Values that came from the control's own configuration — a static default, a [default granularity](#default-granularity) — are not written into the URL. Every viewer already gets those from the dashboard itself, and leaving them out means a link stays correct after the dashboard's defaults change.
 - **Never a personalized default.** A value resolved from a [user attribute](#user-attribute-default) stays out of the link — whether it seeded a filter directly or reached one through a [parent control](#parent) opening on the viewer's own option. Sharing a dashboard never pins your attribute value onto the recipient; they see it through their own attributes.
 - **Filters and granularities together.** Picking both puts both in the link, including when a [parent control](#parent) sets several children at once. A parent control isn't serialized itself — the link carries the values its children ended up with, so the recipient sees the same data while the parent dropdown opens on whatever default it resolves for them, which may not be the option the sharer picked.
-- **Not the field switcher, yet.** A [field switcher](#field-switcher) has no parameter of its own, so a viewer's member choice doesn't travel in the link. The recipient opens on the control's [default option](#default-option), or on their own [user attribute](#field-switcher-user-attribute-default) where one is set — and on the charts the sharer was looking at, built on a different member than the sharer saw.
+- **Not the field switcher, yet.** A [field switcher](#field-switcher) has no parameter of its own, so a viewer's member choice doesn't travel in the link. The recipient opens on the control's [default option](#field-switcher-default-option), or on their own [user attribute](#field-switcher-user-attribute-default) where one is set — and on the charts the sharer was looking at, built on a different member than the sharer saw.
 - **Written out on published dashboards only.** Reading these parameters works anywhere, including [embedded][ref-embed-url-filters] dashboards; it's the writing that is published-only. In the dashboard builder the URL is left to the editing session, so changing a control there doesn't rewrite it.
 
 When a dashboard opens with these parameters, they are applied on top of whatever defaults the controls carry. A parameter is ignored when nothing on the dashboard can honor it — there is no matching control for that dimension, or the requested granularity isn't in the switcher's [allowed granularities](#allowed-granularities).
@@ -295,9 +294,9 @@ Set the visibility from the **Visibility** dropdown when editing the control. **
 
 ## Interaction with charts
 
-This section applies to filters, time granularity switchers and field switchers. A [parent control](#parent) has no dimension and never applies to a chart itself, so it doesn't appear in any chart's [Controls mapping](#controls-mapping) — it acts only through the children it drives, and it's those children that show up here.
+This section applies to filters, time granularity switchers and field switchers. A [parent control](#parent) has no member of its own and never applies to a chart itself, so it doesn't appear in any chart's [Controls mapping](#controls-mapping) — it acts only through the children it drives, and it's those children that show up here.
 
-When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same dimension. Charts that don't reference that dimension are left alone, so a dashboard can mix scoped and unscoped views by default. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different dimension.
+When a control is added to a dashboard, it's automatically wired up to every [chart][ref-charts] whose query already uses the same member. Charts that don't reference that member are left alone, so a dashboard can mix scoped and unscoped views by default. Filters and time granularity switchers always target a dimension; a [field switcher](#field-switcher) targets a dimension or a measure depending on its **Field Type**, and scopes on whichever it is set to. You can override this default per chart from its [Controls mapping](#controls-mapping) — disable the control for that chart, or remap it onto a different member.
 
 ### Incompatible controls
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -313,26 +313,32 @@ Hover over the icon for details. Click it to open the chart's [Controls mapping]
 
 ### Controls mapping
 
-Each chart decides which controls apply to it through its **Controls mapping**. The mapping is resolved automatically in most cases and only needs manual attention when a control targets a dimension the chart doesn't have.
+Each chart decides which controls apply to it through its **Controls mapping**. The mapping is resolved automatically in most cases and only needs manual attention when a control targets a member the chart doesn't have.
 
 Open **Controls mapping** from a chart's settings menu to inspect or override the mapping for that chart. For each control on the dashboard you can:
 
 - **Toggle the control on or off** for the chart, even when a mapping exists
-- **Pick a different dimension** from the chart's semantic view to remap the control to
+- **Pick a different member** from the chart's semantic view to remap the control to
 
 Three states show up in the mapping sidebar:
 
 | Status | What it means |
 |---|---|
-| **Mapped automatically** | The control's dimension exists on the chart's semantic view, so it's wired up without configuration. |
-| **Manually mapped** | You (or an AI agent) picked a specific dimension for this chart. **Reset** restores the automatic mapping. |
-| **Can't map automatically** | The control targets a dimension that doesn't exist on the chart's semantic view. The chart is unaffected by the control until you map it manually. |
+| **Mapped automatically** | The control's member exists on the chart's semantic view, so it's wired up without configuration. |
+| **Manually mapped** | You (or an AI agent) picked a specific member for this chart. **Reset** restores the automatic mapping. |
+| **Can't map automatically** | The control targets a member that doesn't exist on the chart's semantic view. The chart is unaffected by the control until you map it manually. |
 
-For [time granularity switchers][ref-time-grain], the dimension picker is restricted to time-typed dimensions on the chart's semantic view, since other dimension types can't be resolved by the time granularity pipeline.
+Each control's picker offers only the members it can actually be resolved against, so a mapping you can stage is a mapping that will work:
 
-Mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire controls across charts that use different semantic views without you needing to revisit each chart manually.
+| Control | What the picker offers |
+|---|---|
+| [Filter](#filter) | Dimensions on the chart's semantic view. |
+| [Time granularity switcher](#time-granularity-switcher) | Time-typed dimensions only — other types can't be resolved by the time granularity pipeline. |
+| [Field switcher](#field-switcher) set to **Dimension** | Dimensions. |
+| [Field switcher](#field-switcher) set to **Measure** | Measures, since the control replaces a measure. |
 
-[ref-time-grain]: #time-granularity-switcher
+Filter and time granularity mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire those controls across charts that use different semantic views without you needing to revisit each chart manually. Field switchers are outside what agents author, so their mappings are yours to set.
+
 [ref-embed-url-filters]: /embedding/iframe/dashboards#pre-set-dashboard-filters-via-url
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -11,13 +11,13 @@ The dashboard builder supports the following widget types:
 
 - [Charts](/docs/explore-analyze/dashboards/widgets/charts) — Visualize reports from your workbook
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
-- [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, or drive several controls at once
+- [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, swap which field the charts are built on, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
 - [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
 
 ## Adding widgets
 
-Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter**, **Time Granularity** and **Parent** controls.
+Add widgets from the toolbar at the top of the dashboard builder: pick reports from the **Charts** picker to add charts, use the **Add Widgets** menu for text, AI summaries, and layout elements, or the **Add Controls** menu for **Filter**, **Time Granularity**, **Field Switcher** and **Parent** controls.
 
 Each item — a toolbar button, or an option inside the **Add Widgets** / **Add Controls** menus — can be added in two ways:
 


### PR DESCRIPTION
Companion docs for [cubedevinc/cubejs-enterprise#14426](https://github.com/cubedevinc/cubejs-enterprise/pull/14426) (CUB-454), which adds a fourth dashboard control type: the **Field switcher**, letting viewers swap which dimension or measure the charts are built on.

## What this adds

A `## Field switcher` section on the **Controls** page covering what it does, how it differs from the two controls next to it — a filter narrows rows, a time granularity switcher rebuckets them, a field switcher replaces the member itself — and how to configure it.

The settings that are not self-evident from the UI get their own subsections:

| Topic | Why it needs saying |
|---|---|
| **Default option** | Set by picking in the builder, like a filter's static default, not from a field in the settings. Removing that member from the alternatives clears it. |
| **Default granularity per option** | Why it exists at all (a swap otherwise inherits the replaced dimension's granularity), and how it resolves against a time granularity switcher: a viewer's own pick wins, an untouched control does not. |
| **User attribute default** | Why a value outside the alternatives is ignored rather than forced — the attribute is per user, the options are per dashboard, so they drift apart with nobody editing either. |
| **What the swap preserves** | The swapped-in member is queried under the replaced member's output name, so column formatting, sorting, pivots and conditional formatting survive a switch. |
| **When a chart can't take the switch** | The switch applies only if both the SQL and the query description take it; otherwise the chart falls back whole and says so. Distinguished from a chart the control simply doesn't scope, which shows no notice. |

## Limitations stated rather than left to be found

- A field switcher **cannot be a parent control's child**.
- A viewer's choice **is not carried in the shared URL** — the recipient opens on the control's own default, which matters because the charts they see will be built on a different member than the sharer's.
- The **Dashboard Agent does not drive field switchers**. Noted on that page, whose "only controls that exist on the dashboard can be changed" wording would otherwise imply it does.

## Also updated

Every surface that enumerates the control types, so none of them still says "three": the page intro and its list, the widgets index, the **Add Controls** menu listing, **Visibility** ("all four control types"), **Interaction with charts**, and the URL parameter table.

## Verification

- Every in-page anchor referenced resolves to a heading that exists (27 defined, 0 missing). Three headings named *User attribute default* now coexist, so the new one carries an explicit `{#field-switcher-user-attribute-default}` id.
- No undefined `[ref-*]` link references in any changed file.
- Behaviour was read out of the implementation rather than assumed — including one claim I had to correct: a chart whose query does not reference the replaced member shows **no** notice, because the degrade fires only when the two halves of the swap disagree.