### PR TITLE
docs: document embed user pre-provisioning and the split AI billing tabs

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -75,12 +75,14 @@ allowance resets at the start of each calendar month.
 
 ## Tracking usage
 
-Administrators can monitor token consumption through the **AI Tokens Usage**
-tab in the billing settings page. The dashboard shows:
+Administrators can monitor token consumption on the **AI Usage** and **AI
+Requests** tabs in the billing settings page:
 
-- Total token usage over time
-- Remaining allocation from per-seat grants and token packages
-- Breakdown by usage dimension
+- **AI Usage** shows spend per user or per role over a billing period, as a
+  chart or table, including remaining allocation from per-seat grants and
+  token packages
+- **AI Requests** shows the underlying request log, with search and a live
+  tail of recent requests
 
 ## When limits are reached
 

--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -18,6 +18,25 @@ the&nbsp;**Cube Cloud** logo in the top left corner.
   <img src="https://ucarecdn.com/cdd5831a-a8f8-4342-bc3e-25aab2c04a5b/" />
 </Frame>
 
+### Default deployment
+
+If an account has more than one deployment, you can control which one people land
+on when they open the workspace without navigating to a specific deployment
+directly:
+
+- **Account-wide** — an admin opens the **⋯** menu on a row in the deployments
+  list and chooses **Set as default** (or **Remove as default**). The pinned
+  deployment is marked with a home icon and becomes the landing deployment for
+  anyone who hasn't chosen one of their own.
+- **Per user** — anyone can pin their own default from their account
+  **Preferences**, which takes precedence over the account-wide pin. The
+  deployment you most recently switched to also counts as a personal choice and
+  outranks the account pin, so it only applies until you actively switch to
+  something else.
+
+Draft deployments are never candidates for either pin, and a pin you no longer
+have access to is skipped in favor of the next one in this order.
+
 ## Creating a new deployment
 
 Creating a new deployment is an essential prerequisite to running a Cube

--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -147,5 +147,10 @@ not.
 
 ### Editing a calculated field
 
-Select a calculated field in the sidebar to open the editor. You can change its
-**name** and **SQL expression**, then choose **Update** to apply.
+Select a calculated field in the sidebar to open its editor. A field created by
+the **bins** or **groups** panel reopens that same structured editor, letting you
+change its **name** and **SQL expression**. Any other calculated field — a `CASE`
+expression, a calculation like **% of total**, or a field saved to the workbook —
+opens a SQL-only editor showing just its expression, since the field has no
+structured form to round-trip. Edit the SQL and choose **Update** to apply; this
+editor doesn't offer renaming.

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -612,6 +612,16 @@ credential can write to the repository — a `git-receive-pack` probe for a PAT,
 | --- | --- |
 | **Models path** | Directory in the dbt project where generated model files are written. Defaults to `models/marts/cube/`. |
 | **Delivery mode** | **Open a pull request** (default) pushes to a `cube/dbt-push/*` branch and opens a PR/MR. **Commit directly to a branch** commits straight to a branch you name — validation still runs. |
+| **Validation level** | How thoroughly a model is checked before it's committed: **Parse** only confirms the project still parses; **Compile** also compiles the generated SQL; **Build** additionally runs the model (and its tests) against your warehouse, in the **validation schema** below, so a broken model is caught before the PR opens. |
+| **Validation schema** | Schema in your warehouse Cube builds into when validation level is **Build**. You own this schema — Cube never creates or drops it, and only the temporary relation created for that one validation run is cleaned up afterward. Required when validation level is **Build**. |
+
+<Note>
+
+**Build** currently runs on Snowflake, Amazon Redshift, PostgreSQL, and ClickHouse. On
+Google BigQuery, Databricks, and Amazon Athena it falls back to **Parse** until
+connection support for those warehouses is added.
+
+</Note>
 
 Then **Save dbt settings**.
 
@@ -658,6 +668,17 @@ hosts, a prefilled compare link to open it yourself.
 </Step>
 
 </Steps>
+
+### Author models from Analytics Chat
+
+You can also drive the whole push loop from [the agent](/docs/explore-analyze/analytics-chat)
+instead of the dialog above — for example, "turn this into a dbt model and open a PR." The
+agent opens a live sandbox on your dbt project, drafts the model's `.sql` and `.yml`, and
+runs the same validation configured above (parse, compile, or a full build against your
+validation schema). It reports what it found and asks you to confirm before committing or
+opening the pull request, using the delivery mode configured on the integration. Because the
+sandbox stays open across the conversation, you can ask it to adjust the draft and
+re-validate before you confirm.
 
 ### What gets pushed
 

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -22,6 +22,15 @@ same as in a standalone dashboard embed. To hide any of its controls (title,
 back button, Edit, Duplicate) for your embed, see
 [Show or hide header controls](/embedding/iframe/dashboards#show-or-hide-header-controls).
 
+## Workbook header controls
+
+When a user opens a workbook (rather than a published dashboard) inside Creator
+Mode, its header offers the same actions menu as the console: **Rename**,
+**Duplicate**, **View all**, **New workbook**, and **Delete**. Rename and Delete
+require the embed user's **Manage** permission on the workbook; Duplicate
+requires **Manage** or **Edit**. Double-clicking the workbook name also renames
+it, the same as in the full Cube app.
+
 ## Embed tenant scoping
 
 In Creator Mode, content (workbooks, dashboards) and the groups/user attributes referenced by the session are scoped to an **embed tenant**. Pass `embedTenantName` to isolate content per customer; omit it to use the current tenant.

--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -268,6 +268,21 @@ const session = await fetch(
 
 A second call with the same body produces the same end state: the group and attribute already exist, descriptions/display names are reconciled if they changed, and the user's memberships and values are re-applied.
 
+## Provisioning users ahead of their first session
+
+An embed user is normally created only when they generate their first session — so you cannot add them to a group or share a workbook or dashboard with them until they have opened the embed at least once. To make a user addressable immediately, provision them directly:
+
+```text
+POST /api/v1/embed-tenants/{embedTenantName}/user
+POST /api/v1/embed-tenants/{embedTenantName}/users
+```
+
+The singular endpoint provisions one user; the plural endpoint provisions up to 100 in a single request and is partially successful — it returns `succeeded` and `failed` arrays instead of failing the whole batch for one bad entry, with each failure keyed by `externalId`.
+
+Each user takes the same fields as `generate-session` above — `externalId`, `email`, `userProfile`, `groups`, `tenantGroups` — except `userAttributes` and `securityContext`, which every session re-applies and so are not accepted here. Provisioning is idempotent: an existing `externalId` is updated rather than rejected, `email` and `userProfile` are overwritten only when supplied, and each group field is replaced when supplied, left untouched when omitted, and cleared with `[]`. Omit `email` and Cube derives a placeholder address instead, which makes the user harder to recognize in a list.
+
+These endpoints use the same `Api-Key` authentication as Generate Session and require admin access.
+
 ## Embed-tenant admin API
 
 To list or delete the groups and attributes that have been bootstrapped into an embed tenant, use the admin endpoints scoped to that tenant:


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Documentation gaps found while cross-checking recent `cubedevinc/cubejs-enterprise` changes against the docs. All are surgical edits to existing pages — no new pages, no `docs.json` changes.

- `reference/embed-apis/generate-session.mdx`: documents the two new admin endpoints for provisioning an embed user ahead of their first session — `POST /api/v1/embed-tenants/{embedTenantName}/user` and `.../users` (bulk).
- `admin/account-billing/ai-tokens.mdx`: the single "AI Tokens Usage" tab was split into two tabs, **AI Usage** and **AI Requests**; updated the doc to match.
- `admin/deployment/index.mdx`: documents the account-wide and per-user **default deployment** pin (which deployment people land on) and its precedence order.
- `docs/integrations/dbt.mdx`: documents the **Validation level** / **Validation schema** dbt-push settings, the per-warehouse support caveat, and authoring/validating dbt models conversationally from Analytics Chat.
- `embedding/iframe/creator-mode.mdx`: documents the workbook header actions menu (Rename, Duplicate, View all, New workbook, Delete) now available in embedded Creator Mode, and its permission gates.
- `docs/explore-analyze/workbooks/calculated-fields.mdx`: distinguishes the structured bins/groups editor from the new SQL-only fallback editor used for `CASE` expressions, computed calculations, and saved workbook fields.
