### PR TITLE
docs: document the 2,000-character ai_context limit

### DIFF
--- a/docs-mintlify/docs/data-modeling/ai-context.mdx
+++ b/docs-mintlify/docs/data-modeling/ai-context.mdx
@@ -91,6 +91,9 @@ consumed by the AI agent**.
 
 </Note>
 
+Each `ai_context` value is limited to 2,000 characters; anything longer is
+silently truncated before it reaches the agent.
+
 Use `ai_context` on [views][ref-view-meta] to provide high-level guidance,
 and on individual members for member-specific instructions:
 
@@ -269,27 +272,6 @@ view(`sales_overview`, {
 
 </CodeGroup>
 
-## Length limit
-
-Each `ai_context` value is limited to **2,000 characters**, measured on its
-serialized JSON representation. The limit applies independently to every view
-and every member, so a model with many annotated members carries far more than
-2,000 characters of context in total.
-
-<Warning>
-
-Exceeding the limit is not an error. Your data model compiles successfully and
-the AI agent silently receives a shortened copy of the context — everything past
-2,000 characters is dropped. If you generate `ai_context` in bulk, validate the
-length before publishing.
-
-</Warning>
-
-The `description` parameter has no length limit, but that does not make it a
-place to put overflow. Descriptions reach the AI agent in full, so long ones
-consume the agent's context window and crowd out other parts of your model.
-Keep both concise.
-
 ## Descriptions vs. AI context
 
 | | `description` | `meta.ai_context` |
@@ -364,8 +346,6 @@ cube(`order_items`, {
   itself or on individual measures and dimensions.
 - **Be specific.** Vague context like "important metric" is less helpful than
   "use this measure when users ask about monthly recurring revenue."
-- **Keep AI context under 2,000 characters.** Longer values are silently
-  truncated — see [Length limit](#length-limit).
 - **Document relationships.** Use AI context to explain how cubes relate to each
   other and which views to prefer for common questions.
 - **Keep it up to date.** As your data model evolves, update descriptions and AI

--- a/docs-mintlify/docs/data-modeling/ai-context.mdx
+++ b/docs-mintlify/docs/data-modeling/ai-context.mdx
@@ -269,6 +269,27 @@ view(`sales_overview`, {
 
 </CodeGroup>
 
+## Length limit
+
+Each `ai_context` value is limited to **2,000 characters**, measured on its
+serialized JSON representation. The limit applies independently to every view
+and every member, so a model with many annotated members carries far more than
+2,000 characters of context in total.
+
+<Warning>
+
+Exceeding the limit is not an error. Your data model compiles successfully and
+the AI agent silently receives a shortened copy of the context — everything past
+2,000 characters is dropped. If you generate `ai_context` in bulk, validate the
+length before publishing.
+
+</Warning>
+
+The `description` parameter has no length limit, but that does not make it a
+place to put overflow. Descriptions reach the AI agent in full, so long ones
+consume the agent's context window and crowd out other parts of your model.
+Keep both concise.
+
 ## Descriptions vs. AI context
 
 | | `description` | `meta.ai_context` |
@@ -276,6 +297,7 @@ view(`sales_overview`, {
 | Visible in the UI | Yes | No |
 | Used by the AI agent | Yes | Yes |
 | Supported on | Cubes, views, measures, dimensions, segments | Views, measures, dimensions |
+| Length limit | None | 2,000 characters |
 
 Use `description` when the context is useful to both end users and the AI
 agent. Use `ai_context` when you want to provide additional instructions or
@@ -342,6 +364,8 @@ cube(`order_items`, {
   itself or on individual measures and dimensions.
 - **Be specific.** Vague context like "important metric" is less helpful than
   "use this measure when users ask about monthly recurring revenue."
+- **Keep AI context under 2,000 characters.** Longer values are silently
+  truncated — see [Length limit](#length-limit).
 - **Document relationships.** Use AI context to explain how cubes relate to each
   other and which views to prefer for common questions.
 - **Keep it up to date.** As your data model evolves, update descriptions and AI


### PR DESCRIPTION
## What

Documents the `ai_context` length limit on the [AI context](https://docs.cube.dev/docs/data-modeling/ai-context) page. This behavior is currently undocumented.

Each `meta.ai_context` value is capped at **2,000 characters** of serialized JSON, applied independently per view and per member, at the point the agent builds its context (`MAX_AI_CONTEXT_LENGTH` / `truncateAiContext`).

Two things make this worth documenting:

- **Nothing validates it at compile time.** `meta` is `Joi.any()` in `CubeValidator`, so an oversized value compiles cleanly.
- **Overflow is silent.** No error, no warning, no log — the agent just receives a shortened copy. A model can look healthy while the agent has never seen most of its context.

Also notes that `description` has no limit, but is passed to the agent in full and so consumes context window — it is not a safe place to put `ai_context` overflow.

## Changes

- New `## Length limit` section
- `Length limit` row in the description vs. `ai_context` comparison table
- Best-practice bullet linking to the new section

## Why now

Came up confirming the ceiling for a customer bulk-loading AI context across a large model, who wanted a number before standardizing an upload process on top of it. Worth having in the docs rather than in a support thread.

## Verification

- No legacy Nextra components introduced
- `docs.json` still valid JSON (no nav change needed — existing page)
- `check_links.py` reports nothing for the changed file
- `#length-limit` anchor matches the new heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)