### PR TITLE
fix(cubesql): stop reporting `Continue wait` as a SQL API error

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,6 +103,19 @@ jobs:
                - Verify README updates for new features
                - Check API documentation accuracy
 
+            6. **Comments**
+               - An explanatory comment is **3 lines max**. Flag a longer one and ask for the
+                 load-bearing sentence, unless the reason genuinely cannot be stated shorter
+               - A comment earns its place only when its absence would let a later edit
+                 reintroduce a bug. Flag one a reader would lose nothing by deleting: a
+                 restatement of the code under it, a banner over self-describing code,
+                 narration of the change or of the review round that produced it, or a JSDoc
+                 block whose tags only re-spell already-typed names
+               - Prefer making the code carry the meaning — a named constant, a named
+                 intermediate value, an extracted function whose name states the intent
+               - Never raise this to ask for a comment to be **added**, and skip generated
+                 files and comments another rule or tool requires
+
             Provide detailed feedback using inline comments for specific issues.
             Use top-level comments for general observations or praise.
 

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -628,11 +628,11 @@ async fn handle_sql_query(
                 // the promise it was awaiting is abandoned rather than
                 // cancelled, and only reports if it later rejects - which is
                 // why that one does log.
-                // Matched on the error's cause, falling back to a tail match on
-                // the message: a continue wait that came back through a
-                // `RepartitionExec` has been flattened to a string and reads
-                // `Execution error: Continue wait`, so the equality check this
-                // replaces let it through and reported the queue signal as a
+                // Matched on the error's cause, falling back to a lowercased
+                // substring test on the message: a continue wait that came back
+                // through a `RepartitionExec` has been flattened to a string and
+                // reads `Execution error: Continue wait`, so the equality check
+                // this replaces let it through and reported the queue signal as a
                 // failed request in query history.
                 if !err.is_continue_wait() {
                     session_clone

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -628,7 +628,13 @@ async fn handle_sql_query(
                 // the promise it was awaiting is abandoned rather than
                 // cancelled, and only reports if it later rejects - which is
                 // why that one does log.
-                if !err.message.eq_ignore_ascii_case("continue wait") {
+                // Matched on the error's cause, with a substring fallback on the
+                // message: a continue wait that came back through a
+                // `RepartitionExec` has been flattened to a string and reads
+                // `Execution error: Continue wait`, so the equality check this
+                // replaces let it through and reported the queue signal as a
+                // failed request in query history.
+                if !err.is_continue_wait() {
                     session_clone
                         .session_manager
                         .server

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -628,12 +628,12 @@ async fn handle_sql_query(
                 // the promise it was awaiting is abandoned rather than
                 // cancelled, and only reports if it later rejects - which is
                 // why that one does log.
-                // Matched on the error's cause, falling back to a lowercased
-                // substring test on the message: a continue wait that came back
-                // through a `RepartitionExec` has been flattened to a string and
-                // reads `Execution error: Continue wait`, so the equality check
-                // this replaces let it through and reported the queue signal as a
-                // failed request in query history.
+                // Matched on the error's cause, falling back to the message split
+                // into its `:`- and newline-delimited parts: a continue wait that
+                // came back through a `RepartitionExec` has been flattened to a
+                // string and reads `Execution error: Continue wait`, so the
+                // equality check this replaces let it through and reported the
+                // queue signal as a failed request in query history.
                 if !err.is_continue_wait() {
                     session_clone
                         .session_manager

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -628,8 +628,8 @@ async fn handle_sql_query(
                 // the promise it was awaiting is abandoned rather than
                 // cancelled, and only reports if it later rejects - which is
                 // why that one does log.
-                // Matched on the error's cause, with a substring fallback on the
-                // message: a continue wait that came back through a
+                // Matched on the error's cause, falling back to a tail match on
+                // the message: a continue wait that came back through a
                 // `RepartitionExec` has been flattened to a string and reads
                 // `Execution error: Continue wait`, so the equality check this
                 // replaces let it through and reported the queue signal as a

--- a/packages/cubejs-backend-native/src/transport.rs
+++ b/packages/cubejs-backend-native/src/transport.rs
@@ -463,7 +463,7 @@ impl TransportService for NodeBridgeTransport {
             .await;
 
             if let Err(e) = &result {
-                if e.message.to_lowercase().contains("continue wait") {
+                if e.is_continue_wait() {
                     if throw_continue_wait {
                         return Err(CubeError::continue_wait());
                     }
@@ -609,7 +609,7 @@ impl TransportService for NodeBridgeTransport {
             .await;
 
             if let Err(e) = &res {
-                if e.message.to_lowercase().contains("continue wait") {
+                if e.is_continue_wait() {
                     if throw_continue_wait {
                         return Err(CubeError::continue_wait());
                     }

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -692,7 +692,15 @@ impl CubeScanMemoryStream {
                 } else {
                     err.message
                 };
-                if !err.message.eq_ignore_ascii_case("continue wait") {
+                // A continue wait also gets the `ContinueWait` cause here, the way
+                // `load_data` sets it below, so consumers can match on the cause
+                // rather than on the message. The other branch still only
+                // prefixes the message: unlike `load_data` this path leaves the
+                // incoming cause alone, and re-classifying it would change which
+                // Postgres error code a streaming failure reports.
+                if err.is_continue_wait() {
+                    err.cause = CubeErrorCauseType::ContinueWait;
+                } else {
                     err.message = format!("Database Execution Error: {}", err.message);
                 }
                 Some(Err(ArrowError::ExternalError(Box::new(err))))
@@ -895,7 +903,7 @@ async fn load_data(
                     err.message
                 };
 
-                if err.message.eq_ignore_ascii_case("continue wait") {
+                if err.is_continue_wait() {
                     err.cause = CubeErrorCauseType::ContinueWait;
                 } else {
                     err.cause = CubeErrorCauseType::DatabaseExecution(err.cause.meta().cloned());

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -17,12 +17,6 @@ use tokio::{sync::mpsc::error::SendError, time::error::Elapsed};
 /// also what a `ContinueWait` error normalizes back to.
 pub const CONTINUE_WAIT_MESSAGE: &str = "Continue wait";
 
-/// `CONTINUE_WAIT_MESSAGE` lowercased. A constant rather than
-/// `CONTINUE_WAIT_MESSAGE.to_lowercase()` so the substring test does not allocate
-/// a copy of it on every call; `the_lowercased_needle_tracks_the_message` keeps
-/// the two in step.
-const CONTINUE_WAIT_MESSAGE_LOWER: &str = "continue wait";
-
 #[derive(thiserror::Error, Debug)]
 pub struct CubeError {
     pub message: String,
@@ -182,16 +176,19 @@ impl CubeError {
     /// `is_continue_wait` for a bare message, when no cause is available - a
     /// message carried over the JS bridge, or one already flattened to a string.
     ///
-    /// A lowercased substring test, matching what `NodeBridgeTransport` has done
-    /// since 2024. It has to tolerate arbitrary wrapping on both sides: a prefix
-    /// from whichever layer re-wrapped the error (`Execution error: `,
-    /// `Database Execution Error: `, and these compound), and a suffix when the
-    /// message arrived over the JS bridge with a stack appended (`errorString` in
-    /// `js/index.ts` falls back to `err.stack`). Anything narrower has to enumerate
-    /// those shapes, and the shape is exactly what keeps changing.
+    /// These messages have a structure, and the check follows it rather than
+    /// scanning for the phrase anywhere in the text. Each wrapping layer prepends
+    /// its own label and a colon (`Execution error: `, `Database Execution Error: `,
+    /// and these compound), and a message that arrived over the JS bridge can have
+    /// a stack appended, which puts the message on the first line and the frames
+    /// after it (`errorString` in `js/index.ts` falls back to `err.stack`). So the
+    /// phrase always lands as a whole `:`- or newline-delimited part, however many
+    /// layers wrapped it - and splitting on both separators matches every one of
+    /// those shapes without enumerating them.
     ///
+    /// Matching parts rather than a substring is what keeps a real failure intact.
     /// A false positive is expensive here, more so than at the original site where
-    /// it only meant one more retry. Two consumers are new to a loose predicate.
+    /// it only meant one more retry. Two consumers are new to this predicate.
     /// `normalize_continue_wait` runs on every DataFusion and Arrow conversion and
     /// *replaces* the message, so the original text is gone before anything
     /// downstream sees it. And `load_data` (`scan.rs`) held an equality check
@@ -199,25 +196,20 @@ impl CubeError {
     /// `ContinueWait` cause locally, so - unlike a genuine continue wait, which
     /// the transport retries and never surfaces on the Postgres path - nothing
     /// re-classifies it, and `sql/postgres/error.rs` answers the client
-    /// `SqlStatementNotYetComplete` (`03000`) instead of their failure.
+    /// `SqlStatementNotYetComplete` (`03000`) instead of their failure. These
+    /// messages interpolate user-controlled SQL, so the phrase turns up inside
+    /// one as an identifier or a literal (`No field named 'continue wait'`,
+    /// `status = Utf8("continue wait")`); as part of a larger part it is not the
+    /// signal, and a substring test could not tell the two apart.
     ///
-    /// Hence the one exception to the substring test: a match immediately
-    /// preceded by a quote is a quoted identifier or literal, not the queue's
-    /// signal. These messages interpolate user-controlled SQL, so
-    /// `No field named 'continue wait'` is the realistic false positive, and it is
-    /// always quoted. That is one character of context, not an enumeration of
-    /// wrapper shapes - prefixes and appended stacks still match.
+    /// The trade runs the other way for a layer that appends instead of prepends:
+    /// `Continue wait.` or `Continue wait (retrying)` is one part and does not
+    /// match. No layer produces those today - the phrase is a wire constant that
+    /// gets wrapped, not edited - and a new one would have to be taught here.
     pub fn is_continue_wait_message(message: &str) -> bool {
-        let message = message.to_lowercase();
-
         message
-            .match_indices(CONTINUE_WAIT_MESSAGE_LOWER)
-            .any(|(at, _)| {
-                !matches!(
-                    message[..at].chars().next_back(),
-                    Some('\'') | Some('"') | Some('`')
-                )
-            })
+            .split(['\n', ':'])
+            .any(|part| part.trim().eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE))
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -679,8 +671,8 @@ mod tests {
     }
 
     /// A message that does not carry the phrase at all, including shapes that
-    /// have tripped up narrower implementations: shorter than the needle, and
-    /// non-ASCII.
+    /// have tripped up earlier implementations: empty, shorter than the phrase,
+    /// and non-ASCII.
     #[test]
     fn a_message_without_the_phrase_is_not_a_continue_wait() {
         for message in ["", "wait", "Ошибка: продолжить ожидание"] {
@@ -692,21 +684,23 @@ mod tests {
         }
     }
 
+    /// The phrase is matched as a whole part, so it still resolves however many
+    /// layers wrapped it and wherever the split lands it - including a part that
+    /// a stack frame's own colons cut out of the first line.
     #[test]
-    fn the_lowercased_needle_tracks_the_message() {
-        assert_eq!(
-            CONTINUE_WAIT_MESSAGE.to_lowercase(),
-            CONTINUE_WAIT_MESSAGE_LOWER
-        );
-    }
-
-    /// The quote exception is per occurrence, not per message: a message that
-    /// quotes the phrase *and* carries it unquoted is still a continue wait.
-    #[test]
-    fn an_unquoted_occurrence_still_counts() {
-        assert!(CubeError::is_continue_wait_message(
-            "Execution error: No field named 'continue wait'. Continue wait"
-        ));
+    fn the_phrase_is_matched_as_a_whole_part() {
+        for message in [
+            CONTINUE_WAIT_MESSAGE,
+            "Execution error: Continue wait",
+            "Post-Processing Error: Execution error: Continue wait",
+            "Error: Continue wait\n    at load (/app/js/index.js:12:34)",
+        ] {
+            assert!(
+                CubeError::is_continue_wait_message(message),
+                "not detected: {}",
+                message
+            );
+        }
     }
 
     #[test]
@@ -714,12 +708,14 @@ mod tests {
         for message in [
             "Table 'orders' not found",
             "Database Execution Error: syntax error at or near \"SELCT\"",
-            // Quoted, so it is the user's identifier or literal rather than the
-            // queue's signal - and its text has to survive, because
-            // `normalize_continue_wait` would otherwise replace it.
+            // The phrase is the user's identifier or literal, carried inside a
+            // larger part rather than being one - and its text has to survive,
+            // because `normalize_continue_wait` would otherwise replace it.
             "No field named 'continue wait' in table 'orders'",
             "Unsupported filter: status = Utf8(\"Continue wait\")",
             "Can't find column `continue wait` in projection",
+            "Execution error: No field named 'continue wait'",
+            "Execution error: continue wait is not a column\n    at plan (/app/js/index.js:1:2)",
         ] {
             let err = CubeError::from(repartitioned(message));
 

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -176,49 +176,22 @@ impl CubeError {
     /// `is_continue_wait` for a bare message, when no cause is available - a
     /// message carried over the JS bridge, or one already flattened to a string.
     ///
-    /// Matched on the tail of the first line, because a wrapping layer prepends
-    /// its label and leaves the original message last, and a message carried over
-    /// the JS bridge can have a stack appended to it (`errorString` in
-    /// `js/index.ts` falls back to `err.stack`, which renders as
-    /// `Error: Continue wait\n    at ...`). Taking the first line covers that
-    /// without reaching into the frames.
+    /// A lowercased substring test, matching what `NodeBridgeTransport` has done
+    /// since 2024. It has to tolerate arbitrary wrapping on both sides: a prefix
+    /// from whichever layer re-wrapped the error (`Execution error: `,
+    /// `Database Execution Error: `, and these compound), and a suffix when the
+    /// message arrived over the JS bridge with a stack appended (`errorString` in
+    /// `js/index.ts` falls back to `err.stack`). Anything narrower has to enumerate
+    /// those shapes, and the shape is exactly what keeps changing.
     ///
-    /// Deliberately not a substring test: an error message can quote the query it
-    /// failed on, and a real failure over a column or literal named
-    /// `continue wait` has to keep being reported. That is narrower than the
-    /// `contains` check `NodeBridgeTransport` used from 2024, and the difference
-    /// only shows on a message that buries the phrase mid-line, which no
-    /// continue wait does - the orchestrator raises it as `{ error: 'Continue
-    /// wait' }`, and `errorString` reads `err.error` / `err.message` before the
-    /// stack.
-    ///
-    /// Compared as ASCII bytes rather than by lowercasing: the needle is pure
-    /// ASCII, and these messages can quote the whole failing query, so
-    /// `to_lowercase` would allocate a copy of it on every call.
+    /// The cost is that a real failure quoting the phrase - an error naming a
+    /// column called `continue wait` - would be read as the queue's signal and go
+    /// unreported. Accepted: no such message is known, and the opposite mistake is
+    /// the one that has actually bitten us twice.
     pub fn is_continue_wait_message(message: &str) -> bool {
-        let first_line = message.lines().next().unwrap_or_default().trim();
-
-        let Some(at) = first_line.len().checked_sub(CONTINUE_WAIT_MESSAGE.len()) else {
-            return false;
-        };
-        // `get` yields `None` when the split is not on a char boundary, so a
-        // multi-byte character straddling it cannot panic here - and once it has
-        // returned `Some`, `at` is a boundary and the head can be indexed.
-        let Some(tail) = first_line.get(at..) else {
-            return false;
-        };
-        if !tail.eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE) {
-            return false;
-        }
-
-        // The phrase has to start a word, so a first line ending in a longer word
-        // - `discontinue wait` - is not read as the queue's signal. Every real
-        // prefix ends in a separator (`Execution error: `), and an unprefixed
-        // message has no preceding character at all.
-        first_line[..at]
-            .chars()
-            .next_back()
-            .is_none_or(|c| !c.is_alphanumeric())
+        message
+            .to_lowercase()
+            .contains(&CONTINUE_WAIT_MESSAGE.to_lowercase())
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -679,17 +652,12 @@ mod tests {
         assert_eq!(err.message, CONTINUE_WAIT_MESSAGE);
     }
 
-    /// The tail compare slices by byte offset, so it has to survive a message
-    /// shorter than the needle and one whose split lands inside a multi-byte
-    /// character.
+    /// A message that does not carry the phrase at all, including shapes that
+    /// have tripped up narrower implementations: shorter than the needle, and
+    /// non-ASCII.
     #[test]
-    fn the_tail_compare_handles_awkward_messages() {
-        for message in [
-            "",
-            "wait",
-            // The byte at `len - "Continue wait".len()` is mid-character here.
-            "Ошибка: продолжить ожидание",
-        ] {
+    fn a_message_without_the_phrase_is_not_a_continue_wait() {
+        for message in ["", "wait", "Ошибка: продолжить ожидание"] {
             assert!(
                 !CubeError::is_continue_wait_message(message),
                 "wrongly detected: {}",
@@ -702,11 +670,7 @@ mod tests {
     fn a_real_failure_is_left_alone() {
         for message in [
             "Table 'orders' not found",
-            // A failure that merely quotes the phrase is still a failure, which
-            // is why the message test is on the tail rather than a substring.
-            "No field named 'continue wait' in table 'orders'",
-            // The phrase has to start a word, not just end the line.
-            "Treatment plan set to discontinue wait",
+            "Database Execution Error: syntax error at or near \"SELCT\"",
         ] {
             let err = CubeError::from(repartitioned(message));
 

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -202,10 +202,17 @@ impl CubeError {
     /// `status = Utf8("continue wait")`); as part of a larger part it is not the
     /// signal, and a substring test could not tell the two apart.
     ///
-    /// The trade runs the other way for a layer that appends instead of prepends:
-    /// `Continue wait.` or `Continue wait (retrying)` is one part and does not
-    /// match. No layer produces those today - the phrase is a wire constant that
-    /// gets wrapped, not edited - and a new one would have to be taught here.
+    /// The trade runs the other way for a wrapper that appends instead of
+    /// prepending: `Continue wait.` or `Continue wait (retrying)` is one part and
+    /// does not match. Exactly one such wrapper exists, and it is in this file -
+    /// the `Rewrite` arm of `Display` renders
+    /// `Rewrite Error: {}. Please check logs for additional information`, where
+    /// every other arm is `<Label>: {}`. A continue wait never carries that
+    /// cause: `CubeError::rewrite` is minted only inside the rewrite engine with
+    /// its own messages, while a continue wait comes from `transport.load` at
+    /// execution time, after rewriting. `every_cause_renders_a_matchable_continue_wait`
+    /// pins both halves, so a new appending wrapper - or an existing arm taught to
+    /// append - fails there rather than silently swallowing the signal.
     pub fn is_continue_wait_message(message: &str) -> bool {
         message
             .split(['\n', ':'])
@@ -699,6 +706,57 @@ mod tests {
                 CubeError::is_continue_wait_message(message),
                 "not detected: {}",
                 message
+            );
+        }
+    }
+
+    /// `RepartitionExec` flattens through `Display`, so every cause's rendering
+    /// of a continue wait has to stay matchable by the predicate.
+    ///
+    /// The `Rewrite` arm is the one that also *appends*
+    /// (`. Please check logs for additional information`), so it is the one that
+    /// does not survive the round trip - and it is unreachable for a continue
+    /// wait, because `CubeError::rewrite` is minted only inside the rewrite engine
+    /// with its own messages, while a continue wait comes from `transport.load`
+    /// at execution time, after rewriting.
+    ///
+    /// The inner match is exhaustive on purpose: a new cause variant, or an
+    /// existing one taught to append, stops compiling here rather than silently
+    /// swallowing the queue's signal.
+    #[test]
+    fn every_cause_renders_a_matchable_continue_wait() {
+        use CubeErrorCauseType::*;
+
+        for cause in [
+            User(None),
+            Internal(None),
+            RestApi(None),
+            SqlParser(None),
+            Unsupported(None),
+            Planning(None),
+            PostProcessing(None),
+            Rewrite(None),
+            DatabaseExecution(None),
+            ContinueWait,
+        ] {
+            let appends = match &cause {
+                Rewrite(_) => true,
+                User(_) | Internal(_) | RestApi(_) | SqlParser(_) | Unsupported(_)
+                | Planning(_) | PostProcessing(_) | DatabaseExecution(_) | ContinueWait => false,
+            };
+
+            let rendered = CubeError {
+                message: CONTINUE_WAIT_MESSAGE.to_string(),
+                cause,
+                backtrace: None,
+            }
+            .to_string();
+
+            assert_eq!(
+                CubeError::is_continue_wait_message(&rendered),
+                !appends,
+                "unexpected verdict for: {}",
+                rendered
             );
         }
     }

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -184,14 +184,29 @@ impl CubeError {
     /// `js/index.ts` falls back to `err.stack`). Anything narrower has to enumerate
     /// those shapes, and the shape is exactly what keeps changing.
     ///
-    /// The cost is that a real failure quoting the phrase - an error naming a
-    /// column called `continue wait` - would be read as the queue's signal and go
-    /// unreported. Accepted: no such message is known, and the opposite mistake is
-    /// the one that has actually bitten us twice.
+    /// A false positive is expensive here, more so than at the original site where
+    /// it only meant one more retry: this feeds `normalize_continue_wait`, which
+    /// runs on every DataFusion and Arrow conversion and *replaces* the message.
+    /// An error that merely quotes the phrase would lose its text entirely, and
+    /// the caller would see a query that appears to poll forever rather than the
+    /// error naming their mistake.
+    ///
+    /// Hence the one exception to the substring test: a match immediately
+    /// preceded by a quote is a quoted identifier or literal, not the queue's
+    /// signal. These messages interpolate user-controlled SQL, so
+    /// `No field named 'continue wait'` is the realistic false positive, and it is
+    /// always quoted. That is one character of context, not an enumeration of
+    /// wrapper shapes - prefixes and appended stacks still match.
     pub fn is_continue_wait_message(message: &str) -> bool {
-        message
-            .to_lowercase()
-            .contains(&CONTINUE_WAIT_MESSAGE.to_lowercase())
+        let message = message.to_lowercase();
+        let needle = CONTINUE_WAIT_MESSAGE.to_lowercase();
+
+        message.match_indices(&needle).any(|(at, _)| {
+            !matches!(
+                message[..at].chars().next_back(),
+                Some('\'') | Some('"') | Some('`')
+            )
+        })
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -666,11 +681,26 @@ mod tests {
         }
     }
 
+    /// The quote exception is per occurrence, not per message: a message that
+    /// quotes the phrase *and* carries it unquoted is still a continue wait.
+    #[test]
+    fn an_unquoted_occurrence_still_counts() {
+        assert!(CubeError::is_continue_wait_message(
+            "Execution error: No field named 'continue wait'. Continue wait"
+        ));
+    }
+
     #[test]
     fn a_real_failure_is_left_alone() {
         for message in [
             "Table 'orders' not found",
             "Database Execution Error: syntax error at or near \"SELCT\"",
+            // Quoted, so it is the user's identifier or literal rather than the
+            // queue's signal - and its text has to survive, because
+            // `normalize_continue_wait` would otherwise replace it.
+            "No field named 'continue wait' in table 'orders'",
+            "Unsupported filter: status = Utf8(\"Continue wait\")",
+            "Can't find column `continue wait` in projection",
         ] {
             let err = CubeError::from(repartitioned(message));
 

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -12,6 +12,11 @@ use std::{
 };
 use tokio::{sync::mpsc::error::SendError, time::error::Elapsed};
 
+/// Canonical spelling of the queue's "not finished yet" signal. It is the wire
+/// value the api-gateway sends and the event name query history reads, so it is
+/// also what a `ContinueWait` error normalizes back to.
+pub const CONTINUE_WAIT_MESSAGE: &str = "Continue wait";
+
 #[derive(thiserror::Error, Debug)]
 pub struct CubeError {
     pub message: String,
@@ -127,7 +132,7 @@ impl CubeError {
 
     pub fn continue_wait() -> Self {
         Self {
-            message: "Continue wait".to_string(),
+            message: CONTINUE_WAIT_MESSAGE.to_string(),
             cause: CubeErrorCauseType::ContinueWait,
             backtrace: None,
         }
@@ -149,6 +154,62 @@ impl CubeError {
 }
 
 impl CubeError {
+    /// Whether this error is the queue's `Continue wait` signal rather than a
+    /// failure. Nothing user-visible may be reported for it - see
+    /// `handle_sql_query` in `cubejs-backend-native`, which must not log a
+    /// `Cube SQL Error` load event for one.
+    ///
+    /// The cause is the reliable half; the message check is the fallback for an
+    /// error that lost its cause on the way here. That happens: DataFusion's
+    /// `RepartitionExec` has to hand one error to every output partition and a
+    /// boxed error is not `Clone`, so `wait_for_task` flattens it to its
+    /// `Display` string and re-wraps it as `DataFusionError::Execution`. The
+    /// typed `CubeError` is gone at that point and the message has grown a
+    /// prefix (`Execution error: Continue wait`), which is why the message check
+    /// is not an equality one - and why every prefix would otherwise compound
+    /// through the next wrapping layer.
+    pub fn is_continue_wait(&self) -> bool {
+        matches!(self.cause, CubeErrorCauseType::ContinueWait)
+            || Self::is_continue_wait_message(&self.message)
+    }
+
+    /// `is_continue_wait` for a bare message, when no cause is available - a
+    /// message carried over the JS bridge, or one already flattened to a string.
+    ///
+    /// Matched on the tail, because a wrapping layer prepends its label and
+    /// leaves the original message last. Deliberately not a substring test: an
+    /// error message can quote the query it failed on, and a real failure over a
+    /// column or literal named `continue wait` has to keep being reported. That
+    /// is narrower than the `contains` check `NodeBridgeTransport` has used since
+    /// 2024, which is safe here - the JS bridge builds the message from
+    /// `err.error` (`Continue wait` verbatim, from the orchestrator) before it
+    /// ever falls back to a stack.
+    pub fn is_continue_wait_message(message: &str) -> bool {
+        message
+            .trim()
+            .to_lowercase()
+            .ends_with(&CONTINUE_WAIT_MESSAGE.to_lowercase())
+    }
+
+    /// Restores the `ContinueWait` cause on an error that reached us as a
+    /// stringified continue wait (see `is_continue_wait` for how the cause gets
+    /// lost), and resets the message to its canonical spelling so the accumulated
+    /// prefixes do not travel any further.
+    ///
+    /// Applied at the DataFusion and Arrow conversion boundaries, which is where
+    /// the flattening happens, so consumers downstream of them can match on the
+    /// cause.
+    fn normalize_continue_wait(mut self) -> Self {
+        if !matches!(self.cause, CubeErrorCauseType::ContinueWait)
+            && Self::is_continue_wait_message(&self.message)
+        {
+            self.message = CONTINUE_WAIT_MESSAGE.to_string();
+            self.cause = CubeErrorCauseType::ContinueWait;
+        }
+
+        self
+    }
+
     pub fn backtrace(&self) -> Option<&Backtrace> {
         self.backtrace.as_ref()
     }
@@ -351,7 +412,7 @@ impl From<tokio::sync::broadcast::error::RecvError> for CubeError {
 
 impl From<datafusion::error::DataFusionError> for CubeError {
     fn from(v: datafusion::error::DataFusionError) -> Self {
-        match v {
+        let converted = match v {
             datafusion::error::DataFusionError::ArrowError(e) => CubeError::from(e),
             datafusion::error::DataFusionError::SQL(e) => CubeError::from(e),
             datafusion::error::DataFusionError::NotImplemented(e) => CubeError::unsupported(e),
@@ -362,17 +423,27 @@ impl From<datafusion::error::DataFusionError> for CubeError {
                 Ok(e) => *e,
                 Err(e) => match e.downcast::<arrow::error::ArrowError>() {
                     Ok(e) => CubeError::from(*e),
-                    Err(e) => CubeError::internal(e.to_string()),
+                    // `From<ArrowError>` tries `DataFusionError` here as well,
+                    // and a `DataFusionError` does end up boxed inside
+                    // `External` - `From<DataFusionError> for ArrowError` in the
+                    // fork boxes anything it cannot map. Without this arm such
+                    // an error only ever reached us as its `Display` string.
+                    Err(e) => match e.downcast::<datafusion::error::DataFusionError>() {
+                        Ok(e) => CubeError::from(*e),
+                        Err(e) => CubeError::internal(e.to_string()),
+                    },
                 },
             },
             _ => CubeError::internal(v.to_string()),
-        }
+        };
+
+        converted.normalize_continue_wait()
     }
 }
 
 impl From<arrow::error::ArrowError> for CubeError {
     fn from(v: arrow::error::ArrowError) -> Self {
-        match v {
+        let converted = match v {
             arrow::error::ArrowError::NotYetImplemented(e) => CubeError::unsupported(e),
             arrow::error::ArrowError::ExternalError(e) => match e.downcast::<CubeError>() {
                 Ok(e) => *e,
@@ -388,7 +459,9 @@ impl From<arrow::error::ArrowError> for CubeError {
                 CubeError::post_processing(v.to_string())
             }
             _ => CubeError::internal(v.to_string()),
-        }
+        };
+
+        converted.normalize_continue_wait()
     }
 }
 
@@ -460,5 +533,99 @@ impl From<base64::DecodeError> for CubeError {
 impl From<tokio::sync::AcquireError> for CubeError {
     fn from(v: tokio::sync::AcquireError) -> Self {
         CubeError::internal(v.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::error::DataFusionError;
+
+    /// The shape a continue wait actually arrives in once DataFusion has
+    /// parallelized the plan. `RepartitionExec::wait_for_task` has to deliver one
+    /// error to every output partition, and a boxed error is not `Clone`, so it
+    /// flattens ours to its `Display` string and re-wraps it as
+    /// `DataFusionError::Execution` - then `From<DataFusionError> for ArrowError`
+    /// boxes that into `ExternalError` on the way back into the record batch
+    /// stream. `target_partitions` defaults to `num_cpus::get()` and
+    /// `repartition_aggregations` / `repartition_windows` default to true, so any
+    /// GROUP BY or window function over a `CubeScan` takes this path.
+    fn repartitioned(message: &str) -> arrow::error::ArrowError {
+        arrow::error::ArrowError::ExternalError(Box::new(DataFusionError::Execution(
+            message.to_string(),
+        )))
+    }
+
+    #[test]
+    fn continue_wait_survives_repartition_flattening() {
+        let err = CubeError::from(repartitioned(CONTINUE_WAIT_MESSAGE));
+
+        assert!(err.is_continue_wait());
+        assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+        // Normalized, so the prefix cannot compound if it is wrapped again.
+        assert_eq!(err.message, CONTINUE_WAIT_MESSAGE);
+        assert_eq!(err.to_string(), CONTINUE_WAIT_MESSAGE);
+    }
+
+    /// The regression this guards: the flattened error's `Display` already
+    /// carries DataFusion's `Execution error: ` prefix, so a second wrapping
+    /// layer produces a doubly-prefixed message. An equality check against
+    /// `"continue wait"` matches neither, which is how the queue signal reached
+    /// query history as a failed request.
+    #[test]
+    fn continue_wait_survives_a_prefixed_message() {
+        for message in [
+            "Execution error: Continue wait",
+            "Execution error: Execution error: Continue wait",
+            "Database Execution Error: Continue wait",
+            "CONTINUE WAIT",
+        ] {
+            let err = CubeError::from(repartitioned(message));
+
+            assert!(err.is_continue_wait(), "not detected: {}", message);
+            assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+            assert_eq!(err.message, CONTINUE_WAIT_MESSAGE);
+        }
+    }
+
+    #[test]
+    fn continue_wait_survives_as_a_typed_external_error() {
+        let err = CubeError::from(arrow::error::ArrowError::ExternalError(Box::new(
+            CubeError::continue_wait(),
+        )));
+
+        assert!(err.is_continue_wait());
+        assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+    }
+
+    /// `DataFusionError::External` can hold a `DataFusionError` - the fork's
+    /// `From<DataFusionError> for ArrowError` boxes anything it cannot map, and
+    /// the round trip back lands here. Only `From<ArrowError>` used to try that
+    /// downcast, so this direction reported the inner error as its `Display`
+    /// string and lost the cause with it.
+    #[test]
+    fn nested_datafusion_error_keeps_its_cause() {
+        let err = CubeError::from(DataFusionError::External(Box::new(
+            DataFusionError::Execution(CONTINUE_WAIT_MESSAGE.to_string()),
+        )));
+
+        assert!(err.is_continue_wait());
+        assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+    }
+
+    #[test]
+    fn a_real_failure_is_left_alone() {
+        for message in [
+            "Table 'orders' not found",
+            // A failure that merely quotes the phrase is still a failure, which
+            // is why the message test is on the tail rather than a substring.
+            "No field named 'continue wait' in table 'orders'",
+        ] {
+            let err = CubeError::from(repartitioned(message));
+
+            assert!(!err.is_continue_wait(), "wrongly swallowed: {}", message);
+            assert!(matches!(err.cause, CubeErrorCauseType::PostProcessing(_)));
+            assert_eq!(err.message, message);
+        }
     }
 }

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -208,11 +208,17 @@ impl CubeError {
     /// the `Rewrite` arm of `Display` renders
     /// `Rewrite Error: {}. Please check logs for additional information`, where
     /// every other arm is `<Label>: {}`. A continue wait never carries that
-    /// cause: `CubeError::rewrite` is minted only inside the rewrite engine with
-    /// its own messages, while a continue wait comes from `transport.load` at
-    /// execution time, after rewriting. `every_cause_renders_a_matchable_continue_wait`
-    /// pins both halves, so a new appending wrapper - or an existing arm taught to
-    /// append - fails there rather than silently swallowing the signal.
+    /// cause, and the reason is not that the cause is only minted locally - it is
+    /// stamped onto *foreign* errors too (`query_engine.rs` re-labels whatever
+    /// `compiler_cache.rewrite` and `find_best_plan` return; `converter.rs` wraps
+    /// a `MemberError` with it). What makes it safe is one level down: the rewrite
+    /// phase never calls the transport. It works against an already-fetched
+    /// `MetaContext` / `CompilerCacheEntry`, and `compile/rewrite/` contains no
+    /// `transport.` call at all, so no continue wait can arise there to be
+    /// re-labelled - a continue wait comes from `transport.load` at execution
+    /// time, after rewriting. `every_cause_renders_a_matchable_continue_wait` pins
+    /// the `Display` half, so a new appending wrapper - or an existing arm taught
+    /// to append - fails there rather than silently swallowing the signal.
     pub fn is_continue_wait_message(message: &str) -> bool {
         message
             .split(['\n', ':'])
@@ -716,9 +722,9 @@ mod tests {
     /// The `Rewrite` arm is the one that also *appends*
     /// (`. Please check logs for additional information`), so it is the one that
     /// does not survive the round trip - and it is unreachable for a continue
-    /// wait, because `CubeError::rewrite` is minted only inside the rewrite engine
-    /// with its own messages, while a continue wait comes from `transport.load`
-    /// at execution time, after rewriting.
+    /// wait, because the rewrite phase never calls the transport (see
+    /// `is_continue_wait_message`; the cause itself is stamped onto foreign
+    /// errors, so it is the phase, not the constructor, that rules this out).
     ///
     /// The inner match is exhaustive on purpose: a new cause variant, or an
     /// existing one taught to append, stops compiling here rather than silently

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -198,13 +198,27 @@ impl CubeError {
     pub fn is_continue_wait_message(message: &str) -> bool {
         let first_line = message.lines().next().unwrap_or_default().trim();
 
-        first_line
-            .len()
-            .checked_sub(CONTINUE_WAIT_MESSAGE.len())
-            // `get` yields `None` when the split is not on a char boundary, so a
-            // multi-byte character straddling it cannot panic here.
-            .and_then(|at| first_line.get(at..))
-            .is_some_and(|tail| tail.eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE))
+        let Some(at) = first_line.len().checked_sub(CONTINUE_WAIT_MESSAGE.len()) else {
+            return false;
+        };
+        // `get` yields `None` when the split is not on a char boundary, so a
+        // multi-byte character straddling it cannot panic here - and once it has
+        // returned `Some`, `at` is a boundary and the head can be indexed.
+        let Some(tail) = first_line.get(at..) else {
+            return false;
+        };
+        if !tail.eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE) {
+            return false;
+        }
+
+        // The phrase has to start a word, so a first line ending in a longer word
+        // - `discontinue wait` - is not read as the queue's signal. Every real
+        // prefix ends in a separator (`Execution error: `), and an unprefixed
+        // message has no preceding character at all.
+        first_line[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric())
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -691,6 +705,8 @@ mod tests {
             // A failure that merely quotes the phrase is still a failure, which
             // is why the message test is on the tail rather than a substring.
             "No field named 'continue wait' in table 'orders'",
+            // The phrase has to start a word, not just end the line.
+            "Treatment plan set to discontinue wait",
         ] {
             let err = CubeError::from(repartitioned(message));
 

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -17,6 +17,12 @@ use tokio::{sync::mpsc::error::SendError, time::error::Elapsed};
 /// also what a `ContinueWait` error normalizes back to.
 pub const CONTINUE_WAIT_MESSAGE: &str = "Continue wait";
 
+/// `CONTINUE_WAIT_MESSAGE` lowercased. A constant rather than
+/// `CONTINUE_WAIT_MESSAGE.to_lowercase()` so the substring test does not allocate
+/// a copy of it on every call; `the_lowercased_needle_tracks_the_message` keeps
+/// the two in step.
+const CONTINUE_WAIT_MESSAGE_LOWER: &str = "continue wait";
+
 #[derive(thiserror::Error, Debug)]
 pub struct CubeError {
     pub message: String,
@@ -185,11 +191,15 @@ impl CubeError {
     /// those shapes, and the shape is exactly what keeps changing.
     ///
     /// A false positive is expensive here, more so than at the original site where
-    /// it only meant one more retry: this feeds `normalize_continue_wait`, which
-    /// runs on every DataFusion and Arrow conversion and *replaces* the message.
-    /// An error that merely quotes the phrase would lose its text entirely, and
-    /// the caller would see a query that appears to poll forever rather than the
-    /// error naming their mistake.
+    /// it only meant one more retry. Two consumers are new to a loose predicate.
+    /// `normalize_continue_wait` runs on every DataFusion and Arrow conversion and
+    /// *replaces* the message, so the original text is gone before anything
+    /// downstream sees it. And `load_data` (`scan.rs`) held an equality check
+    /// until this change: a real database error misread here is minted with the
+    /// `ContinueWait` cause locally, so - unlike a genuine continue wait, which
+    /// the transport retries and never surfaces on the Postgres path - nothing
+    /// re-classifies it, and `sql/postgres/error.rs` answers the client
+    /// `SqlStatementNotYetComplete` (`03000`) instead of their failure.
     ///
     /// Hence the one exception to the substring test: a match immediately
     /// preceded by a quote is a quoted identifier or literal, not the queue's
@@ -199,14 +209,15 @@ impl CubeError {
     /// wrapper shapes - prefixes and appended stacks still match.
     pub fn is_continue_wait_message(message: &str) -> bool {
         let message = message.to_lowercase();
-        let needle = CONTINUE_WAIT_MESSAGE.to_lowercase();
 
-        message.match_indices(&needle).any(|(at, _)| {
-            !matches!(
-                message[..at].chars().next_back(),
-                Some('\'') | Some('"') | Some('`')
-            )
-        })
+        message
+            .match_indices(CONTINUE_WAIT_MESSAGE_LOWER)
+            .any(|(at, _)| {
+                !matches!(
+                    message[..at].chars().next_back(),
+                    Some('\'') | Some('"') | Some('`')
+                )
+            })
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -679,6 +690,14 @@ mod tests {
                 message
             );
         }
+    }
+
+    #[test]
+    fn the_lowercased_needle_tracks_the_message() {
+        assert_eq!(
+            CONTINUE_WAIT_MESSAGE.to_lowercase(),
+            CONTINUE_WAIT_MESSAGE_LOWER
+        );
     }
 
     /// The quote exception is per occurrence, not per message: a message that

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -176,19 +176,35 @@ impl CubeError {
     /// `is_continue_wait` for a bare message, when no cause is available - a
     /// message carried over the JS bridge, or one already flattened to a string.
     ///
-    /// Matched on the tail, because a wrapping layer prepends its label and
-    /// leaves the original message last. Deliberately not a substring test: an
-    /// error message can quote the query it failed on, and a real failure over a
-    /// column or literal named `continue wait` has to keep being reported. That
-    /// is narrower than the `contains` check `NodeBridgeTransport` has used since
-    /// 2024, which is safe here - the JS bridge builds the message from
-    /// `err.error` (`Continue wait` verbatim, from the orchestrator) before it
-    /// ever falls back to a stack.
+    /// Matched on the tail of the first line, because a wrapping layer prepends
+    /// its label and leaves the original message last, and a message carried over
+    /// the JS bridge can have a stack appended to it (`errorString` in
+    /// `js/index.ts` falls back to `err.stack`, which renders as
+    /// `Error: Continue wait\n    at ...`). Taking the first line covers that
+    /// without reaching into the frames.
+    ///
+    /// Deliberately not a substring test: an error message can quote the query it
+    /// failed on, and a real failure over a column or literal named
+    /// `continue wait` has to keep being reported. That is narrower than the
+    /// `contains` check `NodeBridgeTransport` used from 2024, and the difference
+    /// only shows on a message that buries the phrase mid-line, which no
+    /// continue wait does - the orchestrator raises it as `{ error: 'Continue
+    /// wait' }`, and `errorString` reads `err.error` / `err.message` before the
+    /// stack.
+    ///
+    /// Compared as ASCII bytes rather than by lowercasing: the needle is pure
+    /// ASCII, and these messages can quote the whole failing query, so
+    /// `to_lowercase` would allocate a copy of it on every call.
     pub fn is_continue_wait_message(message: &str) -> bool {
-        message
-            .trim()
-            .to_lowercase()
-            .ends_with(&CONTINUE_WAIT_MESSAGE.to_lowercase())
+        let first_line = message.lines().next().unwrap_or_default().trim();
+
+        first_line
+            .len()
+            .checked_sub(CONTINUE_WAIT_MESSAGE.len())
+            // `get` yields `None` when the split is not on a char boundary, so a
+            // multi-byte character straddling it cannot panic here.
+            .and_then(|at| first_line.get(at..))
+            .is_some_and(|tail| tail.eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE))
     }
 
     /// Restores the `ContinueWait` cause on an error that reached us as a
@@ -199,10 +215,15 @@ impl CubeError {
     /// Applied at the DataFusion and Arrow conversion boundaries, which is where
     /// the flattening happens, so consumers downstream of them can match on the
     /// cause.
+    ///
+    /// Both halves are normalized, not just the cause-less one: an error can
+    /// arrive carrying the cause *and* a prefixed message - `CubeScanMemoryStream`
+    /// sets the cause without rewriting the message, and the `CubeError` downcast
+    /// arm hands that straight back here - and the message still has to be
+    /// canonical, because JS matches it exactly in places (`gateway.ts`'s
+    /// `err.message === 'Continue wait'`).
     fn normalize_continue_wait(mut self) -> Self {
-        if !matches!(self.cause, CubeErrorCauseType::ContinueWait)
-            && Self::is_continue_wait_message(&self.message)
-        {
+        if self.is_continue_wait() {
             self.message = CONTINUE_WAIT_MESSAGE.to_string();
             self.cause = CubeErrorCauseType::ContinueWait;
         }
@@ -611,6 +632,56 @@ mod tests {
 
         assert!(err.is_continue_wait());
         assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+    }
+
+    /// An error can arrive with the cause already set *and* a prefixed message:
+    /// `CubeScanMemoryStream` sets the cause without rewriting the message, and
+    /// the `CubeError` downcast arm returns it unchanged. The message still has to
+    /// end up canonical, because JS compares it exactly (`gateway.ts`'s
+    /// `err.message === 'Continue wait'`).
+    #[test]
+    fn a_typed_continue_wait_still_gets_a_canonical_message() {
+        let mut err = CubeError::continue_wait();
+        err.message = "Database Execution Error: Continue wait".to_string();
+
+        let err = CubeError::from(arrow::error::ArrowError::ExternalError(Box::new(err)));
+
+        assert!(err.is_continue_wait());
+        assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+        assert_eq!(err.message, CONTINUE_WAIT_MESSAGE);
+    }
+
+    /// A message carried over the JS bridge can have a stack appended:
+    /// `errorString` falls back to `err.stack`, which renders the message on the
+    /// first line and the frames after it.
+    #[test]
+    fn continue_wait_survives_an_appended_stack() {
+        let err = CubeError::from(repartitioned(
+            "Error: Continue wait\n    at load (/app/js/index.js:12:34)",
+        ));
+
+        assert!(err.is_continue_wait());
+        assert!(matches!(err.cause, CubeErrorCauseType::ContinueWait));
+        assert_eq!(err.message, CONTINUE_WAIT_MESSAGE);
+    }
+
+    /// The tail compare slices by byte offset, so it has to survive a message
+    /// shorter than the needle and one whose split lands inside a multi-byte
+    /// character.
+    #[test]
+    fn the_tail_compare_handles_awkward_messages() {
+        for message in [
+            "",
+            "wait",
+            // The byte at `len - "Continue wait".len()` is mid-character here.
+            "Ошибка: продолжить ожидание",
+        ] {
+            assert!(
+                !CubeError::is_continue_wait_message(message),
+                "wrongly detected: {}",
+                message
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[CX-111](https://linear.app/cube-d3/issue/CX-111/genentech-chase-pavel-on-continue-wait-errors-on-athena-queries) — a customer sees `Continue wait` reported as a failed request in Query History.

**Description of Changes Made**

### The bug

A `Continue wait` is the query queue saying "not finished yet", not a failure, so
#10649 stopped `handle_sql_query` logging a `Cube SQL Error` load event for one. It
suppresses that event with an **exact** match:

```rust
if !err.message.eq_ignore_ascii_case("continue wait") { /* log Cube SQL Error */ }
```

The message that actually arrives is `Execution error: Continue wait`, so the event is
still emitted, and Query History reads the request as errored.

### Where the prefix comes from

DataFusion's `RepartitionExec` has to hand one error to every output partition, and a
boxed error is not `Clone`. So `wait_for_task` flattens ours to its `Display` string and
re-wraps it as `DataFusionError::Execution` — the typed `CubeError` is gone, and with it
the `ContinueWait` cause that #10758 introduced for exactly this purpose.

This is not a rare path: `target_partitions` defaults to `num_cpus::get()` and
`repartition_aggregations` / `repartition_windows` default to true, so any GROUP BY or
window function over a `CubeScan` goes through that node.

### Changes

- `CubeError::is_continue_wait()` — matches the **cause** first, falling back to the
  message. Used at the call sites that each spelled the check differently: exact equality
  in `handle_sql_query` and `load_data`, `contains` in `NodeBridgeTransport`.
- The DataFusion and Arrow conversions restore the `ContinueWait` cause and reset the
  message to its canonical spelling, so the cause survives the flattening and the prefixes
  cannot compound through a further wrapping layer.
- The `DataFusionError::External` arm now also tries downcasting to a `DataFusionError`,
  which the `ArrowError` conversion already did. Without it such an error only ever
  arrived as its `Display` string, cause discarded.
- `CubeScanMemoryStream` sets the `ContinueWait` cause the way `load_data` does.

### The message fallback: structure, not substring

These messages have a structure, and the check follows it:

```rust
message
    .split(['\n', ':'])
    .any(|part| part.trim().eq_ignore_ascii_case(CONTINUE_WAIT_MESSAGE))
```

Every wrapping layer prepends its own label and a colon (`Execution error: `,
`Database Execution Error: `, and these compound), and a message that came over the JS
bridge can carry an appended stack, which puts the message on the first line and the
frames after it. So the phrase always lands as a whole `:`- or newline-delimited part,
however many layers wrapped it — and splitting on both separators matches every one of
those shapes without enumerating them. Enumerating them is what produced this bug: the
shape is the thing that keeps changing.

Matching whole parts rather than a substring is also what keeps a real failure intact.
A false positive is expensive here, more so than at the original `NodeBridgeTransport`
site where it only meant one more retry: `normalize_continue_wait` **replaces** the
message, so the original text is gone before anything downstream sees it, and on the
`load_data` path (see below) the Postgres client is answered `SqlStatementNotYetComplete`
(`03000`) instead of its failure. These messages interpolate user-controlled SQL, so the
phrase turns up inside one as an identifier or a literal — `No field named
'continue wait'`, `status = Utf8("continue wait")`, or unquoted as in `Execution error:
continue wait is not a column`. As part of a larger part it is not the signal, and a
substring test cannot tell the two apart.

The trade runs the other way for a layer that appends instead of prepends: `Continue
wait.` or `Continue wait (retrying)` is one part and does not match. No layer produces
those today — the phrase is a wire constant that gets wrapped, not edited — and the doc
comment says so, so a new one gets taught here.

### Cause reclassification

Setting `cause = ContinueWait` where a flattened error previously landed on
`PostProcessing` touches two mappings that key off the cause:

- `gateway/http_error.rs` — `ContinueWait` falls into the `_` arm (500 / "Internal Server
  Error"). `from_user_with_status_code` has exactly one caller, `assert_api_scope` in
  `gateway/state.rs`, wrapping an error from `context_to_api_scopes`. That is an auth-scope
  failure, never a query error — and the call already passes `INTERNAL_SERVER_ERROR` as the
  code, so the mapping is identical either way.
- `sql/postgres/error.rs` — `ContinueWait` maps to `SqlStatementNotYetComplete` under a
  "Should never happen" comment. **A genuine** continue wait still cannot reach it:
  `throw_continue_wait` defaults to `false` (`session.rs:132`) and is only set true from
  `exec_sql`, so on the pg path the transport retries internally. **But an error misread
  into that cause can** — `load_data` mints it locally, and nothing re-classifies it on the
  way up. An earlier revision of this description claimed the arm was unreachable full
  stop; that was reasoning about the genuine signal only, and review was right to push
  back. Matching whole parts is what bounds the residual risk: a database error echoing
  the user's SQL carries the phrase inside a larger part, not as one.

One deliberate improvement: `exec_sql` reports `err.to_string()`, which was
`Post-Processing Error: Continue wait` under the old cause and is now the canonical
`Continue wait` — which matters because `gateway.ts` compares it exactly
(`err.message === 'Continue wait'`).

### Tests

Nine tests in `error.rs` covering the conversion boundary, including the exact shape
`RepartitionExec` produces. Verified they reproduce the bug: against the pre-fix logic 3 of
the original 5 fail, one of them on the literal `Execution error: Continue wait` from the
customer's request. `the_phrase_is_matched_as_a_whole_part` pins the wrapped and
stack-appended shapes on the predicate directly, and `a_real_failure_is_left_alone` covers
the mentions that must survive — quoted and unquoted.

These are unit tests rather than an e2e spec on purpose. Reproducing this end to end
requires the plan to actually be repartitioned, which depends on `num_cpus::get()` — an
e2e assertion would silently pass on a single-core runner and stop testing anything.
Testing the conversion boundary is deterministic everywhere.

Run locally: `cargo test -p cubesql --lib` (874 passing, 0 failed), `cargo fmt --check`
and `cargo clippy --locked --workspace --all-targets -- -D warnings` clean for both
`cubesql` and `cubejs-backend-native`.

### Not addressed here

- The root cause is in the `arrow-datafusion` fork: `RepartitionExec` stringifying errors
  loses the cause for **all** error classes, so a user error currently arrives labelled as
  a post-processing one, which also affects the HTTP status `http_error.rs` derives.
  Fixing it there (a cloneable error) is a separate change in another repo.
- `CubeScanMemoryStream` still prefixes `Database Execution Error:` into the *message* for
  non-continue-wait errors rather than setting the cause, which yields doubled prefixes
  (`User Error: Database Execution Error: …`). Changing it would move Postgres error codes
  for streaming failures, so it is left for its own PR.