### PR TITLE
docs(dashboards): say that a chart opened in the workbook keeps the dashboard's filters

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -13,7 +13,7 @@ If the picker is empty, create the report first in a workbook tab — only publi
 
 ## Interaction with controls
 
-Charts respect the [controls][ref-controls] placed on the same dashboard — filters and time granularity switchers. A single control can drive multiple charts at once: its value is applied to every chart whose query references the targeted dimension.
+Charts respect the [controls][ref-controls] placed on the same dashboard — filters, time granularity switchers and field switchers. A single control can drive multiple charts at once: its value is applied to every chart whose query references the targeted dimension.
 
 If some controls are incompatible with a chart's query, the chart skips them and shows a warning icon. See [Incompatible controls][ref-incompatible-controls] for details.
 
@@ -31,7 +31,7 @@ They sit in the report's filter bar next to its own filters, tinted violet to se
 
 - they apply to the results on screen, and are **not** saved to the report. Publishing the workbook again will not pin them onto the chart for everyone.
 - their values cannot be changed in the workbook. To explore a different value, add your own filter on the same field, or change the dashboard's control and reopen the chart.
-- **Clear filter** on the chip drops it for the rest of the session, and the report re-runs without it. Reopening the chart from the dashboard brings the current values back.
+- they can be dropped, but not kept: **Clear filter** on the chip removes it for the rest of the session and the report re-runs without it. Reopening the chart from the dashboard brings the current values back.
 
 To change what a viewer of the dashboard can filter by, edit the [filter control][ref-controls] there — not the report.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -27,11 +27,13 @@ Charts on a published dashboard reflect the most recent published version of the
 
 The dashboard's [filters][ref-controls] come along, so the report opens showing the same slice of data the chart was showing rather than re-running over everything.
 
-They sit in the report's filter bar next to its own filters, in violet, and read the same way — member, operator, value. What is different is that they are not the report's:
+They sit in the report's filter bar next to its own filters, tinted violet to set them apart, and read the same way — member, operator, value. Hovering one says **From dashboard**. What is different is that they are not the report's:
 
-- they apply to the results on screen, and are **not** saved to the report. Publishing the workbook again will not pin them onto the chart for everyone;
-- they cannot be edited here. To change what a viewer can filter by, edit the [filter control][ref-controls] on the dashboard;
+- they apply to the results on screen, and are **not** saved to the report. Publishing the workbook again will not pin them onto the chart for everyone.
+- their values cannot be changed in the workbook. To explore a different value, add your own filter on the same field, or change the dashboard's control and reopen the chart.
 - **Clear filter** on the chip drops it for the rest of the session, and the report re-runs without it. Reopening the chart from the dashboard brings the current values back.
+
+To change what a viewer of the dashboard can filter by, edit the [filter control][ref-controls] there — not the report.
 
 When the report already filters the same field, both filters apply — exactly as they do on the dashboard, so the numbers match the chart you came from. A carried filter that says precisely what the report already says is left out rather than shown twice.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -25,12 +25,17 @@ Charts on a published dashboard reflect the most recent published version of the
 
 ### Filters carried into the workbook
 
-The dashboard's [filters][ref-controls] come along, so the report opens showing the same slice of data the chart was showing rather than re-running over everything. They appear above the report's own filters, marked **From dashboard**, and behave differently from filters you add in the workbook:
+The dashboard's [filters][ref-controls] come along, so the report opens showing the same slice of data the chart was showing rather than re-running over everything.
 
-- they apply to the results on screen, and are **not** saved to the report — publishing the workbook again will not pin them onto the chart for everyone;
-- they are read-only. Remove one with its **×** to see the report without it for the rest of the session; reopening the chart from the dashboard brings the current values back.
+They sit in the report's filter bar next to its own filters, in violet, and read the same way — member, operator, value. What is different is that they are not the report's:
 
-To change what a viewer can filter by, edit the [filter control][ref-controls] on the dashboard, not the report.
+- they apply to the results on screen, and are **not** saved to the report. Publishing the workbook again will not pin them onto the chart for everyone;
+- they cannot be edited here. To change what a viewer can filter by, edit the [filter control][ref-controls] on the dashboard;
+- **Clear filter** on the chip drops it for the rest of the session, and the report re-runs without it. Reopening the chart from the dashboard brings the current values back.
+
+When the report already filters the same field, both filters apply — exactly as they do on the dashboard, so the numbers match the chart you came from. A carried filter that says precisely what the report already says is left out rather than shown twice.
+
+Only filters are carried. A [time granularity switcher or field switcher][ref-controls] on the dashboard does not follow into the workbook, so a report opened this way shows its own granularity and its own fields.
 
 ## Title
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -21,6 +21,17 @@ If some controls are incompatible with a chart's query, the chart skips them and
 
 Charts on a published dashboard reflect the most recent published version of the workbook. To change the query, switch the chart type, or restyle the visualization, edit the underlying report in the workbook and publish a new version of the dashboard.
 
+**Edit in Workbook** in the chart's settings menu opens that report directly, on its own workbook tab.
+
+### Filters carried into the workbook
+
+The dashboard's [filters][ref-controls] come along, so the report opens showing the same slice of data the chart was showing rather than re-running over everything. They appear above the report's own filters, marked **From dashboard**, and behave differently from filters you add in the workbook:
+
+- they apply to the results on screen, and are **not** saved to the report — publishing the workbook again will not pin them onto the chart for everyone;
+- they are read-only. Remove one with its **×** to see the report without it for the rest of the session; reopening the chart from the dashboard brings the current values back.
+
+To change what a viewer can filter by, edit the [filter control][ref-controls] on the dashboard, not the report.
+
 ## Title
 
 Each chart shows the name of the underlying workbook tab as its title. To rename it, open the tab in the workbook, rename the tab, and republish the dashboard — the new name flows through to every chart backed by that tab.


### PR DESCRIPTION
Documents the behaviour shipped in cubedevinc/cubejs-enterprise#14628 (CUB-4102).

"Edit in Workbook" now carries the dashboard's filters into the report session: the report opens on the same slice the chart was showing instead of re-running unfiltered, and the carried filters are shown as a read-only **From dashboard** row that is never saved into the report.

The docs had no entry for "Edit in Workbook" at all, so this adds it under **Updating charts** — the action, and then what happens to the filters, including the two things a reader can get wrong: that these are not report filters (publishing will not pin them onto the chart) and that changing what viewers can filter by means editing the control, not the report.