### PR TITLE
feat(query-orchestrator): honour refreshKeyRenewalThreshold on locally evaluated refresh keys

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1468,7 +1468,8 @@ database, since their values depend on your data and not just on the time.
 
 [`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options] is still
 honoured: an `every`-based key computed locally advances at most once per threshold window,
-the same bound that caching the query result used to provide.
+and no less often than the cached query result used to be re-read. Each key's window is offset
+by the key's own identity, so pre-aggregation rebuilds do not all land at the same instant.
 
 <Warning>
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1464,10 +1464,11 @@ tenant, and timezone in the deployment.
 
 Refresh keys written with `sql` or marked
 [`incremental`](/reference/data-modeling/pre-aggregations#incremental) keep querying the
-database, since their values depend on your data and not just on the time. So do all
-refresh keys if you have set
-[`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options], which
-works by caching the query result.
+database, since their values depend on your data and not just on the time.
+
+[`queryCacheOptions.refreshKeyRenewalThreshold`][ref-config-query-cache-options] is still
+honoured: an `every`-based key computed locally advances at most once per threshold window,
+the same bound that caching the query result used to provide.
 
 <Warning>
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -30,6 +30,7 @@ import {
   getCacheHash,
   evaluateLocalRefreshKey,
   isValidLocalRefreshKey,
+  snapToRenewalThreshold,
 } from './utils';
 import { CacheAndQueryDriverType, MetadataOperationType } from './QueryOrchestrator';
 
@@ -238,25 +239,21 @@ export class QueryCache {
    * run as queries and cached.
    */
   public isLocalRefreshKeyActive(): boolean {
-    return this.localRefreshKeyEnabled && !this.options.refreshKeyRenewalThreshold;
+    return this.localRefreshKeyEnabled;
   }
 
   public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: string }] | null {
-    if (!this.localRefreshKeyEnabled || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
+    if (!this.isLocalRefreshKeyActive() || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
       return null;
     }
 
-    // `refreshKeyRenewalThreshold` throttles how often the SQL result is re-read, and that is
-    // also what bounds how often the key advances: a value cached for a day advances daily,
-    // whatever `every` says. A locally evaluated key has no cache entry to age out, so the only
-    // way to keep honouring the override is to leave these keys on the SQL path.
-    // TODO: support the two together by snapping the local value to the threshold instead of
-    // falling back to a query.
-    if (!this.isLocalRefreshKeyActive()) {
-      return null;
-    }
-
-    return evaluateLocalRefreshKey(<LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey);
+    // The per-key `queryOptions.renewalThreshold` is deliberately not snapped to: it is a fraction
+    // of the interval (`BaseQuery.refreshKeyRenewalThresholdForInterval`), so the SQL path re-reads
+    // faster than the key can move and snapping would only delay the boundary.
+    return evaluateLocalRefreshKey(
+      <LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey,
+      snapToRenewalThreshold(Date.now(), this.options.refreshKeyRenewalThreshold),
+    );
   }
 
   public getCacheDriver(): CacheDriverInterface {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -30,6 +30,7 @@ import {
   getCacheHash,
   evaluateLocalRefreshKey,
   isValidLocalRefreshKey,
+  refreshKeyPhaseSeed,
   snapToRenewalThreshold,
 } from './utils';
 import { CacheAndQueryDriverType, MetadataOperationType } from './QueryOrchestrator';
@@ -242,7 +243,15 @@ export class QueryCache {
     return this.localRefreshKeyEnabled;
   }
 
-  public localRefreshKeyResult(queryOptions?: QueryOptions): [{ refresh_key: string }] | null {
+  /**
+   * `bound` is the cache entry the SQL path would have written for this key. Its TTL caps the
+   * snap window (the entry was re-read once it expired, whatever the threshold said) and its
+   * identity phases the window so keys do not all advance together.
+   */
+  public localRefreshKeyResult(
+    queryOptions?: QueryOptions,
+    bound?: { expiration: number; cacheKey: CacheKey },
+  ): [{ refresh_key: string }] | null {
     if (!this.isLocalRefreshKeyActive() || !isValidLocalRefreshKey(queryOptions?.localRefreshKey)) {
       return null;
     }
@@ -250,9 +259,12 @@ export class QueryCache {
     // The per-key `queryOptions.renewalThreshold` is deliberately not snapped to: it is a fraction
     // of the interval (`BaseQuery.refreshKeyRenewalThresholdForInterval`), so the SQL path re-reads
     // faster than the key can move and snapping would only delay the boundary.
+    const threshold = this.options.refreshKeyRenewalThreshold;
+    const window = threshold ? Math.min(threshold, bound?.expiration ?? threshold) : undefined;
+
     return evaluateLocalRefreshKey(
       <LocalRefreshKeyDescriptor>queryOptions?.localRefreshKey,
-      snapToRenewalThreshold(Date.now(), this.options.refreshKeyRenewalThreshold),
+      snapToRenewalThreshold(Date.now(), window, bound ? refreshKeyPhaseSeed(bound.cacheKey) : 0),
     );
   }
 
@@ -513,13 +525,12 @@ export class QueryCache {
     options: RefreshKeyCacheOptions,
   ) {
     const [query, values, queryOptions] = sqlQuery;
+    const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery, options.dataSource);
 
-    const local = this.localRefreshKeyResult(queryOptions);
+    const local = this.localRefreshKeyResult(queryOptions, { expiration, cacheKey });
     if (local) {
       return local;
     }
-
-    const cacheKey = QueryCache.refreshKeyIdentity(sqlQuery, options.dataSource);
 
     return this.cacheQueryResult(query, values, cacheKey, expiration, {
       ...options,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -52,6 +52,23 @@ export function evaluateLocalRefreshKey(
   return [{ refresh_key: String(Math.floor((utcOffset + nowMs / 1000 - dayOffset) / interval)) }];
 }
 
+/**
+ * `refreshKeyRenewalThreshold` caches the refresh key query result, and that cache is also what
+ * bounds how often the key can advance: a value re-read once a day advances once a day, whatever
+ * `every` says. Sampling the clock at the same granularity reproduces that bound without a query,
+ * and reproduces it identically on every instance, where the SQL path's phase depended on when
+ * each cache entry happened to be written.
+ */
+export function snapToRenewalThreshold(nowMs: number, thresholdSeconds?: number): number {
+  if (!Number.isFinite(thresholdSeconds) || <number>thresholdSeconds <= 0) {
+    return nowMs;
+  }
+
+  const thresholdMs = <number>thresholdSeconds * 1000;
+
+  return Math.floor(nowMs / thresholdMs) * thresholdMs;
+}
+
 export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): boolean {
   return !!descriptor &&
     Number.isFinite(descriptor.interval) && descriptor.interval > 0 &&

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -53,20 +53,25 @@ export function evaluateLocalRefreshKey(
 }
 
 /**
- * `refreshKeyRenewalThreshold` caches the refresh key query result, and that cache is also what
- * bounds how often the key can advance: a value re-read once a day advances once a day, whatever
- * `every` says. Sampling the clock at the same granularity reproduces that bound without a query,
- * and reproduces it identically on every instance, where the SQL path's phase depended on when
- * each cache entry happened to be written.
+ * The threshold bounds how often a key may advance, so the clock is floored to it. `phaseSeed`
+ * shifts each key's window so they do not all flip at the same instant.
  */
-export function snapToRenewalThreshold(nowMs: number, thresholdSeconds?: number): number {
+export function snapToRenewalThreshold(nowMs: number, thresholdSeconds?: number, phaseSeed = 0): number {
   if (!Number.isFinite(thresholdSeconds) || <number>thresholdSeconds <= 0) {
     return nowMs;
   }
 
   const thresholdMs = <number>thresholdSeconds * 1000;
+  const offset = Number.isFinite(phaseSeed) ? phaseSeed % thresholdMs : 0;
 
-  return Math.floor(nowMs / thresholdMs) * thresholdMs;
+  return Math.floor((nowMs - offset) / thresholdMs) * thresholdMs + offset;
+}
+
+/**
+ * md5 of the refresh key identity, so every instance derives the same phase for the same key.
+ */
+export function refreshKeyPhaseSeed(cacheKey: CacheKey): number {
+  return parseInt(getCacheHash(cacheKey).slice(0, 8), 16);
 }
 
 export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): boolean {

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@cubejs-backend/shared';
 import crypto from 'crypto';
 
-import { PreAggregationLoadCache, PreAggregationLoader, PreAggregationPartitionRangeLoader, PreAggregations, QueryCache, LocalCacheDriver, version } from '../../src';
+import { PreAggregationLoadCache, PreAggregationLoader, PreAggregationPartitionRangeLoader, PreAggregations, QueryCache, QueryCacheOptions, LocalCacheDriver, version } from '../../src';
 
 class MockDriver {
   public tables: string[] = [];
@@ -471,20 +471,20 @@ describe('PreAggregations', () => {
     const REFRESH_KEY_SQL = 'SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key';
     const descriptor = { interval: 600, utcOffset: 0, dayOffset: 0, cron: false };
 
-    const newQueryCache = (localRefreshKey?: boolean) => new QueryCache(
+    const newQueryCache = (additional: Partial<QueryCacheOptions> = {}) => new QueryCache(
       'TEST',
       mockDriverFactory as any,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       () => {},
       {
         cacheAndQueueDriver: 'memory',
-        localRefreshKey,
         queueOptions: async () => ({ executionTimeout: 1, concurrency: 2 }),
+        ...additional,
       },
     );
 
-    const newLoadCache = (localRefreshKey?: boolean) => {
-      const cache = newQueryCache(localRefreshKey);
+    const newLoadCache = (additional: Partial<QueryCacheOptions> = {}) => {
+      const cache = newQueryCache(additional);
       (cache.getCacheDriver() as LocalCacheDriver).reset();
 
       const preAggregations = new PreAggregations(
@@ -505,7 +505,7 @@ describe('PreAggregations', () => {
     };
 
     test('keyQueryResult evaluates locally without querying the datasource', async () => {
-      const loadCache = newLoadCache(true);
+      const loadCache = newLoadCache({ localRefreshKey: true });
 
       const result = await loadCache.keyQueryResult(
         [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }],
@@ -517,8 +517,27 @@ describe('PreAggregations', () => {
       expect(mockDriver!.executedQueries).toEqual([]);
     });
 
+    test('keyQueryResult evaluates locally under a refreshKeyRenewalThreshold', async () => {
+      const day = 24 * 60 * 60;
+      const loadCache = newLoadCache({ localRefreshKey: true, refreshKeyRenewalThreshold: day });
+
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(86_400_000 + 600_000);
+      try {
+        const result = await loadCache.keyQueryResult(
+          [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }],
+          false,
+          10,
+        );
+
+        expect(result).toEqual([{ refresh_key: '144' }]);
+        expect(mockDriver!.executedQueries).toEqual([]);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
     test('keyQueryResult still queries when the flag is off', async () => {
-      const loadCache = newLoadCache(false);
+      const loadCache = newLoadCache({ localRefreshKey: false });
 
       await loadCache.keyQueryResult(
         [REFRESH_KEY_SQL, [], { external: false, renewalThreshold: 60, localRefreshKey: descriptor }],
@@ -530,7 +549,7 @@ describe('PreAggregations', () => {
     });
 
     test('keyQueryResult still queries an incremental key that carries no descriptor', async () => {
-      const loadCache = newLoadCache(true);
+      const loadCache = newLoadCache({ localRefreshKey: true });
       const incrementalSql = 'SELECT CASE WHEN NOW() < $1 THEN FLOOR((UNIX_TIMESTAMP()) / 3600) END as refresh_key';
 
       await loadCache.keyQueryResult(
@@ -552,7 +571,7 @@ describe('PreAggregations', () => {
     // interval boundary would look a table up under one content version and enqueue it under
     // another.
     test('keyQueryResult is stable across an interval boundary within one load cache', async () => {
-      const loadCache = newLoadCache(true);
+      const loadCache = newLoadCache({ localRefreshKey: true });
       const key: [string, any[], Record<string, any>] =
         [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }];
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -8,6 +8,7 @@ import {
 import crypto from 'crypto';
 
 import { PreAggregationLoadCache, PreAggregationLoader, PreAggregationPartitionRangeLoader, PreAggregations, QueryCache, QueryCacheOptions, LocalCacheDriver, version } from '../../src';
+import { evaluateLocalRefreshKey, refreshKeyPhaseSeed, snapToRenewalThreshold } from '../../src/orchestrator/utils';
 
 class MockDriver {
   public tables: string[] = [];
@@ -517,11 +518,15 @@ describe('PreAggregations', () => {
       expect(mockDriver!.executedQueries).toEqual([]);
     });
 
+    // `keyQueryResult` caches refresh keys for an hour, so that is the window a daily threshold
+    // is capped to, phased by the key identity.
     test('keyQueryResult evaluates locally under a refreshKeyRenewalThreshold', async () => {
       const day = 24 * 60 * 60;
       const loadCache = newLoadCache({ localRefreshKey: true, refreshKeyRenewalThreshold: day });
+      const now = 86_400_000 + 600_000;
+      const phase = refreshKeyPhaseSeed([REFRESH_KEY_SQL, [], true, 'default']);
 
-      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(86_400_000 + 600_000);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
       try {
         const result = await loadCache.keyQueryResult(
           [REFRESH_KEY_SQL, [], { external: true, renewalThreshold: 60, localRefreshKey: descriptor }],
@@ -529,7 +534,7 @@ describe('PreAggregations', () => {
           10,
         );
 
-        expect(result).toEqual([{ refresh_key: '144' }]);
+        expect(result).toEqual(evaluateLocalRefreshKey(descriptor, snapToRenewalThreshold(now, 60 * 60, phase)));
         expect(mockDriver!.executedQueries).toEqual([]);
       } finally {
         nowSpy.mockRestore();

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -632,16 +632,17 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(executed).toBe(1);
       });
 
-      // Local evaluation would advance the key on every interval boundary, ignoring the
-      // throttle a deployment asked for and multiplying pre-aggregation rebuilds.
-      it('runs the query when refreshKeyRenewalThreshold is configured', async () => {
+      it('evaluates locally under a refreshKeyRenewalThreshold, snapped to it', async () => {
+        const day = 24 * 60 * 60;
         const { result, executed } = await loadRefreshKey(
           { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
-          { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          { localRefreshKey: true, refreshKeyRenewalThreshold: day },
         );
 
-        expect(executed).toBe(1);
-        expect(result).toEqual([{ refresh_key: 12345 }]);
+        expect(executed).toBe(0);
+        expect(result).toEqual([{
+          refresh_key: String(Math.floor(Math.floor(Date.now() / 1000 / day) * day / descriptor.interval)),
+        }]);
       });
 
       // The refresh scheduler reads this to decide whether warming a refresh key is pointless,
@@ -654,7 +655,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         try {
           expect(enabled.isLocalRefreshKeyActive()).toBe(true);
           expect(disabled.isLocalRefreshKeyActive()).toBe(false);
-          expect(throttled.isLocalRefreshKeyActive()).toBe(false);
+          expect(throttled.isLocalRefreshKeyActive()).toBe(true);
         } finally {
           await Promise.all([enabled.cleanup(), disabled.cleanup(), throttled.cleanup()]);
         }
@@ -676,10 +677,6 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       it.each([
         { name: 'the flag is off', additionalOptions: { localRefreshKey: false } },
         { name: 'the flag is unset', additionalOptions: {} },
-        {
-          name: 'refreshKeyRenewalThreshold is configured',
-          additionalOptions: { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
-        },
       ])('does not report the declined local evaluation when $name', async ({ additionalOptions }) => {
         const { logged } = await loadRefreshKey(
           { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
@@ -735,10 +732,28 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
           )).toBeNull();
         }));
 
-        it('declines when refreshKeyRenewalThreshold is configured', () => withCache(
+        // `144` is the value a 10 minute key really has at the start of day two: the throttled key
+        // stays in the un-throttled series instead of being renumbered.
+        it('snaps the value to refreshKeyRenewalThreshold', () => withCache(
           { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
           localCache => {
-            expect(localCache.localRefreshKeyResult(queryOptions(descriptor))).toBeNull();
+            const nowSpy = jest.spyOn(Date, 'now');
+
+            try {
+              nowSpy.mockReturnValue(86_400_000 + 600_000);
+              expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
+                .toEqual([{ refresh_key: '144' }]);
+
+              nowSpy.mockReturnValue(2 * 86_400_000 - 1);
+              expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
+                .toEqual([{ refresh_key: '144' }]);
+
+              nowSpy.mockReturnValue(2 * 86_400_000);
+              expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
+                .toEqual([{ refresh_key: '288' }]);
+            } finally {
+              nowSpy.mockRestore();
+            }
           },
         ));
       });

--- a/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryCache.abstract.ts
@@ -3,6 +3,7 @@ import { CacheMode, createCancelablePromise, pausePromise } from '@cubejs-backen
 import { QueuePriority } from '@cubejs-backend/base-driver';
 
 import { CacheKey, CacheKeyItem, ContinueWaitError, QueryCache, QueryCacheOptions } from '../../src';
+import { evaluateLocalRefreshKey, refreshKeyPhaseSeed, snapToRenewalThreshold } from '../../src/orchestrator/utils';
 
 export type QueryCacheTestOptions = QueryCacheOptions & {
   beforeAll?: () => Promise<void>,
@@ -573,6 +574,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
       const loadRefreshKey = async (
         queryOptions: any,
         additionalOptions: Partial<QueryCacheOptions> = {},
+        expireSecs = 60,
       ) => {
         const localCache = newCache(additionalOptions);
         const spy = jest.spyOn(localCache, 'queryWithRetryAndRelease')
@@ -582,7 +584,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
           const [result] = await Promise.all(
             localCache.loadRefreshKeys(
               [[REFRESH_KEY_SQL, [], queryOptions]],
-              60,
+              expireSecs,
               { dataSource: 'default' },
             )
           );
@@ -632,17 +634,30 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
         expect(executed).toBe(1);
       });
 
-      it('evaluates locally under a refreshKeyRenewalThreshold, snapped to it', async () => {
+      // The window is the cache entry TTL, not the day: the SQL path re-read the key once its
+      // entry expired, whatever the threshold said.
+      it('evaluates locally under a refreshKeyRenewalThreshold, snapped to the entry TTL', async () => {
         const day = 24 * 60 * 60;
-        const { result, executed } = await loadRefreshKey(
-          { external: true, renewalThreshold: 60, localRefreshKey: descriptor },
-          { localRefreshKey: true, refreshKeyRenewalThreshold: day },
-        );
+        const hour = 60 * 60;
+        const queryOptions = { external: true, renewalThreshold: 60, localRefreshKey: descriptor };
+        const phase = refreshKeyPhaseSeed(QueryCache.refreshKeyIdentity([REFRESH_KEY_SQL, [], queryOptions], 'default'));
+        const expectedAt = (now: number) => evaluateLocalRefreshKey(descriptor, snapToRenewalThreshold(now, hour, phase));
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(86_400_000 + 600_000);
 
-        expect(executed).toBe(0);
-        expect(result).toEqual([{
-          refresh_key: String(Math.floor(Math.floor(Date.now() / 1000 / day) * day / descriptor.interval)),
-        }]);
+        try {
+          const first = await loadRefreshKey(queryOptions, { localRefreshKey: true, refreshKeyRenewalThreshold: day }, hour);
+
+          expect(first.executed).toBe(0);
+          expect(first.result).toEqual(expectedAt(86_400_000 + 600_000));
+
+          nowSpy.mockReturnValue(86_400_000 + 600_000 + 3_600_000);
+          const second = await loadRefreshKey(queryOptions, { localRefreshKey: true, refreshKeyRenewalThreshold: day }, hour);
+
+          expect(second.result).toEqual(expectedAt(86_400_000 + 600_000 + 3_600_000));
+          expect(second.result).not.toEqual(first.result);
+        } finally {
+          nowSpy.mockRestore();
+        }
       });
 
       // The refresh scheduler reads this to decide whether warming a refresh key is pointless,
@@ -734,7 +749,7 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
 
         // `144` is the value a 10 minute key really has at the start of day two: the throttled key
         // stays in the un-throttled series instead of being renumbered.
-        it('snaps the value to refreshKeyRenewalThreshold', () => withCache(
+        it('snaps the value to refreshKeyRenewalThreshold without a bound', () => withCache(
           { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
           localCache => {
             const nowSpy = jest.spyOn(Date, 'now');
@@ -751,6 +766,32 @@ export const QueryCacheTest = (name: string, options: QueryCacheTestOptions) => 
               nowSpy.mockReturnValue(2 * 86_400_000);
               expect(localCache.localRefreshKeyResult(queryOptions(descriptor)))
                 .toEqual([{ refresh_key: '288' }]);
+            } finally {
+              nowSpy.mockRestore();
+            }
+          },
+        ));
+
+        it('caps the window at the bound TTL and phases it by the bound identity', () => withCache(
+          { localRefreshKey: true, refreshKeyRenewalThreshold: 24 * 60 * 60 },
+          localCache => {
+            const hourMs = 3_600_000;
+            const cacheKey: CacheKey = [REFRESH_KEY_SQL, [], true, 'default'];
+            const bound = { expiration: 3600, cacheKey };
+            const phase = refreshKeyPhaseSeed(cacheKey) % hourMs;
+            const windowStart = 86_400_000 + phase;
+            const nowSpy = jest.spyOn(Date, 'now');
+
+            try {
+              const at = (now: number) => {
+                nowSpy.mockReturnValue(now);
+                return localCache.localRefreshKeyResult(queryOptions(descriptor), bound);
+              };
+
+              expect(at(windowStart)).toEqual(evaluateLocalRefreshKey(descriptor, windowStart));
+              expect(at(windowStart + hourMs - 1)).toEqual(evaluateLocalRefreshKey(descriptor, windowStart));
+              expect(at(windowStart + hourMs)).toEqual(evaluateLocalRefreshKey(descriptor, windowStart + hourMs));
+              expect(at(windowStart - 1)).toEqual(evaluateLocalRefreshKey(descriptor, windowStart - hourMs));
             } finally {
               nowSpy.mockRestore();
             }

--- a/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { evaluateLocalRefreshKey, isValidLocalRefreshKey } from '../../src/orchestrator/utils';
+import { evaluateLocalRefreshKey, isValidLocalRefreshKey, snapToRenewalThreshold } from '../../src/orchestrator/utils';
 
 describe('evaluateLocalRefreshKey', () => {
   const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
@@ -64,5 +64,64 @@ describe('isValidLocalRefreshKey', () => {
     expect(isValidLocalRefreshKey({ interval: Infinity, utcOffset: 0, dayOffset: 0 })).toBe(false);
     expect(isValidLocalRefreshKey({ interval: 600, utcOffset: NaN, dayOffset: 0 })).toBe(false);
     expect(isValidLocalRefreshKey({ interval: 600, utcOffset: 0, dayOffset: NaN })).toBe(false);
+  });
+});
+
+describe('snapToRenewalThreshold', () => {
+  const day = 24 * 60 * 60;
+
+  test('leaves the clock alone when no threshold is configured', () => {
+    for (const threshold of [undefined, 0, -60, NaN, Infinity]) {
+      expect(snapToRenewalThreshold(1_234_567, threshold)).toBe(1_234_567);
+    }
+  });
+
+  test('floors to the threshold boundary', () => {
+    expect(snapToRenewalThreshold(0, 120)).toBe(0);
+    expect(snapToRenewalThreshold(119_999, 120)).toBe(0);
+    expect(snapToRenewalThreshold(120_000, 120)).toBe(120_000);
+    expect(snapToRenewalThreshold(239_999, 120)).toBe(120_000);
+  });
+
+  test('never goes backwards', () => {
+    let previous = -1;
+
+    for (let ms = 0; ms < 600_000; ms += 17_000) {
+      const snapped = snapToRenewalThreshold(ms, 120);
+
+      expect(snapped).toBeGreaterThanOrEqual(previous);
+      expect(snapped).toBeLessThanOrEqual(ms);
+      previous = snapped;
+    }
+  });
+
+  test('advances a 10 minute key once per daily threshold, staying in its own series', () => {
+    const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
+    const at = (ms: number) => evaluateLocalRefreshKey(tenMinutes, snapToRenewalThreshold(ms, day))[0].refresh_key;
+
+    expect(at(0)).toBe('0');
+    expect(at(600_000)).toBe('0');
+    expect(at(86_399_000)).toBe('0');
+    expect(at(86_400_000)).toBe('144');
+    expect(at(86_400_000 + 600_000)).toBe('144');
+    expect(at(2 * 86_400_000)).toBe('288');
+
+    for (const ms of [0, 86_400_000, 2 * 86_400_000]) {
+      expect(at(ms)).toBe(evaluateLocalRefreshKey(tenMinutes, ms)[0].refresh_key);
+    }
+  });
+
+  test('keeps the numbering of a cron key', () => {
+    // every '0 10 * * *' => interval 1 day, dayOffset 10 hours
+    const daily = { interval: day, utcOffset: 0, dayOffset: 36_000 };
+    const threshold = 4 * 60 * 60;
+    const at = (ms: number) => evaluateLocalRefreshKey(daily, snapToRenewalThreshold(ms, threshold))[0].refresh_key;
+
+    expect(at(36_000_000 - 1)).toBe('-1');
+    // The fire at 10:00 is observed at the 12:00 sample, exactly as a 4 hour cache would have
+    expect(at(36_000_000)).toBe('-1');
+    expect(at(43_200_000)).toBe('0');
+    expect(at(36_000_000 + 86_400_000)).toBe('0');
+    expect(at(43_200_000 + 86_400_000)).toBe('1');
   });
 });

--- a/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { evaluateLocalRefreshKey, isValidLocalRefreshKey, snapToRenewalThreshold } from '../../src/orchestrator/utils';
+import { evaluateLocalRefreshKey, isValidLocalRefreshKey, refreshKeyPhaseSeed, snapToRenewalThreshold } from '../../src/orchestrator/utils';
 
 describe('evaluateLocalRefreshKey', () => {
   const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
@@ -83,16 +83,40 @@ describe('snapToRenewalThreshold', () => {
     expect(snapToRenewalThreshold(239_999, 120)).toBe(120_000);
   });
 
-  test('never goes backwards', () => {
-    let previous = -1;
+  test.each([0, 45_000, 119_999])('never goes backwards with phase %i', (phase) => {
+    let previous = -Infinity;
 
     for (let ms = 0; ms < 600_000; ms += 17_000) {
-      const snapped = snapToRenewalThreshold(ms, 120);
+      const snapped = snapToRenewalThreshold(ms, 120, phase);
 
       expect(snapped).toBeGreaterThanOrEqual(previous);
       expect(snapped).toBeLessThanOrEqual(ms);
       previous = snapped;
     }
+  });
+
+  test('offsets the boundary by the phase', () => {
+    expect(snapToRenewalThreshold(44_999, 120, 45_000)).toBe(45_000 - 120_000);
+    expect(snapToRenewalThreshold(45_000, 120, 45_000)).toBe(45_000);
+    expect(snapToRenewalThreshold(164_999, 120, 45_000)).toBe(45_000);
+    expect(snapToRenewalThreshold(165_000, 120, 45_000)).toBe(165_000);
+  });
+
+  test('wraps a phase seed larger than the window and ignores a non-finite one', () => {
+    expect(snapToRenewalThreshold(165_000, 120, 45_000 + 7 * 120_000)).toBe(165_000);
+    expect(snapToRenewalThreshold(165_000, 120, NaN)).toBe(120_000);
+  });
+
+  test('a phased 10 minute key is constant inside its window and stays in its own series', () => {
+    const tenMinutes = { interval: 600, utcOffset: 0, dayOffset: 0 };
+    const phase = 5 * 3_600_000;
+    const at = (ms: number) => evaluateLocalRefreshKey(tenMinutes, snapToRenewalThreshold(ms, day, phase))[0].refresh_key;
+
+    // The window opens at 05:00 on day one, where a 10 minute key really is 144 + 30
+    expect(at(86_400_000 + phase)).toBe('174');
+    expect(at(2 * 86_400_000 + phase - 1)).toBe('174');
+    expect(at(2 * 86_400_000 + phase)).toBe('318');
+    expect(at(86_400_000 + phase)).toBe(evaluateLocalRefreshKey(tenMinutes, 86_400_000 + phase)[0].refresh_key);
   });
 
   test('advances a 10 minute key once per daily threshold, staying in its own series', () => {
@@ -123,5 +147,23 @@ describe('snapToRenewalThreshold', () => {
     expect(at(43_200_000)).toBe('0');
     expect(at(36_000_000 + 86_400_000)).toBe('0');
     expect(at(43_200_000 + 86_400_000)).toBe('1');
+  });
+});
+
+describe('refreshKeyPhaseSeed', () => {
+  const identity = (sql: string): [string, string[], boolean, string] => [sql, [], true, 'default'];
+
+  test('is the same for the same identity and below 2^32', () => {
+    const seed = refreshKeyPhaseSeed(identity('SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key'));
+
+    expect(seed).toBe(refreshKeyPhaseSeed(identity('SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key')));
+    expect(Number.isInteger(seed)).toBe(true);
+    expect(seed).toBeGreaterThanOrEqual(0);
+    expect(seed).toBeLessThan(2 ** 32);
+  });
+
+  test('differs between refresh keys', () => {
+    expect(refreshKeyPhaseSeed(identity('SELECT FLOOR((UNIX_TIMESTAMP()) / 600) as refresh_key')))
+      .not.toBe(refreshKeyPhaseSeed(identity('SELECT FLOOR((UNIX_TIMESTAMP()) / 3600) as refresh_key')));
   });
 });

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -359,8 +359,7 @@ export class RefreshScheduler {
 
       // This method exists only to warm the shared refresh key cache, and a locally evaluated
       // key has no cache entry to warm — the getSql plus executeQuery per timezone below would
-      // be spent on a result that is thrown away. A `sql` key still hits the data source, and
-      // so do interval keys whenever the cache declines to evaluate them locally.
+      // be spent on a result that is thrown away. A `sql` key still hits the data source.
       const sqlRefreshKey = !!cubeFromPath.refreshKey && 'sql' in cubeFromPath.refreshKey;
       if (localRefreshKey && !sqlRefreshKey) {
         return;

--- a/packages/cubejs-server-core/test/unit/RefreshScheduler.test.ts
+++ b/packages/cubejs-server-core/test/unit/RefreshScheduler.test.ts
@@ -1319,12 +1319,14 @@ describe('Refresh Scheduler', () => {
       expect(sqlKeyQueries.length).toBeGreaterThan(0);
     });
 
-    test('keeps warming interval keys when refreshKeyRenewalThreshold vetoes local evaluation', async () => {
+    // The threshold is applied by snapping the locally computed value, so there is still no
+    // refresh key cache entry to warm.
+    test('skips interval keys when refreshKeyRenewalThreshold is set', async () => {
       process.env.CUBEJS_REFRESH_KEY_LOCAL_TIME = 'true';
 
       const { intervalKeyQueries, sqlKeyQueries } = await runRefresh(120);
 
-      expect(intervalKeyQueries.length).toBeGreaterThan(0);
+      expect(intervalKeyQueries).toEqual([]);
       expect(sqlKeyQueries.length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`CUBEJS_REFRESH_KEY_LOCAL_TIME` used to disable itself whenever `queryCacheOptions.refreshKeyRenewalThreshold` was set, since the threshold caches the refresh key query result and that cache is also what bounds how often an `every`-based key can advance — a locally computed key has no cache entry to age out, so it would have advanced on every interval boundary and multiplied pre-aggregation rebuilds. This reproduces the bound with arithmetic instead: the new `snapToRenewalThreshold` samples the clock at the threshold granularity and the key is evaluated at that instant, so the two options compose and a deployment with a threshold keeps local evaluation (advancing at most once per window, with no query). Snapping keeps the value inside the key's own series — the snapped instant is a real past moment, so a 10 minute key still takes a value it genuinely had.

Two details reproduce the SQL path faithfully rather than idealising it. The refresh key cache entry expired at the caller's TTL (an hour for pre-aggregation keys, `expireSecs` for query keys) and was re-read then, whatever the threshold said, so the snap window is capped at `min(threshold, TTL)`: `cacheRefreshKeyResult` passes the entry TTL and identity into `localRefreshKeyResult`. And where the SQL path phased each key by whenever its entry happened to be written, the window is now phased by the key identity hash — deterministic on every instance, but different keys still do not all flip at 00:00 UTC together. `RefreshScheduler` consequently stops warming interval keys under a threshold, since there is no longer a cache entry worth warming. Unit tests cover the snapping helper (including phase), both `QueryCache` paths, the TTL cap, and the scheduler; the env var reference is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)