### PR TITLE
fix(cubesql): Coerce `CASE` branch types to a common type

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2ba1ea01df982a7d5334e146d70c6a39bb657f5e#2ba1ea01df982a7d5334e146d70c6a39bb657f5e"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "ee20ad38796f4a9966ff58b9ace425c7488459e9", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "2ba1ea01df982a7d5334e146d70c6a39bb657f5e", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/engine/df/columar.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/columar.rs
@@ -10,26 +10,38 @@ use std::sync::Arc;
 macro_rules! if_then_else {
     ($BUILDER_TYPE:ty, $ARRAY_TYPE:ty, $BOOLS:expr, $TRUE:expr, $FALSE:expr) => {{
         let true_values = if $TRUE.data_type() == &DataType::Null {
-            Arc::new(<$ARRAY_TYPE>::from(vec![None; $TRUE.len()]))
+            Arc::new(<$ARRAY_TYPE>::from(vec![None; $TRUE.len()])) as ArrayRef
         } else {
             $TRUE
         };
-        let true_values = true_values
-            .as_ref()
+        let true_values_ref = true_values.as_ref();
+        let true_values = true_values_ref
             .as_any()
             .downcast_ref::<$ARRAY_TYPE>()
-            .expect("true_values downcast failed");
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "true values of type {:?} can not be read as {}",
+                    true_values_ref.data_type(),
+                    stringify!($ARRAY_TYPE)
+                ))
+            })?;
 
         let false_values = if $FALSE.data_type() == &DataType::Null {
-            Arc::new(<$ARRAY_TYPE>::from(vec![None; $FALSE.len()]))
+            Arc::new(<$ARRAY_TYPE>::from(vec![None; $FALSE.len()])) as ArrayRef
         } else {
             $FALSE
         };
-        let false_values = false_values
-            .as_ref()
+        let false_values_ref = false_values.as_ref();
+        let false_values = false_values_ref
             .as_any()
             .downcast_ref::<$ARRAY_TYPE>()
-            .expect("false_values downcast failed");
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "false values of type {:?} can not be read as {}",
+                    false_values_ref.data_type(),
+                    stringify!($ARRAY_TYPE)
+                ))
+            })?;
 
         let mut builder = <$BUILDER_TYPE>::new($BOOLS.len());
         for i in 0..$BOOLS.len() {

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(r#\"\n                SELECT\n                    i,\n                    CASE WHEN i > 1 THEN 0 WHEN i > 0 THEN i END AS c\n                FROM (\n                    SELECT 0::int4 AS i\n                    UNION ALL\n                    SELECT 1::int4 AS i\n                    UNION ALL\n                    SELECT 2::int4 AS i\n                ) AS t\n                ORDER BY i\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL,).await.unwrap()"
+---
++---+------+
+| i | c    |
++---+------+
+| 0 | NULL |
+| 1 | 1    |
+| 2 | 0    |
++---+------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types_over_pg_catalog.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types_over_pg_catalog.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(r#\"\n                SELECT\n                    t.typname,\n                    CASE WHEN t.typtype = 'd' THEN 0\n                         WHEN t.typtype = 'b' THEN t.typbasetype\n                         ELSE 0 END AS base\n                FROM pg_catalog.pg_type t\n                WHERE t.typname IN ('int4', 'text')\n                ORDER BY t.typname\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL,).await.unwrap()"
+---
++---------+------+
+| typname | base |
++---------+------+
+| int4    | 0    |
+| text    | 0    |
++---------+------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types_widening.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_heterogeneous_then_types_widening.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(r#\"\n                SELECT\n                    i,\n                    CASE WHEN i > 1 THEN i WHEN i > 0 THEN 3000000000::int8 END AS c\n                FROM (\n                    SELECT 0::int4 AS i\n                    UNION ALL\n                    SELECT 1::int4 AS i\n                    UNION ALL\n                    SELECT 2::int4 AS i\n                ) AS t\n                ORDER BY i\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL,).await.unwrap()"
+---
++---+------------+
+| i | c          |
++---+------------+
+| 0 | NULL       |
+| 1 | 3000000000 |
+| 2 | 2          |
++---+------------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_null_then_before_typed_then.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_null_then_before_typed_then.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(r#\"\n                SELECT\n                    i,\n                    CASE WHEN i > 1 THEN NULL WHEN i > 0 THEN i END AS c\n                FROM (\n                    SELECT 0::int4 AS i\n                    UNION ALL\n                    SELECT 1::int4 AS i\n                    UNION ALL\n                    SELECT 2::int4 AS i\n                ) AS t\n                ORDER BY i\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL,).await.unwrap()"
+---
++---+------+
+| i | c    |
++---+------+
+| 0 | NULL |
+| 1 | 1    |
+| 2 | NULL |
++---+------+

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_uncoercible_then_types.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__case_with_uncoercible_then_types.snap
@@ -1,0 +1,5 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(r#\"\n                SELECT\n                    CASE WHEN i > 1 THEN true ELSE DATE '2022-01-01' END AS c\n                FROM (SELECT 1::int4 AS i) AS t\n                \"#.to_string(),\nDatabaseProtocol::PostgreSQL,).await.unwrap_err().to_string()"
+---
+Planning Error: Initial planning error: Error during planning: CASE branches have no common type to coerce the results to: [Boolean, Date32]

--- a/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
@@ -181,3 +181,127 @@ async fn test_numeric_math_scalar() {
             .unwrap()
     );
 }
+
+#[tokio::test]
+async fn test_case_with_heterogeneous_then_types() {
+    init_testing_logger();
+
+    insta::assert_snapshot!(execute_query(
+        // language=PostgreSQL
+        r#"
+                SELECT
+                    i,
+                    CASE WHEN i > 1 THEN 0 WHEN i > 0 THEN i END AS c
+                FROM (
+                    SELECT 0::int4 AS i
+                    UNION ALL
+                    SELECT 1::int4 AS i
+                    UNION ALL
+                    SELECT 2::int4 AS i
+                ) AS t
+                ORDER BY i
+                "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .unwrap());
+}
+
+/// The common type has to be picked across all branches, not from the first one: an int4
+/// THEN followed by an int8 THEN must widen to int8, or the int8 value gets truncated.
+#[tokio::test]
+async fn test_case_with_heterogeneous_then_types_widening() {
+    init_testing_logger();
+
+    insta::assert_snapshot!(execute_query(
+        // language=PostgreSQL
+        r#"
+                SELECT
+                    i,
+                    CASE WHEN i > 1 THEN i WHEN i > 0 THEN 3000000000::int8 END AS c
+                FROM (
+                    SELECT 0::int4 AS i
+                    UNION ALL
+                    SELECT 1::int4 AS i
+                    UNION ALL
+                    SELECT 2::int4 AS i
+                ) AS t
+                ORDER BY i
+                "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .unwrap());
+}
+
+#[tokio::test]
+async fn test_case_with_heterogeneous_then_types_over_pg_catalog() {
+    init_testing_logger();
+
+    insta::assert_snapshot!(execute_query(
+        // language=PostgreSQL
+        r#"
+                SELECT
+                    t.typname,
+                    CASE WHEN t.typtype = 'd' THEN 0
+                         WHEN t.typtype = 'b' THEN t.typbasetype
+                         ELSE 0 END AS base
+                FROM pg_catalog.pg_type t
+                WHERE t.typname IN ('int4', 'text')
+                ORDER BY t.typname
+                "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .unwrap());
+}
+
+#[tokio::test]
+async fn test_case_with_null_then_before_typed_then() {
+    init_testing_logger();
+
+    insta::assert_snapshot!(execute_query(
+        // language=PostgreSQL
+        r#"
+                SELECT
+                    i,
+                    CASE WHEN i > 1 THEN NULL WHEN i > 0 THEN i END AS c
+                FROM (
+                    SELECT 0::int4 AS i
+                    UNION ALL
+                    SELECT 1::int4 AS i
+                    UNION ALL
+                    SELECT 2::int4 AS i
+                ) AS t
+                ORDER BY i
+                "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .unwrap());
+}
+
+/// Branches that have no common type have to fail to plan, rather than reach execution
+/// and panic there.
+#[tokio::test]
+async fn test_case_with_uncoercible_then_types() {
+    init_testing_logger();
+
+    insta::assert_snapshot!(execute_query(
+        // language=PostgreSQL
+        r#"
+                SELECT
+                    CASE WHEN i > 1 THEN true ELSE DATE '2022-01-01' END AS c
+                FROM (SELECT 1::int4 AS i) AS t
+                "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await
+    .unwrap_err()
+    .to_string());
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@2ba1ea0, resolving the type of a `CASE` expression as the common type of all its `THEN` and `ELSE` branches and casting every branch to it, so heterogeneous branch types no longer panic during execution. Related tests are included.
