### PR TITLE
docs: explain how to check whether a deployment is suspended

### DIFF
--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -95,19 +95,22 @@ deployment is currently suspended, without opening it.
 
 <Warning>
 
-Opening a deployment in Cube Cloud resumes it, so browsing to a deployment is
-not a way to check whether it was suspended. The Deployments page reads stored
-state and leaves the deployment alone.
+Opening a deployment in Cube resumes it, so browsing to a deployment is not a
+way to check whether it was suspended. The Deployments page reads stored state
+and leaves the deployment alone.
 
 </Warning>
 
-[Multi-cluster deployments][ref-prod-multi-cluster] show **Always on**, because
-auto-suspension does not apply to them.
+A deployment shows **Always on** when it never auto-suspends: a
+[Multi-cluster deployment][ref-prod-multi-cluster], or a
+[Dedicated deployment][ref-deployment-prod-cluster] with auto-suspension turned
+off.
 
 To find deployments that are unused, rather than merely suspended right now, go
-to **Billing → Cost and Usage Explorer** and group by deployment: for a Shared
-deployment, CCU corresponds to the hours it was allocated. Like the Deployments
-page, this reads stored data and resumes nothing.
+to **Billing → Cost and Usage** and group by deployment: for a
+[Shared deployment][ref-deployment-dev-instance],
+[CCU][ref-deployment-pricing] corresponds to the hours it was allocated. Like
+the Deployments page, this reads stored data and resumes nothing.
 
 ## Resuming a suspended deployment
 

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -88,6 +88,27 @@ it's not recommended to choose anything below 1 hour.
 The deployment will temporarily become unavailable for reconfiguration; this
 usually takes less than a minute.
 
+## Checking whether a deployment is suspended
+
+Go to **Admin → Deployments**. The **Status** column shows whether each
+deployment is currently suspended, without opening it.
+
+<Warning>
+
+Opening a deployment in Cube Cloud resumes it, so browsing to a deployment is
+not a way to check whether it was suspended. The Deployments page reads stored
+state and leaves the deployment alone.
+
+</Warning>
+
+[Multi-cluster deployments][ref-prod-multi-cluster] show **Always on**, because
+auto-suspension does not apply to them.
+
+To find deployments that are unused, rather than merely suspended right now, go
+to **Billing → Cost and Usage Explorer** and group by deployment: for a Shared
+deployment, CCU corresponds to the hours it was allocated. Like the Deployments
+page, this reads stored data and resumes nothing.
+
 ## Resuming a suspended deployment
 
 To resume a suspended deployment, send a query to Cube using the API or by


### PR DESCRIPTION
Opening a deployment in Cube Cloud resumes it, and that was the only documented way to check on one — so there was no way to tell whether a deployment was suspended without changing the answer. This adds a section explaining where to look instead, and warns about the resume side effect.

It also points at Cost and Usage Explorer for the related question the same gap blocks: finding deployments that are genuinely unused, rather than merely suspended at this moment.

The Deployments page grows a Status column in a companion change; this documents it.
