### PR TITLE
fix(query-orchestrator): drop duplicate `preAggregationId`/`type` declarations

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -167,8 +167,6 @@ export type LoadPreAggregationResult = {
   partitionRange?: QueryDateRange;
   isMultiTableUnion?: boolean;
   usageTargetTableNames?: Record<string, string>;
-  type?: 'rollup' | 'originalSql';
-  preAggregationId?: string;
   dataSource?: string;
   timezone?: string;
 };
@@ -596,7 +594,6 @@ export class PreAggregations {
             ...loadResult,
             preAggregationId: p.preAggregationId,
             type: p.type,
-            preAggregationId: p.preAggregationId,
             dataSource: p.dataSource || 'default',
             timezone: p.timezone,
           };


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Master does not currently compile — this unbreaks it. Introduced by #11591 (`49319017`).

**Description of Changes Made**

`49319017` added `preAggregationId?` and `type?` to `LoadPreAggregationResult`, which already declared both eight lines below, and added a second `preAggregationId: p.preAggregationId` to the `usedPreAggregation` literal that already had one:

```
PreAggregations.ts(162,3): error TS2300: Duplicate identifier 'preAggregationId'.
PreAggregations.ts(163,3): error TS2300: Duplicate identifier 'type'.
PreAggregations.ts(170,3): error TS2300: Duplicate identifier 'type'.
PreAggregations.ts(171,3): error TS2300: Duplicate identifier 'preAggregationId'.
PreAggregations.ts(599,13): error TS1117: An object literal cannot have multiple properties with the same name.
```

**Blast radius.** `@cubejs-backend/query-orchestrator:build` is the *only* failed lerna task, but it emits no declarations, so everything downstream dies with `Cannot find module '@cubejs-backend/query-orchestrator' or its corresponding type declarations` — **268 errors across 22 packages**. That takes down `build`, `unit (24.x, 3.13)`, `Build & Test :dev for Debian`, `integration-smoke` and `integration-cubestore`, on master and on every open PR (a `pull_request` build checks out `refs/pull/N/merge`, so the breakage reaches PRs whose own diff is unrelated).

**The fix removes the duplicates and keeps the documented pair. Nothing is lost:**

- `PreAggregationType` is declared in this same file as `'rollup' | 'originalSql'`, so `type?: PreAggregationType` and `type?: 'rollup' | 'originalSql'` were identical.
- Both object-literal entries assigned the same `p.preAggregationId`.

**Verification**

Reproduced the failure and confirmed the fix clears it, typechecking the file before and after:

```
=== before (master) ===
  before.ts(162,3): error TS2300: Duplicate identifier 'preAggregationId'.
  before.ts(163,3): error TS2300: Duplicate identifier 'type'.
  before.ts(170,3): error TS2300: Duplicate identifier 'type'.
  before.ts(171,3): error TS2300: Duplicate identifier 'preAggregationId'.
  before.ts(599,13): error TS1117: An object literal cannot have multiple properties with the same name.
=== after (this PR) ===
  (no errors)
```

No behaviour change and no new tests: this deletes three lines that were exact duplicates of lines kept alongside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFsWyd58aFEWhLT2CjuiiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFsWyd58aFEWhLT2CjuiiV)_