### PR TITLE
docs: document undocumented Cube Cloud features from the last two weeks

### DIFF
--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -18,6 +18,11 @@ the&nbsp;**Cube Cloud** logo in the top left corner.
   <img src="https://ucarecdn.com/cdd5831a-a8f8-4342-bc3e-25aab2c04a5b/" />
 </Frame>
 
+With more than one deployment, an admin can pin one as the account-wide default from its
+row's&nbsp;**⋯**&nbsp;menu (**Set as default** / **Remove as default**). This is what a user
+lands on when they open Cube without a deployment in the URL and haven't set their own
+[default deployment](/preferences#default-deployment) or previously switched deployments.
+
 ## Creating a new deployment
 
 Creating a new deployment is an essential prerequisite to running a Cube

--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -21,7 +21,7 @@ the&nbsp;**Cube Cloud** logo in the top left corner.
 With more than one deployment, an admin can pin one as the account-wide default from its
 row's&nbsp;**⋯**&nbsp;menu (**Set as default** / **Remove as default**). This is what a user
 lands on when they open Cube without a deployment in the URL and haven't set their own
-[default deployment](/preferences#default-deployment) or previously switched deployments.
+[default deployment](/docs/preferences#default-deployment) or previously switched deployments.
 
 ## Creating a new deployment
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
@@ -23,7 +23,7 @@ Stages come from shared node names rather than from a stage field: rows `A → B
 
 A row with a blank endpoint, or a value of zero or less, is not a flow and is left out — a sankey cannot draw a ribbon with no thickness.
 
-Cyclic data is rejected rather than drawn. A flow that returns to a node it already passed through has no left-to-right layout, so the chart names the loop and asks you to remove one hop.
+A flow that returns to a node it already passed through is a cycle. Rather than being rejected, the returned-to node is split into a numbered copy so the diagram still lays out left-to-right — `A → B → A` draws as `A → B → A (2)`. Every copy of a node shares its color, and hovering one highlights the ribbons of all of them. A node that flows directly to itself has no valid split and is still rejected.
 
 ## Node grouping
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/sankey.mdx
@@ -23,7 +23,9 @@ Stages come from shared node names rather than from a stage field: rows `A → B
 
 A row with a blank endpoint, or a value of zero or less, is not a flow and is left out — a sankey cannot draw a ribbon with no thickness.
 
-A flow that returns to a node it already passed through is a cycle. Rather than being rejected, the returned-to node is split into a numbered copy so the diagram still lays out left-to-right — `A → B → A` draws as `A → B → A (2)`. Every copy of a node shares its color, and hovering one highlights the ribbons of all of them. A node that flows directly to itself has no valid split and is still rejected.
+A flow that returns to a node it already passed through is a cycle. The returned-to node is split into a numbered copy so the diagram still lays out left-to-right — `A → B → A` draws as `A → B → A (2)`. Every copy of a node shares its color, and hovering one highlights the ribbons of all of them.
+
+A node that flows directly to itself has no valid split, and the chart names the loop and asks you to remove one hop.
 
 ## Node grouping
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -87,8 +87,9 @@ the same way.
 
 You can also bucket an existing dimension without writing SQL. Open its menu in
 the field picker sidebar and choose **Create bins…** on a number dimension, or
-**Group values…** on a string one. Time dimensions have granularities instead,
-and an already derived field cannot be bucketed again.
+**Group values…** on a string or boolean one (grouping a boolean dimension is
+how you rename its `true`/`false` values). Time dimensions have granularities
+instead, and an already derived field cannot be bucketed again.
 
 <Frame>
   <img
@@ -98,18 +99,24 @@ and an already derived field cannot be bucketed again.
 </Frame>
 
 **Bins** take their boundaries either as a list (**Custom ranges**) or from a
-**Start**, **Width**, and number of **Ranges** (**Equal width**). Each boundary
-opens a bucket that includes its lower bound and excludes the upper one, and two
-open-ended buckets are added at the edges—so `0, 18, 25` yields `< 0`, `[0, 18)`,
-`[18, 25)`, `>= 25`, and no row is dropped. **Label style** renders a bucket as
-`[10, 20)`, `>= 10 and < 20`, or `10 to 19`; the last is offered only while every
-boundary is a whole number. Rows where the dimension is `NULL` are reported as
-`Unknown`.
+**Range start** and **Range end** (**Equal intervals**), which are prefilled
+from the column's own minimum and maximum. For equal intervals, choose whether
+the range is split by **Number of bins** or by a fixed **Bin size**. Each
+boundary opens a bucket that includes its lower bound and excludes the upper
+one, and two open-ended buckets are added at the edges—so `0, 18, 25` yields
+`< 0`, `[0, 18)`, `[18, 25)`, `>= 25`, and no row is dropped. **Label style**
+renders a bucket as `[10, 20)`, `>= 10 and < 20`, `10 to 19` (offered only while
+every boundary is a whole number), or **Custom**, which lets you type your own
+label for each bucket. Turn off **Label empty values separately** to fold rows
+where the dimension is `NULL` into the last bucket instead of reporting them
+under their own label (`Unknown` by default).
 
 **Value groups** collect the dimension's values into named sets: pick values, name
-the group, and choose **Add group**. A value belongs to one group at a time.
-Whatever you did not pick—including empty values—falls under **Everything else**,
-which defaults to `Other`.
+the group, and choose **Add group**. A value belongs to one group at a time, and
+an existing group's picked values can be changed later via **Edit group**. By
+default, whatever you did not pick—including empty values—falls under
+**Everything else**, which defaults to `Other`; turn off **Group remaining
+values** to have those rows return `NULL` instead.
 
 Bucket labels carry their position as a prefix (`1.`, `2.`, zero-padded past nine
 buckets) so that sorting the column sorts it by value rather than alphabetically,
@@ -134,7 +141,7 @@ CASE WHEN orders_view.age IS NULL THEN 'Unknown'
 
 <Info>
 
-**Equal width** ranges are resolved into boundaries when the field is created, not
+**Equal intervals** ranges are resolved into boundaries when the field is created, not
 recomputed from the data. Values arriving later outside the range join the first
 and last buckets instead of extending them.
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -135,11 +135,19 @@ by clicking **Save**.
 
 ## Work with saved reports
 
-Go to the add-on menu and click **View saved reports** to see a list of
-reports. Use the search box above the list to quickly find a folder or
-exploration by name across your whole deployment, not just the current
-folder — results are grouped by type and show each item's folder location,
-and selecting one navigates you straight to it.
+Opening the add-on shows the current spreadsheet's home: every exploration
+placed in this spreadsheet, grouped by sheet, with each placement's range and
+how long ago it last refreshed. A placement is tagged **Stale** when its
+source exploration has been edited since that copy was written to the sheet.
+Running an exploration keeps its progress even if you close the pane before
+saving — the spreadsheet home lists it under **Unsaved**, and reopening it
+resumes exactly where you left off. The pane can also hold more than one
+exploration open at once, switchable from a picker at the top.
+
+Click **Browse all explorations** to search by name across your whole
+deployment, not just the current folder — results are grouped by type and
+show each item's folder location, and selecting one navigates you straight to
+it.
 
 An exploration can be placed more than once — on different sheets or at
 different anchors in the same spreadsheet, and in more than one document at

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -143,11 +143,19 @@ by clicking **Save**.
 
 ## Work with saved reports
 
-Go to the add-in menu and click **View saved reports** to see a list of
-reports. Use the search box above the list to quickly find a folder or
-exploration by name across your whole deployment, not just the current
-folder — results are grouped by type and show each item's folder location,
-and selecting one navigates you straight to it.
+Opening the add-in shows the current workbook's home: every exploration
+placed in this spreadsheet, grouped by sheet, with each placement's range and
+how long ago it last refreshed. A placement is tagged **Stale** when its
+source exploration has been edited since that copy was written to the sheet.
+Running an exploration keeps its progress even if you close the pane before
+saving — the workbook home lists it under **Unsaved**, and reopening it
+resumes exactly where you left off. The pane can also hold more than one
+exploration open at once, switchable from a picker at the top.
+
+Click **Browse all explorations** to search by name across your whole
+deployment, not just the current folder — results are grouped by type and
+show each item's folder location, and selecting one navigates you straight to
+it.
 
 An exploration can be placed more than once — on different sheets or at
 different anchors in the same workbook, and in more than one document at

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -144,7 +144,7 @@ by clicking **Save**.
 ## Work with saved reports
 
 Opening the add-in shows the current workbook's home: every exploration
-placed in this spreadsheet, grouped by sheet, with each placement's range and
+placed in this workbook, grouped by sheet, with each placement's range and
 how long ago it last refreshed. A placement is tagged **Stale** when its
 source exploration has been edited since that copy was written to the sheet.
 Running an exploration keeps its progress even if you close the pane before

--- a/docs-mintlify/docs/preferences.mdx
+++ b/docs-mintlify/docs/preferences.mdx
@@ -17,6 +17,7 @@ account, apply across all devices, and don't affect other users in the account.
 | Code editor | Switch to the new CodeMirror-based code editor for data models | Off |
 | New message scrolling | Automatically scroll to new messages in chat | On |
 | Alternating row colors | Highlight alternating rows in data tables | Off |
+| Default deployment | Open this deployment when you go to Cube without one in the URL | Account default |
 
 ## Language
 
@@ -70,3 +71,12 @@ everyone queries in the account-wide zone.
 
 See [Time zones](/admin/time-zones) for what a zone changes and how dashboards carry their
 own.
+
+## Default deployment
+
+On an account with more than one deployment, **Default deployment** on the **Preferences**
+page picks which one you land on when you open Cube without a deployment specified in the
+URL. Leaving it as **Account default** falls back, in order, to the deployment you last
+switched to, then the account-wide default an admin can set from the
+[deployments list](/admin/deployment#list-of-deployments), then your most recently created
+deployment. The control is hidden on accounts with only one reachable deployment.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -68,7 +68,7 @@ Embed users in Creator Mode can share the workbooks and dashboards they build wi
 
 ## Folders and workbook actions
 
-Embed users in Creator Mode can create, rename, and delete folders in their own workspace — gated by the same permissions as the full Cube app, and disabled inside a folder shared in from the main workspace. Opening a workbook's actions menu from its header (click the workbook name, or its chevron) offers **Rename**, **Duplicate**, **View all**, **New workbook**, and **Delete**, also permission-gated the same way.
+Embed users in Creator Mode can create, rename, and delete folders in their own workspace — gated by the same permissions as the full Cube app, and disabled inside a folder shared in from the main workspace. Opening a workbook's actions menu from its header (click the workbook name, or its chevron) offers **Rename**, **Duplicate**, and **Delete**, permission-gated the same way as the full app, plus **View all** and **New workbook** for navigating between workbooks.
 
 ## Example
 

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -66,6 +66,10 @@ Embed users in Creator Mode can share the workbooks and dashboards they build wi
   Sharing is scoped to the [embed tenant](#embed-tenant-scoping): users can only share with others in the same tenant, never across tenants.
 </Note>
 
+## Folders and workbook actions
+
+Embed users in Creator Mode can create, rename, and delete folders in their own workspace — gated by the same permissions as the full Cube app, and disabled inside a folder shared in from the main workspace. Opening a workbook's actions menu from its header (click the workbook name, or its chevron) offers **Rename**, **Duplicate**, **View all**, **New workbook**, and **Delete**, also permission-gated the same way.
+
 ## Example
 
 ```javascript


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (N/A — docs-only)
- [ ] Linter has been run for changed code (N/A — docs-only)
- [ ] Tests for the changes have been added if not covered yet (N/A — docs-only)

**Description of Changes Made**

Result of a scheduled audit cross-checking recent `cubedevinc/cubejs-enterprise` changes against these docs, filtered against the team&#39;s customer-facing criteria. Five small, surgical gaps, one commit each:

1. **Bin/group editor updates** (`docs/explore-analyze/workbooks/calculated-fields.mdx`) — Equal-width bins became **Equal intervals** with a range prefilled from the column&#39;s own data and a **Number of bins** / **Bin size** choice, a **Custom** label style, a toggle to fold empty values into the last bucket, a toggle to return `NULL` for ungrouped/empty values instead of **Everything else**, in-place editing of an existing value group, and **Group values…** support on boolean dimensions (to rename `true`/`false`).
2. **Sheets/Excel add-in workbook home** (`docs/integrations/google-sheets.mdx`, `docs/integrations/microsoft-excel.mdx`) — the pane now opens on the current spreadsheet&#39;s own placements (grouped by sheet, with a **Stale** tag when a placement has drifted from its source), with the full library moved behind **Browse all explorations**; an unsaved run now survives closing the pane; the pane supports multiple open explorations at once.
3. **Default landing deployment** (`docs/preferences.mdx`, `admin/deployment/index.mdx`) — an admin can pin an account-wide default deployment, and each user can override it with their own default in Preferences.
4. **Creator Mode folders & workbook actions** (`embedding/iframe/creator-mode.mdx`) — embed users can now create/rename/delete folders in their own workspace and rename/duplicate/delete workbooks from an actions menu, permission-gated the same way as the full app.
5. **Sankey cyclic flows** (`docs/explore-analyze/charts/chart-types/sankey.mdx`) — a flow that loops back on itself is no longer rejected; the chart now splits the returned-to node into a numbered copy so the diagram still lays out left-to-right.

A larger gap (a new **Funnel** chart type, which shipped without any docs page) was also found but needs its own new page rather than a surgical edit — flagging separately rather than including here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WY2gyENdrKib3mWSVNbCfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY2gyENdrKib3mWSVNbCfs)_