### PR TITLE
feat(server-core): size the data model compiler cache from `CUBEJS_COMPILER_CACHE_SIZE`

### DIFF
--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -216,6 +216,7 @@ module.exports = {
 Maximum number of compiled data models to persist with in-memory cache. Defaults
 to 250, but optimum value will depend on deployed environment. When the max is
 reached, will start dropping the least recently used data models from the cache.
+Must be a positive integer; the cache can not be disabled.
 
 <CodeGroup>
 

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -235,7 +235,9 @@ module.exports = {
 </CodeGroup>
 
 This configuration option can also be set using the [`CUBEJS_COMPILER_CACHE_SIZE`](/reference/configuration/environment-variables#cubejs_compiler_cache_size)
-environment variable, and takes precedence over it.
+environment variable, and takes precedence over it. Note that the environment
+variable also sizes the SQL API's compiler cache, which this option does not
+affect.
 
 ### `max_compiler_cache_keep_alive`
 

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -233,6 +233,9 @@ module.exports = {
 
 </CodeGroup>
 
+This configuration option can also be set using the [`CUBEJS_COMPILER_CACHE_SIZE`](/reference/configuration/environment-variables#cubejs_compiler_cache_size)
+environment variable, and takes precedence over it.
+
 ### `max_compiler_cache_keep_alive`
 
 Maximum length of time in ms to keep compiled data models in memory. Default

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -137,18 +137,26 @@ The maximum number of compiled data models to keep in the in-memory compiler
 cache. When the maximum is reached, the least recently used data models are
 dropped from the cache. The optimum value depends on the deployed environment.
 
-| Possible Values   | Default in Development | Default in Production |
-| ----------------- | ---------------------- | --------------------- |
-| A positive number | `250`                  | `250`                 |
+This variable sizes two separate caches: the data model compiler cache and the
+[SQL API][ref-sql-api]'s own compiler cache. Setting it applies the same maximum
+to both. When it is unset, each falls back to its own default, so the effective
+default differs between them.
+
+| Cache                     | Possible Values   | Default in Development | Default in Production |
+| ------------------------- | ----------------- | ---------------------- | --------------------- |
+| Data model compiler cache | A positive number | `250`                  | `250`                 |
+| SQL API compiler cache    | A positive number | `100`                  | `100`                 |
 
 <Note>
-The cache can not be disabled, so `0` is rejected rather than accepted and
+Neither cache can be disabled, so `0` is rejected rather than accepted and
 ignored. The same applies to the configuration option.
 </Note>
 
-It can be also set using the [`compiler_cache_size` configuration
-option](/reference/configuration/config#compiler_cache_size), which takes
-precedence over this environment variable.
+The data model compiler cache can be also sized using the [`compiler_cache_size`
+configuration option](/reference/configuration/config#compiler_cache_size),
+which takes precedence over this environment variable. The SQL API compiler
+cache reads this environment variable only, so the configuration option does not
+affect it.
 
 ## `CUBEJS_CONCURRENCY`
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -141,6 +141,11 @@ dropped from the cache. The optimum value depends on the deployed environment.
 | ----------------- | ---------------------- | --------------------- |
 | A positive number | `250`                  | `250`                 |
 
+<Note>
+The cache can not be disabled, so `0` is rejected rather than accepted and
+ignored.
+</Note>
+
 It can be also set using the [`compiler_cache_size` configuration
 option](/reference/configuration/config#compiler_cache_size), which takes
 precedence over this environment variable.

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -131,6 +131,20 @@ The cache and queue driver to use for the Cube deployment.
 It can be also set using the [`cache_and_queue_driver` configuration
 option](/reference/configuration/config#cache_and_queue_driver).
 
+## `CUBEJS_COMPILER_CACHE_SIZE`
+
+The maximum number of compiled data models to keep in the in-memory compiler
+cache. When the maximum is reached, the least recently used data models are
+dropped from the cache. The optimum value depends on the deployed environment.
+
+| Possible Values   | Default in Development | Default in Production |
+| ----------------- | ---------------------- | --------------------- |
+| A positive number | `250`                  | `250`                 |
+
+It can be also set using the [`compiler_cache_size` configuration
+option](/reference/configuration/config#compiler_cache_size), which takes
+precedence over this environment variable.
+
 ## `CUBEJS_CONCURRENCY`
 
 The number of concurrent connections each query queue has to the database.

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -143,7 +143,7 @@ dropped from the cache. The optimum value depends on the deployed environment.
 
 <Note>
 The cache can not be disabled, so `0` is rejected rather than accepted and
-ignored.
+ignored. The same applies to the configuration option.
 </Note>
 
 It can be also set using the [`compiler_cache_size` configuration

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -315,9 +315,24 @@ const variables: Record<string, (...args: any) => any> = {
   /**
    * Maximum number of compiled data models to keep in the in-memory compiler cache.
    */
-  compilerCacheSize: () => get('CUBEJS_COMPILER_CACHE_SIZE')
-    .default('250')
-    .asIntPositive(),
+  compilerCacheSize: () => {
+    const size = get('CUBEJS_COMPILER_CACHE_SIZE')
+      .default('250')
+      .asIntPositive();
+
+    // env-var's asIntPositive() lets 0 through, but every consumer of this option
+    // falls back to the default on a falsy value, so 0 would quietly mean 250
+    // instead of doing what it looks like it does.
+    if (size === 0) {
+      throw new InvalidConfiguration(
+        'CUBEJS_COMPILER_CACHE_SIZE',
+        size,
+        'Must be a positive integer. The compiler cache can not be disabled.',
+      );
+    }
+
+    return size;
+  },
   nativeSqlPlanner: () => {
     const explicitlySet = process.env.CUBEJS_TESSERACT_SQL_PLANNER !== undefined;
     const enabled = get('CUBEJS_TESSERACT_SQL_PLANNER').default('true').asBool();

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -312,6 +312,12 @@ const variables: Record<string, (...args: any) => any> = {
   scheduledRefreshBatchSize: () => get('CUBEJS_SCHEDULED_REFRESH_BATCH_SIZE')
     .default('1')
     .asInt(),
+  /**
+   * Maximum number of compiled data models to keep in the in-memory compiler cache.
+   */
+  compilerCacheSize: () => get('CUBEJS_COMPILER_CACHE_SIZE')
+    .default('250')
+    .asIntPositive(),
   nativeSqlPlanner: () => {
     const explicitlySet = process.env.CUBEJS_TESSERACT_SQL_PLANNER !== undefined;
     const enabled = get('CUBEJS_TESSERACT_SQL_PLANNER').default('true').asBool();

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -301,6 +301,13 @@ describe('getEnv(compilerCacheSize)', () => {
     expect(getEnv('compilerCacheSize')).toBe(1000);
   });
 
+  test('throws on zero, so it is never silently coerced to the default', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '0';
+    expect(() => getEnv('compilerCacheSize')).toThrowError(
+      'Value "0" is not valid for CUBEJS_COMPILER_CACHE_SIZE. Must be a positive integer. The compiler cache can not be disabled.'
+    );
+  });
+
   test('throws on a negative or non-integer value', () => {
     process.env.CUBEJS_COMPILER_CACHE_SIZE = '-1';
     expect(() => getEnv('compilerCacheSize')).toThrowError(

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -287,12 +287,15 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
 });
 
 describe('getEnv(compilerCacheSize)', () => {
+  beforeEach(() => {
+    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
+  });
+
   afterEach(() => {
     delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
   });
 
   test('defaults to 250', () => {
-    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
     expect(getEnv('compilerCacheSize')).toBe(250);
   });
 
@@ -308,18 +311,12 @@ describe('getEnv(compilerCacheSize)', () => {
     );
   });
 
-  test('throws on a negative or non-integer value', () => {
-    process.env.CUBEJS_COMPILER_CACHE_SIZE = '-1';
-    expect(() => getEnv('compilerCacheSize')).toThrowError(
-      /CUBEJS_COMPILER_CACHE_SIZE/
-    );
-
-    process.env.CUBEJS_COMPILER_CACHE_SIZE = 'abc';
-    expect(() => getEnv('compilerCacheSize')).toThrowError(
-      /CUBEJS_COMPILER_CACHE_SIZE/
-    );
-
-    process.env.CUBEJS_COMPILER_CACHE_SIZE = '1.5';
+  test.each([
+    '-1',
+    'abc',
+    '1.5',
+  ])('throws on the negative or non-integer value %j', (value) => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = value;
     expect(() => getEnv('compilerCacheSize')).toThrowError(
       /CUBEJS_COMPILER_CACHE_SIZE/
     );

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -287,10 +287,6 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
 });
 
 describe('getEnv(compilerCacheSize)', () => {
-  beforeEach(() => {
-    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
-  });
-
   afterEach(() => {
     delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
   });

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -301,13 +301,18 @@ describe('getEnv(compilerCacheSize)', () => {
     expect(getEnv('compilerCacheSize')).toBe(1000);
   });
 
-  test('throws on a non positive integer', () => {
-    process.env.CUBEJS_COMPILER_CACHE_SIZE = '0';
+  test('throws on a negative or non-integer value', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '-1';
     expect(() => getEnv('compilerCacheSize')).toThrowError(
       /CUBEJS_COMPILER_CACHE_SIZE/
     );
 
     process.env.CUBEJS_COMPILER_CACHE_SIZE = 'abc';
+    expect(() => getEnv('compilerCacheSize')).toThrowError(
+      /CUBEJS_COMPILER_CACHE_SIZE/
+    );
+
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '1.5';
     expect(() => getEnv('compilerCacheSize')).toThrowError(
       /CUBEJS_COMPILER_CACHE_SIZE/
     );

--- a/packages/cubejs-backend-shared/test/env.test.ts
+++ b/packages/cubejs-backend-shared/test/env.test.ts
@@ -285,3 +285,31 @@ describe('getEnv(defaultTimezone / scheduledRefreshTimezones)', () => {
     );
   });
 });
+
+describe('getEnv(compilerCacheSize)', () => {
+  afterEach(() => {
+    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
+  });
+
+  test('defaults to 250', () => {
+    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
+    expect(getEnv('compilerCacheSize')).toBe(250);
+  });
+
+  test('reads CUBEJS_COMPILER_CACHE_SIZE', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '1000';
+    expect(getEnv('compilerCacheSize')).toBe(1000);
+  });
+
+  test('throws on a non positive integer', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '0';
+    expect(() => getEnv('compilerCacheSize')).toThrowError(
+      /CUBEJS_COMPILER_CACHE_SIZE/
+    );
+
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = 'abc';
+    expect(() => getEnv('compilerCacheSize')).toThrowError(
+      /CUBEJS_COMPILER_CACHE_SIZE/
+    );
+  });
+});

--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -407,6 +407,7 @@ export class OptsHandler {
       dashboardAppPort: 3000,
       scheduledRefreshConcurrency: getEnv('scheduledRefreshQueriesPerAppId'),
       scheduledRefreshBatchSize: getEnv('scheduledRefreshBatchSize'),
+      compilerCacheSize: getEnv('compilerCacheSize'),
       preAggregationsSchema:
         getEnv('preAggregationsSchema') ||
         (this.isDevMode()

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -113,7 +113,7 @@ const schemaOptions = Joi.object().keys({
   scheduledRefreshConcurrency: Joi.number().min(1).integer(),
   scheduledRefreshBatchSize: Joi.number().min(1).integer(),
   // Compiler cache
-  compilerCacheSize: Joi.number().min(0).integer(),
+  compilerCacheSize: Joi.number().min(1).integer(),
   updateCompilerCacheKeepAlive: Joi.boolean(),
   maxCompilerCacheKeepAlive: Joi.number().min(0).integer(),
   telemetry: Joi.boolean(),

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -1287,7 +1287,7 @@ describe('OptsHandler compilerCacheSize', () => {
     expect(core.options.compilerCacheSize).toBe(7);
   });
 
-  test('must throw at construction if CUBEJS_COMPILER_CACHE_SIZE is not a positive integer', () => {
+  test('must throw at construction if CUBEJS_COMPILER_CACHE_SIZE is not a valid size', () => {
     process.env.CUBEJS_COMPILER_CACHE_SIZE = 'abc';
 
     expect(() => new CubejsServerCoreExposed(conf))

--- a/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
+++ b/packages/cubejs-server-core/test/unit/OptsHandler.test.ts
@@ -1252,3 +1252,45 @@ describe('OptsHandler timezone env validation', () => {
     expect(core.options.scheduledRefreshTimeZones).toEqual(['UTC', 'America/New_York']);
   });
 });
+
+describe('OptsHandler compilerCacheSize', () => {
+  beforeEach(() => {
+    process.env.CUBEJS_DB_TYPE = 'postgres';
+  });
+
+  afterEach(() => {
+    delete process.env.CUBEJS_COMPILER_CACHE_SIZE;
+  });
+
+  test('must default to 250 when neither the option nor the env variable is set', () => {
+    const core = new CubejsServerCoreExposed(conf);
+
+    expect(core.options.compilerCacheSize).toBe(250);
+  });
+
+  test('must take the value from CUBEJS_COMPILER_CACHE_SIZE', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '42';
+
+    const core = new CubejsServerCoreExposed(conf);
+
+    expect(core.options.compilerCacheSize).toBe(42);
+  });
+
+  test('must prefer CreateOptions.compilerCacheSize over the env variable', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = '42';
+
+    const core = new CubejsServerCoreExposed({
+      ...conf,
+      compilerCacheSize: 7,
+    });
+
+    expect(core.options.compilerCacheSize).toBe(7);
+  });
+
+  test('must throw at construction if CUBEJS_COMPILER_CACHE_SIZE is not a positive integer', () => {
+    process.env.CUBEJS_COMPILER_CACHE_SIZE = 'abc';
+
+    expect(() => new CubejsServerCoreExposed(conf))
+      .toThrow(/CUBEJS_COMPILER_CACHE_SIZE/);
+  });
+});

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -122,7 +122,20 @@ describe('index.test', () => {
     };
 
     expect(() => new CubejsServerCore(options))
-      .toThrowError(/"compilerCacheSize" must be greater than or equal to 0/);
+      .toThrowError(/"compilerCacheSize" must be greater than or equal to 1/);
+  });
+
+  // 0 used to validate and then get silently replaced by the default through the
+  // `|| 250` guards, which reads like a way to disable the compiler cache but isn't.
+  test('Should throw error, compilerCacheSize of 0', () => {
+    const options = {
+      externalDbType: <DatabaseType>'mysql',
+      devServer: true,
+      compilerCacheSize: 0,
+    };
+
+    expect(() => new CubejsServerCore(options))
+      .toThrowError(/"compilerCacheSize" must be greater than or equal to 1/);
   });
 
   test('Should create instance of CubejsServerCore, orchestratorOptions as func', () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`compilerCacheSize` could previously only be set through the configuration file. This wires the data model compiler cache up to `CUBEJS_COMPILER_CACHE_SIZE` as well, so it can be sized without a config file change.

Note that `CUBEJS_COMPILER_CACHE_SIZE` is **not a new variable name** — CubeSQL already reads it at `rust/cubesql/cubesql/src/config/mod.rs:192` to size the SQL API's compiler LRU, with its own default of `100`. The name is kept rather than a distinct one invented, since it mirrors the existing `compilerCacheSize` config option and both caches are compiler caches in the same process; the docs now describe both consumers and both defaults.

- `packages/cubejs-backend-shared/src/env.ts` — new `compilerCacheSize` variable reading `CUBEJS_COMPILER_CACHE_SIZE`, defaulting to `250`.
- `packages/cubejs-server-core/src/core/OptsHandler.ts` — resolves `compilerCacheSize: getEnv('compilerCacheSize')` alongside the other env-backed options, placed *before* the `...opts` spread so the configuration file keeps taking precedence. From there it flows into both consumers (`server.ts:205` compiler LRU and `server.ts:750` → `CompilerApi.ts:163/168/173`).
- `packages/cubejs-server-core/src/core/optionsValidate.ts` — `compilerCacheSize` tightened from `Joi.number().min(0)` to `min(1)`, matching `scheduledRefreshConcurrency` and `scheduledRefreshBatchSize` directly above it.
- Docs — new `CUBEJS_COMPILER_CACHE_SIZE` section covering both caches, plus a cross-reference from `config.mdx`.

Behavior is unchanged for the data model compiler cache when the variable is unset — it still defaults to `250`.

**On rejecting `0`**

Both entry points now reject `0` rather than accepting it and silently coercing it to `250` via the `|| 250` guards. `0` never sized the cache to anything but the default, so nothing can depend on its behavior, and nothing in the repo sets it. This also matches what CubeSQL already effectively required — `NonZeroUsize::new(compiler_cache_size).unwrap()` at `compiler_cache.rs:244` panics on `0`.

The five `|| 250` guards are deliberately kept: `CompilerApi` is publicly exported and constructed directly with options that omit `compilerCacheSize` (e.g. `index.test.ts:325`), bypassing both Joi and `OptsHandler`, and `LRUCache` throws `At least one of max, maxSize, or ttl is required` on `max: undefined`. Consolidating the default would need a default parameter on `CompilerApi` itself.

**Testing**

- `cubejs-backend-shared` `env.test.ts` — 31/31 pass, including default, env value, rejection of `0`, and `test.each` coverage of `-1` / `abc` / `1.5`.
- `cubejs-server-core` — four new `OptsHandler` cases (default `250`, env value, config-file precedence, throw on invalid); `optionsValidate.test.ts` green; `index.test.ts` validation cases updated for `min(1)` plus a new `compilerCacheSize: 0` case.
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsJnAHifeU7RMbdumCLSDb