### PR TITLE
feat(client-core): forward `usedPreAggregations` on `cubeSql` results

### DIFF
--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -143,7 +143,7 @@ callback? | [LoadMethodCallback](#loadmethodcallback)‹[CubeSqlResult](#cubesql
 >  **cubeSqlStream**(**sqlQuery**: string, **options?**: [CubeSqlOptions](#cubesqloptions)): *AsyncGenerator‹CubeSqlStreamChunk›*
 
 Same as [`cubeSql`](#cubesql), but yields the results as they stream in. Each
-chunk is either `{ type: 'schema', schema, lastRefreshTime?, usedPreAggregations? }`,
+chunk is either `{ type: 'schema', schema, lastRefreshTime?, external?, usedPreAggregations? }`,
 `{ type: 'data', data }` (one row), or `{ type: 'error', error }`.
 
 ```js
@@ -924,7 +924,8 @@ Name | Type | Description |
 schema | `{ name: string, column_type: string, format?: string }[]` | - |
 data | `(string \| number \| boolean \| null)[][]` | - |
 lastRefreshTime? | string | - |
-usedPreAggregations? | `Record<string, { preAggregationId?: string, lastUpdatedAt?: number, type: string }>` | Pre-aggregations this result was served from, keyed by pre-aggregation table name. Absent when the query hit none, and on deployments older than the field. |
+external? | boolean | Whether the result was served from the external (pre-aggregation) store. Only reported when true. |
+usedPreAggregations? | `Record<string, { preAggregationId?: string, lastUpdatedAt?: number, type: string }>` | Pre-aggregations this result was served from, keyed by pre-aggregation table name. Absent when the query hit none, and on deployments older than the field. Entries also carry `targetTableName` in dev mode and for the Playground. |
 
 ### `DateRange`
 

--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -143,7 +143,7 @@ callback? | [LoadMethodCallback](#loadmethodcallback)‹[CubeSqlResult](#cubesql
 >  **cubeSqlStream**(**sqlQuery**: string, **options?**: [CubeSqlOptions](#cubesqloptions)): *AsyncGenerator‹CubeSqlStreamChunk›*
 
 Same as [`cubeSql`](#cubesql), but yields the results as they stream in. Each
-chunk is either `{ type: 'schema', schema, lastRefreshTime? }`,
+chunk is either `{ type: 'schema', schema, lastRefreshTime?, usedPreAggregations? }`,
 `{ type: 'data', data }` (one row), or `{ type: 'error', error }`.
 
 ```js
@@ -919,11 +919,12 @@ Name | Type | Optional? | Description |
 
 ### `CubeSqlResult`
 
-Name | Type |
------- | ------ |
-schema | `{ name: string, column_type: string, format?: string }[]` |
-data | `(string \| number \| boolean \| null)[][]` |
-lastRefreshTime? | string |
+Name | Type | Description |
+------ | ------ | ------ |
+schema | `{ name: string, column_type: string, format?: string }[]` | - |
+data | `(string \| number \| boolean \| null)[][]` | - |
+lastRefreshTime? | string | - |
+usedPreAggregations? | `Record<string, { preAggregationId?: string, lastUpdatedAt?: number, type: string }>` | Pre-aggregations this result was served from, keyed by pre-aggregation table name. Absent when the query hit none, and on deployments older than the field. |
 
 ### `DateRange`
 

--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -18,7 +18,8 @@ import {
   Query,
   QueryOrder,
   QueryType,
-  TransformedQuery
+  TransformedQuery,
+  UsedPreAggregation
 } from './types.js';
 
 export type LoadMethodCallback<T> = (error: Error | null, resultSet: T) => void;
@@ -141,17 +142,46 @@ export type CubeSqlSchemaColumn = {
   format?: DimensionFormat | MeasureFormat;
 };
 
+/**
+ * Metadata the SQL API reports alongside the schema, describing the result as a
+ * whole rather than its columns. Optional throughout: a deployment older than the
+ * field, or a query that hit no pre-aggregation, simply omits it.
+ */
+export type CubeSqlResultMetadata = {
+  lastRefreshTime?: string;
+  /**
+   * Pre-aggregations this result was served from, keyed by pre-aggregation table
+   * name. Absent when the query hit none. Carries identity only, so a client can
+   * match a result to the pre-aggregation build behind it.
+   */
+  usedPreAggregations?: Record<string, UsedPreAggregation>;
+};
+
 export type CubeSqlResult = {
   schema: CubeSqlSchemaColumn[];
   data: (string | number | boolean | null)[][];
-  lastRefreshTime?: string;
-};
+} & CubeSqlResultMetadata;
 
-export type CubeSqlStreamChunk = {
+/**
+ * Pick the result-level metadata out of a parsed SQL API schema line.
+ *
+ * Every field here is optional on the wire, and three call sites re-emit them
+ * (`cubeSql`, and `cubeSqlStream` for both its per-chunk and trailing-buffer
+ * paths), so the spread lives in one place: adding a field to the response
+ * previously meant remembering all three, and a site that was missed dropped the
+ * new field silently, with the result still type-checking.
+ */
+function pickCubeSqlResultMetadata(parsed: any): CubeSqlResultMetadata {
+  return {
+    ...(parsed.lastRefreshTime ? { lastRefreshTime: parsed.lastRefreshTime } : {}),
+    ...(parsed.usedPreAggregations ? { usedPreAggregations: parsed.usedPreAggregations } : {}),
+  };
+}
+
+export type CubeSqlStreamChunk = ({
   type: 'schema';
   schema: CubeSqlSchemaColumn[];
-  lastRefreshTime?: string;
-} | {
+} & CubeSqlResultMetadata) | {
   type: 'data';
   data: (string | number | boolean | null)[];
 } | {
@@ -864,7 +894,7 @@ class CubeApi {
         return {
           schema: parsedSchema.schema,
           data: rows,
-          ...(parsedSchema.lastRefreshTime ? { lastRefreshTime: parsedSchema.lastRefreshTime } : {}),
+          ...pickCubeSqlResultMetadata(parsedSchema),
         };
       },
       options,
@@ -914,7 +944,7 @@ class CubeApi {
                 yield {
                   type: 'schema' as const,
                   schema: parsed.schema,
-                  ...(parsed.lastRefreshTime ? { lastRefreshTime: parsed.lastRefreshTime } : {}),
+                  ...pickCubeSqlResultMetadata(parsed),
                 };
               } else if (parsed.data) {
                 yield {
@@ -945,7 +975,7 @@ class CubeApi {
             yield {
               type: 'schema' as const,
               schema: parsed.schema,
-              ...(parsed.lastRefreshTime ? { lastRefreshTime: parsed.lastRefreshTime } : {}),
+              ...pickCubeSqlResultMetadata(parsed),
             };
           } else if (parsed.data) {
             yield {

--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -170,12 +170,10 @@ export type CubeSqlResult = {
 /**
  * Pick the result-level metadata out of a parsed SQL API schema line.
  *
- * One place for all of it, because three call sites re-emit these fields
- * (`cubeSql`, and `cubeSqlStream` for both its per-chunk and trailing-buffer
- * paths) and a site missed when a field is added drops it silently, while still
- * type-checking. The invariant: this must cover every result-level field the
- * writer puts on the schema line (`node_export.rs`), and an absent field must
- * stay absent rather than become an explicit `undefined`.
+ * Must cover every result-level field the writer puts on that line
+ * (`node_export.rs`), and must leave an absent field absent rather than set it to
+ * an explicit `undefined`. Shared by all three emitters — `cubeSql`, and
+ * `cubeSqlStream` for both its per-chunk and trailing-buffer paths.
  */
 function pickCubeSqlResultMetadata(parsed: any): CubeSqlResultMetadata {
   return {

--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -150,6 +150,11 @@ export type CubeSqlSchemaColumn = {
 export type CubeSqlResultMetadata = {
   lastRefreshTime?: string;
   /**
+   * Whether the result was served from the external (pre-aggregation) store.
+   * Only ever reported as `true`; absent means "not external, or not reported".
+   */
+  external?: boolean;
+  /**
    * Pre-aggregations this result was served from, keyed by pre-aggregation table
    * name. Absent when the query hit none. Carries identity only, so a client can
    * match a result to the pre-aggregation build behind it.
@@ -165,15 +170,17 @@ export type CubeSqlResult = {
 /**
  * Pick the result-level metadata out of a parsed SQL API schema line.
  *
- * Every field here is optional on the wire, and three call sites re-emit them
+ * One place for all of it, because three call sites re-emit these fields
  * (`cubeSql`, and `cubeSqlStream` for both its per-chunk and trailing-buffer
- * paths), so the spread lives in one place: adding a field to the response
- * previously meant remembering all three, and a site that was missed dropped the
- * new field silently, with the result still type-checking.
+ * paths) and a site missed when a field is added drops it silently, while still
+ * type-checking. The invariant: this must cover every result-level field the
+ * writer puts on the schema line (`node_export.rs`), and an absent field must
+ * stay absent rather than become an explicit `undefined`.
  */
 function pickCubeSqlResultMetadata(parsed: any): CubeSqlResultMetadata {
   return {
     ...(parsed.lastRefreshTime ? { lastRefreshTime: parsed.lastRefreshTime } : {}),
+    ...(parsed.external ? { external: parsed.external } : {}),
     ...(parsed.usedPreAggregations ? { usedPreAggregations: parsed.usedPreAggregations } : {}),
   };
 }

--- a/packages/cubejs-client-core/test/CubeApi.test.ts
+++ b/packages/cubejs-client-core/test/CubeApi.test.ts
@@ -427,6 +427,7 @@ describe('CubeApi cubeSql', () => {
         { name: 'status', column_type: 'String' },
       ],
       lastRefreshTime: '2026-02-24T00:34:01.594Z',
+      external: true,
       usedPreAggregations: {
         'dev_pre_aggregations.orders_main': {
           preAggregationId: 'Orders.main',
@@ -658,8 +659,9 @@ describe('CubeApi cubeSql', () => {
         type: 'rollup',
       },
     });
-    // The metadata fields are independent: reading one must not drop the other.
+    // The metadata fields are independent: reading one must not drop the others.
     expect(res.lastRefreshTime).toBe('2026-02-24T00:34:01.594Z');
+    expect(res.external).toBe(true);
     expect(res.data).toEqual([['Active']]);
   });
 
@@ -678,7 +680,10 @@ describe('CubeApi cubeSql', () => {
 
     const res = await cubeApi.cubeSql('SELECT status FROM users');
     expect(res.usedPreAggregations).toBeUndefined();
+    expect(res.external).toBeUndefined();
+    // Absent must stay ABSENT, not become an explicit `undefined` key.
     expect('usedPreAggregations' in res).toBe(false);
+    expect('external' in res).toBe(false);
   });
 
   test('should emit usedPreAggregations on the stream schema chunk', async () => {

--- a/packages/cubejs-client-core/test/CubeApi.test.ts
+++ b/packages/cubejs-client-core/test/CubeApi.test.ts
@@ -418,6 +418,26 @@ describe('CubeApi cubeSql', () => {
     JSON.stringify({ data: [['Shipped', '45102']] }),
   ].join('\n');
 
+  // The SQL API reports the pre-aggregations behind a result next to
+  // `lastRefreshTime` on the schema line, so a client can match the result to the
+  // build behind it (CORE-664).
+  const cubeSqlResponseBodyWithPreAggregations = [
+    JSON.stringify({
+      schema: [
+        { name: 'status', column_type: 'String' },
+      ],
+      lastRefreshTime: '2026-02-24T00:34:01.594Z',
+      usedPreAggregations: {
+        'dev_pre_aggregations.orders_main': {
+          preAggregationId: 'Orders.main',
+          lastUpdatedAt: 1771893241594,
+          type: 'rollup',
+        },
+      },
+    }),
+    JSON.stringify({ data: [['Active']] }),
+  ].join('\n');
+
   const cubeSqlResponseBodyNoRefreshTime = [
     JSON.stringify({
       schema: [
@@ -615,6 +635,105 @@ describe('CubeApi cubeSql', () => {
     // `undefined` is dropped both by JSON.stringify (POST body) and by
     // requestStream's query-string builder, so it never reaches the wire.
     expect(requestStreamSpy.mock.calls[0]?.[1]?.params?.timezone).toBeUndefined();
+  });
+
+  test('should parse usedPreAggregations from response', async () => {
+    vi.spyOn(HttpTransport.prototype, 'request').mockImplementation(() => ({
+      subscribe: (cb) => Promise.resolve(cb({
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ error: cubeSqlResponseBodyWithPreAggregations })),
+      } as any,
+      async () => undefined as any))
+    }));
+
+    const cubeApi = new CubeApi('token', {
+      apiUrl: 'http://localhost:4000/cubejs-api/v1',
+    });
+
+    const res = await cubeApi.cubeSql('SELECT status FROM orders');
+    expect(res.usedPreAggregations).toEqual({
+      'dev_pre_aggregations.orders_main': {
+        preAggregationId: 'Orders.main',
+        lastUpdatedAt: 1771893241594,
+        type: 'rollup',
+      },
+    });
+    // The metadata fields are independent: reading one must not drop the other.
+    expect(res.lastRefreshTime).toBe('2026-02-24T00:34:01.594Z');
+    expect(res.data).toEqual([['Active']]);
+  });
+
+  test('should omit usedPreAggregations when the query hit no pre-aggregation', async () => {
+    vi.spyOn(HttpTransport.prototype, 'request').mockImplementation(() => ({
+      subscribe: (cb) => Promise.resolve(cb({
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ error: cubeSqlResponseBodyNoRefreshTime })),
+      } as any,
+      async () => undefined as any))
+    }));
+
+    const cubeApi = new CubeApi('token', {
+      apiUrl: 'http://localhost:4000/cubejs-api/v1',
+    });
+
+    const res = await cubeApi.cubeSql('SELECT status FROM users');
+    expect(res.usedPreAggregations).toBeUndefined();
+    expect('usedPreAggregations' in res).toBe(false);
+  });
+
+  test('should emit usedPreAggregations on the stream schema chunk', async () => {
+    vi.spyOn(HttpTransport.prototype, 'requestStream').mockImplementation(() => ({
+      stream: async () => (async function* generate() {
+        yield new TextEncoder().encode(`${cubeSqlResponseBodyWithPreAggregations}\n`);
+      }()),
+    }));
+
+    const cubeApi = new CubeApi('token', {
+      apiUrl: 'http://localhost:4000/cubejs-api/v1',
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of cubeApi.cubeSqlStream('SELECT status FROM orders')) {
+      chunks.push(chunk);
+    }
+
+    const schemaChunk = chunks.find((chunk) => chunk.type === 'schema');
+    expect(schemaChunk?.usedPreAggregations).toEqual({
+      'dev_pre_aggregations.orders_main': {
+        preAggregationId: 'Orders.main',
+        lastUpdatedAt: 1771893241594,
+        type: 'rollup',
+      },
+    });
+    expect(schemaChunk?.lastRefreshTime).toBe('2026-02-24T00:34:01.594Z');
+  });
+
+  test('should emit usedPreAggregations when the schema arrives in the trailing buffer', async () => {
+    // No newline after the schema line, so it is only flushed by the
+    // end-of-stream drain — a second, easily-forgotten copy of the same spread.
+    vi.spyOn(HttpTransport.prototype, 'requestStream').mockImplementation(() => ({
+      stream: async () => (async function* generate() {
+        yield new TextEncoder().encode(cubeSqlResponseBodyWithPreAggregations.split('\n')[0]);
+      }()),
+    }));
+
+    const cubeApi = new CubeApi('token', {
+      apiUrl: 'http://localhost:4000/cubejs-api/v1',
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of cubeApi.cubeSqlStream('SELECT status FROM orders')) {
+      chunks.push(chunk);
+    }
+
+    const schemaChunk = chunks.find((chunk) => chunk.type === 'schema');
+    expect(schemaChunk?.usedPreAggregations).toEqual({
+      'dev_pre_aggregations.orders_main': {
+        preAggregationId: 'Orders.main',
+        lastUpdatedAt: 1771893241594,
+        type: 'rollup',
+      },
+    });
   });
 });
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Follow-up to #11591. That PR exposes `usedPreAggregations` on the data responses so a client can match a result to the pre-aggregation build behind it, and the SQL API does emit it — `node_export.rs` inserts it into the schema line next to `lastRefreshTime` and `external`. But `cubeSql` builds its result by whitelisting `{ schema, data, lastRefreshTime }` off that line, so the field is dropped before it reaches the caller. Consumers reading the SQL API through this client rather than `/v1/load` cannot see it at all.

This forwards it on both `cubeSql` and `cubeSqlStream`, and types it on `CubeSqlResult` and the stream's schema chunk. Absent stays absent: a query that hit no pre-aggregation, or a deployment older than the field, omits the key rather than reporting an empty object — so nothing changes for existing callers.

One small refactor comes with it. The spread that picks these fields off the schema line existed in three copies — `cubeSql`, and `cubeSqlStream` for both its per-chunk and its trailing-buffer path — which is the shape that loses the *next* field to a missed call site, silently and while still type-checking. It is now a single `pickCubeSqlResultMetadata` helper feeding all three, and the added tests cover the trailing-buffer path specifically.

**Verification**

`vitest run test/CubeApi.test.ts` in `packages/cubejs-client-core` — 40 passed. Reverting the `src/index.ts` change turns 3 of the 4 new tests red (the fourth is the negative case, which passes either way by construction). `eslint src/index.ts` reports the same 11 findings as the unmodified file on `master`, i.e. no new ones.