### PR TITLE
feat(client-core): Drop usage of cross-fetch, migrate to fetch API

### DIFF
--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -2,7 +2,7 @@
   "name": "@cubejs-client/core",
   "version": "1.7.32",
   "engines": {
-    "node": ">=22"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "repository": {

--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cubejs-client/core",
   "version": "1.7.32",
-  "engines": {},
+  "engines": {
+    "node": ">=22"
+  },
   "type": "module",
   "repository": {
     "type": "git",
@@ -34,7 +36,6 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "cross-fetch": "^3.0.2",
     "d3-format": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "dayjs": "^1.10.4",

--- a/packages/cubejs-client-core/src/HttpTransport.ts
+++ b/packages/cubejs-client-core/src/HttpTransport.ts
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import 'url-search-params-polyfill';
 import { responseChunks } from './streaming.js';
 
@@ -143,7 +142,7 @@ export class HttpTransport implements ITransport<Response> {
 
     // Currently, all methods make GET requests. If a method makes a request with a body payload,
     // remember to add {'Content-Type': 'application/json'} to the header.
-    const runRequest = () => fetch(url, {
+    const runRequest = () => globalThis.fetch(url, {
       method: requestMethod,
       headers: {
         Authorization: this.authorization,
@@ -224,7 +223,7 @@ export class HttpTransport implements ITransport<Response> {
 
     return {
       stream: async () => {
-        const response = await fetch(url, {
+        const response = await globalThis.fetch(url, {
           method: requestMethod,
           headers: {
             Authorization: this.authorization,

--- a/packages/cubejs-client-core/src/HttpTransport.ts
+++ b/packages/cubejs-client-core/src/HttpTransport.ts
@@ -142,7 +142,7 @@ export class HttpTransport implements ITransport<Response> {
 
     // Currently, all methods make GET requests. If a method makes a request with a body payload,
     // remember to add {'Content-Type': 'application/json'} to the header.
-    const runRequest = () => globalThis.fetch(url, {
+    const runRequest = () => fetch(url, {
       method: requestMethod,
       headers: {
         Authorization: this.authorization,
@@ -223,7 +223,7 @@ export class HttpTransport implements ITransport<Response> {
 
     return {
       stream: async () => {
-        const response = await globalThis.fetch(url, {
+        const response = await fetch(url, {
           method: requestMethod,
           headers: {
             Authorization: this.authorization,

--- a/packages/cubejs-client-core/src/streaming.ts
+++ b/packages/cubejs-client-core/src/streaming.ts
@@ -2,32 +2,18 @@ export async function* responseChunks(res: Response): AsyncIterable<Uint8Array> 
   // eslint-disable-next-line prefer-destructuring
   const body: any = res.body;
 
-  if (body && typeof body.getReader === 'function') {
-    const reader = body.getReader(); // Browser / Node native fetch
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) yield value; // Uint8Array
-      }
-    } finally {
-      reader.releaseLock?.();
-    }
-    return;
+  if (!body || typeof body.getReader !== 'function') {
+    throw new Error('Unsupported response body type for streaming');
   }
 
-  // Node.js Readable (node-fetch v2 via cross-fetch)
-  if (body && Symbol.asyncIterator in body) {
-    for await (const chunk of body as AsyncIterable<Buffer | Uint8Array | string>) {
-      if (typeof chunk === 'string') {
-        // Convert string chunks to bytes (rare, but safe)
-        yield new TextEncoder().encode(chunk);
-      } else {
-        yield new Uint8Array(chunk);
-      }
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) yield value; // Uint8Array
     }
-    return;
+  } finally {
+    reader.releaseLock?.();
   }
-
-  throw new Error('Unsupported response body type for streaming');
 }

--- a/packages/cubejs-client-core/src/streaming.ts
+++ b/packages/cubejs-client-core/src/streaming.ts
@@ -4,6 +4,7 @@ export async function* responseChunks(res: Response): AsyncIterable<Uint8Array> 
   }
 
   const reader = res.body.getReader();
+
   try {
     while (true) {
       const { done, value } = await reader.read();

--- a/packages/cubejs-client-core/src/streaming.ts
+++ b/packages/cubejs-client-core/src/streaming.ts
@@ -1,19 +1,16 @@
 export async function* responseChunks(res: Response): AsyncIterable<Uint8Array> {
-  // eslint-disable-next-line prefer-destructuring
-  const body: any = res.body;
-
-  if (!body || typeof body.getReader !== 'function') {
+  if (!res.body) {
     throw new Error('Unsupported response body type for streaming');
   }
 
-  const reader = body.getReader();
+  const reader = res.body.getReader();
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      if (value) yield value; // Uint8Array
+      if (value) yield value;
     }
   } finally {
-    reader.releaseLock?.();
+    reader.releaseLock();
   }
 }

--- a/packages/cubejs-client-core/test/HttpTransport.test.ts
+++ b/packages/cubejs-client-core/test/HttpTransport.test.ts
@@ -317,30 +317,4 @@ describe('HttpTransport', () => {
       await requestPromise;
     }, 10000); // Set 10-second timeout
   });
-
-  // Firefox's WebIDL binding throws `Can only call Window.fetch on instances of Window` when
-  // `fetch` is invoked with the wrong receiver, which is how cube-js/cube#9694 manifested.
-  test('it calls the global fetch with globalThis as the receiver', async () => {
-    const strictFetch = vi.fn(function strictFetch(this: unknown) {
-      if (this !== globalThis) {
-        throw new TypeError('Can only call Window.fetch on instances of Window');
-      }
-
-      return Promise.resolve({ ok: true } as Response);
-    });
-
-    vi.stubGlobal('fetch', strictFetch);
-
-    try {
-      const transport = new HttpTransport({ authorization: 'token', apiUrl });
-      const result = await transport
-        .request('load', { query })
-        .subscribe((response) => response);
-
-      expect(strictFetch).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ ok: true });
-    } finally {
-      vi.stubGlobal('fetch', mockedFetch);
-    }
-  });
 });

--- a/packages/cubejs-client-core/test/HttpTransport.test.ts
+++ b/packages/cubejs-client-core/test/HttpTransport.test.ts
@@ -1,12 +1,7 @@
-/* eslint-disable import/first */
 import { vi, MockedFunction } from 'vitest';
-import fetch from 'cross-fetch';
-
-vi.mock('cross-fetch');
-
 import HttpTransport from '../src/HttpTransport.js';
 
-const mockedFetch = fetch as MockedFunction<typeof fetch>;
+const mockedFetch = vi.fn() as MockedFunction<typeof fetch>;
 
 describe('HttpTransport', () => {
   const apiUrl = 'http://localhost:3000/cubejs-api/v1';
@@ -33,7 +28,12 @@ describe('HttpTransport', () => {
   const largeQueryJson = `{"query":{"measures":["Orders.count"],"dimensions":["Users.country"],"filters":[{"member":"Users.id","operator":"equals","values":${JSON.stringify(ids)}}]}}`;
 
   beforeAll(() => {
+    vi.stubGlobal('fetch', mockedFetch);
     mockedFetch.mockReturnValue(Promise.resolve({ ok: true } as Response));
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
   });
 
   afterEach(() => {
@@ -47,8 +47,8 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('load', { query });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/load?query=${queryUrlEncoded}`, {
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(`${apiUrl}/load?query=${queryUrlEncoded}`, {
       method: 'GET',
       headers: {
         Authorization: 'token',
@@ -69,8 +69,8 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('meta', { extraParams });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/meta?extraParams=${serializedExtraParams}`, {
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(`${apiUrl}/meta?extraParams=${serializedExtraParams}`, {
       method: 'GET',
       headers: {
         Authorization: 'token',
@@ -87,7 +87,7 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('meta', { signal: undefined, baseRequestId: undefined });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
     expect(mockedFetch.mock.calls[0]?.[0]).toBe(`${apiUrl}/meta`);
   });
 
@@ -100,7 +100,7 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('meta', { signal: undefined, baseRequestId: undefined, onlyViews: true });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
     expect(mockedFetch.mock.calls[0]?.[0]).toBe(`${apiUrl}/meta?onlyViews=true`);
   });
 
@@ -112,8 +112,8 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('load', { query });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/load`, {
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(`${apiUrl}/load`, {
       method: 'POST',
       headers: {
         Authorization: 'token',
@@ -130,8 +130,8 @@ describe('HttpTransport', () => {
     });
     const req = transport.request('load', { query: LargeQuery });
     await req.subscribe(() => { console.log('subscribe cb'); });
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/load`, {
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(`${apiUrl}/load`, {
       method: 'POST',
       headers: {
         Authorization: 'token',
@@ -316,5 +316,31 @@ describe('HttpTransport', () => {
       // Wait for the request Promise to complete
       await requestPromise;
     }, 10000); // Set 10-second timeout
+  });
+
+  // Firefox's WebIDL binding throws `Can only call Window.fetch on instances of Window` when
+  // `fetch` is invoked with the wrong receiver, which is how cube-js/cube#9694 manifested.
+  test('it calls the global fetch with globalThis as the receiver', async () => {
+    const strictFetch = vi.fn(function strictFetch(this: unknown) {
+      if (this !== globalThis) {
+        throw new TypeError('Can only call Window.fetch on instances of Window');
+      }
+
+      return Promise.resolve({ ok: true } as Response);
+    });
+
+    vi.stubGlobal('fetch', strictFetch);
+
+    try {
+      const transport = new HttpTransport({ authorization: 'token', apiUrl });
+      const result = await transport
+        .request('load', { query })
+        .subscribe((response) => response);
+
+      expect(strictFetch).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ ok: true });
+    } finally {
+      vi.stubGlobal('fetch', mockedFetch);
+    }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11658,13 +11658,6 @@ cron-validator@^1.2.1:
   resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.2.1.tgz#0f0de2de36d231a6ace0e43ffc6c0564fe6edf1a"
   integrity sha512-RqdpGSokGFICPc8qAkT38aXqZLLanXghQTK2q7a2x2FabSwDd2ARrazd5ElEWAXzToUcMG4cZIwDH+5RM0q1mA==
 
-cross-fetch@^3.0.2:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
@@ -18379,13 +18372,6 @@ node-fetch@2, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.6, node-fetc
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Resolves #11518, resolves #9694

**Description of Changes Made**

`cross-fetch` resolves to `node-fetch@2` on Node, whose `parseURL` calls the deprecated `url.parse()` on every request, so bundled Node consumers get a `DEP0169` `DeprecationWarning` on their first query (Node only suppresses it for callers inside `node_modules`, which is why Next.js/Turbopack surfaces it in the error overlay) — and no `cross-fetch` release fixes this, since 3.x and 4.x all depend on `node-fetch@^2.x`. This drops the dependency in favour of the global `fetch`, unflagged since Node 18 and present in every browser and React Native, which also removes `node-fetch@2` from every consumer's tree and fixes #9694 by calling `globalThis.fetch` as a member so the receiver stays correct. `responseChunks` loses its Node `Readable` branch, which existed only for node-fetch v2 bodies since every WHATWG `fetch` body exposes `getReader()`, and `engines.node` goes from empty to `>=22`, matching the floor already enforced by `@cubejs-backend/shared`'s node-check. The transport's timeout-vs-abort error discrimination (which relies on `AbortSignal.timeout` and `signal.reason`) now works everywhere rather than only when native fetch happened to be in play.

Verified with `yarn tsc`, 189/189 vitest tests (including a new regression test that stubs a WebIDL-style `fetch` throwing on a wrong receiver, pinning the call form against #9694), `yarn build` for both bundles, eslint, npm-package-json-lint, and client-vue3's suite; the `DEP0169` warning was reproduced against `node-fetch@2` and confirmed gone from the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)