### PR TITLE
fix(cubesql): Keep distinct count pushdown grouped

### DIFF
--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -68,10 +68,24 @@ You can connect a Cube deployment to Power BI using the [SQL API][ref-sql-api]
 as if Cube is a Postgres database. It would provide much more limited functionality
 than the DAX API. However, this is the only option when using Cube Core.
 
+<Note>
+
+When Power BI aggregates a measure of the [`count_distinct`][ref-count-distinct]
+type, it generates SQL that counts `NULL` as one additional distinct value:
+`COUNT(DISTINCT measure) + MAX(CASE WHEN measure IS NULL THEN 1 ELSE 0 END)`.
+Cube does not support counting `NULL` as a distinct value, so it returns the
+distinct count of non-`NULL` values only. Any group that contains a `NULL` comes
+back one lower than Power BI asks for. Groups without `NULL` values are
+unaffected, and a group is never ranked above one with a genuinely higher count,
+so a sorted visual keeps its order except among groups that would otherwise tie.
+
+</Note>
+
 
 [link-powerbi]: https://www.microsoft.com/en-gb/power-platform/products/power-bi/
 [link-powerbi-desktop-vs-service]: https://learn.microsoft.com/en-us/power-bi/fundamentals/service-service-vs-desktop
 [link-powerbi-gateway]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
+[ref-count-distinct]: /reference/data-modeling/measures#type
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
 [ref-sql-api]: /reference/core-data-apis/sql-api

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/aggregate_function.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/aggregate_function.rs
@@ -273,7 +273,23 @@ impl SplitRules {
             rules,
         );
         // TODO: workaround for PowerBI, it uses COUNT(DISTINCT(col)) + MAX(CASE ...) to count in NULLs
-        // as a distinct value. We don't support that yet, so don't count them
+        // as a distinct value. We don't support that yet, so don't count them: the MAX(CASE ...)
+        // half is replaced with a literal 0, so a group containing a NULL comes back one lower
+        // than the query asks for. For rows (city, customer_key) = (Berlin, c1), (Berlin, c1),
+        // (Berlin, c2), (Lisbon, c3), (Lisbon, NULL), (Oslo, NULL), grouped by city:
+        //
+        //     city   | asked for | returned
+        //     -------+-----------+---------
+        //     Berlin |         2 |        2
+        //     Lisbon |         2 |        1
+        //     Oslo   |         1 |        0
+        //
+        // The term adds at most 1, so it can only turn a tie into a strict order or back, never
+        // rank a group above one the query ranks higher -- but an outer ORDER BY with a LIMIT
+        // can still return a different one of the tied groups.
+        //
+        // Keep in sync with "wrapper-push-down-powerbi-count-distinct-max-case": narrowing one
+        // alone would make results depend on whether the query has an ORDER BY.
         self.single_arg_split_point_rules_aggregate_function(
             "aggregate-function-powerbi-count-distinct-max-case",
             || {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
@@ -5,7 +5,7 @@ use crate::{
             agg_fun_expr, agg_fun_expr_within_group_empty_tail, aggregate, alias_expr,
             analysis::ConstantFolding,
             binary_expr, case_expr, column_expr, cube_scan_wrapper, grouping_set_expr,
-            literal_bool, literal_null, original_expr_name, rewrite,
+            is_null_expr, literal_bool, literal_int, literal_null, original_expr_name, rewrite,
             rewriter::{CubeEGraph, CubeRewrite},
             rules::{members::MemberRules, wrapper::WrapperRules},
             subquery, transforming_chain_rewrite, transforming_rewrite, udaf_expr, wrapped_select,
@@ -462,6 +462,56 @@ impl WrapperRules {
                     "?distinct",
                     "?cube_members",
                     "?replace_agg_type",
+                    "?out_measure_alias",
+                ),
+            ),
+            // TODO: workaround for PowerBI, it uses COUNT(DISTINCT(col)) + MAX(CASE ...) to
+            // count NULLs as a distinct value. We don't support that yet, so don't count
+            // them: fold the MAX(CASE ...) half into a literal 0, which is also what lets
+            // the aggregation keep pushing to Cube instead of falling back to an ungrouped
+            // scan. Keep in sync with "aggregate-function-powerbi-count-distinct-max-case",
+            // whose note carries the effect on results.
+            transforming_chain_rewrite(
+                "wrapper-push-down-powerbi-count-distinct-max-case",
+                wrapper_pushdown_replacer("?aggr_expr", "?context"),
+                vec![
+                    (
+                        "?aggr_expr",
+                        agg_fun_expr(
+                            "Max",
+                            vec![case_expr(
+                                None,
+                                vec![(
+                                    is_null_expr(column_expr("?measure_column")),
+                                    literal_int(1),
+                                )],
+                                Some(literal_int(0)),
+                            )],
+                            "?distinct",
+                            agg_fun_expr_within_group_empty_tail(),
+                        ),
+                    ),
+                    (
+                        "?context",
+                        wrapper_replacer_context(
+                            "?alias_to_cube",
+                            "WrapperReplacerContextPushToCube:true",
+                            "?in_projection",
+                            "?cube_members",
+                            "?grouped_subqueries",
+                            "?ungrouped_scan",
+                            "?input_data_source",
+                        ),
+                    ),
+                ],
+                wrapper_pullup_replacer(
+                    alias_expr(literal_int(0), "?out_measure_alias"),
+                    "?context",
+                ),
+                self.transform_powerbi_max_case(
+                    "?aggr_expr",
+                    "?measure_column",
+                    "?cube_members",
                     "?out_measure_alias",
                 ),
             ),
@@ -1273,6 +1323,75 @@ impl WrapperRules {
                 &meta,
                 disable_strict_agg_type_match,
             )
+        }
+    }
+
+    /// The column has to resolve to a Cube measure `is_same_agg_type("countDistinct")`
+    /// accepts, which is `countDistinct` and `countDistinctApprox` but also `number`.
+    /// It does not require the paired COUNT(DISTINCT ...) to be present, so a lone
+    /// MAX(CASE WHEN <number measure> IS NULL ...) folds to 0 as well. Both are true of
+    /// "aggregate-function-powerbi-count-distinct-max-case" as well, and the two must
+    /// keep matching: narrowing one alone would make results depend on whether the query
+    /// has an ORDER BY.
+    fn transform_powerbi_max_case(
+        &self,
+        aggr_expr_var: &'static str,
+        column_var: &'static str,
+        cube_members_var: &'static str,
+        out_measure_alias_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let aggr_expr_var = var!(aggr_expr_var);
+        let column_var = var!(column_var);
+        let cube_members_var = var!(cube_members_var);
+        let out_measure_alias_var = var!(out_measure_alias_var);
+
+        let meta = self.meta_context.clone();
+
+        move |egraph, subst| {
+            let Some(alias) = original_expr_name(egraph, subst[aggr_expr_var]) else {
+                return false;
+            };
+
+            let columns = var_iter!(egraph[subst[column_var]], ColumnExprColumn)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let Some(member_names_to_expr) = &mut egraph
+                .index_mut(subst[cube_members_var])
+                .data
+                .member_name_to_expr
+            else {
+                return false;
+            };
+
+            let mut found = false;
+            for column in columns {
+                let Some((&(Some(ref member), _, _), _)) =
+                    LogicalPlanData::do_find_member_by_alias(member_names_to_expr, &column.name)
+                else {
+                    continue;
+                };
+
+                let Some(measure) = meta.find_measure_with_name(member) else {
+                    continue;
+                };
+
+                if measure.is_same_agg_type("countDistinct", false) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if !found {
+                return false;
+            }
+
+            subst.insert(
+                out_measure_alias_var,
+                egraph.add(LogicalPlanLanguage::AliasExprAlias(AliasExprAlias(alias))),
+            );
+
+            true
         }
     }
 

--- a/rust/cubesql/cubesql/src/compile/test/test_bi_workarounds.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_bi_workarounds.rs
@@ -9,6 +9,10 @@ use crate::{
     transport::TransportLoadRequestQuery,
 };
 
+/// Plain grouped pushdown of the PowerBI distinct-count idiom. The
+/// `MAX(CASE ...)` half is dropped rather than counted, so a group holding a
+/// NULL comes back one lower than the query asks for -- see the note on
+/// "aggregate-function-powerbi-count-distinct-max-case" for the numbers.
 #[tokio::test]
 async fn test_powerbi_count_distinct_with_max_case() {
     if !Rewriter::sql_push_down_enabled() {
@@ -50,4 +54,197 @@ async fn test_powerbi_count_distinct_with_max_case() {
             ..Default::default()
         }
     )
+}
+
+/// Same idiom reached through a subselect and with an outer `ORDER BY`, the shape
+/// that used to give up on push to cube and rebuild the distinct count as SQL over
+/// an ungrouped scan. It must stay a grouped request.
+#[tokio::test]
+async fn test_powerbi_count_distinct_with_max_case_order_by_limit() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        select
+            "rows"."customer_gender" as "customer_gender",
+            count(distinct("rows"."countDistinct")) + max(
+                case
+                    when "rows"."countDistinct" is null then 1
+                    else 0
+                end
+            ) as "a0"
+        from
+            (
+                select
+                    "_"."customer_gender",
+                    "_"."countDistinct"
+                from
+                    "public"."KibanaSampleDataEcommerce" "_"
+            ) "rows"
+        group by
+            "customer_gender"
+        order by
+            "a0" desc
+        limit
+            10
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+
+    let sql = logical_plan
+        .find_cube_scan_wrapped_sql_deep()
+        .wrapped_sql
+        .sql;
+    // The key is absent entirely from a grouped request, so this holds whatever
+    // spacing the serializer uses.
+    assert!(
+        !sql.contains(r#""ungrouped""#),
+        "expected a grouped request, got: {}",
+        sql
+    );
+    assert!(
+        !sql.contains("COUNT(DISTINCT"),
+        "distinct count must be left to Cube, not rebuilt as SQL, got: {}",
+        sql
+    );
+    assert!(
+        sql.contains("${KibanaSampleDataEcommerce.countDistinct}"),
+        "expected the measure to be pushed to Cube, got: {}",
+        sql
+    );
+    assert!(
+        sql.contains(r#"\"sql\":\"0\""#),
+        "expected the MAX(CASE ...) half to become a literal 0 member, got: {}",
+        sql
+    );
+    assert!(
+        sql.contains("ORDER BY") && sql.contains("LIMIT 10"),
+        "expected order and limit to be pushed down, got: {}",
+        sql
+    );
+}
+
+/// A measure whose agg type `is_same_agg_type("countDistinct")` rejects -- `max`
+/// here -- keeps its `MAX(CASE ...)`, which must not be folded away.
+#[tokio::test]
+async fn test_powerbi_max_case_over_non_count_distinct_is_not_dropped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        select
+            "rows"."customer_gender" as "customer_gender",
+            max(
+                case
+                    when "rows"."maxPrice" is null then 1
+                    else 0
+                end
+            ) as "a0"
+        from
+            (
+                select
+                    "_"."customer_gender",
+                    "_"."maxPrice"
+                from
+                    "public"."KibanaSampleDataEcommerce" "_"
+            ) "rows"
+        group by
+            "customer_gender"
+        order by
+            "a0" desc
+        limit
+            10
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql_deep()
+        .wrapped_sql
+        .sql;
+    assert!(
+        sql.contains("MAX(CASE WHEN"),
+        "expected the CASE to survive for a non-distinct measure, got: {}",
+        sql
+    );
+    // `MAX(CASE WHEN` alone would also appear on the old lossy fallback path, so
+    // pin the part that actually distinguishes the two: no literal 0 member.
+    assert!(
+        !sql.contains(r#"\"sql\":\"0\""#),
+        "MAX(CASE ...) must not be folded to a literal 0 here, got: {}",
+        sql
+    );
+}
+
+/// `is_same_agg_type("countDistinct")` also accepts `number`, and neither rule
+/// requires the paired `COUNT(DISTINCT ...)` to be present, so a lone
+/// `MAX(CASE WHEN <number measure> IS NULL ...)` is folded to 0 as well. That is
+/// wider than the idiom this workaround targets; it is pinned here because the
+/// grouped path at "aggregate-function-powerbi-count-distinct-max-case" does the
+/// same, and the two must keep matching.
+#[tokio::test]
+async fn test_powerbi_max_case_over_number_measure_is_dropped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        select
+            "rows"."dim_str0" as "d",
+            max(
+                case
+                    when "rows"."measure_num0" is null then 1
+                    else 0
+                end
+            ) as "a0"
+        from
+            (
+                select
+                    "_"."dim_str0",
+                    "_"."measure_num0"
+                from
+                    "MultiTypeCube" "_"
+            ) "rows"
+        group by
+            "d"
+        order by
+            "a0" desc
+        limit
+            10
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql_deep()
+        .wrapped_sql
+        .sql;
+    assert!(
+        sql.contains(r#"\"sql\":\"0\""#),
+        "expected the MAX(CASE ...) over a number measure to fold to 0, got: {}",
+        sql
+    );
+    assert!(
+        !sql.contains("MAX(CASE WHEN"),
+        "expected no MAX(CASE ...) left in the pushed down SQL, got: {}",
+        sql
+    );
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Issue Reference this PR resolves**

#11542

**Description of Changes Made**

This PR fixes a `COUNT(DISTINCT measure) + MAX(CASE ...)` query with an outer `ORDER BY` silently returning 1 per group instead of the real distinct count, by folding the `MAX(CASE ...)` half into a literal 0 in the SQL API wrapper the same way the existing grouped pushdown rule does, so the aggregation reaches Cube as a grouped request. Related test is included.