### PR TITLE
docs(dashboards): an export carries every control's selection, not just two

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -81,8 +81,9 @@ title.
 PNG and PDF downloads are server-rendered snapshots — Cube re-opens the
 dashboard (or, for a single chart, that chart on its own), waits for rendering
 to finish, and captures the result. This can take up to a couple of minutes
-for large dashboards. The filter and time-grain selections you currently have
-applied in your browser are carried into the export. (CSV is generated from the
+for large dashboards. The control selections you currently have applied in your
+browser are carried into the export — filters, time grains and [field
+switchers][ref-controls] alike. (CSV is generated from the
 data already loaded in the chart and downloads immediately.)
 
 Downloading the whole dashboard requires **Manage** permission on the workbook
@@ -94,6 +95,7 @@ after a [scheduled refresh][ref-scheduled-refreshes].
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-widgets]: /docs/explore-analyze/dashboards/widgets
+[ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
 [ref-dimension-links]: /docs/data-modeling/dimensions#links
 [ref-notifications]: /docs/explore-analyze/notifications
 [ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -82,9 +82,11 @@ PNG and PDF downloads are server-rendered snapshots — Cube re-opens the
 dashboard (or, for a single chart, that chart on its own), waits for rendering
 to finish, and captures the result. This can take up to a couple of minutes
 for large dashboards. The control selections you currently have applied in your
-browser are carried into the export — filters, time grains and [field
-switchers][ref-controls] alike. (CSV is generated from the
-data already loaded in the chart and downloads immediately.)
+browser are carried into a download you start yourself — filters, time
+granularity switchers and [field switchers][ref-controls] alike. A scheduled
+notification has no browser session, so its attachment renders the selections
+configured on the notification instead. (CSV is generated from the data already
+loaded in the chart and downloads immediately.)
 
 Downloading the whole dashboard requires **Manage** permission on the workbook
 that owns it; exporting a single chart requires the **Download data**

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -84,9 +84,9 @@ to finish, and captures the result. This can take up to a couple of minutes
 for large dashboards. The control selections you currently have applied in your
 browser are carried into a download you start yourself — filters, time
 granularity switchers and [field switchers][ref-controls] alike. A scheduled
-notification has no browser session, so its attachment renders the selections
-configured on the notification instead. (CSV is generated from the data already
-loaded in the chart and downloads immediately.)
+notification has no browser session, so its attachment renders the dashboard's
+own defaults, unless that notification carries selections of its own. (CSV is
+generated from the data already loaded in the chart and downloads immediately.)
 
 Downloading the whole dashboard requires **Manage** permission on the workbook
 that owns it; exporting a single chart requires the **Download data**


### PR DESCRIPTION
`docs/explore-analyze/dashboards/index.mdx` says a server-rendered PNG/PDF carries "the filter and time-grain selections you currently have applied in your browser". [CUB-4289](https://linear.app/cube-d3/issue/CUB-4289) ([cubedevinc/cubejs-enterprise#14633](https://github.com/cubedevinc/cubejs-enterprise/pull/14633), merged) makes a **field switcher's** member travel with the export as well, so that list named two of the three things carried and silently excluded the third.

Verified rather than assumed: on `staging-mngr-7` running that build, the export request carries `ms_orders.status=users_city` and the returned PNG renders the Users City column instead of the control's default. There is Playwright coverage in `tests/probation/dashboards/field-switcher-export.spec.ts`.

## Also scoped to the manual download

Review flagged that the sentence was over-broad, and it was. Three paragraphs down the page says the same screenshot mechanism powers PNG/PDF attachments on scheduled notifications — so "the selections you currently have applied in your browser" invited the reader to carry that into the scheduled case, where there is no browser session and the attachment renders what the notification itself carries (`filters` / `timeGrains` / `memberSwitchers`). That over-broadness predates this PR — the original sentence made the same claim about filters and time grains — and is fixed here because this PR is what draws attention to the sentence.

## Correction to an earlier version of this description

It said "the same claim on the Controls and embedding pages was fixed in #11721". That was wrong, and review caught it: #11721's *merged* text does not mention exports at all — `controls.mdx` on `master` contains the word zero times. Those pages never carried the export claim, so nothing in the tree contradicted this page; this sentence was simply the only place the stale enumeration survived.

## Not included

`memberSwitchers`, the notification-API field that sets a switcher for a scheduled export, is deliberately not hand-written here: `filters` and `timeGrains` aren't documented on these pages either. All three reach readers through the generated management-API reference, and the new one lands there with the next SDK release.