### PR TITLE
feat(clickhouse-driver): Pass the X-Request-ID as ClickHouse query_id

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
@@ -196,6 +196,20 @@ module.exports = {
 
 </CodeGroup>
 
+## Query attribution
+
+Cube sets the ClickHouse [`query_id`](https://clickhouse.com/docs/operations/system-tables/query_log)
+of every statement it runs to `<cube-query-id>-<uuid>`, where `<cube-query-id>` is the
+identifier shown for the query in Query History and `<uuid>` is generated per statement, so
+one Cube query matches as many rows as it ran statements. Use it to trace a Cube query to the
+statements it produced in ClickHouse:
+
+```sql
+SELECT query_id, query, event_time
+FROM system.query_log
+WHERE query_id LIKE '<cube-query-id>%'
+```
+
 ## Additional Configuration
 
 You can connect to a ClickHouse database when your user's permissions are

--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -31,3 +31,4 @@ export * from './disposedProxy';
 export * from './logger';
 export * from './pool';
 export * from './sql-escape';
+export * from './request-id';

--- a/packages/cubejs-backend-shared/src/request-id.ts
+++ b/packages/cubejs-backend-shared/src/request-id.ts
@@ -1,0 +1,7 @@
+/**
+ * Extracts the UUID prefix from a request ID by stripping the `-span-N` suffix.
+ */
+export function extractRequestUUID(requestId: string): string {
+  const idx = requestId.lastIndexOf('-span-');
+  return idx !== -1 ? requestId.substring(0, idx) : requestId;
+}

--- a/packages/cubejs-backend-shared/src/request-id.ts
+++ b/packages/cubejs-backend-shared/src/request-id.ts
@@ -1,7 +1,3 @@
-/**
- * A request ID carries a `-span-N` suffix per query span within the request. Consumers that
- * key off the request itself (queue dedup, query tagging) want the ID without that suffix.
- */
 export function extractRequestUUID(requestId: string): string {
   const idx = requestId.lastIndexOf('-span-');
   return idx !== -1 ? requestId.substring(0, idx) : requestId;

--- a/packages/cubejs-backend-shared/src/request-id.ts
+++ b/packages/cubejs-backend-shared/src/request-id.ts
@@ -1,5 +1,6 @@
 /**
- * Extracts the UUID prefix from a request ID by stripping the `-span-N` suffix.
+ * A request ID carries a `-span-N` suffix per query span within the request. Consumers that
+ * key off the request itself (queue dedup, query tagging) want the ID without that suffix.
  */
 export function extractRequestUUID(requestId: string): string {
   const idx = requestId.lastIndexOf('-span-');

--- a/packages/cubejs-base-driver/src/BaseDriver.ts
+++ b/packages/cubejs-base-driver/src/BaseDriver.ts
@@ -552,7 +552,7 @@ export abstract class BaseDriver implements DriverInterface {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async queryColumnTypes(sql: string, params: unknown[]): Promise<{ name: any; type: string; }[]> {
+  public async queryColumnTypes(sql: string, params: unknown[], options?: QueryOptions): Promise<{ name: any; type: string; }[]> {
     return [];
   }
 

--- a/packages/cubejs-base-driver/src/driver.interface.ts
+++ b/packages/cubejs-base-driver/src/driver.interface.ts
@@ -167,19 +167,11 @@ type UnloadQuery = {
 export type UnloadOptions = {
   maxFileSize: number,
   query?: UnloadQuery;
-  /**
-   * Cube request identifier, forwarded so drivers can tag the underlying
-   * database job/query for tracing (e.g. BigQuery job labels).
-   */
   requestId?: string;
 };
 
 export type QueryOptions = {
   inlineTables?: InlineTables,
-  /**
-   * Cube request identifier, forwarded so drivers can tag the underlying
-   * database job/query for tracing (e.g. BigQuery job labels).
-   */
   requestId?: string,
   [key: string]: any
 };

--- a/packages/cubejs-base-driver/src/driver.interface.ts
+++ b/packages/cubejs-base-driver/src/driver.interface.ts
@@ -167,10 +167,20 @@ type UnloadQuery = {
 export type UnloadOptions = {
   maxFileSize: number,
   query?: UnloadQuery;
+  /**
+   * Cube request identifier, forwarded so drivers can tag the underlying
+   * database job/query for tracing (e.g. BigQuery job labels).
+   */
+  requestId?: string;
 };
 
 export type QueryOptions = {
   inlineTables?: InlineTables,
+  /**
+   * Cube request identifier, forwarded so drivers can tag the underlying
+   * database job/query for tracing (e.g. BigQuery job labels).
+   */
+  requestId?: string,
   [key: string]: any
 };
 
@@ -250,7 +260,7 @@ export interface DriverInterface {
   query<R = unknown>(query: string, params: unknown[], options?: QueryOptions): Promise<R[]>;
   //
   tableColumnTypes: (table: string) => Promise<TableStructure>;
-  queryColumnTypes: (sql: string, params: unknown[]) => Promise<{ name: any; type: string; }[]>;
+  queryColumnTypes: (sql: string, params: unknown[], options?: QueryOptions) => Promise<{ name: any; type: string; }[]>;
   //
   getSchemas: () => Promise<QuerySchemasResult[]>;
   tablesSchema: () => Promise<any>;

--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -7,6 +7,7 @@
 import {
   getEnv,
   assertDataSource,
+  extractRequestUUID,
   pausePromise,
   Required,
 } from '@cubejs-backend/shared';
@@ -432,9 +433,7 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
       return undefined;
     }
 
-    const rawId = String(requestId);
-    const spanIdx = rawId.lastIndexOf('-span-');
-    const queryUuid = spanIdx !== -1 ? rawId.substring(0, spanIdx) : rawId;
+    const queryUuid = extractRequestUUID(String(requestId));
 
     const value = queryUuid.toLowerCase().replace(/[^a-z0-9_-]/g, '_').slice(0, 63);
     if (!value) {

--- a/packages/cubejs-clickhouse-driver/package.json
+++ b/packages/cubejs-clickhouse-driver/package.json
@@ -32,7 +32,6 @@
     "@cubejs-backend/base-driver": "1.7.32",
     "@cubejs-backend/shared": "1.7.32",
     "moment": "^2.24.0",
-    "sqlstring": "^2.3.1",
     "uuid": "^11.1.1"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -7,6 +7,7 @@
 import {
   getEnv,
   assertDataSource,
+  extractRequestUUID,
 } from '@cubejs-backend/shared';
 import {
   BaseDriver,
@@ -204,8 +205,15 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     this.client = this.createClient(maxPoolSize);
   }
 
-  protected withCancel<T>(fn: (con: ClickHouseClient, queryId: string, signal: AbortSignal) => Promise<T>): Promise<T> {
-    const queryId = uuidv4();
+  protected withCancel<T>(
+    fn: (con: ClickHouseClient, queryId: string, signal: AbortSignal) => Promise<T>,
+    options?: QueryOptions,
+  ): Promise<T> {
+    // ClickHouse echoes query_id into system.query_log, so prefixing it with the Cube query
+    // id makes every statement traceable to a query in Query History. The uuid suffix keeps
+    // it unique: ClickHouse rejects a query whose query_id is already running, and one Cube
+    // request can run several statements concurrently.
+    const queryId = options?.requestId ? `${extractRequestUUID(options.requestId)}-${uuidv4()}` : uuidv4();
 
     const abortController = new AbortController();
     const { signal } = abortController;
@@ -234,7 +242,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       const killClient = this.createClient(1);
       try {
         await killClient.command({
-          query: `KILL QUERY WHERE query_id = '${queryId}'`,
+          query: `KILL QUERY WHERE query_id = ${sqlstring.escape(queryId)}`,
         });
       } finally {
         await killClient.close();
@@ -268,12 +276,12 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       true;
   }
 
-  public async query<R = unknown>(query: string, values: unknown[]): Promise<R[]> {
-    const response = await this.queryResponse(query, values);
+  public async query<R = unknown>(query: string, values: unknown[], options?: QueryOptions): Promise<R[]> {
+    const response = await this.queryResponse(query, values, options);
     return this.normaliseResponse(response);
   }
 
-  protected queryResponse(query: string, values: unknown[]): Promise<ResponseJSON<Record<string, unknown>>> {
+  protected queryResponse(query: string, values: unknown[], options?: QueryOptions): Promise<ResponseJSON<Record<string, unknown>>> {
     const formattedQuery = sqlstring.format(query, values);
 
     return this.withCancel(async (connection, queryId, signal) => {
@@ -301,7 +309,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
         // TODO replace string formatting with proper cause
         throw new Error(`Query failed: ${e}; query id: ${queryId}`);
       }
-    });
+    }, options);
   }
 
   protected normaliseResponse<R = unknown>(res: ResponseJSON<Record<string, unknown>>): Array<R> {
@@ -372,11 +380,11 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     query: string,
     values: unknown[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { highWaterMark }: StreamOptions
+    { highWaterMark, requestId }: StreamOptions
   ): Promise<StreamTableDataWithTypes> {
     // Use separate client for this long-living query
     const client = this.createClient(1);
-    const queryId = uuidv4();
+    const queryId = requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();
 
     try {
       const formattedQuery = sqlstring.format(query, values);
@@ -461,7 +469,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       return this.stream(query, values, options);
     }
 
-    const response = await this.queryResponse(query, values);
+    const response = await this.queryResponse(query, values, options);
 
     return {
       rows: this.normaliseResponse(response),
@@ -513,8 +521,8 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     return this.query('SELECT name as table_name FROM system.tables WHERE database = ?', [schemaName]);
   }
 
-  public override async dropTable(tableName: string, _options?: QueryOptions): Promise<void> {
-    await this.command(`DROP TABLE ${tableName}`);
+  public override async dropTable(tableName: string, options?: QueryOptions): Promise<void> {
+    await this.command(`DROP TABLE ${tableName}`, options);
   }
 
   protected getExportBucket(
@@ -566,7 +574,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   /**
    * Returns an array of queried fields meta info.
    */
-  public async queryColumnTypes(sql: string, params: unknown[]): Promise<TableStructure> {
+  public async queryColumnTypes(sql: string, params: unknown[], options?: QueryOptions): Promise<TableStructure> {
     // For DESCRIBE we expect that each row would have special structure
     // See https://clickhouse.com/docs/en/sql-reference/statements/describe-table
     // TODO complete this type
@@ -574,7 +582,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       name: string,
       type: string
     };
-    const columns = await this.query<DescribeRow>(`DESCRIBE ${sql}`, params);
+    const columns = await this.query<DescribeRow>(`DESCRIBE ${sql}`, params, options);
     if (!columns) {
       throw new Error('Unable to describe table');
     }
@@ -615,12 +623,12 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     );
   }
 
-  public async unloadFromQuery(sql: string, params: unknown[], _options: UnloadOptions): Promise<DownloadTableCSVData> {
+  public async unloadFromQuery(sql: string, params: unknown[], options: UnloadOptions): Promise<DownloadTableCSVData> {
     if (!this.config.exportBucket) {
       throw new Error('Unload is not configured');
     }
 
-    const types = await this.queryColumnTypes(`(${sql})`, params);
+    const types = await this.queryColumnTypes(`(${sql})`, params, { requestId: options?.requestId });
     const { bucketName, path } = this.parseBucketUrl(this.config.exportBucket.bucketName);
     const exportPrefix = path ? `${path}/${uuidv4()}` : uuidv4();
 
@@ -635,7 +643,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       ${sql}
     `, params);
 
-    await this.command(formattedQuery);
+    await this.command(formattedQuery, { requestId: options?.requestId });
 
     const csvFile = await this.extractUnloadedFilesFromS3(
       {
@@ -666,18 +674,18 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   }
 
   // This is not part of a driver interface, and marked public only for testing
-  public async command(query: string): Promise<void> {
+  public async command(query: string, options?: QueryOptions): Promise<void> {
     await this.withCancel(async (connection, queryId, signal) => {
       await connection.command({
         query,
         query_id: queryId,
         abort_signal: signal,
       });
-    });
+    }, options);
   }
 
   // This is not part of a driver interface, and marked public only for testing
-  public async insert(table: string, values: Array<Array<unknown>>): Promise<void> {
+  public async insert(table: string, values: Array<Array<unknown>>, options?: QueryOptions): Promise<void> {
     await this.withCancel(async (connection, queryId, signal) => {
       await connection.insert({
         table,
@@ -686,6 +694,6 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
         query_id: queryId,
         abort_signal: signal,
       });
-    });
+    }, options);
   }
 }

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -206,9 +206,9 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   }
 
   /**
-   * ClickHouse echoes query_id into system.query_log, so prefixing it with the Cube query id
-   * makes every statement traceable to a query in Query History. ClickHouse rejects a query_id
-   * that is already running, so each statement gets its own uuid suffix.
+   * ClickHouse echoes query_id into system.query_log, which is what makes a statement
+   * traceable to a query in Query History. The uuid suffix is required because ClickHouse
+   * rejects a query_id that is already running.
    */
   private buildQueryId(requestId?: string): string {
     return requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -37,12 +37,6 @@ import { transformRow, transformStreamRow } from './HydrationStream';
 
 const SUPPORTED_BUCKET_TYPES = ['s3'];
 
-/**
- * ClickHouse echoes query_id back in the X-ClickHouse-Query-Id response header, and the Cube
- * request id can come from a client supplied `x-request-id`, which is unbounded — past a few
- * dozen KB every query of that request dies with `Parse Error: Header overflow`. Same clamp
- * as the BigQuery job label, and enough for a request uuid or `scheduler-<uuid>`.
- */
 const MAX_QUERY_ID_PREFIX_LENGTH = 64;
 
 const ClickhouseTypeToGeneric: Record<string, string> = {
@@ -213,11 +207,6 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     this.client = this.createClient(maxPoolSize);
   }
 
-  /**
-   * ClickHouse echoes query_id into system.query_log, which is what makes a statement
-   * traceable to a query in Query History. The uuid suffix is required because ClickHouse
-   * rejects a query_id that is already running.
-   */
   private buildQueryId(requestId?: string): string {
     const prefix = requestId
       ? extractRequestUUID(requestId).slice(0, MAX_QUERY_ID_PREFIX_LENGTH)

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -8,6 +8,7 @@ import {
   getEnv,
   assertDataSource,
   extractRequestUUID,
+  formatMySql,
 } from '@cubejs-backend/shared';
 import {
   BaseDriver,
@@ -31,7 +32,6 @@ import { Readable } from 'node:stream';
 import { ClickHouseClient, createClient } from '@clickhouse/client';
 import type { ClickHouseSettings, ResponseJSON } from '@clickhouse/client';
 import { v4 as uuidv4 } from 'uuid';
-import sqlstring from 'sqlstring';
 
 import { transformRow, transformStreamRow } from './HydrationStream';
 
@@ -242,7 +242,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       const killClient = this.createClient(1);
       try {
         await killClient.command({
-          query: `KILL QUERY WHERE query_id = ${sqlstring.escape(queryId)}`,
+          query: formatMySql('KILL QUERY WHERE query_id = ?', [queryId]),
         });
       } finally {
         await killClient.close();
@@ -282,7 +282,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   }
 
   protected queryResponse(query: string, values: unknown[], options?: QueryOptions): Promise<ResponseJSON<Record<string, unknown>>> {
-    const formattedQuery = sqlstring.format(query, values);
+    const formattedQuery = formatMySql(query, values);
 
     return this.withCancel(async (connection, queryId, signal) => {
       try {
@@ -387,7 +387,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     const queryId = requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();
 
     try {
-      const formattedQuery = sqlstring.format(query, values);
+      const formattedQuery = formatMySql(query, values);
 
       const format = 'JSONCompactEachRowWithNamesAndTypes';
 
@@ -632,7 +632,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     const { bucketName, path } = this.parseBucketUrl(this.config.exportBucket.bucketName);
     const exportPrefix = path ? `${path}/${uuidv4()}` : uuidv4();
 
-    const formattedQuery = sqlstring.format(`
+    const formattedQuery = formatMySql(`
       INSERT INTO FUNCTION
          s3(
              'https://${bucketName}.s3.${this.config.exportBucket.region}.amazonaws.com/${exportPrefix}/export.csv.gz',

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -205,15 +205,20 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     this.client = this.createClient(maxPoolSize);
   }
 
+  /**
+   * ClickHouse echoes query_id into system.query_log, so prefixing it with the Cube query id
+   * makes every statement traceable to a query in Query History. ClickHouse rejects a query_id
+   * that is already running, so each statement gets its own uuid suffix.
+   */
+  private buildQueryId(requestId?: string): string {
+    return requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();
+  }
+
   protected withCancel<T>(
     fn: (con: ClickHouseClient, queryId: string, signal: AbortSignal) => Promise<T>,
     options?: QueryOptions,
   ): Promise<T> {
-    // ClickHouse echoes query_id into system.query_log, so prefixing it with the Cube query
-    // id makes every statement traceable to a query in Query History. The uuid suffix keeps
-    // it unique: ClickHouse rejects a query whose query_id is already running, and one Cube
-    // request can run several statements concurrently.
-    const queryId = options?.requestId ? `${extractRequestUUID(options.requestId)}-${uuidv4()}` : uuidv4();
+    const queryId = this.buildQueryId(options?.requestId);
 
     const abortController = new AbortController();
     const { signal } = abortController;
@@ -384,7 +389,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   ): Promise<StreamTableDataWithTypes> {
     // Use separate client for this long-living query
     const client = this.createClient(1);
-    const queryId = requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();
+    const queryId = this.buildQueryId(requestId);
 
     try {
       const formattedQuery = formatMySql(query, values);

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -37,6 +37,14 @@ import { transformRow, transformStreamRow } from './HydrationStream';
 
 const SUPPORTED_BUCKET_TYPES = ['s3'];
 
+/**
+ * ClickHouse echoes query_id back in the X-ClickHouse-Query-Id response header, and the Cube
+ * request id can come from a client supplied `x-request-id`, which is unbounded — past a few
+ * dozen KB every query of that request dies with `Parse Error: Header overflow`. Same clamp
+ * as the BigQuery job label, and enough for a request uuid or `scheduler-<uuid>`.
+ */
+const MAX_QUERY_ID_PREFIX_LENGTH = 64;
+
 const ClickhouseTypeToGeneric: Record<string, string> = {
   enum: 'text',
   string: 'text',
@@ -211,7 +219,11 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
    * rejects a query_id that is already running.
    */
   private buildQueryId(requestId?: string): string {
-    return requestId ? `${extractRequestUUID(requestId)}-${uuidv4()}` : uuidv4();
+    const prefix = requestId
+      ? extractRequestUUID(requestId).slice(0, MAX_QUERY_ID_PREFIX_LENGTH)
+      : '';
+
+    return prefix ? `${prefix}-${uuidv4()}` : uuidv4();
   }
 
   protected withCancel<T>(

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -37,8 +37,6 @@ import { transformRow, transformStreamRow } from './HydrationStream';
 
 const SUPPORTED_BUCKET_TYPES = ['s3'];
 
-const MAX_QUERY_ID_PREFIX_LENGTH = 64;
-
 const ClickhouseTypeToGeneric: Record<string, string> = {
   enum: 'text',
   string: 'text',
@@ -208,11 +206,13 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   }
 
   private buildQueryId(requestId?: string): string {
-    const prefix = requestId
-      ? extractRequestUUID(requestId).slice(0, MAX_QUERY_ID_PREFIX_LENGTH)
-      : '';
+    if (!requestId) {
+      return uuidv4();
+    }
 
-    return prefix ? `${prefix}-${uuidv4()}` : uuidv4();
+    const prefix = extractRequestUUID(requestId).slice(0, 63);
+
+    return `${prefix}-${uuidv4()}`;
   }
 
   protected withCancel<T>(

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -206,11 +206,10 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   }
 
   private buildQueryId(requestId?: string): string {
-    if (!requestId) {
+    const prefix = requestId ? extractRequestUUID(requestId).slice(0, 63) : '';
+    if (!prefix) {
       return uuidv4();
     }
-
-    const prefix = extractRequestUUID(requestId).slice(0, 63);
 
     return `${prefix}-${uuidv4()}`;
   }

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -633,7 +633,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       throw new Error('Unload is not configured');
     }
 
-    const types = await this.queryColumnTypes(`(${sql})`, params, { requestId: options?.requestId });
+    const types = await this.queryColumnTypes(`(${sql})`, params, { requestId: options.requestId });
     const { bucketName, path } = this.parseBucketUrl(this.config.exportBucket.bucketName);
     const exportPrefix = path ? `${path}/${uuidv4()}` : uuidv4();
 
@@ -648,7 +648,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       ${sql}
     `, params);
 
-    await this.command(formattedQuery, { requestId: options?.requestId });
+    await this.command(formattedQuery, { requestId: options.requestId });
 
     const csvFile = await this.extractUnloadedFilesFromS3(
       {

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -68,6 +68,19 @@ describe('ClickHouseDriver query id', () => {
     });
   });
 
+  it('clamps an over-long request id, which would overflow the response header', async () => {
+    await createDriver().query('SELECT 1', [], { requestId: `${'x'.repeat(500)}-span-1` });
+
+    const { query_id: queryId } = mockQuery.mock.calls[0][0];
+    expect(queryId).toMatch(new RegExp(`^x{64}-${UUID}$`));
+  });
+
+  it('falls back to a generated uuid when the request id is all span suffix', async () => {
+    await createDriver().query('SELECT 1', [], { requestId: '-span-1' });
+
+    expect(mockQuery.mock.calls[0][0].query_id).toMatch(UUID_RE);
+  });
+
   it('falls back to a generated uuid when there is no request id', async () => {
     await createDriver().query('SELECT 1', []);
 

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -72,13 +72,7 @@ describe('ClickHouseDriver query id', () => {
     await createDriver().query('SELECT 1', [], { requestId: `${'x'.repeat(500)}-span-1` });
 
     const { query_id: queryId } = mockQuery.mock.calls[0][0];
-    expect(queryId).toMatch(new RegExp(`^x{64}-${UUID}$`));
-  });
-
-  it('falls back to a generated uuid when the request id is all span suffix', async () => {
-    await createDriver().query('SELECT 1', [], { requestId: '-span-1' });
-
-    expect(mockQuery.mock.calls[0][0].query_id).toMatch(UUID_RE);
+    expect(queryId).toMatch(new RegExp(`^x{63}-${UUID}$`));
   });
 
   it('falls back to a generated uuid when there is no request id', async () => {

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -86,7 +86,7 @@ describe('ClickHouseDriver query id', () => {
 
     await promise.cancel();
     expect(mockCommand.mock.calls[0][0]).toEqual({
-      query: `KILL QUERY WHERE query_id = 'a\\'${queryId.slice(2)}'`,
+      query: `KILL QUERY WHERE query_id = 'a''${queryId.slice(2)}'`,
     });
   });
 

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -1,0 +1,128 @@
+import { createClient } from '@clickhouse/client';
+
+import { ClickHouseDriver } from '../../src';
+
+const mockQuery = jest.fn(async (_params: any) => ({
+  response_headers: {} as Record<string, string>,
+  json: async () => ({ data: [], meta: [] }),
+}));
+const mockCommand = jest.fn(async (_params: any) => ({}));
+const mockInsert = jest.fn(async (_params: any) => ({}));
+const mockPing = jest.fn(async () => ({ success: true }));
+
+jest.mock('@clickhouse/client', () => ({
+  createClient: jest.fn(() => ({
+    ping: mockPing,
+    query: mockQuery,
+    command: mockCommand,
+    insert: mockInsert,
+    close: jest.fn(),
+  })),
+}));
+
+const createClientMock = createClient as unknown as jest.Mock;
+
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+const UUID_RE = new RegExp(`^${UUID}$`);
+
+function createDriver(): ClickHouseDriver {
+  return new ClickHouseDriver({
+    host: 'localhost',
+    port: '8123',
+    dataSource: 'default',
+  });
+}
+
+describe('ClickHouseDriver query id', () => {
+  beforeEach(() => {
+    createClientMock.mockClear();
+    mockQuery.mockClear();
+    mockCommand.mockClear();
+    mockInsert.mockClear();
+  });
+
+  it('prefixes query_id with the Cube request id, without the span suffix', async () => {
+    await createDriver().query('SELECT 1', [], { requestId: '5c2c96a1-d0b3-4a9e-8f52-2b6b7f0b1e11-span-3' });
+
+    expect(mockQuery.mock.calls[0][0]).toMatchObject({
+      query_id: expect.stringMatching(new RegExp(`^5c2c96a1-d0b3-4a9e-8f52-2b6b7f0b1e11-${UUID}$`)),
+    });
+  });
+
+  it('generates a unique query_id per statement of the same request', async () => {
+    const driver = createDriver();
+    const requestId = 'req-0-span-1';
+
+    await driver.query('SELECT 1', [], { requestId });
+    await driver.query('SELECT 2', [], { requestId });
+
+    const [first, second] = mockQuery.mock.calls.map(([params]) => params.query_id);
+    expect(first).not.toEqual(second);
+  });
+
+  it('keeps a request id without a span suffix as the prefix', async () => {
+    await createDriver().query('SELECT 1', [], { requestId: 'my-request-id' });
+
+    expect(mockQuery.mock.calls[0][0]).toMatchObject({
+      query_id: expect.stringMatching(new RegExp(`^my-request-id-${UUID}$`)),
+    });
+  });
+
+  it('falls back to a generated uuid when there is no request id', async () => {
+    await createDriver().query('SELECT 1', []);
+
+    const { query_id: queryId } = mockQuery.mock.calls[0][0];
+    expect(queryId).toMatch(UUID_RE);
+  });
+
+  it('escapes the query id in the KILL QUERY statement', async () => {
+    const driver = createDriver();
+    // queryResponse() returns the cancellable promise; query() awaits it and drops `cancel`
+    const promise = (driver as any).queryResponse('SELECT 1', [], { requestId: 'a\'b-span-1' });
+    await promise;
+
+    const { query_id: queryId } = mockQuery.mock.calls[0][0];
+    expect(queryId).toMatch(new RegExp(`^a'b-${UUID}$`));
+
+    await promise.cancel();
+    expect(mockCommand.mock.calls[0][0]).toEqual({
+      query: `KILL QUERY WHERE query_id = 'a\\'${queryId.slice(2)}'`,
+    });
+  });
+
+  it('tags streaming queries', async () => {
+    const driver = createDriver();
+
+    // The mocked client returns no rows, so stream() throws while reading the header rows;
+    // we only care about the query_id it sent.
+    await expect(driver.stream('SELECT 1', [], { highWaterMark: 100, requestId: 'req-1-span-1' }))
+      .rejects.toThrow();
+
+    expect(mockQuery.mock.calls[0][0]).toMatchObject({
+      query_id: expect.stringMatching(new RegExp(`^req-1-${UUID}$`)),
+    });
+  });
+
+  it('tags commands and inserts', async () => {
+    const driver = createDriver();
+
+    await driver.command('DROP TABLE t', { requestId: 'req-2-span-1' });
+    expect(mockCommand.mock.calls[0][0]).toMatchObject({
+      query_id: expect.stringMatching(new RegExp(`^req-2-${UUID}$`)),
+    });
+
+    await driver.insert('t', [[1]], { requestId: 'req-3-span-1' });
+    expect(mockInsert.mock.calls[0][0]).toMatchObject({
+      query_id: expect.stringMatching(new RegExp(`^req-3-${UUID}$`)),
+    });
+  });
+
+  it('tags dropTable through the options it receives', async () => {
+    await createDriver().dropTable('t', { requestId: 'req-4-span-1' });
+
+    expect(mockCommand.mock.calls[0][0]).toMatchObject({
+      query: 'DROP TABLE t',
+      query_id: expect.stringMatching(new RegExp(`^req-4-${UUID}$`)),
+    });
+  });
+});

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -90,7 +90,6 @@ describe('ClickHouseDriver query id', () => {
 
   it('escapes the query id in the KILL QUERY statement', async () => {
     const driver = createDriver();
-    // queryResponse() returns the cancellable promise; query() awaits it and drops `cancel`
     const promise = (driver as any).queryResponse('SELECT 1', [], { requestId: 'a\'b-span-1' });
     await promise;
 
@@ -106,7 +105,6 @@ describe('ClickHouseDriver query id', () => {
   it('tags streaming queries', async () => {
     const driver = createDriver();
 
-    // The mocked client returns no rows, so stream() throws on the missing header rows
     await expect(driver.stream('SELECT 1', [], { highWaterMark: 100, requestId: 'req-1-span-1' }))
       .rejects.toThrow();
 

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -93,8 +93,7 @@ describe('ClickHouseDriver query id', () => {
   it('tags streaming queries', async () => {
     const driver = createDriver();
 
-    // The mocked client returns no rows, so stream() throws while reading the header rows;
-    // we only care about the query_id it sent.
+    // The mocked client returns no rows, so stream() throws on the missing header rows
     await expect(driver.stream('SELECT 1', [], { highWaterMark: 100, requestId: 'req-1-span-1' }))
       .rejects.toThrow();
 

--- a/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query-id.test.ts
@@ -75,6 +75,12 @@ describe('ClickHouseDriver query id', () => {
     expect(queryId).toMatch(new RegExp(`^x{63}-${UUID}$`));
   });
 
+  it('falls back to a generated uuid when the request id is all span suffix', async () => {
+    await createDriver().query('SELECT 1', [], { requestId: '-span-1' });
+
+    expect(mockQuery.mock.calls[0][0].query_id).toMatch(UUID_RE);
+  });
+
   it('falls back to a generated uuid when there is no request id', async () => {
     await createDriver().query('SELECT 1', []);
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -670,7 +670,7 @@ export class PreAggregationLoader {
         const actualTables = await client.getTablesQuery(this.preAggregation.preAggregationsSchema);
         const mappedActualTables = actualTables.map(t => `${this.preAggregation.preAggregationsSchema}.${t.table_name || t.TABLE_NAME}`);
         if (mappedActualTables.includes(targetTableName)) {
-          await client.dropTable(targetTableName);
+          await client.dropTable(targetTableName, queryOptions);
         }
       });
     }
@@ -794,14 +794,16 @@ export class PreAggregationLoader {
   protected getUnloadOptions(): UnloadOptions {
     return {
       // Default: 16mb for Snowflake, Should be specified in MBs, because drivers convert it
-      maxFileSize: 64
+      maxFileSize: 64,
+      requestId: this.requestId,
     };
   }
 
   protected getStreamingOptions(): StreamOptions {
     return {
       // Default: 16384 (16KB), or 16 for objectMode streams. PostgreSQL/MySQL use object streams
-      highWaterMark: 10000
+      highWaterMark: 10000,
+      requestId: this.requestId,
     };
   }
 
@@ -915,11 +917,11 @@ export class PreAggregationLoader {
         tableData.rowStream = stream;
       }
     } else {
-      tableData = { rows: await saveCancelFn(client.query(sql, params)) };
+      tableData = { rows: await saveCancelFn(client.query(sql, params, queryOptions)) };
     }
 
     if (!tableData.types && client.queryColumnTypes) {
-      tableData.types = await saveCancelFn(client.queryColumnTypes(sql, params));
+      tableData.types = await saveCancelFn(client.queryColumnTypes(sql, params, queryOptions));
     }
 
     return tableData;
@@ -966,7 +968,7 @@ export class PreAggregationLoader {
     const indexesSql = this.prepareIndexesSql(newVersionEntry, queryOptions);
     for (let i = 0; i < indexesSql.length; i++) {
       const [query, params] = indexesSql[i].sql;
-      await saveCancelFn(driver.query(query, params));
+      await saveCancelFn(driver.query(query, params, queryOptions));
     }
   }
 
@@ -1070,7 +1072,7 @@ export class PreAggregationLoader {
         .map(t => `${this.preAggregation.preAggregationsSchema}.${t.table_name || t.TABLE_NAME}`)
         .filter(t => toSave.indexOf(t) === -1);
 
-      await Promise.all(toDrop.map(table => saveCancelFn(client.dropTable(table))));
+      await Promise.all(toDrop.map(table => saveCancelFn(client.dropTable(table, queryOptions))));
       this.logger('Dropping orphaned tables completed', {
         ...queryOptions,
         external,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -9,6 +9,7 @@ import {
   streamToArray,
   CacheMode,
   LoggerFn,
+  extractRequestUUID,
 } from '@cubejs-backend/shared';
 import { CubeStoreCacheDriver, CubeStoreDriver } from '@cubejs-backend/cubestore-driver';
 import {
@@ -27,7 +28,6 @@ import { DriverFactory, DriverFactoryByDataSource } from './DriverFactory';
 import { LoadPreAggregationResult, PreAggregationDescription } from './PreAggregations';
 import {
   getCacheHash,
-  extractRequestUUID,
   evaluateLocalRefreshKey,
   isValidLocalRefreshKey,
 } from './utils';

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -209,8 +209,7 @@ export class QueryQueue {
     };
 
     if (options.requestId) {
-      const idx = options.requestId.lastIndexOf('-span-');
-      options.externalId = idx !== -1 ? options.requestId.substring(0, idx) : options.requestId;
+      options.externalId = extractRequestUUID(options.requestId);
     }
 
     if (this.skipQueue) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { getEnv, getProcessUid, LoggerFn } from '@cubejs-backend/shared';
+import { getEnv, getProcessUid, LoggerFn, extractRequestUUID } from '@cubejs-backend/shared';
 import {
   QueueDriverInterface,
   QueryKey,
@@ -18,7 +18,6 @@ import { ContinueWaitError } from './ContinueWaitError';
 import { LocalQueueDriver } from './LocalQueueDriver';
 import { QueryStream } from './QueryStream';
 import { CacheAndQueryDriverType } from './QueryOrchestrator';
-import { extractRequestUUID } from './utils';
 
 export type CancelHandlerFn = (query: QueryDef) => Promise<void>;
 export type QueryHandlerFn = (query: QueryDef, cancelHandler: CancelHandlerFn) => Promise<unknown>;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -4,6 +4,8 @@ import { getProcessUid } from '@cubejs-backend/shared';
 import { QueryKey, QueryKeyHash } from '@cubejs-backend/base-driver';
 import { CacheKey, LocalRefreshKeyDescriptor } from './QueryCache';
 
+export { extractRequestUUID } from '@cubejs-backend/shared';
+
 /**
  * Unique process ID regexp.
  */
@@ -57,12 +59,4 @@ export function isValidLocalRefreshKey(descriptor?: LocalRefreshKeyDescriptor): 
     Number.isFinite(descriptor.interval) && descriptor.interval > 0 &&
     Number.isFinite(descriptor.utcOffset) &&
     Number.isFinite(descriptor.dayOffset);
-}
-
-/**
- * Extracts the UUID prefix from a request ID by stripping the `-span-N` suffix.
- */
-export function extractRequestUUID(requestId: string): string {
-  const idx = requestId.lastIndexOf('-span-');
-  return idx !== -1 ? requestId.substring(0, idx) : requestId;
 }

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -4,8 +4,6 @@ import { getProcessUid } from '@cubejs-backend/shared';
 import { QueryKey, QueryKeyHash } from '@cubejs-backend/base-driver';
 import { CacheKey, LocalRefreshKeyDescriptor } from './QueryCache';
 
-export { extractRequestUUID } from '@cubejs-backend/shared';
-
 /**
  * Unique process ID regexp.
  */


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

CORE-841

**Description of Changes Made (if issue reference is not provided)**

Nothing identified a Cube query on the ClickHouse side: `ClickHouseDriver` minted a random `uuidv4()` as `query_id` only so `.cancel()` could `KILL QUERY`, and the `requestId` the orchestrator already passes was dropped because `query()` declared just two parameters. Every statement now runs with `query_id = <cube-query-id>-<uuid4>` (the `-span-N` suffix stripped, a uuid appended per statement since ClickHouse rejects a `query_id` that is already running), so a query from Query History can be found with `WHERE query_id LIKE '<cube-query-id>%'` in `system.query_log` — verified live against clickhouse-server:24.8 for SELECT, streaming SELECT, CREATE/DROP TABLE and three concurrent SELECTs. The id is escaped at the `KILL QUERY` call site because it can originate from a client-supplied `x-request-id` header.

This also closes the pre-aggregation paths that reached drivers with no request id at all (`getUnloadOptions`, `getStreamingOptions`, `createIndexes`, `dropOrphanedTables`), which BigQuery's job labels benefit from too, and moves the `-span-N` stripping into `@cubejs-backend/shared` as `extractRequestUUID`, replacing its three copies (BigQuery labels, `QueryQueue.executeInQueue`, `orchestrator/utils`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)