### PR TITLE
perf(clickhouse-driver): drop the per-query ping

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
@@ -38,7 +38,7 @@ CUBEJS_DB_PASS=**********
 | [`CUBEJS_DB_PASS`](/reference/configuration/environment-variables#cubejs_db_pass)                   | The password used to connect to the database                                        | A valid database password |    ✅    |
 | [`CUBEJS_DB_CLICKHOUSE_READONLY`](/reference/configuration/environment-variables#cubejs_db_clickhouse_readonly)    | Whether the ClickHouse user has read-only access or not                             | `true`, `false`           |    ❌    |
 | [`CUBEJS_DB_CLICKHOUSE_COMPRESSION`](/reference/configuration/environment-variables#cubejs_db_clickhouse_compression) | Whether the ClickHouse client has compression enabled or not                        | `true`, `false`           |    ❌    |
-| [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)               | The maximum number of concurrent database connections to pool. Default is `10`      | A valid number            |    ❌    |
+| [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)               | The maximum number of concurrent database connections to pool. Default is `20`      | A valid number            |    ❌    |
 | [`CUBEJS_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_concurrency)               | The number of [concurrent queries][ref-data-source-concurrency] to the data source  | A valid number            |    ❌    |
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency

--- a/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/clickhouse.mdx
@@ -38,7 +38,7 @@ CUBEJS_DB_PASS=**********
 | [`CUBEJS_DB_PASS`](/reference/configuration/environment-variables#cubejs_db_pass)                   | The password used to connect to the database                                        | A valid database password |    ✅    |
 | [`CUBEJS_DB_CLICKHOUSE_READONLY`](/reference/configuration/environment-variables#cubejs_db_clickhouse_readonly)    | Whether the ClickHouse user has read-only access or not                             | `true`, `false`           |    ❌    |
 | [`CUBEJS_DB_CLICKHOUSE_COMPRESSION`](/reference/configuration/environment-variables#cubejs_db_clickhouse_compression) | Whether the ClickHouse client has compression enabled or not                        | `true`, `false`           |    ❌    |
-| [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)               | The maximum number of concurrent database connections to pool. Default is `20`      | A valid number            |    ❌    |
+| [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)               | The maximum number of concurrent database connections to pool. Default is `10`      | A valid number            |    ❌    |
 | [`CUBEJS_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_concurrency)               | The number of [concurrent queries][ref-data-source-concurrency] to the data source  | A valid number            |    ❌    |
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -1,7 +1,3 @@
-/**
- * @fileoverview The `ClickHouseDriver` and related types declaration.
- */
-
 import {
   getEnv,
   assertDataSource,

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -199,9 +199,6 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       headers: config.headers ?? {},
     };
 
-    // server-core passes `maxPoolSize` explicitly (2 * queue concurrency); this fallback only
-    // covers a driver built straight from `driver_factory`, where a pool below the concurrency
-    // would leave statements waiting on sockets.
     const maxPoolSize = config.maxPoolSize ??
       getEnv('dbMaxPoolSize', { dataSource, preAggregations }) ??
       ClickHouseDriver.getDefaultConcurrency();

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -230,10 +230,6 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     const { signal } = abortController;
 
     const promise = (async () => {
-      // No health probe before the statement: `client.ping()` cost an extra HTTP round trip and a
-      // socket from the same `max_open_connections` pool as the statement itself, while `GET /ping`
-      // verifies neither credentials nor database. Stale keep-alive sockets are already recycled by
-      // the client (`keep_alive.idle_socket_ttl`), and an unreachable host fails at connect anyway.
       signal.throwIfAborted();
       // Queries sent by `fn` can hit a timeout error, would _not_ get killed, and continue running in ClickHouse
       // TODO should we kill those as well?
@@ -603,7 +599,11 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
 
   public override async createTable(quotedTableName: string, columns: TableColumn[]) {
     const createTableSql = this.createTableSql(quotedTableName, columns);
-    await this.command(createTableSql);
+    try {
+      await this.command(createTableSql);
+    } catch (e) {
+      throw new Error(`Create table ${quotedTableName} failed: ${formatError(e)}`, { cause: e });
+    }
   }
 
   /**

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -1,6 +1,4 @@
 /**
- * @copyright Cube Dev, Inc.
- * @license Apache-2.0
  * @fileoverview The `ClickHouseDriver` and related types declaration.
  */
 

--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -34,6 +34,7 @@ import type { ClickHouseSettings, ResponseJSON } from '@clickhouse/client';
 import { v4 as uuidv4 } from 'uuid';
 
 import { transformRow, transformStreamRow } from './HydrationStream';
+import { formatError } from './utils';
 
 const SUPPORTED_BUCKET_TYPES = ['s3'];
 
@@ -200,7 +201,12 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       headers: config.headers ?? {},
     };
 
-    const maxPoolSize = config.maxPoolSize ?? getEnv('dbMaxPoolSize', { dataSource, preAggregations }) ?? 8;
+    // server-core passes `maxPoolSize` explicitly (2 * queue concurrency); this fallback only
+    // covers a driver built straight from `driver_factory`, where a pool below the concurrency
+    // would leave statements waiting on sockets.
+    const maxPoolSize = config.maxPoolSize ??
+      getEnv('dbMaxPoolSize', { dataSource, preAggregations }) ??
+      ClickHouseDriver.getDefaultConcurrency();
 
     this.client = this.createClient(maxPoolSize);
   }
@@ -224,16 +230,10 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
     const { signal } = abortController;
 
     const promise = (async () => {
-      const pingResult = await this.client.ping();
-      if (!pingResult.success) {
-        // TODO replace string formatting with proper cause
-        // pingResult.error can be AggregateError when ClickHouse hostname resolves to multiple addresses
-        let errorMessage = pingResult.error.toString();
-        if (pingResult.error instanceof AggregateError) {
-          errorMessage = `Aggregate error: ${pingResult.error.message}; errors: ${pingResult.error.errors.join('; ')}`;
-        }
-        throw new Error(`Connection check failed: ${errorMessage}`);
-      }
+      // No health probe before the statement: `client.ping()` cost an extra HTTP round trip and a
+      // socket from the same `max_open_connections` pool as the statement itself, while `GET /ping`
+      // verifies neither credentials nor database. Stale keep-alive sockets are already recycled by
+      // the client (`keep_alive.idle_socket_ttl`), and an unreachable host fails at connect anyway.
       signal.throwIfAborted();
       // Queries sent by `fn` can hit a timeout error, would _not_ get killed, and continue running in ClickHouse
       // TODO should we kill those as well?
@@ -311,8 +311,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
         const results = await resultSet.json<Record<string, unknown>>();
         return results;
       } catch (e) {
-        // TODO replace string formatting with proper cause
-        throw new Error(`Query failed: ${e}; query id: ${queryId}`);
+        throw new Error(`Query failed: ${formatError(e)}; query id: ${queryId}`, { cause: e });
       }
     }, options);
   }
@@ -460,8 +459,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       };
     } catch (e) {
       await client.close();
-      // TODO replace string formatting with proper cause
-      throw new Error(`Stream query failed: ${e}; query id: ${queryId}`);
+      throw new Error(`Stream query failed: ${formatError(e)}; query id: ${queryId}`, { cause: e });
     }
   }
 
@@ -605,12 +603,7 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
 
   public override async createTable(quotedTableName: string, columns: TableColumn[]) {
     const createTableSql = this.createTableSql(quotedTableName, columns);
-    try {
-      await this.command(createTableSql);
-    } catch (e) {
-      // TODO replace string formatting with proper cause
-      throw new Error(`Create table failed: ${e}`);
-    }
+    await this.command(createTableSql);
   }
 
   /**
@@ -681,24 +674,32 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   // This is not part of a driver interface, and marked public only for testing
   public async command(query: string, options?: QueryOptions): Promise<void> {
     await this.withCancel(async (connection, queryId, signal) => {
-      await connection.command({
-        query,
-        query_id: queryId,
-        abort_signal: signal,
-      });
+      try {
+        await connection.command({
+          query,
+          query_id: queryId,
+          abort_signal: signal,
+        });
+      } catch (e) {
+        throw new Error(`Command failed: ${formatError(e)}; query id: ${queryId}`, { cause: e });
+      }
     }, options);
   }
 
   // This is not part of a driver interface, and marked public only for testing
   public async insert(table: string, values: Array<Array<unknown>>, options?: QueryOptions): Promise<void> {
     await this.withCancel(async (connection, queryId, signal) => {
-      await connection.insert({
-        table,
-        values,
-        format: 'JSONCompactEachRow',
-        query_id: queryId,
-        abort_signal: signal,
-      });
+      try {
+        await connection.insert({
+          table,
+          values,
+          format: 'JSONCompactEachRow',
+          query_id: queryId,
+          abort_signal: signal,
+        });
+      } catch (e) {
+        throw new Error(`Insert failed: ${formatError(e)}; query id: ${queryId}`, { cause: e });
+      }
     }, options);
   }
 }

--- a/packages/cubejs-clickhouse-driver/src/utils.ts
+++ b/packages/cubejs-clickhouse-driver/src/utils.ts
@@ -3,13 +3,6 @@
  * @license Apache-2.0
  */
 
-/**
- * Node rejects with an `AggregateError` when a hostname resolves to several addresses and every
- * connection attempt fails; `${err}` on it renders as just "AggregateError" and drops every reason.
- *
- * Upstream only ever reads `message`/`stack` (QueryQueue logs, api-gateway response), never `cause`,
- * so the detail has to live in the string.
- */
 export function formatError(e: unknown): string {
   if (e instanceof AggregateError) {
     // Node leaves `message` empty for the errors it raises itself

--- a/packages/cubejs-clickhouse-driver/src/utils.ts
+++ b/packages/cubejs-clickhouse-driver/src/utils.ts
@@ -1,8 +1,3 @@
-/**
- * @copyright Cube Dev, Inc.
- * @license Apache-2.0
- */
-
 export function formatError(e: unknown): string {
   if (e instanceof AggregateError) {
     // Node leaves `message` empty for the errors it raises itself

--- a/packages/cubejs-clickhouse-driver/src/utils.ts
+++ b/packages/cubejs-clickhouse-driver/src/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * @copyright Cube Dev, Inc.
+ * @license Apache-2.0
+ */
+
+/**
+ * Node rejects with an `AggregateError` when a hostname resolves to several addresses and every
+ * connection attempt fails; `${err}` on it renders as just "AggregateError" and drops every reason.
+ *
+ * Upstream only ever reads `message`/`stack` (QueryQueue logs, api-gateway response), never `cause`,
+ * so the detail has to live in the string.
+ */
+export function formatError(e: unknown): string {
+  if (e instanceof AggregateError) {
+    // Node leaves `message` empty for the errors it raises itself
+    const prefix = e.message ? `Aggregate error: ${e.message}` : 'Aggregate error';
+    return `${prefix}; errors: ${e.errors.map((inner) => formatError(inner)).join('; ')}`;
+  }
+
+  return `${e}`;
+}

--- a/packages/cubejs-clickhouse-driver/test/unit/pool.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/pool.test.ts
@@ -9,13 +9,19 @@ jest.mock('@clickhouse/client', () => ({
 const createClientMock = createClient as unknown as jest.Mock;
 
 describe('ClickHouseDriver pool size', () => {
+  const originalMaxPool = process.env.CUBEJS_DB_MAX_POOL;
+
   beforeEach(() => {
     createClientMock.mockClear();
     delete process.env.CUBEJS_DB_MAX_POOL;
   });
 
   afterAll(() => {
-    delete process.env.CUBEJS_DB_MAX_POOL;
+    if (originalMaxPool === undefined) {
+      delete process.env.CUBEJS_DB_MAX_POOL;
+    } else {
+      process.env.CUBEJS_DB_MAX_POOL = originalMaxPool;
+    }
   });
 
   const createDriver = (options = {}) => new ClickHouseDriver({

--- a/packages/cubejs-clickhouse-driver/test/unit/pool.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/pool.test.ts
@@ -1,0 +1,49 @@
+import { createClient } from '@clickhouse/client';
+
+import { ClickHouseDriver } from '../../src';
+
+jest.mock('@clickhouse/client', () => ({
+  createClient: jest.fn(() => ({ close: jest.fn() })),
+}));
+
+const createClientMock = createClient as unknown as jest.Mock;
+
+describe('ClickHouseDriver pool size', () => {
+  beforeEach(() => {
+    createClientMock.mockClear();
+    delete process.env.CUBEJS_DB_MAX_POOL;
+  });
+
+  afterAll(() => {
+    delete process.env.CUBEJS_DB_MAX_POOL;
+  });
+
+  const createDriver = (options = {}) => new ClickHouseDriver({
+    host: 'localhost',
+    port: '8123',
+    dataSource: 'default',
+    ...options,
+  });
+
+  const maxOpenConnections = () => createClientMock.mock.calls[0][0].max_open_connections;
+
+  it('defaults to the driver concurrency, so statements do not queue on sockets', () => {
+    createDriver();
+
+    expect(maxOpenConnections()).toEqual(ClickHouseDriver.getDefaultConcurrency());
+  });
+
+  it('follows CUBEJS_DB_MAX_POOL', () => {
+    process.env.CUBEJS_DB_MAX_POOL = '3';
+    createDriver();
+
+    expect(maxOpenConnections()).toEqual(3);
+  });
+
+  it('prefers an explicit maxPoolSize over CUBEJS_DB_MAX_POOL', () => {
+    process.env.CUBEJS_DB_MAX_POOL = '3';
+    createDriver({ maxPoolSize: 42 });
+
+    expect(maxOpenConnections()).toEqual(42);
+  });
+});

--- a/packages/cubejs-clickhouse-driver/test/unit/query.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query.test.ts
@@ -57,21 +57,44 @@ describe('ClickHouseDriver statement path', () => {
   });
 
   it('reports the reason of a failed query in the message', async () => {
-    client.query.mockRejectedValue(new AggregateError(
+    const cause = new AggregateError(
       [new Error('connect ECONNREFUSED ::1:8123'), new Error('connect ECONNREFUSED 127.0.0.1:8123')],
       'All promises were rejected',
-    ));
+    );
+    client.query.mockRejectedValue(cause);
 
-    await expect(createDriver().query('SELECT 1', [])).rejects.toThrow(
+    const { rejects } = expect(createDriver().query('SELECT 1', []));
+    await rejects.toThrow(
       /Query failed: Aggregate error: All promises were rejected; errors: Error: connect ECONNREFUSED ::1:8123; Error: connect ECONNREFUSED 127\.0\.0\.1:8123; query id: /
     );
+    await rejects.toMatchObject({ cause });
   });
 
   it('reports the reason of a failed command in the message', async () => {
-    client.command.mockRejectedValue(new Error('Timeout error.'));
+    const cause = new Error('Timeout error.');
+    client.command.mockRejectedValue(cause);
 
-    await expect(createDriver().command('DROP TABLE test.t')).rejects.toThrow(
-      /Command failed: Error: Timeout error\.; query id: /
+    const { rejects } = expect(createDriver().command('DROP TABLE test.t'));
+    await rejects.toThrow(/Command failed: Error: Timeout error\.; query id: /);
+    await rejects.toMatchObject({ cause });
+  });
+
+  it('reports the reason of a failed insert in the message', async () => {
+    const cause = new Error('Timeout error.');
+    client.insert.mockRejectedValue(cause);
+
+    const { rejects } = expect(createDriver().insert('test.t', [[1]]));
+    await rejects.toThrow(/Insert failed: Error: Timeout error\.; query id: /);
+    await rejects.toMatchObject({ cause });
+  });
+
+  it('names the table when a create table fails', async () => {
+    client.command.mockRejectedValue(new Error('Unknown data type family'));
+
+    await expect(
+      createDriver().createTable('test.t', [{ name: 'a', type: 'int' }])
+    ).rejects.toThrow(
+      /Create table test\.t failed: Error: Command failed: Error: Unknown data type family; query id: /
     );
   });
 });

--- a/packages/cubejs-clickhouse-driver/test/unit/query.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/query.test.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@clickhouse/client';
+
+import { ClickHouseDriver } from '../../src';
+import { formatError } from '../../src/utils';
+
+jest.mock('@clickhouse/client', () => ({
+  createClient: jest.fn(),
+}));
+
+const createClientMock = createClient as unknown as jest.Mock;
+
+describe('ClickHouseDriver statement path', () => {
+  let client: Record<'ping' | 'query' | 'command' | 'insert' | 'close', jest.Mock>;
+
+  beforeEach(() => {
+    client = {
+      ping: jest.fn(async () => ({ success: true })),
+      query: jest.fn(async () => ({
+        response_headers: {},
+        json: async () => ({ meta: [{ name: 'one', type: 'UInt8' }], data: [{ one: 1 }] }),
+      })),
+      command: jest.fn(async () => ({ query_id: 'test' })),
+      insert: jest.fn(async () => ({ executed: true })),
+      close: jest.fn(async () => undefined),
+    };
+    createClientMock.mockReset();
+    createClientMock.mockImplementation(() => client);
+  });
+
+  const createDriver = () => new ClickHouseDriver({
+    host: 'localhost',
+    port: '8123',
+    dataSource: 'default',
+  });
+
+  it('does not run a health check per query', async () => {
+    const driver = createDriver();
+
+    expect(await driver.query('SELECT 1 AS one', [])).toEqual([{ one: '1' }]);
+    await driver.query('SELECT 1 AS one', []);
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.ping).not.toHaveBeenCalled();
+    // A single long-lived client, so no extra socket pool per statement
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run a health check per command or insert', async () => {
+    const driver = createDriver();
+
+    await driver.command('CREATE DATABASE IF NOT EXISTS test');
+    await driver.insert('test.t', [[1]]);
+
+    expect(client.command).toHaveBeenCalledTimes(1);
+    expect(client.insert).toHaveBeenCalledTimes(1);
+    expect(client.ping).not.toHaveBeenCalled();
+  });
+
+  it('reports the reason of a failed query in the message', async () => {
+    client.query.mockRejectedValue(new AggregateError(
+      [new Error('connect ECONNREFUSED ::1:8123'), new Error('connect ECONNREFUSED 127.0.0.1:8123')],
+      'All promises were rejected',
+    ));
+
+    await expect(createDriver().query('SELECT 1', [])).rejects.toThrow(
+      /Query failed: Aggregate error: All promises were rejected; errors: Error: connect ECONNREFUSED ::1:8123; Error: connect ECONNREFUSED 127\.0\.0\.1:8123; query id: /
+    );
+  });
+
+  it('reports the reason of a failed command in the message', async () => {
+    client.command.mockRejectedValue(new Error('Timeout error.'));
+
+    await expect(createDriver().command('DROP TABLE test.t')).rejects.toThrow(
+      /Command failed: Error: Timeout error\.; query id: /
+    );
+  });
+});
+
+describe('formatError', () => {
+  it('flattens nested aggregate errors', () => {
+    const error = new AggregateError(
+      [new AggregateError([new Error('inner')], 'nested'), new Error('outer')],
+      'All promises were rejected',
+    );
+
+    expect(formatError(error)).toEqual(
+      'Aggregate error: All promises were rejected; errors: Aggregate error: nested; errors: Error: inner; Error: outer'
+    );
+  });
+
+  it('omits the prefix message when the aggregate error carries none', () => {
+    const error = new AggregateError([new Error('connect ECONNREFUSED ::1:1')]);
+
+    expect(formatError(error)).toEqual('Aggregate error; errors: Error: connect ECONNREFUSED ::1:1');
+  });
+
+  it('stringifies plain errors', () => {
+    expect(formatError(new Error('boom'))).toEqual('Error: boom');
+  });
+});


### PR DESCRIPTION
`withCancel` ran `client.ping()` before every query, command and insert — an extra HTTP round trip per statement that also borrowed a socket from the same `max_open_connections` pool as the statement itself, so pings queued against real queries under concurrency. It bought almost nothing: `GET /ping` verifies neither credentials nor database, stale keep-alive sockets are already recycled by the client (`keep_alive.idle_socket_ttl`), an unreachable host fails at connect for the statement anyway, and `stream()` already skipped it.

Its one real contribution was a readable connection error, so the `AggregateError` flattening moves into `formatError` and is applied to the existing catch blocks — plus new ones in `command` and `insert`, which had no catch at all and are where that message did the most work. Also aligns the `maxPoolSize` fallback with the driver's own concurrency (`8` → `getDefaultConcurrency()` = 10; it only applies to a driver built straight from `driver_factory`, since server-core passes `maxPoolSize` explicitly) and fixes the docs cell for `CUBEJS_DB_MAX_POOL`, which claimed 20.

The wider confusion around how that pool default is derived is tracked separately in CORE-845.

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

`yarn unit` 12 passed, `yarn integration` (testcontainers) 13 passed, `yarn lint` 0 errors. New `test/unit/query.test.ts` asserts no ping is issued per statement and that connection errors keep their reason; new `test/unit/pool.test.ts` covers the pool-size precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)