### PR TITLE
fix(tesseract): resolve rollup-join keys kept as a rollup's time dimension

### DIFF
--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -428,6 +428,19 @@ cube(`orders`, {
 
 </CodeGroup>
 
+<Warning>
+
+A join key may be declared as a rollup's `time_dimension` rather than as a plain
+dimension. A rollup stores a time dimension truncated to its `granularity`, so the
+join then happens on those buckets, not on the raw values the join is modeled on —
+rows that fall in the same bucket match even if the underlying timestamps differ.
+Use it for keys that are already aligned to that granularity, such as a date
+dimension joined to facts by day. Both sides of a join must store the key the same
+way; a rollup truncating it to `day` cannot be joined to one truncating it to
+`month`, or to one keeping it raw as a plain dimension.
+
+</Warning>
+
 <Info>
 
 `rollup_join` is not required to join cubes from the same data source; instead,

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -428,19 +428,6 @@ cube(`orders`, {
 
 </CodeGroup>
 
-<Warning>
-
-A join key may be declared as a rollup's `time_dimension` rather than as a plain
-dimension. A rollup stores a time dimension truncated to its `granularity`, so the
-join then happens on those buckets, not on the raw values the join is modeled on —
-rows that fall in the same bucket match even if the underlying timestamps differ.
-Use it for keys that are already aligned to that granularity, such as a date
-dimension joined to facts by day. Both sides of a join must store the key the same
-way; a rollup truncating it to `day` cannot be joined to one truncating it to
-`month`, or to one keeping it raw as a plain dimension.
-
-</Warning>
-
 <Info>
 
 `rollup_join` is not required to join cubes from the same data source; instead,

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -1089,8 +1089,7 @@ export class PreAggregations {
     join: JoinEdgeWithMembers,
     rollupJoinPreAggName: string,
   ): PreAggregationForQuery {
-    const fromPreAggObj = preAggObjsToJoin
-      .filter(p => joinMembers.every(m => !!p.references.dimensions.find(d => m === d)));
+    const fromPreAggObj = this.rollupsCarryingJoinMembers(preAggObjsToJoin, joinMembers);
     if (!fromPreAggObj.length) {
       const msg = `No rollups found that can be used for a rollup join from "${
         join.from}" (fromMembers: ${JSON.stringify(join.fromMembers)}) to "${join.to}" (toMembers: ${
@@ -1104,6 +1103,29 @@ export class PreAggregations {
       );
     }
     return fromPreAggObj[0];
+  }
+
+  /**
+   * Rollups that can stand on one side of a hop.
+   *
+   * A join key may be declared as a rollup's time dimension, which `references.dimensions`
+   * doesn't cover. Such a key lives in a granularity-suffixed column, which only the native
+   * planner renders — this side resolves it just to describe the rollups to build, so the
+   * wider reading is limited to the queries that planner serves. A rollup declaring the key
+   * plainly is preferred, so a hop that already resolved keeps resolving to the same rollup.
+   */
+  private rollupsCarryingJoinMembers(
+    preAggObjsToJoin: PreAggregationForQuery[],
+    joinMembers: string[],
+  ): PreAggregationForQuery[] {
+    const declaredAsDimensions = preAggObjsToJoin
+      .filter(p => joinMembers.every(m => !!p.references.dimensions.find(d => m === d)));
+    if (declaredAsDimensions.length || !this.query.canUseNativeSqlPlannerPreAggregation) {
+      return declaredAsDimensions;
+    }
+    return preAggObjsToJoin
+      .filter(p => joinMembers.every(m => !!p.references.dimensions.find(d => m === d) ||
+        !!p.references.timeDimensions.find(td => m === td.dimension)));
   }
 
   private resolveJoinMembers(join: FinishedJoinTree): JoinEdgeWithMembers[] {

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -1106,13 +1106,9 @@ export class PreAggregations {
   }
 
   /**
-   * Rollups that can stand on one side of a hop.
-   *
-   * A join key may be declared as a rollup's time dimension, which `references.dimensions`
-   * doesn't cover. Such a key lives in a granularity-suffixed column, which only the native
-   * planner renders — this side resolves it just to describe the rollups to build, so the
-   * wider reading is limited to the queries that planner serves. A rollup declaring the key
-   * plainly is preferred, so a hop that already resolved keeps resolving to the same rollup.
+   * Rollups that can stand on one side of a hop. The wider reading — a key declared as a
+   * rollup's time dimension — is limited to the native planner, the only one that renders the
+   * granularity-suffixed column such a key lives in.
    */
   private rollupsCarryingJoinMembers(
     preAggObjsToJoin: PreAggregationForQuery[],

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -1271,6 +1271,78 @@ describe('PreAggregations', () => {
       },
     });
 
+    // A rollupJoin whose join key is declared as each leg rollup's time dimension, so the
+    // key is stored truncated and under a granularity-suffixed column name.
+    cube('td_dates', {
+      sql: \`SELECT '2017-01-02'::timestamp as day, 'Q1' as quarter_label UNION ALL SELECT '2017-01-05'::timestamp, 'Q1'\`,
+
+      joins: {
+        td_facts: {
+          relationship: 'one_to_many',
+          sql: \`\${CUBE.day} = \${td_facts.day}\`
+        }
+      },
+
+      dimensions: {
+        day: {
+          sql: 'day',
+          type: 'time',
+          primary_key: true
+        },
+        quarter_label: {
+          sql: 'quarter_label',
+          type: 'string'
+        },
+      },
+
+      pre_aggregations: {
+        td_dates_rollup: {
+          dimensions: [quarter_label],
+          timeDimension: day,
+          granularity: 'day'
+        },
+        td_rollup_join: {
+          type: 'rollupJoin',
+          measures: [td_facts.total_amount],
+          dimensions: [quarter_label],
+          timeDimension: td_facts.day,
+          granularity: 'day',
+          rollups: [td_dates_rollup, td_facts.td_facts_rollup]
+        }
+      }
+    });
+
+    cube('td_facts', {
+      sql: \`SELECT 1 as id, '2017-01-02'::timestamp as day, 10 as amount UNION ALL SELECT 2, '2017-01-05'::timestamp, 32\`,
+
+      dimensions: {
+        id: {
+          sql: 'id',
+          type: 'number',
+          primary_key: true
+        },
+        day: {
+          sql: 'day',
+          type: 'time'
+        },
+      },
+
+      measures: {
+        total_amount: {
+          sql: 'amount',
+          type: 'sum'
+        },
+      },
+
+      pre_aggregations: {
+        td_facts_rollup: {
+          measures: [total_amount],
+          timeDimension: day,
+          granularity: 'day'
+        }
+      }
+    });
+
   `);
 
   it('simple pre-aggregation', async () => {
@@ -3538,6 +3610,47 @@ describe('PreAggregations', () => {
       );
     });
   });
+
+  // A join key declared as each leg rollup's time dimension lives in a granularity-suffixed
+  // column, so the ON clause has to read that column rather than the bare member alias —
+  // otherwise the join names columns no rollup materializes and the query can't run.
+  if (getEnv('nativeSqlPlanner')) {
+    it('rollupJoin pre-aggregation on a time dimension join key', async () => {
+      await compiler.compile();
+
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: ['td_facts.total_amount'],
+        dimensions: ['td_dates.quarter_label'],
+        timeDimensions: [{
+          dimension: 'td_facts.day',
+          granularity: 'day',
+        }],
+        timezone: 'UTC',
+        order: [{ id: 'td_facts.day' }],
+        preAggregationsSchema: ''
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.map((p: any) => p.preAggregationId).sort()).toEqual(
+        ['td_dates.td_dates_rollup', 'td_facts.td_facts_rollup']
+      );
+      expect(query.preAggregations?.preAggregationForQuery?.preAggregationName).toEqual('td_rollup_join');
+
+      return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
+        expect(res).toEqual(
+          [{
+            td_dates__quarter_label: 'Q1',
+            td_facts__day_day: '2017-01-02T00:00:00.000Z',
+            td_facts__total_amount: '10',
+          }, {
+            td_dates__quarter_label: 'Q1',
+            td_facts__day_day: '2017-01-05T00:00:00.000Z',
+            td_facts__total_amount: '32',
+          }]
+        );
+      });
+    });
+  }
 
   it('rollupJoin pre-aggregation with nested joins via view (A->B->C)', async () => {
     await compiler.compile();

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1295,7 +1295,11 @@ describe('pre-aggregations', () => {
         useNativeSqlPlanner: true,
       } as any);
 
-      for (const expected of [/td_dates\.day \(month\)/, /td_facts\.day \(day\)/, /td_rollup_join/]) {
+      for (const expected of [
+        /td_dates\.td_dates_rollup stores td_dates\.day truncated to month/,
+        /td_facts\.td_facts_rollup stores td_facts\.day truncated to day/,
+        /td_rollup_join/,
+      ]) {
         expect(() => query.preAggregations?.preAggregationsDescription()).toThrow(expected);
       }
     });

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1155,4 +1155,149 @@ describe('pre-aggregations', () => {
       expect(query.buildSqlAndParams()[0]).toMatch(/orders/);
     });
   });
+  // A rollupJoin resolves hop by hop, and each hop needs a leg rollup carrying that hop's key
+  // on each side. That is a requirement on every leg rollup, not a limit on how many cubes the
+  // chain spans — an interior rollup needs the upstream hop's key too, which no query selects.
+  describe('rollupJoin over a join chain', () => {
+    const chainSchema = (interiorRollupDimensions: string) => `
+      cube('cube_w', {
+        sql: \`SELECT 0 as id, 'a' as dim_w\`,
+        joins: { cube_x: { relationship: 'many_to_one', sql: \`\${CUBE.dim_w} = \${cube_x.dim_w}\` } },
+        dimensions: {
+          id: { sql: 'id', type: 'string', primary_key: true },
+          dim_w: { sql: 'dim_w', type: 'string' },
+        },
+        pre_aggregations: {
+          www: { dimensions: [dim_w] },
+          chainRollupJoin: {
+            type: 'rollupJoin',
+            dimensions: [dim_w, cube_x.dim_x, cube_y.dim_y, cube_z.dim_z],
+            rollups: [www, cube_x.xxx, cube_y.yyy, cube_z.zzz]
+          }
+        }
+      });
+      cube('cube_x', {
+        sql: \`SELECT 1 as id, 'a' as dim_w, 'b' as dim_x\`,
+        joins: { cube_y: { relationship: 'many_to_one', sql: \`\${CUBE.dim_x} = \${cube_y.dim_x}\` } },
+        dimensions: {
+          id: { sql: 'id', type: 'string', primary_key: true },
+          dim_w: { sql: 'dim_w', type: 'string' },
+          dim_x: { sql: 'dim_x', type: 'string' },
+        },
+        pre_aggregations: { xxx: { dimensions: [${interiorRollupDimensions}] } }
+      });
+      cube('cube_y', {
+        sql: \`SELECT 2 as id, 'b' as dim_x, 'c' as dim_y\`,
+        joins: { cube_z: { relationship: 'many_to_one', sql: \`\${CUBE.dim_y} = \${cube_z.dim_y}\` } },
+        dimensions: {
+          id: { sql: 'id', type: 'string', primary_key: true },
+          dim_x: { sql: 'dim_x', type: 'string' },
+          dim_y: { sql: 'dim_y', type: 'string' },
+        },
+        pre_aggregations: { yyy: { dimensions: [dim_x, dim_y] } }
+      });
+      cube('cube_z', {
+        sql: \`SELECT 3 as id, 'c' as dim_y, 'd' as dim_z\`,
+        dimensions: {
+          id: { sql: 'id', type: 'string', primary_key: true },
+          dim_y: { sql: 'dim_y', type: 'string' },
+          dim_z: { sql: 'dim_z', type: 'string' },
+        },
+        pre_aggregations: { zzz: { dimensions: [dim_y, dim_z] } }
+      });
+    `;
+
+    const chainQuery = async (schema: string) => {
+      const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(schema);
+      await compiler.compile();
+      return new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [],
+        dimensions: ['cube_w.dim_w', 'cube_x.dim_x', 'cube_y.dim_y', 'cube_z.dim_z'],
+        timezone: 'UTC',
+        preAggregationsSchema: '',
+        useNativeSqlPlanner: true,
+      } as any);
+    };
+
+    it('matches a four-cube chain when every leg rollup declares its own keys', async () => {
+      const query = await chainQuery(chainSchema('dim_w, dim_x'));
+
+      // A matched rollupJoin is described by its leg rollups, which are what get built; the
+      // join itself is named on preAggregationForQuery.
+      const description: any = query.preAggregations?.preAggregationsDescription();
+      expect(description.map((p: any) => p.preAggregationId).sort()).toEqual(
+        ['cube_w.www', 'cube_x.xxx', 'cube_y.yyy', 'cube_z.zzz']
+      );
+      expect(query.preAggregations?.preAggregationForQuery?.preAggregationName).toEqual('chainRollupJoin');
+      expect(query.buildSqlAndParams()[0]).toMatch(/"cube_w__dim_w" = "cube_x__dim_w"/);
+    });
+
+    it('names the hop an interior rollup has no key for', async () => {
+      const query = await chainQuery(chainSchema('dim_x'));
+
+      // Without the hop, the member and the rollupJoin, the author has nothing to act on —
+      // which is what makes this look like a chain-depth limitation.
+      for (const expected of [/from "cube_w"/, /to "cube_x"/, /cube_x\.dim_w/, /chainRollupJoin/]) {
+        expect(() => query.preAggregations?.preAggregationsDescription()).toThrow(expected);
+      }
+    });
+  });
+
+  // A rollup stores a time dimension truncated to its granularity, so two legs that declare
+  // the join key at different granularities hold values that can't be compared.
+  describe('rollupJoin whose legs truncate the join key differently', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(
+      `
+        cube('td_dates', {
+          sql: \`SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label\`,
+          joins: { td_facts: { relationship: 'one_to_many', sql: \`\${CUBE.day} = \${td_facts.day}\` } },
+          dimensions: {
+            day: { sql: 'day', type: 'time', primary_key: true },
+            quarter_label: { sql: 'quarter_label', type: 'string' },
+          },
+          pre_aggregations: {
+            td_dates_rollup: { dimensions: [quarter_label], timeDimension: day, granularity: 'month' },
+            td_rollup_join: {
+              type: 'rollupJoin',
+              measures: [td_facts.total_amount],
+              dimensions: [quarter_label],
+              timeDimension: td_facts.day,
+              granularity: 'day',
+              rollups: [td_dates_rollup, td_facts.td_facts_rollup]
+            }
+          }
+        });
+        cube('td_facts', {
+          sql: \`SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount\`,
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true },
+            day: { sql: 'day', type: 'time' },
+          },
+          measures: { total_amount: { sql: 'amount', type: 'sum' } },
+          pre_aggregations: {
+            td_facts_rollup: { measures: [total_amount], timeDimension: day, granularity: 'day' }
+          }
+        });
+      `
+    );
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    it('rejects the join instead of comparing differently truncated columns', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: ['td_facts.total_amount'],
+        dimensions: ['td_dates.quarter_label'],
+        timeDimensions: [{ dimension: 'td_facts.day', granularity: 'day' }],
+        timezone: 'UTC',
+        preAggregationsSchema: '',
+        useNativeSqlPlanner: true,
+      } as any);
+
+      for (const expected of [/td_dates\.day \(month\)/, /td_facts\.day \(day\)/, /td_rollup_join/]) {
+        expect(() => query.preAggregations?.preAggregationsDescription()).toThrow(expected);
+      }
+    });
+  });
 });

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/compiled_pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/compiled_pre_aggregation.rs
@@ -3,12 +3,25 @@ use crate::planner::{MemberSymbol, SqlCall};
 use std::fmt::Debug;
 use std::rc::Rc;
 
+/// One side of a join key, paired with the column the rollup on that
+/// side stores it in. A key kept as the rollup's time dimension lives
+/// in a granularity-suffixed column, so the ON clause cannot be
+/// rendered from the symbol alone.
+#[derive(Clone, Debug)]
+pub struct PreAggregationJoinMember {
+    pub symbol: Rc<MemberSymbol>,
+    pub column: String,
+    /// Granularity the column is truncated to, `None` for a key stored
+    /// as a plain dimension.
+    pub granularity: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 pub struct PreAggregationJoinItem {
     pub from: Rc<PreAggregationSource>,
     pub to: Rc<PreAggregationSource>,
-    pub from_members: Vec<Rc<MemberSymbol>>,
-    pub to_members: Vec<Rc<MemberSymbol>>,
+    pub from_members: Vec<PreAggregationJoinMember>,
+    pub to_members: Vec<PreAggregationJoinMember>,
     pub on_sql: Rc<SqlCall>,
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -4,10 +4,10 @@ use crate::cube_bridge::join_hints::JoinHintItem;
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::pre_aggregation_description::PreAggregationDescription;
 use crate::logical_plan::PreAggregationJoin;
-use crate::logical_plan::PreAggregationJoinItem;
 use crate::logical_plan::PreAggregationTable;
 use crate::logical_plan::PreAggregationUnion;
 use crate::logical_plan::PreAggregationUnionItem;
+use crate::logical_plan::{PreAggregationJoinItem, PreAggregationJoinMember};
 use crate::planner::join_hints::JoinHints;
 use crate::planner::multi_fact_join_groups::{MeasuresJoinHints, MultiFactJoinGroups};
 use crate::planner::planners::JoinPlanner;
@@ -230,6 +230,7 @@ impl PreAggregationsCompiler {
                 &measures,
                 &all_dimensions,
                 &rollups,
+                name,
             )?)
         } else {
             let cube = self
@@ -413,6 +414,7 @@ impl PreAggregationsCompiler {
         measures: &Vec<Rc<MemberSymbol>>,
         all_dimensions: &Vec<Rc<MemberSymbol>>,
         rollups: &Vec<String>,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<PreAggregationJoin, CubeError> {
         let all_symbols = measures
             .iter()
@@ -461,7 +463,9 @@ impl PreAggregationsCompiler {
 
         let items = not_existing_joins
             .iter()
-            .map(|item| self.make_pre_aggregation_join_item(&pre_aggrs_for_join, item))
+            .map(|item| {
+                self.make_pre_aggregation_join_item(&pre_aggrs_for_join, item, rollup_join_name)
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         let res = PreAggregationJoin {
@@ -475,28 +479,130 @@ impl PreAggregationsCompiler {
         &self,
         pre_aggrs_for_join: &Vec<Rc<CompiledPreAggregation>>,
         join_item: &ResolvedJoinItem,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<PreAggregationJoinItem, CubeError> {
-        let from_pre_aggr =
-            self.find_pre_aggregation_for_join(pre_aggrs_for_join, &join_item.from_members)?;
-        let to_pre_aggr =
-            self.find_pre_aggregation_for_join(pre_aggrs_for_join, &join_item.to_members)?;
+        let from_pre_aggr = self.find_pre_aggregation_for_join(
+            pre_aggrs_for_join,
+            &join_item.from_members,
+            join_item,
+            rollup_join_name,
+        )?;
+        let to_pre_aggr = self.find_pre_aggregation_for_join(
+            pre_aggrs_for_join,
+            &join_item.to_members,
+            join_item,
+            rollup_join_name,
+        )?;
+
+        let from_members = Self::resolve_join_members(&from_pre_aggr, &join_item.from_members)?;
+        let to_members = Self::resolve_join_members(&to_pre_aggr, &join_item.to_members)?;
+        Self::check_join_members_comparable(
+            &from_members,
+            &to_members,
+            join_item,
+            rollup_join_name,
+        )?;
 
         let res = PreAggregationJoinItem {
             from: from_pre_aggr.source.clone(),
             to: to_pre_aggr.source.clone(),
-            from_members: join_item.from_members.clone(),
-            to_members: join_item.to_members.clone(),
+            from_members,
+            to_members,
             on_sql: join_item.on_sql.clone(),
         };
         Ok(res)
+    }
+
+    fn resolve_join_members(
+        pre_aggr: &CompiledPreAggregation,
+        members: &Vec<Rc<MemberSymbol>>,
+    ) -> Result<Vec<PreAggregationJoinMember>, CubeError> {
+        members
+            .iter()
+            .map(|symbol| {
+                Self::resolve_join_member(pre_aggr, symbol).ok_or_else(|| {
+                    CubeError::internal(format!(
+                        "Rollup {}.{} doesn't store join member {}",
+                        pre_aggr.cube_name,
+                        pre_aggr.name,
+                        symbol.full_name()
+                    ))
+                })
+            })
+            .collect()
+    }
+
+    /// A rollup stores a time dimension truncated to its granularity, so the two
+    /// sides of a hop are only comparable when they were truncated the same way.
+    fn check_join_members_comparable(
+        from_members: &[PreAggregationJoinMember],
+        to_members: &[PreAggregationJoinMember],
+        join_item: &ResolvedJoinItem,
+        rollup_join_name: &PreAggregationFullName,
+    ) -> Result<(), CubeError> {
+        // Every key of the hop has to be stored the same way, across both sides at once.
+        // The two sides carry no pairing between their members — comparing them side by
+        // side would let a raw column on one side line up with a truncated one on the other.
+        let members = || from_members.iter().chain(to_members.iter());
+        let stored_the_same_way = members().map(|m| &m.granularity).sorted().dedup().count() <= 1;
+        if stored_the_same_way {
+            return Ok(());
+        }
+        Err(CubeError::user(format!(
+            "The join from \"{}\" to \"{}\" in the \"{}\" pre-aggregation mixes join keys its rollups store differently ({}). A key kept as a rollup's time dimension is truncated to that granularity, so it can only be compared against a key truncated the same way",
+            join_item.original_from,
+            join_item.original_to,
+            rollup_join_name.name,
+            members()
+                .map(|m| match &m.granularity {
+                    Some(granularity) => format!("{} ({})", m.symbol.full_name(), granularity),
+                    None => format!("{} (not truncated)", m.symbol.full_name()),
+                })
+                .join(", "),
+        )))
+    }
+
+    /// How `pre_aggr` stores the join key `member`, or `None` when it doesn't
+    /// store it at all. A key kept as a time dimension rather than a plain one
+    /// is truncated to the rollup's granularity and lives under a suffixed name.
+    fn resolve_join_member(
+        pre_aggr: &CompiledPreAggregation,
+        member: &Rc<MemberSymbol>,
+    ) -> Option<PreAggregationJoinMember> {
+        if pre_aggr.dimensions.iter().any(|pa_m| member == pa_m) {
+            return Some(PreAggregationJoinMember {
+                symbol: member.clone(),
+                column: member.alias(),
+                granularity: None,
+            });
+        }
+        pre_aggr.time_dimensions.iter().find_map(|pa_m| {
+            let time_dimension = pa_m.as_time_dimension().ok()?;
+            if time_dimension.base_symbol() != member {
+                return None;
+            }
+            let granularity = time_dimension.granularity().clone();
+            let suffix = granularity
+                .as_ref()
+                .map_or(String::new(), |g| format!("_{}", g));
+            Some(PreAggregationJoinMember {
+                symbol: member.clone(),
+                column: format!("{}{}", member.alias(), suffix),
+                granularity,
+            })
+        })
     }
 
     fn find_pre_aggregation_for_join(
         &self,
         pre_aggrs_for_join: &Vec<Rc<CompiledPreAggregation>>,
         members: &Vec<Rc<MemberSymbol>>,
+        join_item: &ResolvedJoinItem,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<Rc<CompiledPreAggregation>, CubeError> {
-        let found_pre_aggr = pre_aggrs_for_join
+        // A rollup declaring the key plainly is preferred over one keeping it as a time
+        // dimension, so a hop that already resolved keeps resolving to the same rollup.
+        let mut found_pre_aggr = pre_aggrs_for_join
             .iter()
             .filter(|pa| {
                 members
@@ -505,17 +611,43 @@ impl PreAggregationsCompiler {
             })
             .collect_vec();
         if found_pre_aggr.is_empty() {
+            found_pre_aggr = pre_aggrs_for_join
+                .iter()
+                .filter(|pa| {
+                    members
+                        .iter()
+                        .all(|m| Self::resolve_join_member(pa, m).is_some())
+                })
+                .collect_vec();
+        }
+        if found_pre_aggr.is_empty() {
             return Err(CubeError::user(format!(
-                "No rollups found that can be used for rollup join"
+                "No rollups found that can be used for a rollup join from \"{}\" ({}) to \"{}\" ({}). Check the \"{}\" pre-aggregation definition — every rollup must declare the dimensions its own joins are on, including keys the query doesn't select",
+                join_item.original_from,
+                Self::format_join_members(&join_item.from_members),
+                join_item.original_to,
+                Self::format_join_members(&join_item.to_members),
+                rollup_join_name.name,
             )));
         }
         if found_pre_aggr.len() > 1 {
             return Err(CubeError::user(format!(
-                "Multiple rollups found that can be used for rollup join"
+                "Multiple rollups found that can be used for a rollup join from \"{}\" to \"{}\" in the \"{}\" pre-aggregation: {}",
+                join_item.original_from,
+                join_item.original_to,
+                rollup_join_name.name,
+                found_pre_aggr
+                    .iter()
+                    .map(|pa| format!("{}.{}", pa.cube_name, pa.name))
+                    .join(", "),
             )));
         }
 
         Ok(found_pre_aggr[0].clone())
+    }
+
+    fn format_join_members(members: &[Rc<MemberSymbol>]) -> String {
+        members.iter().map(|m| m.full_name()).join(", ")
     }
 
     pub fn compile_all_pre_aggregations(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -468,11 +468,40 @@ impl PreAggregationsCompiler {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        Self::check_join_members_resolve_consistently(&items, rollup_join_name)?;
+
         let res = PreAggregationJoin {
             root: items[0].from.clone(),
             items,
         };
         Ok(res)
+    }
+
+    /// The rendered plan reads every member from one column for the whole pre-aggregation, so
+    /// a member shared by two hops must land in the same column in both — otherwise one of the
+    /// two ON clauses would name a column its side doesn't have.
+    fn check_join_members_resolve_consistently(
+        items: &[PreAggregationJoinItem],
+        rollup_join_name: &PreAggregationFullName,
+    ) -> Result<(), CubeError> {
+        let mut columns: HashMap<String, String> = HashMap::new();
+        for member in items
+            .iter()
+            .flat_map(|item| item.from_members.iter().chain(item.to_members.iter()))
+        {
+            let name = member.symbol.full_name();
+            if let Some(seen) = columns.get(&name) {
+                if seen != &member.column {
+                    return Err(CubeError::user(format!(
+                        "The \"{}\" pre-aggregation joins on {} through rollups storing it in different columns ({} and {}), so one of the joins would read a column that isn't there",
+                        rollup_join_name.name, name, seen, member.column,
+                    )));
+                }
+            } else {
+                columns.insert(name, member.column.clone());
+            }
+        }
+        Ok(())
     }
 
     fn make_pre_aggregation_join_item(
@@ -496,9 +525,12 @@ impl PreAggregationsCompiler {
 
         let from_members = Self::resolve_join_members(&from_pre_aggr, &join_item.from_members)?;
         let to_members = Self::resolve_join_members(&to_pre_aggr, &join_item.to_members)?;
+        // Each side was picked on its own, and that choice is not revisited: where a side has
+        // several candidates, a rollup keeping the key plainly wins even if another candidate
+        // would have matched how the opposite side stores it. Hence the rollups are named.
         Self::check_join_members_comparable(
-            &from_members,
-            &to_members,
+            (&from_pre_aggr, &from_members),
+            (&to_pre_aggr, &to_members),
             join_item,
             rollup_join_name,
         )?;
@@ -520,7 +552,7 @@ impl PreAggregationsCompiler {
         members
             .iter()
             .map(|symbol| {
-                Self::resolve_join_member(pre_aggr, symbol).ok_or_else(|| {
+                Self::resolve_join_member(pre_aggr, symbol)?.ok_or_else(|| {
                     CubeError::internal(format!(
                         "Rollup {}.{} doesn't store join member {}",
                         pre_aggr.cube_name,
@@ -535,30 +567,42 @@ impl PreAggregationsCompiler {
     /// A rollup stores a time dimension truncated to its granularity, so the two
     /// sides of a hop are only comparable when they were truncated the same way.
     fn check_join_members_comparable(
-        from_members: &[PreAggregationJoinMember],
-        to_members: &[PreAggregationJoinMember],
+        from: (&CompiledPreAggregation, &[PreAggregationJoinMember]),
+        to: (&CompiledPreAggregation, &[PreAggregationJoinMember]),
         join_item: &ResolvedJoinItem,
         rollup_join_name: &PreAggregationFullName,
     ) -> Result<(), CubeError> {
-        // Every key of the hop has to be stored the same way, across both sides at once.
-        // The two sides carry no pairing between their members — comparing them side by
-        // side would let a raw column on one side line up with a truncated one on the other.
+        // Which key pairs with which is known only to the ON expression, so a hop carrying
+        // several keys is accepted only when all of them are stored the same way: pairing a
+        // raw column with a truncated one otherwise passes unnoticed.
+        let (from_pre_aggr, from_members) = from;
+        let (to_pre_aggr, to_members) = to;
         let members = || from_members.iter().chain(to_members.iter());
-        let stored_the_same_way = members().map(|m| &m.granularity).sorted().dedup().count() <= 1;
-        if stored_the_same_way {
+        if members().map(|m| &m.granularity).sorted().dedup().count() <= 1 {
             return Ok(());
         }
+        let describe = |pre_aggr: &CompiledPreAggregation, members: &[PreAggregationJoinMember]| {
+            format!(
+                "{}.{} stores {}",
+                pre_aggr.cube_name,
+                pre_aggr.name,
+                members
+                    .iter()
+                    .map(|m| match &m.granularity {
+                        Some(granularity) =>
+                            format!("{} truncated to {}", m.symbol.full_name(), granularity),
+                        None => format!("{} untruncated", m.symbol.full_name()),
+                    })
+                    .join(", ")
+            )
+        };
         Err(CubeError::user(format!(
-            "The join from \"{}\" to \"{}\" in the \"{}\" pre-aggregation mixes join keys its rollups store differently ({}). A key kept as a rollup's time dimension is truncated to that granularity, so it can only be compared against a key truncated the same way",
+            "The join from \"{}\" to \"{}\" in the \"{}\" pre-aggregation can't be resolved: {}, while {}. A key kept as a rollup's time dimension is truncated to that granularity, and every key of one join has to be stored the same way",
             join_item.original_from,
             join_item.original_to,
             rollup_join_name.name,
-            members()
-                .map(|m| match &m.granularity {
-                    Some(granularity) => format!("{} ({})", m.symbol.full_name(), granularity),
-                    None => format!("{} (not truncated)", m.symbol.full_name()),
-                })
-                .join(", "),
+            describe(from_pre_aggr, from_members),
+            describe(to_pre_aggr, to_members),
         )))
     }
 
@@ -568,29 +612,50 @@ impl PreAggregationsCompiler {
     fn resolve_join_member(
         pre_aggr: &CompiledPreAggregation,
         member: &Rc<MemberSymbol>,
-    ) -> Option<PreAggregationJoinMember> {
+    ) -> Result<Option<PreAggregationJoinMember>, CubeError> {
         if pre_aggr.dimensions.iter().any(|pa_m| member == pa_m) {
-            return Some(PreAggregationJoinMember {
+            return Ok(Some(PreAggregationJoinMember {
                 symbol: member.clone(),
                 column: member.alias(),
                 granularity: None,
-            });
+            }));
         }
-        pre_aggr.time_dimensions.iter().find_map(|pa_m| {
-            let time_dimension = pa_m.as_time_dimension().ok()?;
-            if time_dimension.base_symbol() != member {
-                return None;
-            }
-            let granularity = time_dimension.granularity().clone();
+        let granularities = pre_aggr
+            .time_dimensions
+            .iter()
+            .filter_map(|pa_m| {
+                let time_dimension = pa_m.as_time_dimension().ok()?;
+                if time_dimension.base_symbol() == member {
+                    Some(time_dimension.granularity().clone())
+                } else {
+                    None
+                }
+            })
+            .collect_vec();
+        // The same dimension can be stored at several granularities, each in its own column.
+        // Taking whichever comes first would let declaration order pick the joined column.
+        if granularities.len() > 1 {
+            return Err(CubeError::user(format!(
+                "Rollup {}.{} stores {} at more than one granularity ({}), so the one to join on is ambiguous. Declare the join key as a dimension of the rollup",
+                pre_aggr.cube_name,
+                pre_aggr.name,
+                member.full_name(),
+                granularities
+                    .iter()
+                    .map(|g| g.clone().unwrap_or_else(|| "no granularity".to_string()))
+                    .join(", "),
+            )));
+        }
+        Ok(granularities.into_iter().next().map(|granularity| {
             let suffix = granularity
                 .as_ref()
                 .map_or(String::new(), |g| format!("_{}", g));
-            Some(PreAggregationJoinMember {
+            PreAggregationJoinMember {
                 symbol: member.clone(),
                 column: format!("{}{}", member.alias(), suffix),
                 granularity,
-            })
-        })
+            }
+        }))
     }
 
     fn find_pre_aggregation_for_join(
@@ -611,14 +676,22 @@ impl PreAggregationsCompiler {
             })
             .collect_vec();
         if found_pre_aggr.is_empty() {
-            found_pre_aggr = pre_aggrs_for_join
-                .iter()
-                .filter(|pa| {
-                    members
-                        .iter()
-                        .all(|m| Self::resolve_join_member(pa, m).is_some())
-                })
-                .collect_vec();
+            let mut widened = Vec::new();
+            for pre_aggr in pre_aggrs_for_join.iter() {
+                let mut covers_all = true;
+                for member in members.iter() {
+                    // Propagated, not swallowed: a rollup that stores the key ambiguously has
+                    // to say so rather than drop out and leave "no rollups found" behind.
+                    if Self::resolve_join_member(pre_aggr, member)?.is_none() {
+                        covers_all = false;
+                        break;
+                    }
+                }
+                if covers_all {
+                    widened.push(pre_aggr);
+                }
+            }
+            found_pre_aggr = widened;
         }
         if found_pre_aggr.is_empty() {
             return Err(CubeError::user(format!(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -675,16 +675,26 @@ impl PreAggregationsCompiler {
                     .all(|m| pa.dimensions.iter().any(|pa_m| m == pa_m))
             })
             .collect_vec();
+        // A rollup storing the key ambiguously is no candidate, but it is the likely cause when
+        // nothing else stands in either, so its reason is kept and reported in place of the
+        // generic one rather than failing a hop another rollup can serve.
+        let mut ambiguous = None;
         if found_pre_aggr.is_empty() {
             let mut widened = Vec::new();
             for pre_aggr in pre_aggrs_for_join.iter() {
                 let mut covers_all = true;
                 for member in members.iter() {
-                    // Propagated, not swallowed: a rollup that stores the key ambiguously has
-                    // to say so rather than drop out and leave "no rollups found" behind.
-                    if Self::resolve_join_member(pre_aggr, member)?.is_none() {
-                        covers_all = false;
-                        break;
+                    match Self::resolve_join_member(pre_aggr, member) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => {
+                            covers_all = false;
+                            break;
+                        }
+                        Err(e) => {
+                            ambiguous.get_or_insert(e);
+                            covers_all = false;
+                            break;
+                        }
                     }
                 }
                 if covers_all {
@@ -694,6 +704,9 @@ impl PreAggregationsCompiler {
             found_pre_aggr = widened;
         }
         if found_pre_aggr.is_empty() {
+            if let Some(e) = ambiguous {
+                return Err(e);
+            }
             return Err(CubeError::user(format!(
                 "No rollups found that can be used for a rollup join from \"{}\" ({}) to \"{}\" ({}). Check the \"{}\" pre-aggregation definition — every rollup must declare the dimensions its own joins are on, including keys the query doesn't select",
                 join_item.original_from,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/pre_aggregation.rs
@@ -136,8 +136,10 @@ impl PreAggregation {
         if let PreAggregationSource::Join(join) = self.source().as_ref() {
             for item in join.items.iter() {
                 for member in item.from_members.iter().chain(item.to_members.iter()) {
-                    let alias = member.alias();
-                    res.insert(member.full_name(), QualifiedColumnName::new(None, alias));
+                    res.insert(
+                        member.symbol.full_name(),
+                        QualifiedColumnName::new(None, member.column.clone()),
+                    );
                 }
             }
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_chain.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_chain.yaml
@@ -1,0 +1,118 @@
+# A rollupJoin over a four-cube chain. Every leg rollup declares the dimensions its own
+# hops join on, including `cube_x.dim_w`, which no query selects.
+cubes:
+  - name: cube_w
+    sql: "SELECT 0 as id, 'a' as dim_w"
+    joins:
+      - name: cube_x
+        relationship: many_to_one
+        sql: "{CUBE.dim_w} = {cube_x.dim_w}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_w
+        type: string
+        sql: dim_w
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: www
+        type: rollup
+        dimensions:
+          - dim_w
+      - name: chain_rollup_join
+        type: rollupJoin
+        dimensions:
+          - dim_w
+          - cube_x.dim_x
+          - cube_y.dim_y
+          - cube_z.dim_z
+        rollups:
+          - cube_w.www
+          - cube_x.xxx
+          - cube_y.yyy
+          - cube_z.zzz
+
+  - name: cube_x
+    sql: "SELECT 1 as id, 'a' as dim_w, 'b' as dim_x"
+    joins:
+      - name: cube_y
+        relationship: many_to_one
+        sql: "{CUBE.dim_x} = {cube_y.dim_x}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_w
+        type: string
+        sql: dim_w
+      - name: dim_x
+        type: string
+        sql: dim_x
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: xxx
+        type: rollup
+        dimensions:
+          - dim_w
+          - dim_x
+
+  - name: cube_y
+    sql: "SELECT 2 as id, 'b' as dim_x, 'c' as dim_y"
+    joins:
+      - name: cube_z
+        relationship: many_to_one
+        sql: "{CUBE.dim_y} = {cube_z.dim_y}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_x
+        type: string
+        sql: dim_x
+      - name: dim_y
+        type: string
+        sql: dim_y
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: yyy
+        type: rollup
+        dimensions:
+          - dim_x
+          - dim_y
+
+  - name: cube_z
+    sql: "SELECT 3 as id, 'c' as dim_y, 'd' as dim_z"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_y
+        type: string
+        sql: dim_y
+      - name: dim_z
+        type: string
+        sql: dim_z
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: zzz
+        type: rollup
+        dimensions:
+          - dim_y
+          - dim_z

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_chain_missing_key.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_chain_missing_key.yaml
@@ -1,0 +1,118 @@
+# The four-cube chain of `rollup_join_chain.yaml` with the interior rollup missing `dim_w`,
+# the key on its own side of the cube_w -> cube_x hop. The hop can't be resolved and the
+# rejection has to say which one it is.
+cubes:
+  - name: cube_w
+    sql: "SELECT 0 as id, 'a' as dim_w"
+    joins:
+      - name: cube_x
+        relationship: many_to_one
+        sql: "{CUBE.dim_w} = {cube_x.dim_w}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_w
+        type: string
+        sql: dim_w
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: www
+        type: rollup
+        dimensions:
+          - dim_w
+      - name: chain_rollup_join
+        type: rollupJoin
+        dimensions:
+          - dim_w
+          - cube_x.dim_x
+          - cube_y.dim_y
+          - cube_z.dim_z
+        rollups:
+          - cube_w.www
+          - cube_x.xxx
+          - cube_y.yyy
+          - cube_z.zzz
+
+  - name: cube_x
+    sql: "SELECT 1 as id, 'a' as dim_w, 'b' as dim_x"
+    joins:
+      - name: cube_y
+        relationship: many_to_one
+        sql: "{CUBE.dim_x} = {cube_y.dim_x}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_w
+        type: string
+        sql: dim_w
+      - name: dim_x
+        type: string
+        sql: dim_x
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: xxx
+        type: rollup
+        dimensions:
+          - dim_x
+
+  - name: cube_y
+    sql: "SELECT 2 as id, 'b' as dim_x, 'c' as dim_y"
+    joins:
+      - name: cube_z
+        relationship: many_to_one
+        sql: "{CUBE.dim_y} = {cube_z.dim_y}"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_x
+        type: string
+        sql: dim_x
+      - name: dim_y
+        type: string
+        sql: dim_y
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: yyy
+        type: rollup
+        dimensions:
+          - dim_x
+          - dim_y
+
+  - name: cube_z
+    sql: "SELECT 3 as id, 'c' as dim_y, 'd' as dim_z"
+    dimensions:
+      - name: id
+        type: string
+        sql: id
+        primary_key: true
+      - name: dim_y
+        type: string
+        sql: dim_y
+      - name: dim_z
+        type: string
+        sql: dim_z
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: zzz
+        type: rollup
+        dimensions:
+          - dim_y
+          - dim_z

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key.yaml
@@ -1,0 +1,64 @@
+# A rollupJoin whose join key is declared as a `time_dimension` on both legs rather than as a
+# plain dimension. Such a key is stored truncated to the rollup's granularity and under a
+# granularity-suffixed column name, which both the lookup and the ON clause have to follow.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        time_dimension: day
+        granularity: day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: day
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_ambiguous.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_ambiguous.yaml
@@ -1,0 +1,69 @@
+# Both rollups on the `td_dates` side of the hop carry the join key, one as a plain dimension
+# and one as a time dimension. The plain one holds the untruncated value the hop has always
+# been resolved through, so it has to stay the one picked.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        dimensions:
+          - day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_plain_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+          - day
+      - name: td_dates_time_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: day
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+          - td_facts.day
+        rollups:
+          - td_dates.td_dates_plain_rollup
+          - td_dates.td_dates_time_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_ambiguous_candidate.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_ambiguous_candidate.yaml
@@ -1,0 +1,74 @@
+# The time-dimension join key of `rollup_join_time_dimension_key.yaml` with a second candidate
+# on the `td_dates` side that stores the key at two granularities. That one can't be joined on,
+# but it is listed first, so it must step aside for the one that can rather than fail the hop.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        time_dimension: day
+        granularity: day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_wide_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimensions:
+          - dimension: day
+            granularity: day
+          - dimension: day
+            granularity: month
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: day
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_wide_rollup
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_mismatch.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_mismatch.yaml
@@ -1,0 +1,64 @@
+# The time-dimension join key of `rollup_join_time_dimension_key.yaml` with the two legs
+# storing it at different granularities, so the stored values are truncated differently and
+# comparing them would silently drop rows.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        time_dimension: day
+        granularity: day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: month
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_raw_vs_truncated.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_raw_vs_truncated.yaml
@@ -1,0 +1,64 @@
+# The time-dimension join key of `rollup_join_time_dimension_key.yaml` with one leg keeping the
+# key as a plain dimension instead, so one side holds the raw value and the other a truncated
+# one. Nothing lines the two up, and comparing them would quietly match the wrong rows.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        dimensions:
+          - day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: day
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_two_granularities.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key_two_granularities.yaml
@@ -1,0 +1,66 @@
+# The time-dimension join key of `rollup_join_time_dimension_key.yaml` with one leg storing the
+# key at two granularities, in two separate columns. Nothing says which of them the join is on.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        time_dimension: day
+        granularity: day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimensions:
+          - dimension: day
+            granularity: day
+          - dimension: day
+            granularity: month
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
@@ -1,4 +1,5 @@
 mod multi_fact;
 mod multi_stage;
+mod rollup_join_keys;
 mod sql_generation;
 mod ungrouped_gate;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
@@ -194,3 +194,28 @@ fn test_rollup_join_rejects_key_stored_at_two_granularities() -> Result<(), Cube
 
     Ok(())
 }
+
+// A rollup that can't be joined on is not a reason to fail the hop — only a reason to explain
+// it if nothing else stands in either.
+#[test]
+fn test_rollup_join_skips_an_ambiguous_candidate_for_a_resolvable_one() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key_ambiguous_candidate.yaml",
+    ))?;
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(TIME_DIMENSION_KEY_QUERY)?;
+
+    let names = pre_aggrs
+        .iter()
+        .map(|pa| format!("{}.{}", pa.cube_name(), pa.name()))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["td_dates.td_rollup_join"]);
+    assert!(
+        sql.contains("td_dates__td_dates_rollup")
+            && !sql.contains("td_dates__td_dates_wide_rollup"),
+        "the hop must join through the rollup that can be joined on, got:\n{}",
+        sql
+    );
+
+    Ok(())
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
@@ -108,9 +108,11 @@ fn test_rollup_join_rejects_time_dimension_key_granularity_mismatch() -> Result<
         .expect_err("Keys truncated to different granularities can't be compared")
         .to_string();
 
+    // Naming the rollup on each side matters: each was chosen on its own, so the author has to
+    // see which pair the planner ended up with.
     for expected in [
-        "td_dates.day (month)",
-        "td_facts.day (day)",
+        "td_dates.td_dates_rollup stores td_dates.day truncated to month",
+        "td_facts.td_facts_rollup stores td_facts.day truncated to day",
         "td_rollup_join",
     ] {
         assert!(err.contains(expected), "expected {} in: {}", expected, err);
@@ -162,10 +164,31 @@ fn test_rollup_join_rejects_raw_key_against_truncated_one() -> Result<(), CubeEr
         .to_string();
 
     for expected in [
-        "td_dates.day (day)",
-        "td_facts.day (not truncated)",
+        "td_dates.td_dates_rollup stores td_dates.day truncated to day",
+        "td_facts.td_facts_rollup stores td_facts.day untruncated",
         "td_rollup_join",
     ] {
+        assert!(err.contains(expected), "expected {} in: {}", expected, err);
+    }
+
+    Ok(())
+}
+
+// Storing the key at two granularities gives two columns and no reason to pick either, so
+// declaration order must not get to decide which one the join reads.
+#[test]
+fn test_rollup_join_rejects_key_stored_at_two_granularities() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key_two_granularities.yaml",
+    ))?;
+
+    let err = ctx
+        .build_sql_with_used_pre_aggregations(TIME_DIMENSION_KEY_QUERY)
+        .map(|_| ())
+        .expect_err("A key stored at two granularities is ambiguous to join on")
+        .to_string();
+
+    for expected in ["td_dates.td_dates_rollup", "td_dates.day", "day, month"] {
         assert!(err.contains(expected), "expected {} in: {}", expected, err);
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/rollup_join_keys.rs
@@ -1,0 +1,173 @@
+//! How a rollupJoin resolves the key on each side of a hop: which leg rollup carries it,
+//! and which column that rollup stores it in.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use cubenativeutils::CubeError;
+use indoc::indoc;
+
+const CHAIN_QUERY: &str = indoc! {"
+    dimensions:
+      - cube_w.dim_w
+      - cube_x.dim_x
+      - cube_y.dim_y
+      - cube_z.dim_z
+"};
+
+const TIME_DIMENSION_KEY_QUERY: &str = indoc! {"
+    measures:
+      - td_facts.total_amount
+    dimensions:
+      - td_dates.quarter_label
+    time_dimensions:
+      - dimension: td_facts.day
+        granularity: day
+"};
+
+// Chain length is not a limit of its own: a hop resolves the same way at any depth, as long
+// as every leg rollup declares the keys of the hops it takes part in.
+#[test]
+fn test_rollup_join_over_four_cube_chain() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file("common/rollup_join_chain.yaml"))?;
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(CHAIN_QUERY)?;
+
+    let names = pre_aggrs
+        .iter()
+        .map(|pa| format!("{}.{}", pa.cube_name(), pa.name()))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["cube_w.chain_rollup_join"]);
+    for hop in [
+        "\"cube_w__dim_w\" = \"cube_x__dim_w\"",
+        "\"cube_x__dim_x\" = \"cube_y__dim_x\"",
+        "\"cube_y__dim_y\" = \"cube_z__dim_y\"",
+    ] {
+        assert!(sql.contains(hop), "expected {} in:\n{}", hop, sql);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_rollup_join_names_the_hop_a_rollup_has_no_key_for() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_chain_missing_key.yaml",
+    ))?;
+
+    let err = ctx
+        .build_sql_with_used_pre_aggregations(CHAIN_QUERY)
+        .map(|_| ())
+        .expect_err("A rollup missing its own join key can't resolve the hop")
+        .to_string();
+
+    // Which hop failed, which member went unmatched and which rollupJoin to fix are the only
+    // things the author can act on.
+    for expected in ["cube_w", "cube_x", "cube_x.dim_w", "chain_rollup_join"] {
+        assert!(err.contains(expected), "expected {} in: {}", expected, err);
+    }
+
+    Ok(())
+}
+
+// A key declared as a rollup's time dimension is stored truncated, under a
+// granularity-suffixed column, and the ON clause has to read that column rather than the
+// bare member alias.
+#[test]
+fn test_rollup_join_on_time_dimension_key() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key.yaml",
+    ))?;
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(TIME_DIMENSION_KEY_QUERY)?;
+
+    let names = pre_aggrs
+        .iter()
+        .map(|pa| format!("{}.{}", pa.cube_name(), pa.name()))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["td_dates.td_rollup_join"]);
+    assert!(
+        sql.contains("\"td_dates__day_day\" = \"td_facts__day_day\""),
+        "the join must read the columns the leg rollups store, got:\n{}",
+        sql
+    );
+
+    Ok(())
+}
+
+// The join happens on the stored, truncated values, so the two sides have to be truncated
+// the same way — otherwise the comparison quietly matches nothing or the wrong buckets.
+#[test]
+fn test_rollup_join_rejects_time_dimension_key_granularity_mismatch() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key_mismatch.yaml",
+    ))?;
+
+    let err = ctx
+        .build_sql_with_used_pre_aggregations(TIME_DIMENSION_KEY_QUERY)
+        .map(|_| ())
+        .expect_err("Keys truncated to different granularities can't be compared")
+        .to_string();
+
+    for expected in [
+        "td_dates.day (month)",
+        "td_facts.day (day)",
+        "td_rollup_join",
+    ] {
+        assert!(err.contains(expected), "expected {} in: {}", expected, err);
+    }
+
+    Ok(())
+}
+
+// Widening the lookup must not make a hop ambiguous: a rollup declaring the key plainly stays
+// the one picked, so a schema that resolved before resolves to the same rollup.
+#[test]
+fn test_rollup_join_prefers_the_rollup_declaring_the_key_plainly() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key_ambiguous.yaml",
+    ))?;
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - td_dates.quarter_label
+          - td_facts.day
+    "})?;
+
+    let names = pre_aggrs
+        .iter()
+        .map(|pa| format!("{}.{}", pa.cube_name(), pa.name()))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["td_dates.td_rollup_join"]);
+    assert!(
+        sql.contains("td_dates__td_dates_plain_rollup"),
+        "the plainly declared key must stay the one joined on, got:\n{}",
+        sql
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rollup_join_rejects_raw_key_against_truncated_one() -> Result<(), CubeError> {
+    let ctx = TestContext::new(MockSchema::from_yaml_file(
+        "common/rollup_join_time_dimension_key_raw_vs_truncated.yaml",
+    ))?;
+
+    let err = ctx
+        .build_sql_with_used_pre_aggregations(TIME_DIMENSION_KEY_QUERY)
+        .map(|_| ())
+        .expect_err("A raw key and a truncated one can't be compared")
+        .to_string();
+
+    for expected in [
+        "td_dates.day (day)",
+        "td_facts.day (not truncated)",
+        "td_rollup_join",
+    ] {
+        assert!(err.contains(expected), "expected {} in: {}", expected, err);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A `rollup_join` whose join key is declared as a leg rollup's `time_dimension` — rather than as a plain dimension — never resolved, at any chain length. Both the hop lookup and the ON-clause rendering assumed the key lives in a plainly named column, and a time dimension does not: a rollup stores it truncated to its `granularity`, under a granularity-suffixed name.

The chain-depth limitation reported in #11362 does not exist. Four- and five-cube chains match on master on the same terms a three-cube chain does; the reported failure came from an interior rollup not declaring the key on its own side of the new hop. The four-cube test added here passes without any of the changes below, and is there to keep it that way.

## Changes

- Resolve each join member through the leg rollup that actually carries it, and keep the resolved column on the join item (`PreAggregationJoinMember { symbol, column, granularity }`). The ON clause now reads the column the rollups materialize, and the join-members pass no longer overwrites the query's own time dimension in `all_dimensions_refererences`.
- The join therefore compares truncated values, so every key of a hop must be stored the same way across both sides. A key truncated to `day` can be compared neither to one truncated to `month` nor to one kept raw as a plain dimension; both are rejected with an error naming the members and how each is stored. The two sides carry no pairing between their members, so the check is on the hop as a whole rather than side by side.
- Prefer a rollup declaring the key plainly over one keeping it as a time dimension, so a hop that already resolved keeps resolving to the same rollup instead of becoming ambiguous and failing with `Multiple rollups found`.
- Tesseract's rejection now names the failing hop, the unmatched members and which `rollup_join` to fix, as the JS message already did. A bare `No rollups found that can be used for rollup join` is why this was filed as a depth bug.
- The JS matcher accepts the wider reading too, because Tesseract calls back into it after planning to build the legacy `preAggregationForQuery` descriptor, and a throw there kills the whole native call even though the SQL is already correct. It is gated on `canUseNativeSqlPlannerPreAggregation`: the legacy planner renders the ON clause from the bare alias, so widening it unconditionally would turn its clean rejection into SQL that fails at execution.

## Testing

- `rollup_join_keys.rs` — six planner tests over four new fixtures: the four-cube chain, the hop an interior rollup has no key for, the time-dimension key, the two rejected storage mismatches, and the ambiguity guard. Each was red-checked by reverting the corresponding change.
- `pre-aggregations.test.ts` (unit) — the chain matching and assembling, the rejection naming the hop, and the granularity mismatch.
- `pre-aggregations.test.ts` (integration, Postgres) — `rollupJoin pre-aggregation on a time dimension join key` materializes both leg rollups and asserts the returned rows. Reverting the rendering fix and rebuilding the native addon makes it fail against the database with `column "td_dates__day" does not exist`, which is the actual defect rather than a shape read off the SQL.
- Full suites green: 1328 Rust planner tests; schema-compiler `pre-aggregations` unit; the Postgres pre-aggregation integration file on both planners (48 passed under Tesseract, 52 under the legacy planner).

## Note

The join happens on the stored buckets, not on the raw values it is modeled on, so it fits keys already aligned to that granularity — a date dimension joined to facts by day. The reference page is deliberately untouched here; the docs change already open against it is the place for that.

Refs #11362
