### PR TITLE
docs: document embed folder sharing, usage analytics API token, session renewal, and pivot drag-and-drop

### DIFF
--- a/docs-mintlify/admin/monitoring/usage-analytics.mdx
+++ b/docs-mintlify/admin/monitoring/usage-analytics.mdx
@@ -64,6 +64,35 @@ The API Requests view includes the security context behind each request, so
 embedded analytics customers can slice usage by tenant — for example, to find
 the heaviest tenants or compare per-tenant latency and cache efficiency.
 
+## Query programmatically
+
+Beyond the embedded dashboards, account administrators can mint a short-lived
+Cube API token to query the same usage and billing data directly — from the
+[REST API](https://cube.dev/docs/product/apis-integrations/rest-api), a BI
+tool, or a script — instead of only viewing it in-app.
+
+```bash
+curl -X POST https://your-account.cubecloud.dev/api/v1/usage-analytics/token \
+  -H "Authorization: Bearer <api-token>"
+```
+
+The response includes a `token`, the `apiUrl` to send it to, and an
+`expiresAt` timestamp:
+
+```json
+{
+  "token": "eyJhbGc...",
+  "apiUrl": "https://usage-analytics.cubecloud.dev/cubejs-api/v1",
+  "deploymentId": 331,
+  "expiresAt": "2026-09-03T13:00:00.000Z"
+}
+```
+
+The token is scoped to your account, the same way the embedded page is, so
+queries only ever see your own data. It expires after **1 hour** — issue a
+fresh one for each session or scheduled refresh rather than caching it.
+Requires an admin-scoped API key and Usage Analytics enabled for the account.
+
 ## Data freshness and isolation
 
 Usage Analytics data is available on a slight delay compared to live activity.

--- a/docs-mintlify/admin/monitoring/usage-analytics.mdx
+++ b/docs-mintlify/admin/monitoring/usage-analytics.mdx
@@ -91,7 +91,7 @@ The response includes a `token`, the `apiUrl` to send it to, and an
 The token is scoped to your account, the same way the embedded page is, so
 queries only ever see your own data. It expires after **1 hour** — issue a
 fresh one for each session or scheduled refresh rather than caching it.
-Requires an admin-scoped API key and Usage Analytics enabled for the account.
+Requires an API key belonging to an account administrator, and Usage Analytics enabled for the account.
 
 ## Data freshness and isolation
 

--- a/docs-mintlify/admin/monitoring/usage-analytics.mdx
+++ b/docs-mintlify/admin/monitoring/usage-analytics.mdx
@@ -91,7 +91,8 @@ The response includes a `token`, the `apiUrl` to send it to, and an
 The token is scoped to your account, the same way the embedded page is, so
 queries only ever see your own data. It expires after **1 hour** — issue a
 fresh one for each session or scheduled refresh rather than caching it.
-Requires an API key belonging to an account administrator, and Usage Analytics enabled for the account.
+Requires an API key belonging to an account administrator, and Usage
+Analytics enabled for the account.
 
 ## Data freshness and isolation
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -82,11 +82,10 @@ filters are pre-populated as soon as you select the view — the same way they
 are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
-Click on members to add them to **Rows** and **Measures**, or drag a member
-straight from the list onto **Rows**, **Columns**, or **Measures** to place it
-there directly. If needed, drag dimensions from **Rows** to **Columns**. Click
-on the funnel buttons to add members to **Filters**. Click on **×** to remove
-members from a query.
+Click on members to add them to **Rows** and **Measures**, or drag a member from
+the list straight onto **Rows**, **Columns**, or **Measures**. You can also drag
+members between zones to rearrange them. Click on the funnel buttons to add
+members to **Filters**. Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -82,10 +82,11 @@ filters are pre-populated as soon as you select the view — the same way they
 are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
-Click on members to add them to **Rows** and **Measures**.
-If needed, drag dimensions from **Rows** to **Columns**. Click on
-the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+Click on members to add them to **Rows** and **Measures**, or drag a member
+straight from the list onto **Rows**, **Columns**, or **Measures** to place it
+there directly. If needed, drag dimensions from **Rows** to **Columns**. Click
+on the funnel buttons to add members to **Filters**. Click on **×** to remove
+members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -90,10 +90,11 @@ filters are pre-populated as soon as you select the view — the same way they
 are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
-Click on members to add them to **Rows** and **Measures**.
-If needed, drag dimensions from **Rows** to **Columns**. Click on
-the funnel buttons to add members to **Filters**. Click on **×** to
-remove members from a query.
+Click on members to add them to **Rows** and **Measures**, or drag a member
+straight from the list onto **Rows**, **Columns**, or **Measures** to place it
+there directly. If needed, drag dimensions from **Rows** to **Columns**. Click
+on the funnel buttons to add members to **Filters**. Click on **×** to remove
+members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -90,11 +90,10 @@ filters are pre-populated as soon as you select the view — the same way they
 are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
-Click on members to add them to **Rows** and **Measures**, or drag a member
-straight from the list onto **Rows**, **Columns**, or **Measures** to place it
-there directly. If needed, drag dimensions from **Rows** to **Columns**. Click
-on the funnel buttons to add members to **Filters**. Click on **×** to remove
-members from a query.
+Click on members to add them to **Rows** and **Measures**, or drag a member from
+the list straight onto **Rows**, **Columns**, or **Measures**. You can also drag
+members between zones to rearrange them. Click on the funnel buttons to add
+members to **Filters**. Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -58,9 +58,9 @@ Keep the following behavior in mind:
 - Embed users can't edit content shared from the main workspace. Opening a shared workbook shows its published dashboard, so a workbook must have a published dashboard for users to open it.
 - Removing the share from the **All embed users** group removes those items from embed users' workspaces immediately.
 
-## Sharing workbooks and dashboards
+## Sharing workbooks, dashboards, and folders
 
-Embed users in Creator Mode can share the workbooks and dashboards they build with other users, the same way they would in the full Cube app.
+Embed users in Creator Mode can share the workbooks, dashboards, and folders they build with other users, the same way they would in the full Cube app. Sharing a folder shares everything inside it, and follows the same access levels — **Full access**, **Can edit**, **Can view** — as sharing a workbook.
 
 <Note>
   Sharing is scoped to the [embed tenant](#embed-tenant-scoping): users can only share with others in the same tenant, never across tenants.

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -499,7 +499,11 @@ import { connectCubeEmbed } from "@cube-dev/embed-sdk";
 const cube = connectCubeEmbed(iframe);
 
 cube.autoRenewSession({
-  mintSession: () => fetch("/api/cube-embed-session", { method: "POST" }).then((r) => r.json()),
+  // must resolve to the new session id
+  mintSession: () =>
+    fetch("/api/cube-embed-session", { method: "POST" })
+      .then((r) => r.json())
+      .then(({ sessionId }) => sessionId),
 });
 ```
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -486,7 +486,7 @@ lifecycle](/embedding/iframe/auth/signed#how-it-works)) and can't refresh
 itself — left alone, a tab open that long drops to a "Session expired"
 message. Renew it in place instead.
 
-If you're using [`@cube-dev/embed-sdk`](/embedding/react-embed-sdk), call
+If you're using `@cube-dev/embed-sdk`, call
 `autoRenewSession` on the connection instead of hand-rolling the listener
 below — it drives renewal from all three triggers (both events plus the tab
 returning to the foreground, which catches a renewal that timers missed while

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -484,7 +484,31 @@ for it and retry.
 A signed embed's token is usable for about 23 hours (see [Session
 lifecycle](/embedding/iframe/auth/signed#how-it-works)) and can't refresh
 itself — left alone, a tab open that long drops to a "Session expired"
-message. Renew it in place instead, using the events and action above:
+message. Renew it in place instead.
+
+If you're using [`@cube-dev/embed-sdk`](/embedding/react-embed-sdk), call
+`autoRenewSession` on the connection instead of hand-rolling the listener
+below — it drives renewal from all three triggers (both events plus the tab
+returning to the foreground, which catches a renewal that timers missed while
+the tab was hidden), and collapses concurrent triggers into one in-flight
+renewal:
+
+```js
+import { connectCubeEmbed } from "@cube-dev/embed-sdk";
+
+const cube = connectCubeEmbed(iframe);
+
+cube.autoRenewSession({
+  mintSession: () => fetch("/api/cube-embed-session", { method: "POST" }).then((r) => r.json()),
+});
+```
+
+`mintSession` is your own backend endpoint, calling [Generate
+Session](/reference/embed-apis/generate-session) — an API key that must never
+reach the browser. Each id is single-use and expires 5 minutes after minting,
+so mint a fresh one on every call rather than caching one ahead of time.
+
+Without the SDK, drive the same renewal by hand from the raw events and action:
 
 ```js
 let renewing = false;
@@ -509,12 +533,6 @@ window.addEventListener("message", (event) => {
   }
 });
 ```
-
-Mint the replacement session on your own backend — [Generate
-Session](/reference/embed-apis/generate-session) needs an API key that must
-never reach the browser. Each id is single-use and expires 5 minutes after
-minting, so mint it in response to the event rather than caching one ahead of
-time.
 
 ## Surfaces
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -486,12 +486,11 @@ lifecycle](/embedding/iframe/auth/signed#how-it-works)) and can't refresh
 itself — left alone, a tab open that long drops to a "Session expired"
 message. Renew it in place instead.
 
-If you're using `@cube-dev/embed-sdk`, call
-`autoRenewSession` on the connection instead of hand-rolling the listener
-below — it drives renewal from all three triggers (both events plus the tab
-returning to the foreground, which catches a renewal that timers missed while
-the tab was hidden), and collapses concurrent triggers into one in-flight
-renewal:
+If you're using `@cube-dev/embed-sdk`, call `autoRenewSession` on the
+connection instead of hand-rolling the listener below — it drives renewal
+from all three triggers (both events plus the tab returning to the
+foreground, which catches a renewal that timers missed while the tab was
+hidden), and collapses concurrent triggers into one in-flight renewal:
 
 ```js
 import { connectCubeEmbed } from "@cube-dev/embed-sdk";

--- a/docs-mintlify/embedding/react-embed-sdk.mdx
+++ b/docs-mintlify/embedding/react-embed-sdk.mdx
@@ -45,6 +45,8 @@ function App() {
 
 The React Embed SDK uses the same session-based authentication as [signed embedding](/embedding/iframe/auth/signed). Generate a session using the [Generate Session API](/reference/embed-apis/generate-session) and pass the `sessionId` to the provider.
 
+A session expires after about 23 hours. `@cube-dev/embed-sdk` also exposes `connectCubeEmbed` and `autoRenewSession` for keeping an iframe's session alive without a reload — see [Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive).
+
 ## Example
 
 For a complete working implementation, see the [antd-cube-embed-sdk example](https://github.com/cubedevinc/cube-agent-examples/tree/main/examples/antd-cube-embed-sdk) on GitHub.

--- a/docs-mintlify/embedding/react-embed-sdk.mdx
+++ b/docs-mintlify/embedding/react-embed-sdk.mdx
@@ -45,7 +45,7 @@ function App() {
 
 The React Embed SDK uses the same session-based authentication as [signed embedding](/embedding/iframe/auth/signed). Generate a session using the [Generate Session API](/reference/embed-apis/generate-session) and pass the `sessionId` to the provider.
 
-A session expires after about 23 hours. `@cube-dev/embed-sdk` also exposes `connectCubeEmbed` and `autoRenewSession` for keeping an iframe's session alive without a reload — see [Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive).
+A session expires after about 23 hours. This page's provider talks to Cube's APIs directly rather than through an iframe, so the `postMessage` event contract described in [Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive) — including the `autoRenewSession` helper — doesn't apply here; that's for iframe embedding only. For the React Embed SDK, mint a new `sessionId` before the current one expires and re-render the provider with it.
 
 ## Example
 

--- a/docs-mintlify/embedding/react-embed-sdk.mdx
+++ b/docs-mintlify/embedding/react-embed-sdk.mdx
@@ -45,7 +45,7 @@ function App() {
 
 The React Embed SDK uses the same session-based authentication as [signed embedding](/embedding/iframe/auth/signed). Generate a session using the [Generate Session API](/reference/embed-apis/generate-session) and pass the `sessionId` to the provider.
 
-A session expires after about 23 hours. This page's provider talks to Cube's APIs directly rather than through an iframe, so the `postMessage` event contract described in [Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive) — including the `autoRenewSession` helper — doesn't apply here; that's for iframe embedding only. For the React Embed SDK, mint a new `sessionId` before the current one expires and re-render the provider with it.
+A session expires after about 23 hours. SDK embedding talks to Cube's APIs directly rather than through an iframe, so the `postMessage` renewal contract in [Keeping a signed session alive](/embedding/iframe/events#keeping-a-signed-session-alive) — including the `autoRenewSession` helper — applies to iframe embedding only. With the React Embed SDK, mint a new `sessionId` before the current one expires and re-render the provider with it.
 
 ## Example
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (n/a — docs-only change)
- [ ] Linter has been run for changed code (n/a — docs-only change)
- [ ] Tests for the changes have been added if not covered yet (n/a — docs-only change)

**Description of Changes Made**

A batch of small, surgical doc updates covering recently-shipped Cube Cloud behavior that wasn't yet reflected in the docs:

- **Creator Mode embedding**: folder rows in the embedded workspace can now be shared, not just workbooks and dashboards. Widened the "Sharing workbooks and dashboards" section (now "Sharing workbooks, dashboards, and folders") to say so.
- **Usage Analytics**: admins can mint a short-lived API token to query the same usage/billing data outside the embedded UI. Added a "Query programmatically" section with the request/response shape and the token's actual 1-hour lifetime.
- **Signed embedding**: documented the `@cube-dev/embed-sdk` `autoRenewSession` helper as the recommended way to keep a session alive in place, alongside the existing manual `postMessage` pattern — plus a pointer to it from the React Embed SDK page.
- **Excel/Google Sheets pivot builder**: tightened the wording of the drag-and-drop-into-a-pivot-zone description per review feedback on this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URmfqB34wUUfuZ42gF4mtK