### PR TITLE
docs: calendar granularity sql naming rule and the interval alternative

### DIFF
--- a/docs-mintlify/docs/data-modeling/concepts/calendar-cubes.mdx
+++ b/docs-mintlify/docs/data-modeling/concepts/calendar-cubes.mdx
@@ -468,6 +468,49 @@ When querying `sales.revenue` by `custom_calendar.date` with monthly granularity
 `mid_month` column will be used instead of the standard `DATE_TRUNC('month', date)`
 expression in the generated SQL.
 
+### Naming a granularity defined with `sql`
+
+A granularity defined with `sql` must be named after a default granularity: `second`,
+`minute`, `hour`, `day`, `week`, `month`, `quarter`, or `year`. Names are matched
+case-insensitively. The `sql` parameter changes what an existing unit of time means; it
+cannot introduce a new one. A granularity under a name of your own, such as `fiscal_week`,
+does not compile:
+
+```
+dimensions.<dimension>.granularities.fiscal_week: a granularity defined with 'sql'
+must be named after one of the predefined granularities (day, hour, minute, month,
+quarter, second, week, year). Define 'fiscal_week' with 'interval' instead
+```
+
+The reason is that `interval` is what places a granularity in the `day` → `week` →
+`month` → `quarter` → `year` hierarchy, so Cube knows what to roll it up from and what to
+decompose it into. A default granularity brings that position with it; a name of your own
+does not, so it has to state its `interval`.
+
+The two styles serve different purposes:
+
+| | `interval` with `offset` or `origin` | `sql` |
+| --- | --- | --- |
+| **Name** | Any name of your own | A default granularity only |
+| **Definition** | Derived arithmetically from a fixed-length unit | Read from a pre-calculated column |
+| **Variable-length periods** | Not supported | Supported |
+
+Use `interval` to add a granularity, for example a fiscal week of a regular seven days.
+See the [custom granularity recipe][ref-recipe-custom-granularity] for `fiscal_week`,
+`fiscal_quarter`, and `fiscal_year` defined that way. Use `sql` when a period varies in
+length and cannot be derived arithmetically, such as the months and quarters of a 4-5-4
+retail calendar. The [custom calendar recipe][ref-recipe-custom-calendar] models a 4-5-4
+calendar in full.
+
+<Info>
+
+**A [pre-aggregation][ref-pre-aggregations] over an overridden granularity must declare
+that granularity.** A rollup on the `month` granularity above serves queries at `month`,
+and it is built from the `mid_month` column rather than `DATE_TRUNC`. A rollup at another
+granularity will not serve those queries correctly.
+
+</Info>
+
 
 [ref-time-shift]: /docs/data-modeling/measures#time-shift
 [ref-time-dimension]: /docs/data-modeling/dimensions#time-dimensions
@@ -475,4 +518,7 @@ expression in the generated SQL.
 [ref-cubes]: /reference/data-modeling/cube
 [ref-cubes-calendar]: /reference/data-modeling/cube#calendar
 [link-tesseract]: https://cube.dev/blog/introducing-next-generation-data-modeling-engine
+[ref-recipe-custom-granularity]: /recipes/data-modeling/custom-granularity
+[ref-recipe-custom-calendar]: /recipes/data-modeling/custom-calendar
+[ref-pre-aggregations]: /docs/pre-aggregations/matching-pre-aggregations
 [ref-primary-key]: /reference/data-modeling/dimensions#primary_key

--- a/docs-mintlify/recipes/data-modeling/custom-granularity.mdx
+++ b/docs-mintlify/recipes/data-modeling/custom-granularity.mdx
@@ -10,7 +10,8 @@ different from [default granularities][ref-default-granularities] such as `week`
 (starting on Monday) or `year` (starting on January 1).
 
 Below, we explore the following examples of custom granularities:
-* *Week starting on Sunday*, commonly used in the US and some other countries.
+* *Week starting on Sunday*, commonly used in the US and some other countries. A
+*fiscal week* that starts on any other day is defined the same way.
 * *[Fiscal year][wiki-fiscal-year]* and *fiscal quarter*, commonly used in
 accounting and financial reporting.
 
@@ -18,6 +19,14 @@ accounting and financial reporting.
 
 Consider the following data model. `interval` and `offset` parameters are used to
 configure each custom granularity in `granularities`.
+
+`interval` is the only way to define a granularity under a name of your own, and it
+places the granularity in the `day` → `week` → `month` → `quarter` → `year` hierarchy,
+so Cube derives it arithmetically and rolls it up with the units around it. In exchange,
+the period has to be a fixed length. A period that varies in length, such as a month of
+a 4-5-4 retail calendar, is read from a pre-calculated column instead — see [overriding
+granularities][ref-calendar-cubes] and the [custom calendar
+recipe][ref-recipe-custom-calendar].
 
 Note that each custom granularity is also exposed via a [proxy
 dimension][ref-proxy-granularity]. This is not just a convenience: while the
@@ -171,3 +180,5 @@ Querying this data modal would yield the following result:
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-graphql-api]: /reference/core-data-apis/graphql-api
 [ref-proxy-granularity]: /docs/data-modeling/dimensions#time-dimension-granularity-references
+[ref-calendar-cubes]: /docs/data-modeling/concepts/calendar-cubes#overriding-granularities
+[ref-recipe-custom-calendar]: /recipes/data-modeling/custom-calendar

--- a/docs-mintlify/reference/data-modeling/cube.mdx
+++ b/docs-mintlify/reference/data-modeling/cube.mdx
@@ -672,7 +672,7 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-syntax-cube-sql]: /docs/data-modeling/concepts/syntax#cubesql-function
 [ref-extension]: /docs/data-modeling/extending-cubes
 [ref-calendar-cubes]: /docs/data-modeling/concepts/calendar-cubes
-[ref-calendar-cubes-time-shifts]: /docs/data-modeling/concepts/calendar-cubes#time-shifts
-[ref-calendar-cubes-granularities]: /docs/data-modeling/concepts/calendar-cubes#granularities
+[ref-calendar-cubes-time-shifts]: /docs/data-modeling/concepts/calendar-cubes#overriding-time-shifts
+[ref-calendar-cubes-granularities]: /docs/data-modeling/concepts/calendar-cubes#overriding-granularities
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
 [ref-time-shift]: /docs/data-modeling/measures#time-shift

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -1096,7 +1096,9 @@ dimension][ref-proxy-granularity] that references it.
 
 For each custom granularity, the `interval` parameter is required. It specifies
 the duration of the time interval and has the following format:
-`quantity unit [quantity unit...]`, e.g., `5 days` or `1 year 6 months`.
+`quantity unit [quantity unit...]`, e.g., `5 days` or `1 year 6 months`. The only
+exception is a granularity that overrides a default granularity with `sql`, described
+[below](#calendar-cubes).
 
 Optionally, a custom granularity might use the `offset` parameter to specify how
 the time interval is shifted forward or backward in time. It has the same
@@ -1174,14 +1176,19 @@ cube(`orders`, {
 
 </CodeGroup>
 
-{/*
 #### Calendar cubes
 
-When the `granularities` parameter is used in time dimensions within [calendar
-cubes][ref-calendar-cubes], you can still use it to define custom granularities.
+The `granularities` parameter can also override the _default granularities_ by mapping
+them to pre-calculated columns with the `sql` parameter. This is most useful in
+[calendar cubes][ref-calendar-cubes], for modeling custom calendars such as fiscal
+calendars.
 
-Additionally, you can override the _default granularities_. This can be useful for
-modeling custom calendars, such as fiscal calendars.
+A granularity defined with `sql` must be named after a default granularity:
+`second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, or `year`. Names are
+matched case-insensitively. Use `sql` to change what an existing unit of time means,
+not to introduce a new one. A granularity under a name of your own, such as
+`fiscal_week`, must be defined with `interval` instead. See [overriding
+granularities][ref-calendar-cubes-granularities] for when to use each style.
 
 <CodeGroup>
 
@@ -1259,7 +1266,13 @@ cube(`fiscal_calendar`, {
 ```
 
 </CodeGroup>
-*/}
+
+<Info>
+
+**A pre-aggregation over an overridden granularity must declare that granularity.**
+A rollup at another granularity will not serve those queries correctly.
+
+</Info>
 
 ### `time_shift`
 
@@ -1402,3 +1415,4 @@ cube(`fiscal_calendar`, {
 [ref-filter-params]: /reference/data-modeling/context-variables#filter_params
 [link-encode-uri-component]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 [ref-rest-filters]: /reference/core-data-apis/rest-api/query-format#query-properties
+[ref-calendar-cubes-granularities]: /docs/data-modeling/concepts/calendar-cubes#overriding-granularities


### PR DESCRIPTION
## Summary

Documents the naming rule for custom granularities on calendar cubes, introduced in v1.7.32 (#11709): a granularity defined with `sql` must be named after a predefined granularity. A novel name such as `fiscal_week` with only `sql` is a compile-time error.

- **`docs/data-modeling/concepts/calendar-cubes.mdx`** — the main page. States the rule with the error message, explains why it exists (`interval` is what places a granularity in the `day` → `week` → `month` → `quarter` → `year` hierarchy), and adds a table comparing the two styles: `interval` with `offset`/`origin` names a *new* granularity but needs a fixed-length unit, while `sql` only ever *overrides an existing* unit and can express variable-length periods.
- **`reference/data-modeling/dimensions.mdx`** — the page asserted that `interval` is unconditionally required, which contradicted the calendar cubes page. It now names the `sql` override as the exception. Also unhides the calendar-cubes subsection, which had been commented out; it is edited rather than restored verbatim, since it predates the rule.
- **`recipes/data-modeling/custom-granularity.mdx`** — adds a `fiscal_week` example in the `interval` + `offset`/`origin` style, beside the existing `fiscal_year` and `fiscal_quarter`, and states what each style buys and costs.
- **`reference/data-modeling/cube.mdx`** — fixes two broken anchors: `#time-shifts` and `#granularities` do not exist on the calendar cubes page; the headings are `#overriding-time-shifts` and `#overriding-granularities`.

Also notes that a pre-aggregation over an overridden granularity must declare that granularity.

## Test plan

- Every data-model example was verified to compile against `master`, in both the YAML and JavaScript variants, and the generated SQL was checked: both `fiscal_week` forms emit the expected offset arithmetic.
- The quoted error message was reproduced, not transcribed from source.
- `mint broken-links` reports no broken links, so the two corrected anchors and all new cross-links resolve.
- All four changed pages return HTTP 200 under `mint dev`, i.e. they compile without MDX errors.
