### PR TITLE
docs(excel): rename "Cube Cloud for Excel" to "Cube for Excel"

### DIFF
--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -20,7 +20,7 @@ popular spreadsheet application.
 
 Cube Cloud provides two options to connect to Excel:
 
-| | [MDX API][ref-mdx-api] | [Cube Cloud for Excel][ref-cube-cloud-for-excel] |
+| | [MDX API][ref-mdx-api] | [Cube for Excel][ref-cube-cloud-for-excel] |
 | --- | --- | --- |
 | Operating systems | Microsoft Windows | All, including macOS |
 | Platforms | Desktop | All, including web and mobile |
@@ -48,7 +48,7 @@ the `/cubejs-api/v2/mdx` path, as the server name.
 The MDX API supports Kerberos and NTLM authentication, configured on the
 **Settings → Power BI** page of your deployment.
 
-### Cube Cloud for Excel
+### Cube for Excel
 
 Follow the instructions to [install][ref-cube-cloud-for-excel-installation] the
 add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud.

--- a/docs-mintlify/admin/deployment/providers/azure.mdx
+++ b/docs-mintlify/admin/deployment/providers/azure.mdx
@@ -26,7 +26,7 @@ Cube Cloud integrates with the following [data sources](/admin/connect-to-data/d
 
 Cube Cloud integrates with the following [data visualization tools](/admin/connect-to-data/visualization-tools):
 
-- [Microsoft Excel][ref-excel] via [Cube Cloud for Excel][ref-cube-cloud-for-excel]
+- [Microsoft Excel][ref-excel] via [Cube for Excel][ref-cube-cloud-for-excel]
 
 ## Storage
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -1,6 +1,6 @@
 ---
-title: Cube Cloud for Excel
-description: "Cube Cloud for Excel is the native Microsoft Excel add-in for Cube Cloud."
+title: Cube for Excel
+description: "Cube for Excel is the native Microsoft Excel add-in for Cube Cloud."
 ---
 
 it works with Excel on all operating systems,
@@ -31,12 +31,12 @@ reports via pivot table](#create-reports-via-pivot-table) and work with
 
 ## Configuration
 
-Cube Cloud for Excel uses the SQL API internally. So, the SQL API has to be
+Cube for Excel uses the SQL API internally. So, the SQL API has to be
 [enabled][ref-sql-api-enabled] in the Cube Cloud deployment settings.
 
 ## Installation
 
-You have to install Cube Cloud for Excel into your Microsoft 365 organization.
+You have to install Cube for Excel into your Microsoft 365 organization.
 To do so, navigate to its [page in the Microsoft AppSource][link-ms-appsource]
 and click **Get it now**:
 
@@ -49,7 +49,7 @@ button. Where this button is located depends on the [Excel version][link-excel-a
 For example, in Excel for the web, it's located on the rightmost side of the
 **Home** ribbon.
 
-Search for `Cube Cloud for Excel (add-in)` and click **Add**:
+Search for `Cube for Excel (add-in)` and click **Add**:
 
 <Frame>
   <img src="https://ucarecdn.com/83ab1e1f-e7d0-4c9c-bea1-f12c193d5e94/" />
@@ -57,7 +57,7 @@ Search for `Cube Cloud for Excel (add-in)` and click **Add**:
 
 ## Authentication
 
-You need to authenticate Cube Cloud for Excel to retrieve data from Cube Cloud.
+You need to authenticate Cube for Excel to retrieve data from Cube Cloud.
 To do so, open the sidebar by clicking on the **Cube Cloud** button in
 the **Home** ribbon. Then, click **Sign in**.
 
@@ -81,7 +81,7 @@ looks and feels like [Playground][ref-playground].
 
 <Info>
 
-Cube Cloud for Excel works only with [views][ref-views], not cubes.
+Cube for Excel works only with [views][ref-views], not cubes.
 
 </Info>
 
@@ -104,7 +104,7 @@ cell and then confirm with the target button under **Result location**.
   <img src="https://ucarecdn.com/4c3af7b9-4ef6-4f7f-8d0f-6d579609482e/" />
 </Frame>
 
-With every change to your query, Cube Cloud for Excel will update the report on
+With every change to your query, Cube for Excel will update the report on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -10,7 +10,7 @@ Core Data APIs enable you to query and retrieve data from your Cube semantic lay
 
 ## Choosing the Right API
 
-* To connect to [Microsoft Excel][ref-excel], use [Cube Cloud for Excel][ref-cube-cloud-for-excel]
+* To connect to [Microsoft Excel][ref-excel], use [Cube for Excel][ref-cube-cloud-for-excel]
 
 * To connect to [Google Sheets][ref-sheets], use [Cube Cloud for Sheets][ref-cube-cloud-for-sheets]
 
@@ -36,8 +36,8 @@ tools][ref-viz-tools]. Some of the features with partial support are listed belo
 
 | Feature | ✅ Supported in |
 | --- | --- |
-| [Hierarchies][ref-hierarchies] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
-| Flat [folders][ref-folders] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
+| [Hierarchies][ref-hierarchies] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
+| Flat [folders][ref-folders] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
 | [Custom time formats][ref-custom-time-formats] | [Playground][ref-playground] and [Workbooks][ref-workbooks] |
 
 ## Personal Core Data API Token
@@ -61,7 +61,7 @@ tools][ref-viz-tools]:
 | --- | --- |
 | [User name and password][ref-auth-user-pass] | [MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
 | Kerberos and NTLM | [MDX API][ref-mdx-api] |
-| [Identity provider][ref-auth-idp] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
+| [Identity provider][ref-auth-idp] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
 
 [cube-issbi]: https://cube.dev/use-cases/semantic-layer

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -7,7 +7,7 @@ The MDX API enables Cube to connect to [Microsoft Excel][ref-excel]. It derives
 its name from [multidimensional data expressions][link-mdx], a query language
 for OLAP in the Microsoft ecosystem.
 
-Unlike [Cube Cloud for Excel][ref-cube-cloud-for-excel], it only works with Excel
+Unlike [Cube for Excel][ref-cube-cloud-for-excel], it only works with Excel
 on Microsoft Windows. However, it allows using the data from the MDX API with the
 native [PivotTable][link-pivottable] in Excel.
 


### PR DESCRIPTION
Renames the add-in to **Cube for Excel** across the active Mintlify docs (title, description, headings, cross-references). Link reference ids (`ref-cube-cloud-for-excel`) are left as-is — internal anchors only.

Legacy `/docs` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)