### PR TITLE
perf(clickhouse-driver): keep transformed rows in fast-properties mode

### DIFF
--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -31,4 +31,5 @@ export * from './disposedProxy';
 export * from './logger';
 export * from './pool';
 export * from './sql-escape';
+export * from './object-shape';
 export * from './request-id';

--- a/packages/cubejs-backend-shared/src/object-shape.ts
+++ b/packages/cubejs-backend-shared/src/object-shape.ts
@@ -1,0 +1,41 @@
+/**
+ * V8 keeps at most 128 properties on a fast-mode object, so a wider shape is a dictionary itself
+ * and cloning it costs an order of magnitude more than filling a fresh object.
+ */
+export const MAX_OBJECT_SHAPE_COLUMNS = 127;
+
+/**
+ * Builds an object holding every column of a result set, to be cloned per row with the object
+ * spread:
+ *
+ * ```js
+ * const objectShape = buildObjectShape(names);
+ * const row = objectShape === null ? {} : { ...objectShape };
+ * for (let i = 0; i < names.length; i++) row[names[i]] = values[i];
+ * ```
+ *
+ * Filling a clone overwrites fields that already exist instead of growing the object, which is what
+ * keeps the row in fast-properties mode. Adding properties one at a time to a fresh `{}` drops the
+ * object into a dictionary past ~19 of them, and everything that later reads the row by name pays
+ * for it -- `rowsToColumnarBuffer` reads every cell of every row by name.
+ *
+ * Only the spread clones the shape. `Object.assign({}, shape)` grows a fresh object and lands back
+ * in a dictionary, so it is not a substitute.
+ *
+ * `JSON.parse` is what makes the shape worth having: it returns a fast-mode object holding all the
+ * columns, and it defines a `__proto__` column as an own data property rather than invoking
+ * `Object.prototype`'s setter, so a column aliased to `__proto__` stays a normal cell. Names are
+ * escaped with `JSON.stringify`, which is what makes them safe to take from the wire.
+ *
+ * @see https://v8.dev/blog/fast-properties for what fast-properties and dictionary mode mean.
+ *
+ * @returns the shape to clone, or `null` when cloning cannot pay off and rows should be built from
+ * a plain `{}`.
+ */
+export function buildObjectShape(names: ReadonlyArray<string>): Record<string, unknown> | null {
+  if (names.length === 0 || names.length > MAX_OBJECT_SHAPE_COLUMNS) {
+    return null;
+  }
+
+  return JSON.parse(`{${names.map((name) => `${JSON.stringify(name)}:null`).join(',')}}`);
+}

--- a/packages/cubejs-backend-shared/test/object-shape.test.ts
+++ b/packages/cubejs-backend-shared/test/object-shape.test.ts
@@ -1,0 +1,82 @@
+import { MAX_OBJECT_SHAPE_COLUMNS, buildObjectShape } from '../src/object-shape';
+
+const columns = (count: number) => Array.from({ length: count }, (_, i) => `c${i}`);
+
+const fill = (names: ReadonlyArray<string>, values: ReadonlyArray<unknown>) => {
+  const shape = buildObjectShape(names);
+  const row: Record<string, unknown> = shape === null ? {} : { ...shape };
+
+  for (let i = 0; i < names.length; i++) {
+    row[names[i]] = values[i];
+  }
+
+  return row;
+};
+
+describe('buildObjectShape', () => {
+  it('holds every column, with no values of its own', () => {
+    const shape = buildObjectShape(['s', 'n']);
+
+    expect(shape).toEqual({ s: null, n: null });
+    expect(Object.keys(shape as object)).toEqual(['s', 'n']);
+    expect(Object.getPrototypeOf(shape)).toBe(Object.prototype);
+  });
+
+  it('declines a result set without columns', () => {
+    expect(buildObjectShape([])).toBeNull();
+  });
+
+  it('declines past the width V8 keeps in fast mode', () => {
+    expect(MAX_OBJECT_SHAPE_COLUMNS).toEqual(127);
+    expect(buildObjectShape(columns(127))).not.toBeNull();
+    expect(buildObjectShape(columns(128))).toBeNull();
+  });
+
+  it('carries any column name a query can alias into', () => {
+    // Names reach the shape as JSON string literals, so they arrive from the wire safely.
+    const names = [
+      'a"; x = 1; //',
+      'a`b',
+      // eslint-disable-next-line no-template-curly-in-string
+      'a${b}',
+      'a\nb',
+      'a\\b',
+      'a b',
+      'a\u2028b',
+      'constructor',
+      'toString',
+      'hasOwnProperty',
+      ' ',
+    ];
+    const row = fill(names, names.map((_, i) => `v${i}`));
+
+    expect(Object.keys(row)).toEqual(names);
+    names.forEach((name, i) => {
+      expect(Object.getOwnPropertyDescriptor(row, name)?.value).toEqual(`v${i}`);
+    });
+  });
+
+  it('keeps a __proto__ column an own property of the row', () => {
+    const row = fill(['__proto__', 'n'], ['pwned', '1']);
+
+    expect(Object.keys(row)).toEqual(['__proto__', 'n']);
+    expect(Object.getOwnPropertyDescriptor(row, '__proto__')?.value).toEqual('pwned');
+    expect(Object.getPrototypeOf(row)).toBe(Object.prototype);
+    expect(({} as any).pwned).toBeUndefined();
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+  });
+
+  it('reproduces what JSON.parse does to duplicate and integer-like names', () => {
+    expect(JSON.stringify(fill(['x', 'y', 'x'], ['1', 'a', '2'])))
+      .toEqual(JSON.stringify(JSON.parse('{"x":"1","y":"a","x":"2"}')));
+    expect(JSON.stringify(fill(['b', '0'], ['b', 'zero'])))
+      .toEqual(JSON.stringify(JSON.parse('{"b":"b","0":"zero"}')));
+  });
+
+  it('builds the same row with and without a shape', () => {
+    const values = (count: number) => columns(count).map((_, i) => `v${i}`);
+
+    expect(fill(columns(128), values(128)))
+      .toEqual({ ...fill(columns(127), values(127)), c127: 'v127' });
+  });
+});

--- a/packages/cubejs-clickhouse-driver/src/Transform.ts
+++ b/packages/cubejs-clickhouse-driver/src/Transform.ts
@@ -1,4 +1,5 @@
 import * as moment from 'moment';
+import { buildObjectShape } from '@cubejs-backend/shared';
 
 export type ColumnConverter = (value: unknown) => unknown;
 
@@ -7,7 +8,7 @@ export type ColumnMeta = { name: string, type: string };
 export type Transform = {
   names: Array<string>,
   converters: Array<ColumnConverter | null>,
-  nullPrototype: boolean,
+  objectShape: Record<string, unknown> | null,
 };
 
 const CHAR_0 = 48;
@@ -268,9 +269,7 @@ function buildTransform(names: Array<string>, converters: Array<ColumnConverter 
   return {
     names,
     converters,
-    // Assignment to `__proto__` invokes Object.prototype's setter. Limit the slower null-prototype
-    // object to result sets that need it.
-    nullPrototype: names.includes('__proto__'),
+    objectShape: buildObjectShape(names),
   };
 }
 
@@ -302,13 +301,15 @@ export function buildTransformFromNamesAndTypes(names: Array<string>, types: Arr
 // Left-to-right assignment preserves JSON.parse's ordering and last-value behavior for duplicate
 // column names, keeping pre-aggregation content versions stable.
 export function transformRow(row: ReadonlyArray<unknown>, transform: Transform): Record<string, unknown> {
-  const { names, converters } = transform;
+  const { names, converters, objectShape } = transform;
 
   if (row.length !== names.length) {
     throw new Error(`Unexpected row and names/types length mismatch; row ${row.length} vs names ${names.length}`);
   }
 
-  const rowObj: Record<string, unknown> = transform.nullPrototype ? Object.create(null) : {};
+  // Cloning a shape that already holds every column keeps the row in fast-properties mode; see
+  // buildObjectShape for why that matters to everything reading the row afterwards.
+  const rowObj: Record<string, unknown> = objectShape === null ? {} : { ...objectShape };
 
   for (let i = 0; i < names.length; i++) {
     const converter = converters[i];

--- a/packages/cubejs-clickhouse-driver/test/unit/transform.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/transform.test.ts
@@ -323,12 +323,11 @@ describe('buildTransformFromMeta', () => {
       { name: 'n', type: 'Int32' },
     ]);
 
-    expect(transform.nullPrototype).toBe(true);
-
     const row = transformRow(['pwned', 1], transform);
 
     expect(Object.keys(row)).toEqual(['__proto__', 'n']);
     expect(Object.getOwnPropertyDescriptor(row, '__proto__')?.value).toEqual('pwned');
+    expect(Object.getPrototypeOf(row)).toBe(Object.prototype);
     expect(({} as any).pwned).toBeUndefined();
     expect(Object.getPrototypeOf({})).toBe(Object.prototype);
   });
@@ -341,6 +340,36 @@ describe('buildTransformFromMeta', () => {
 
     expect(() => transformRow(['only-one'], transform))
       .toThrow('Unexpected row and names/types length mismatch; row 1 vs names 2');
+  });
+});
+
+// Rows are cloned from an object shape holding every column, which is what keeps them in
+// fast-properties mode; buildObjectShape carries the reasoning and its own tests.
+describe('row object shape', () => {
+  const meta = (count: number) => Array.from({ length: count }, (_, i) => ({ name: `c${i}`, type: 'String' }));
+  const values = (count: number) => Array.from({ length: count }, (_, i) => `v${i}`);
+
+  it('is resolved once per result set', () => {
+    const transform = buildTransformFromMeta([
+      { name: 's', type: 'String' },
+      { name: 'n', type: 'Int64' },
+    ]);
+
+    expect(transform.objectShape).toEqual({ s: null, n: null });
+  });
+
+  it('is skipped for a result set buildObjectShape declines', () => {
+    expect(buildTransformFromMeta([]).objectShape).toBeNull();
+    expect(buildTransformFromMeta(meta(128)).objectShape).toBeNull();
+  });
+
+  it('produces the same row as the shapeless path', () => {
+    const wide = buildTransformFromMeta(meta(128));
+    const narrow = buildTransformFromMeta(meta(127));
+
+    expect(wide.objectShape).toBeNull();
+    expect(narrow.objectShape).not.toBeNull();
+    expect(transformRow(values(128), wide)).toEqual({ ...transformRow(values(127), narrow), c127: 'v127' });
   });
 });
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Follow-up to #11752, which cut result transformation by ~3.5s on a 48 column / 400k row query while the request only got 2.6s faster: `transformRow` built each row by adding 48 properties to a fresh `{}` through a computed key, which drops the object into a V8 dictionary past ~19 properties, and everything reading the row by name afterwards pays for it — `rowsToColumnar` reads every cell of every row by name. Rows are now cloned from an object shape that already holds every column, so filling them overwrites existing fields instead of growing the object; the helper lands in `@cubejs-backend/shared` as `buildObjectShape` since any driver materialising rows from positional data can reuse it. It is built with `JSON.parse`, which returns a fast-mode object and defines a `__proto__` column as an own data property instead of invoking `Object.prototype`'s setter, so the `nullPrototype` / `Object.create(null)` branch is gone and duplicate / integer-like column names keep behaving exactly as they did under `format JSON`; past 127 columns the shape itself would be a dictionary, so wider result sets keep the plain `{}`.

Measured HEAD vs this branch, 400k rows x 48 columns, medians of 3, one process per run — retained row memory on the buffered path also drops from 2112 MB to 1047 MB, while the streaming path gains little because each row is read back immediately and dropped with its chunk:

| node | consumer | old total | new total | gain |
| --- | --- | --- | --- | --- |
| 22.22 | query (`rowsToColumnar`) | 3498ms | 2208ms | 1.58x |
| 24.18 | query | 2909ms | 1901ms | 1.53x |
| 26.8 | query | 2880ms | 1929ms | 1.49x |
| 22.22 | stream (`ColumnarChunkBuilder`) | 2440ms | 2297ms | 1.06x |
| 24.18 | stream | 2135ms | 2035ms | 1.05x |
| 26.8 | stream | 2288ms | 2131ms | 1.07x |

Unit tests and linter pass for both packages (85 tests); the Docker-based `test/integration/ClickHouseDriver.test.ts` was not run locally, so its row-serialisation and `stream()` assertions are worth a CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)