### PR TITLE
perf(clickhouse-driver): Stream rows up to 2.2x faster by honouring highWaterMark

### DIFF
--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -23,7 +23,6 @@ import {
   UnloadOptions,
 } from '@cubejs-backend/base-driver';
 
-import { Readable } from 'node:stream';
 import { ClickHouseClient, ClickHouseLogLevel, createClient } from '@clickhouse/client';
 import type {
   ClickHouseSettings,
@@ -35,9 +34,8 @@ import type {
 } from '@clickhouse/client';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  buildTransformFromMeta, buildTransformFromNamesAndTypes, transformRow
-} from './Transform';
+import { ClickHouseRowStream } from './RowStream';
+import { buildTransformFromMeta, transformRow } from './Transform';
 import { formatError } from './utils';
 
 const SUPPORTED_BUCKET_TYPES = ['s3'];
@@ -445,7 +443,6 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
   public async stream(
     query: string,
     values: unknown[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     { highWaterMark, requestId }: StreamOptions
   ): Promise<StreamTableDataWithTypes> {
     // Use separate client for this long-living query
@@ -471,44 +468,11 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
       // Array<unknown> is okay, because we use fixed JSONCompactEachRowWithNamesAndTypes format
       // And each row after first two will look like this: [42, "hello", [0,1]]
       // https://clickhouse.com/docs/en/interfaces/formats#jsoncompacteachrowwithnamesandtypes
-      const resultSetStream = resultSet.stream<Array<unknown>>();
-
-      const allRowsIter = (async function* allRowsIter() {
-        for await (const rowsBatch of resultSetStream) {
-          for (const row of rowsBatch) {
-            yield row.json();
-          }
-        }
-      }());
-
-      const first = await allRowsIter.next();
-      if (first.done) {
-        throw new Error('Unexpected stream end before row with names');
-      }
-      // JSONCompactEachRowWithNamesAndTypes: expect first row to be column names as string
-      const names = first.value as Array<string>;
-
-      const second = await allRowsIter.next();
-      if (second.done) {
-        throw new Error('Unexpected stream end before row with types');
-      }
-      // JSONCompactEachRowWithNamesAndTypes: expect first row to be column names as string
-      const types = second.value as Array<string>;
-
-      const transform = buildTransformFromNamesAndTypes(names, types);
-
-      const dataRowsIter = (async function* () {
-        try {
-          for await (const row of allRowsIter) {
-            yield transformRow(row, transform);
-          }
-        } catch (e) {
-          // Since 25.11 the server reports an exception raised after the first block through
-          // the response headers and an in-stream tag, and the client rethrows it here.
-          throw new Error(`Stream query failed: ${formatError(e)}; query id: ${queryId}`, { cause: e });
-        }
-      }());
-      const rowStream = Readable.from(dataRowsIter);
+      const { rowStream, names, types } = await ClickHouseRowStream.open(
+        resultSet.stream<Array<unknown>>()[Symbol.asyncIterator](),
+        queryId,
+        highWaterMark || getEnv('dbQueryStreamHighWaterMark'),
+      );
 
       return {
         rowStream,

--- a/packages/cubejs-clickhouse-driver/src/RowStream.ts
+++ b/packages/cubejs-clickhouse-driver/src/RowStream.ts
@@ -1,0 +1,112 @@
+import { Readable } from 'node:stream';
+import type { Row } from '@clickhouse/client';
+
+import { buildTransformFromNamesAndTypes, transformRow, type Transform } from './Transform';
+import { formatError } from './utils';
+
+type RowBatch = Array<Row<Array<unknown>>>;
+
+/**
+ * Streams a JSONCompactEachRowWithNamesAndTypes result set as hydrated row objects.
+ *
+ * @clickhouse/client hands out batches of rows, so a whole batch is pushed per `await` on the
+ * source instead of one row per `await`, and the caller's `highWaterMark` decides how far ahead
+ * of the consumer we read.
+ */
+export class ClickHouseRowStream extends Readable {
+  private reading: boolean = false;
+
+  private batch: RowBatch = [];
+
+  private idx: number = 0;
+
+  private transform!: Transform;
+
+  private constructor(
+    private readonly source: AsyncIterator<RowBatch>,
+    private readonly queryId: string,
+    highWaterMark: number,
+  ) {
+    super({ objectMode: true, highWaterMark });
+  }
+
+  /**
+   * Consumes the two header rows the format starts with. Reading them here rather than through
+   * a consumer keeps it to the one moment where skipping rows is correct.
+   */
+  public static async open(
+    source: AsyncIterator<RowBatch>,
+    queryId: string,
+    highWaterMark: number,
+  ): Promise<{ rowStream: ClickHouseRowStream, names: Array<string>, types: Array<string> }> {
+    const rowStream = new ClickHouseRowStream(source, queryId, highWaterMark);
+
+    const names = await rowStream.readRawRow() as Array<string> | undefined;
+    if (!names) {
+      throw new Error('Unexpected stream end before row with names');
+    }
+
+    const types = await rowStream.readRawRow() as Array<string> | undefined;
+    if (!types) {
+      throw new Error('Unexpected stream end before row with types');
+    }
+
+    rowStream.transform = buildTransformFromNamesAndTypes(names, types);
+
+    return { rowStream, names, types };
+  }
+
+  /** Advances to the next non-empty batch; false once the source is exhausted. */
+  private async fetchBatch(): Promise<boolean> {
+    do {
+      const next = await this.source.next();
+      if (next.done) {
+        return false;
+      }
+
+      this.batch = next.value;
+      this.idx = 0;
+    } while (this.batch.length === 0);
+
+    return true;
+  }
+
+  private async readRawRow(): Promise<Array<unknown> | undefined> {
+    if (this.idx >= this.batch.length && !await this.fetchBatch()) {
+      return undefined;
+    }
+
+    return this.batch[this.idx++].json();
+  }
+
+  public override async _read(): Promise<void> {
+    // A synchronous push() can re-enter _read() while the loop below is still running
+    if (this.reading) {
+      return;
+    }
+    this.reading = true;
+
+    try {
+      let canPush = true;
+
+      while (canPush) {
+        if (this.idx >= this.batch.length && !await this.fetchBatch()) {
+          this.push(null);
+          return;
+        }
+
+        canPush = this.push(transformRow(this.batch[this.idx++].json(), this.transform));
+      }
+
+      this.reading = false;
+    } catch (e) {
+      // Since 25.11 the server reports an exception raised after the first block through
+      // the response headers and an in-stream tag, and the client rethrows it here.
+      this.destroy(new Error(`Stream query failed: ${formatError(e)}; query id: ${this.queryId}`, { cause: e }));
+    }
+  }
+
+  public override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
+    Promise.resolve(this.source.return?.()).then(() => callback(error), () => callback(error));
+  }
+}

--- a/packages/cubejs-clickhouse-driver/src/RowStream.ts
+++ b/packages/cubejs-clickhouse-driver/src/RowStream.ts
@@ -41,19 +41,26 @@ export class ClickHouseRowStream extends Readable {
   ): Promise<{ rowStream: ClickHouseRowStream, names: Array<string>, types: Array<string> }> {
     const rowStream = new ClickHouseRowStream(source, queryId, highWaterMark);
 
-    const names = await rowStream.readRawRow() as Array<string> | undefined;
-    if (!names) {
-      throw new Error('Unexpected stream end before row with names');
+    try {
+      const names = await rowStream.readRawRow() as Array<string> | undefined;
+      if (!names) {
+        throw new Error('Unexpected stream end before row with names');
+      }
+
+      const types = await rowStream.readRawRow() as Array<string> | undefined;
+      if (!types) {
+        throw new Error('Unexpected stream end before row with types');
+      }
+
+      rowStream.transform = buildTransformFromNamesAndTypes(names, types);
+
+      return { rowStream, names, types };
+    } catch (e) {
+      // Nobody holds the stream yet, so destroy it without an error to release the source
+      // rather than emit 'error' with no listener attached
+      rowStream.destroy();
+      throw e;
     }
-
-    const types = await rowStream.readRawRow() as Array<string> | undefined;
-    if (!types) {
-      throw new Error('Unexpected stream end before row with types');
-    }
-
-    rowStream.transform = buildTransformFromNamesAndTypes(names, types);
-
-    return { rowStream, names, types };
   }
 
   /** Advances to the next non-empty batch; false once the source is exhausted. */

--- a/packages/cubejs-clickhouse-driver/src/RowStream.ts
+++ b/packages/cubejs-clickhouse-driver/src/RowStream.ts
@@ -102,14 +102,20 @@ export class ClickHouseRowStream extends Readable {
           return;
         }
 
+        // A destroy() while parked on the source settles the pending next() via source.return();
+        // the rows it carried have no reader anymore
+        if (this.destroyed) {
+          return;
+        }
+
         canPush = this.push(transformRow(this.batch[this.idx++].json(), this.transform));
       }
-
-      this.reading = false;
     } catch (e) {
       // Since 25.11 the server reports an exception raised after the first block through
       // the response headers and an in-stream tag, and the client rethrows it here.
       this.destroy(new Error(`Stream query failed: ${formatError(e)}; query id: ${this.queryId}`, { cause: e }));
+    } finally {
+      this.reading = false;
     }
   }
 

--- a/packages/cubejs-clickhouse-driver/src/RowStream.ts
+++ b/packages/cubejs-clickhouse-driver/src/RowStream.ts
@@ -97,15 +97,18 @@ export class ClickHouseRowStream extends Readable {
       let canPush = true;
 
       while (canPush) {
-        if (this.idx >= this.batch.length && !await this.fetchBatch()) {
-          this.push(null);
-          return;
-        }
+        if (this.idx >= this.batch.length) {
+          if (!await this.fetchBatch()) {
+            this.push(null);
+            return;
+          }
 
-        // A destroy() while parked on the source settles the pending next() via source.return();
-        // the rows it carried have no reader anymore
-        if (this.destroyed) {
-          return;
+          // A destroy() while parked on the source settles the pending next() via source.return();
+          // the rows it carried have no reader anymore. A destroy() mid-batch needs no check of its
+          // own: push() into a destroyed stream returns false, so the loop exits on its own
+          if (this.destroyed) {
+            return;
+          }
         }
 
         canPush = this.push(transformRow(this.batch[this.idx++].json(), this.transform));

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -20,13 +20,19 @@ let source: SourceState;
 
 /**
  * Mimics @clickhouse/client: a Readable of batches, every batch an array of `Row` objects.
- * The names and types header rows are prepended to the first batch.
+ * A batch given as a promise is pushed once it settles, which keeps the source parked on that
+ * fetch until the test releases it.
  */
-function mockSource(batches: Array<Batch>, error?: Error): SourceState {
-  const remaining = batches.length
-    ? [[NAMES, TYPES, ...batches[0]], ...batches.slice(1)]
-    : [];
+function rawSource(batches: Array<Batch | Promise<Batch>>, error?: Error): SourceState {
+  const remaining = [...batches];
   const state: Partial<SourceState> = { pulledRows: 0, destroyed: false };
+
+  const toRows = (batch: Batch) => batch.map((row) => ({
+    json: () => {
+      state.pulledRows! += 1;
+      return row;
+    },
+  }));
 
   const stream = new Readable({
     objectMode: true,
@@ -42,18 +48,25 @@ function mockSource(batches: Array<Batch>, error?: Error): SourceState {
         return;
       }
 
-      this.push(batch.map((row) => ({
-        json: () => {
-          state.pulledRows! += 1;
-          return row;
-        },
-      })));
+      if (batch instanceof Promise) {
+        batch.then((settled) => this.push(toRows(settled)));
+      } else {
+        this.push(toRows(batch));
+      }
     },
   });
   stream.on('close', () => { state.destroyed = true; });
 
   state.stream = stream;
   return state as SourceState;
+}
+
+/** `rawSource` with the names and types header rows prepended to the first batch. */
+function mockSource(batches: Array<Batch>, error?: Error): SourceState {
+  return rawSource(
+    batches.length ? [[NAMES, TYPES, ...batches[0]], ...batches.slice(1)] : [],
+    error,
+  );
 }
 
 const mockQuery = jest.fn(async (_params: any) => ({
@@ -239,35 +252,23 @@ describe('ClickHouseDriver stream', () => {
   });
 
   it('stops pushing when destroyed while waiting on the source', async () => {
-    source = mockSource([]);
-    let resolveNext!: (batch: any) => void;
-    const pending = new Promise((resolve) => { resolveNext = resolve; });
-    let hydrated = 0;
-    const late = [{ json: () => { hydrated += 1; return [1, 'a', '2020-01-01 00:00:00']; } }];
-
-    // Header batch arrives at once; the next batch stays in flight until we release it
-    source.stream = new Readable({
-      objectMode: true,
-      read() {
-        if (!this.readableLength && this.readableDidRead === false) {
-          this.push([{ json: () => NAMES }, { json: () => TYPES }]);
-          return;
-        }
-        pending.then((batch) => { this.push(batch); this.push(null); });
-      },
-    });
+    let releaseBatch!: (batch: Batch) => void;
+    const inFlight = new Promise<Batch>((resolve) => { releaseBatch = resolve; });
+    // Header batch arrives at once; the next batch stays in flight until the test releases it
+    source = rawSource([[NAMES, TYPES], inFlight]);
     const { rowStream } = await openStream({ highWaterMark: 100 });
 
     const received: Array<unknown> = [];
     rowStream.on('data', (row) => received.push(row));
     await settle();
+    const pulledBefore = source.pulledRows;
 
     rowStream.destroy();
-    resolveNext(late);
+    releaseBatch([[1, 'a', '2020-01-01 00:00:00']]);
     await settle();
 
     expect(received).toEqual([]);
-    expect(hydrated).toEqual(0);
+    expect(source.pulledRows).toEqual(pulledBefore);
   });
 
   it('wraps a source error raised before the header rows and closes the client', async () => {
@@ -290,11 +291,9 @@ describe('ClickHouseDriver stream', () => {
   });
 
   it('releases the result stream when the header rows are malformed', async () => {
-    source = mockSource([]);
     // A names row shorter than the types row fails validation inside open(), after the
     // stream already owns the source iterator
-    source.stream = Readable.from([[{ json: () => ['only_names'] }, { json: () => ['Int64', 'String'] }]]);
-    source.stream.on('close', () => { source.destroyed = true; });
+    source = rawSource([[['only_names'], ['Int64', 'String']]]);
 
     await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100 }))
       .rejects.toThrow('Unexpected names and types length mismatch');

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -278,8 +278,6 @@ describe('ClickHouseDriver stream', () => {
     await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100, requestId: 'req-10-span-1' }))
       .rejects.toThrow(/^Stream query failed: Error: Code: 60\. DB::Exception: Table default\.missing does not exist; query id: req-10-/);
 
-    // open() failed before the stream was handed out, so the dedicated client (created after the
-    // constructor's shared one) is released here
     expect(createClientMock).toHaveBeenCalledTimes(2);
     // open() failed before the stream was handed out, so the dedicated client (created after the
     // constructor's shared one) is released here

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -1,0 +1,244 @@
+import { Readable } from 'node:stream';
+import { createClient } from '@clickhouse/client';
+
+import { ClickHouseDriver } from '../../src';
+
+const FORMAT = 'JSONCompactEachRowWithNamesAndTypes';
+
+const NAMES = ['id', 'name', 'created_at'];
+const TYPES = ['Int64', 'String', 'DateTime'];
+
+type Batch = Array<Array<unknown>>;
+
+interface SourceState {
+  pulledRows: number;
+  destroyed: boolean;
+  stream: Readable;
+}
+
+let source: SourceState;
+
+/**
+ * Mimics @clickhouse/client: a Readable of batches, every batch an array of `Row` objects.
+ * The names and types header rows are prepended to the first batch.
+ */
+function mockSource(batches: Array<Batch>, error?: Error): SourceState {
+  const remaining = batches.length
+    ? [[NAMES, TYPES, ...batches[0]], ...batches.slice(1)]
+    : [];
+  const state: Partial<SourceState> = { pulledRows: 0, destroyed: false };
+
+  const stream = new Readable({
+    objectMode: true,
+    highWaterMark: 1,
+    read() {
+      const batch = remaining.shift();
+      if (!batch) {
+        if (error) {
+          this.destroy(error);
+        } else {
+          this.push(null);
+        }
+        return;
+      }
+
+      this.push(batch.map((row) => ({
+        json: () => {
+          state.pulledRows! += 1;
+          return row;
+        },
+      })));
+    },
+  });
+  stream.on('close', () => { state.destroyed = true; });
+
+  state.stream = stream;
+  return state as SourceState;
+}
+
+const mockQuery = jest.fn(async (_params: any) => ({
+  response_headers: { 'x-clickhouse-format': FORMAT } as Record<string, string>,
+  stream: () => source.stream,
+}));
+
+jest.mock('@clickhouse/client', () => ({
+  ...jest.requireActual('@clickhouse/client'),
+  createClient: jest.fn(() => ({
+    query: mockQuery,
+    close: jest.fn(),
+  })),
+}));
+
+const createClientMock = createClient as unknown as jest.Mock;
+
+function createDriver(): ClickHouseDriver {
+  return new ClickHouseDriver({ host: 'localhost', port: '8123', dataSource: 'default' });
+}
+
+/** `StreamTableData` types the stream loosely and marks `release` optional; narrow it once here. */
+async function openStream(options: any) {
+  const res = await createDriver().stream('SELECT 1', [], options);
+  return {
+    ...res,
+    rowStream: res.rowStream as unknown as Readable,
+    release: res.release as () => Promise<void>,
+  };
+}
+
+function rows(count: number): Array<Batch> {
+  return [Array.from({ length: count }, (_, i) => [i, `name-${i}`, '2020-01-01 00:00:00'])];
+}
+
+/** Lets the stream machinery run without consuming anything. */
+const settle = () => new Promise((resolve) => { setTimeout(resolve, 10); });
+
+describe('ClickHouseDriver stream', () => {
+  beforeEach(() => {
+    createClientMock.mockClear();
+    mockQuery.mockClear();
+    delete process.env.CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK;
+  });
+
+  it('sizes the row stream with the requested highWaterMark', async () => {
+    source = mockSource(rows(1));
+    const { rowStream, release } = await openStream({ highWaterMark: 1234 });
+
+    expect(rowStream.readableHighWaterMark).toEqual(1234);
+    expect(rowStream.readableObjectMode).toEqual(true);
+
+    rowStream.destroy();
+    await release();
+  });
+
+  it('falls back to CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK when the option is missing', async () => {
+    source = mockSource(rows(1));
+    const { rowStream, release } = await openStream({});
+
+    expect(rowStream.readableHighWaterMark).toEqual(8192);
+
+    rowStream.destroy();
+    await release();
+
+    source = mockSource(rows(1));
+    process.env.CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK = '256';
+    const withEnv = await openStream({});
+
+    expect(withEnv.rowStream.readableHighWaterMark).toEqual(256);
+
+    withEnv.rowStream.destroy();
+    await withEnv.release();
+  });
+
+  it('reads the header rows and hydrates every data row', async () => {
+    source = mockSource(rows(3));
+    const { rowStream, types, release } = await openStream({ highWaterMark: 100 });
+
+    expect(types).toEqual([
+      { name: 'id', type: 'bigint' },
+      { name: 'name', type: 'text' },
+      { name: 'created_at', type: 'timestamp' },
+    ]);
+
+    const received: Array<unknown> = [];
+    for await (const row of rowStream) {
+      received.push(row);
+    }
+
+    expect(received).toEqual([
+      { id: '0', name: 'name-0', created_at: '2020-01-01T00:00:00.000' },
+      { id: '1', name: 'name-1', created_at: '2020-01-01T00:00:00.000' },
+      { id: '2', name: 'name-2', created_at: '2020-01-01T00:00:00.000' },
+    ]);
+
+    await release();
+  });
+
+  it('reads rows spread over multiple batches', async () => {
+    source = mockSource([
+      [[1, 'a', '2020-01-01 00:00:00']],
+      [[2, 'b', '2020-01-02 00:00:00'], [3, 'c', '2020-01-03 00:00:00']],
+    ]);
+    const { rowStream, release } = await openStream({ highWaterMark: 100 });
+
+    const received: Array<any> = [];
+    for await (const row of rowStream) {
+      received.push(row);
+    }
+
+    expect(received.map((r) => r.id)).toEqual(['1', '2', '3']);
+
+    await release();
+  });
+
+  it('stops reading ahead of the consumer once highWaterMark is reached', async () => {
+    source = mockSource(rows(500));
+    const { rowStream, release } = await openStream({ highWaterMark: 4 });
+
+    // Nothing is consumed yet, only the two header rows should have been pulled
+    await settle();
+    expect(source.pulledRows).toEqual(2);
+
+    rowStream.resume();
+    rowStream.pause();
+    await settle();
+
+    // 2 header rows + at most highWaterMark + 1 buffered rows
+    expect(source.pulledRows).toBeLessThanOrEqual(2 + 4 + 1);
+
+    rowStream.destroy();
+    await release();
+  });
+
+  it('reads ahead up to a large highWaterMark', async () => {
+    source = mockSource(rows(500));
+    const { rowStream, release } = await openStream({ highWaterMark: 8192 });
+
+    rowStream.resume();
+    rowStream.pause();
+    await settle();
+
+    expect(source.pulledRows).toEqual(2 + 500);
+
+    rowStream.destroy();
+    await release();
+  });
+
+  it('wraps an exception raised after the first block with the query id', async () => {
+    source = mockSource(rows(2), new Error('Code: 241. DB::Exception: Memory limit exceeded'));
+    const { rowStream, release } = await openStream({ highWaterMark: 100, requestId: 'req-9-span-1' });
+
+    const { query_id: queryId } = mockQuery.mock.calls[0][0];
+
+    const received: Array<unknown> = [];
+    await expect((async () => {
+      for await (const row of rowStream) {
+        received.push(row);
+      }
+    })()).rejects.toThrow(`Stream query failed: Error: Code: 241. DB::Exception: Memory limit exceeded; query id: ${queryId}`);
+
+    // The rows that did arrive before the exception are still delivered
+    expect(received).toHaveLength(2);
+
+    await release();
+  });
+
+  it('destroys the underlying result stream when the row stream is destroyed', async () => {
+    source = mockSource(rows(500));
+    const { rowStream, release } = await openStream({ highWaterMark: 4 });
+
+    expect(source.destroyed).toEqual(false);
+
+    rowStream.destroy();
+    await settle();
+
+    expect(source.destroyed).toEqual(true);
+
+    await release();
+  });
+
+  it('fails when the stream ends before the header rows', async () => {
+    source = mockSource([]);
+    await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100 }))
+      .rejects.toThrow('Unexpected stream end before row with names');
+  });
+});

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -241,4 +241,18 @@ describe('ClickHouseDriver stream', () => {
     await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100 }))
       .rejects.toThrow('Unexpected stream end before row with names');
   });
+
+  it('releases the result stream when the header rows are malformed', async () => {
+    source = mockSource([]);
+    // A names row shorter than the types row fails validation inside open(), after the
+    // stream already owns the source iterator
+    source.stream = Readable.from([[{ json: () => ['only_names'] }, { json: () => ['Int64', 'String'] }]]);
+    source.stream.on('close', () => { source.destroyed = true; });
+
+    await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100 }))
+      .rejects.toThrow('Unexpected names and types length mismatch');
+
+    await settle();
+    expect(source.destroyed).toEqual(true);
+  });
 });

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -280,8 +280,10 @@ describe('ClickHouseDriver stream', () => {
 
     // open() failed before the stream was handed out, so the dedicated client (created after the
     // constructor's shared one) is released here
-    const client = createClientMock.mock.results.at(-1)!.value;
     expect(createClientMock).toHaveBeenCalledTimes(2);
+    // open() failed before the stream was handed out, so the dedicated client (created after the
+    // constructor's shared one) is released here
+    const client = createClientMock.mock.results.at(-1)!.value;
     expect(client.close).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -236,6 +236,38 @@ describe('ClickHouseDriver stream', () => {
     await release();
   });
 
+  it('stops pushing when destroyed while waiting on the source', async () => {
+    source = mockSource([]);
+    let resolveNext!: (batch: any) => void;
+    const pending = new Promise((resolve) => { resolveNext = resolve; });
+    let hydrated = 0;
+    const late = [{ json: () => { hydrated += 1; return [1, 'a', '2020-01-01 00:00:00']; } }];
+
+    // Header batch arrives at once; the next batch stays in flight until we release it
+    source.stream = new Readable({
+      objectMode: true,
+      read() {
+        if (!this.readableLength && this.readableDidRead === false) {
+          this.push([{ json: () => NAMES }, { json: () => TYPES }]);
+          return;
+        }
+        pending.then((batch) => { this.push(batch); this.push(null); });
+      },
+    });
+    const { rowStream } = await openStream({ highWaterMark: 100 });
+
+    const received: Array<unknown> = [];
+    rowStream.on('data', (row) => received.push(row));
+    await settle();
+
+    rowStream.destroy();
+    resolveNext(late);
+    await settle();
+
+    expect(received).toEqual([]);
+    expect(hydrated).toEqual(0);
+  });
+
   it('fails when the stream ends before the header rows', async () => {
     source = mockSource([]);
     await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100 }))

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -261,14 +261,15 @@ describe('ClickHouseDriver stream', () => {
     const received: Array<unknown> = [];
     rowStream.on('data', (row) => received.push(row));
     await settle();
-    const pulledBefore = source.pulledRows;
+    // Only the two header rows, i.e. the loop is parked on the in-flight second batch
+    expect(source.pulledRows).toEqual(2);
 
     rowStream.destroy();
     releaseBatch([[1, 'a', '2020-01-01 00:00:00']]);
     await settle();
 
     expect(received).toEqual([]);
-    expect(source.pulledRows).toEqual(pulledBefore);
+    expect(source.pulledRows).toEqual(2);
   });
 
   it('wraps a source error raised before the header rows and closes the client', async () => {

--- a/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
+++ b/packages/cubejs-clickhouse-driver/test/unit/stream.test.ts
@@ -97,6 +97,8 @@ describe('ClickHouseDriver stream', () => {
     createClientMock.mockClear();
     mockQuery.mockClear();
     delete process.env.CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK;
+    // A test that forgets to set up its source must fail, not reuse the previous one's drained stream
+    source = undefined as unknown as SourceState;
   });
 
   it('sizes the row stream with the requested highWaterMark', async () => {
@@ -266,6 +268,19 @@ describe('ClickHouseDriver stream', () => {
 
     expect(received).toEqual([]);
     expect(hydrated).toEqual(0);
+  });
+
+  it('wraps a source error raised before the header rows and closes the client', async () => {
+    source = mockSource([], new Error('Code: 60. DB::Exception: Table default.missing does not exist'));
+
+    await expect(createDriver().stream('SELECT 1', [], { highWaterMark: 100, requestId: 'req-10-span-1' }))
+      .rejects.toThrow(/^Stream query failed: Error: Code: 60\. DB::Exception: Table default\.missing does not exist; query id: req-10-/);
+
+    // open() failed before the stream was handed out, so the dedicated client (created after the
+    // constructor's shared one) is released here
+    const client = createClientMock.mock.results.at(-1)!.value;
+    expect(createClientMock).toHaveBeenCalledTimes(2);
+    expect(client.close).toHaveBeenCalledTimes(1);
   });
 
   it('fails when the stream ends before the header rows', async () => {


### PR DESCRIPTION
**End-to-end**

Confirmed on a real Cube 1.7.33 server against ClickHouse 25.8 in Docker, 2M-row table, `CUBESQL_STREAM_MODE=true`, one ungrouped `LIMIT 2000000` query per row width so every request streams. `server` is the `Performing query completed` figure from the server log, `wall` is psql's; medians, with the baseline re-run after the branch run to rule out drift.

| row width | before (server) | after (server) | speedup | before (wall) | after (wall) | speedup |
| --- | --- | --- | --- | --- | --- | --- |
| 3 cols | 3606 ms | 1921 ms | **1.88x** | 4176 ms | 2535 ms | 1.65x |
| 8 cols | 5364 ms | 3420 ms | **1.57x** | 6801 ms | 4897 ms | 1.39x |
| 16 cols | 8720 ms | 6296 ms | **1.39x** | 11758 ms | 9307 ms | 1.26x |
| 32 cols | 15682 ms | 13424 ms | **1.17x** | 21704 ms | 19607 ms | 1.11x |

The saving is a fixed per-row cost — one event-loop round-trip — so it stays roughly constant in absolute terms (~0.85 ms per 1k rows at 3 columns, ~1.1 ms per 1k at 32) while its share shrinks as the per-row hydration work grows with the row width.