### PR TITLE
docs: distinguish reports from explorations

### DIFF
--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -56,7 +56,7 @@ add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel
-[ref-cube-cloud-for-excel-pivot]: /docs/integrations/microsoft-excel#create-reports-via-pivot-table
+[ref-cube-cloud-for-excel-pivot]: /docs/integrations/microsoft-excel#create-explorations-via-pivot-table
 [ref-cube-cloud-for-excel-installation]: /docs/integrations/microsoft-excel#installation
 [ref-cube-cloud-for-excel-authentication]: /docs/integrations/microsoft-excel#authentication
 [ref-integrations-tools]: /admin/connect-to-data/visualization-tools

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -1145,6 +1145,10 @@
   },
   "redirects": [
     {
+      "source": "/docs/workspace/saved-reports",
+      "destination": "/docs/explore-analyze/explore#saving-explorations"
+    },
+    {
       "source": "/admin/ai/agent-rules",
       "destination": "/admin/ai/rules"
     },

--- a/docs-mintlify/docs/data-modeling/content-validator.mdx
+++ b/docs-mintlify/docs/data-modeling/content-validator.mdx
@@ -1,9 +1,9 @@
 ---
 title: Content Validator
-description: Find saved reports that reference data model fields or views that no longer exist, and fix or remove them before a model change breaks live dashboards.
+description: Find workbook reports that reference data model fields or views that no longer exist, and fix or remove them before a model change breaks live dashboards.
 ---
 
-The Content Validator finds saved reports whose queries reference data model
+The Content Validator finds workbook reports whose queries reference data model
 members — individual fields or whole views — that no longer exist in your
 current data model. Use it to catch and fix broken content while you are
 changing the model, before the change ships and breaks live

--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -13,7 +13,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 
 - **Natural language queries** – Ask questions in plain language without knowing SQL
 - **Multi-query reasoning** – The AI creates and synthesizes multiple queries for complex questions
-- **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it as a re-runnable report or exploration (in preview)
+- **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it as a re-runnable workbook report or exploration (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
 - **Save your results** – Ask the agent to save a result as a [report](/docs/explore-analyze/workbooks) inside a workbook, or as a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) when you don't want to create a workbook
@@ -86,7 +86,6 @@ Analytics Chat can be [embedded](/embedding) into your applications for customer
 ## Learn more
 
 - [Workbooks](/docs/explore-analyze/workbooks) – Build and organize reports with AI assistance
-- [Python analysis](/docs/explore-analyze/workbooks/python-analysis) – Save a Python analysis from chat as a re-runnable report
+- [Python analysis](/docs/explore-analyze/workbooks/python-analysis) – Save a Python analysis from chat as a re-runnable workbook report or exploration
 - [Embedding](/embedding) – Embed analytics in your applications
 - [Cube Agentic Analytics announcement](https://cube.dev/blog/cube-agentic-analytics) – Learn about the vision behind agentic analytics
-

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -117,15 +117,17 @@ and will be restored when you open Playground once again.
 
 You can also double-click on a query tab to give it a meaningful name.
 
-### Saving a report
+### Saving an exploration
 
-You can save a _query to a view_ by clicking **Save Report** in the top right corner.
+You can save a _query to a view_ as an exploration by clicking **Save** in the
+top right corner.
 
 <Frame>
   <img src="https://ucarecdn.com/c4865552-59ab-4d20-bd7d-5310be07e16c/" />
 </Frame>
 
-You can manage saved reports in the **[Saved Reports][ref-saved-reports]** page.
+The saved exploration appears in your workspace. See
+[Saving explorations][ref-explorations] for details.
 
 ## Viewing results
 
@@ -211,4 +213,4 @@ manually.
 [ref-row-limit]: /reference/core-data-apis/queries#limit
 [ref-chart-prototyping]: /embedding/vizard
 [ref-boolean-filters]: /reference/core-data-apis/rest-api/query-format#boolean-logical-operators
-[ref-saved-reports]: /docs/workspace/saved-reports
+[ref-explorations]: /docs/explore-analyze/explore#saving-explorations

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -122,11 +122,7 @@ You can also double-click on a query tab to give it a meaningful name.
 You can save a _query to a view_ as an exploration by clicking **Save** in the
 top right corner.
 
-<Frame>
-  <img src="https://ucarecdn.com/c4865552-59ab-4d20-bd7d-5310be07e16c/" />
-</Frame>
-
-The saved exploration appears in your workspace. See
+In Cube Cloud, the saved exploration appears in your workspace. See
 [Saving explorations][ref-explorations] for details.
 
 ## Viewing results

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -64,7 +64,7 @@ last Python run, and a freshly attached script has none until you press **Run**.
 Attaching Python in Explore is only available on a **saved** exploration. On an
 unsaved one the **Python** button is disabled with the tooltip *"Save the
 exploration to add Python"* — **Run** executes server-persisted code, so the
-analysis needs a saved report to live on.
+analysis needs a saved exploration to live on.
 
 ## Writing the script
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python analysis
-description: Attach a Python script to a report to run forecasting, regression, cohort, and other analysis that SQL can't express, and save the result as a re-runnable report.
+description: Attach a Python script to a workbook report or exploration to run forecasting, regression, cohort, and other analysis that SQL can't express.
 ---
 
 <Warning>
@@ -11,10 +11,10 @@ team](/admin/account-billing/support) to activate this feature for your account.
 
 </Warning>
 
-A report can carry an attached **Python script** that transforms the report's SQL
-result. The report's chart then renders the script's **output** instead of the raw
-SQL rows. This turns an analysis that would otherwise scroll away in a chat
-transcript into a saved, re-runnable, shareable report.
+A workbook report or exploration can carry an attached **Python script** that
+transforms its SQL result. Its chart then renders the script's **output** instead
+of the raw SQL rows. This turns an analysis that would otherwise scroll away in a
+chat transcript into a saved, re-runnable, shareable analysis.
 
 Use it for work SQL can't express — forecasting, regression, cohort analysis,
 statistical tests, clustering, and anomaly detection.
@@ -23,7 +23,7 @@ statistical tests, clustering, and anomaly detection.
   <img src="https://static.cube.dev/docs/explore-analyze/workbooks/python-analysis/code-panel-forecast.png" alt="A workbook report with the Python code panel open, showing a Prophet forecast script above a chart plotting actual monthly orders alongside the forecast and its confidence interval" />
 </Frame>
 
-## Adding Python to a report
+## Adding Python to a workbook report or exploration
 
 ### From Analytics Chat
 
@@ -43,7 +43,7 @@ The agent reaches for Python **only** when the answer genuinely needs a statisti
 or machine-learning library. Ordinary aggregations, top-N, ratios, running totals,
 period-over-period comparisons, and time series all stay in SQL, because a Python
 run costs a re-query plus a sandbox start. If you expected Python and got a plain
-SQL report, that is usually correct behavior.
+SQL query, that is usually correct behavior.
 
 </Info>
 
@@ -55,11 +55,11 @@ Click **Python** in the toolbar to open the Python panel, then **Add script** to
 attach one. Cube seeds a starter script and opens it on the **Script** tab.
 Opening the panel does not attach anything by itself — only **Add script** does.
 
-**Remove**, in the panel header, detaches the script, after which the report
-behaves like any SQL-backed one again.
+**Remove**, in the panel header, detaches the script, after which the analysis is
+SQL-backed again.
 
-Attaching Python clears any existing SQL result: a python-backed report renders its
-last Python run, and a freshly attached script has none until you press **Run**.
+Attaching Python clears any existing SQL result: a Python-backed analysis renders
+its last Python run, and a freshly attached script has none until you press **Run**.
 
 Attaching Python in Explore is only available on a **saved** exploration. On an
 unsaved one the **Python** button is disabled with the tooltip *"Save the
@@ -95,7 +95,7 @@ These packages are pre-installed, along with their dependencies:
 | `prophet` | Time series forecasting with seasonality and holidays |
 | `matplotlib`, `seaborn`, `plotly` | Plotting |
 
-Figures are not a supported output. The report's chart is built from `output.json`, and
+Figures are not a supported output. The chart is built from `output.json`, and
 anything a script writes to disk is discarded with the sandbox — so the plotting
 libraries are importable, but a saved figure has nowhere to go.
 
@@ -112,7 +112,7 @@ adding packages to the environment is coming.
 The panel's **Script** tab is editable in place, with line numbers. **Reset**
 restores the starter template.
 
-- **Edits do not run anything.** They save with the report, and the rendered result
+- **Edits do not run anything.** They save with the analysis, and the rendered result
   keeps showing the previous run.
 - When the code or its input SQL has changed since the last run, the result is
   marked **Outdated**, with the tooltip *"The Python code or its input SQL changed
@@ -122,22 +122,23 @@ restores the starter template.
 - The **Output** tab shows what the last run printed — the script's stdout and
   stderr, so `print()` is how you inspect intermediate values. Both are captured up
   to the cap in [Limits](#limits), so a chatty script gets truncated.
-- The **input SQL panel is read-only** on a python report: that SQL is the
+- The **input SQL panel is read-only** on a Python-backed analysis: that SQL is the
   sandbox's input, not what gets charted. It still offers the **Semantic SQL** and
   **Generated SQL** tabs, both derived from that input query.
 - **A failed run keeps the previous chart.** The error surfaces alongside the last
   successful result, which stays rendered.
 
-**Run is the only way the saved result changes.** Opening the report, reloading the
-page, or viewing a dashboard never re-runs anything on its own.
+**Run is the only way the saved result changes.** Opening the workbook report or
+exploration, reloading the page, or viewing a dashboard never re-runs anything on
+its own.
 
 {/* TODO: screenshot — the code panel showing the Outdated tag */}
 
 ## On dashboards
 
-Python reports render their **saved output** on dashboards. Nothing re-runs on
-dashboard load, so a dashboard full of Python reports costs no compute to open —
-each widget shows whatever the last **Run** produced.
+Python-backed workbook reports render their **saved output** on dashboards.
+Nothing re-runs on dashboard load, so a dashboard full of Python reports costs
+no compute to open — each widget shows whatever the last **Run** produced.
 
 A python widget can be opened in [Explore](/docs/explore-analyze/explore) from a
 dashboard and run from there.
@@ -147,8 +148,8 @@ dashboard and run from there.
 <Warning>
 
 Python runs with the **security context of the person who pressed Run** — or of the
-chat user who saved the analysis. The result is then persisted on the report, and
-**anyone who can view the workbook can see it**.
+chat user who saved the analysis. The result is then persisted with the workbook
+report or exploration, and **anyone who can view that item can see the result**.
 
 Row-level security is applied at **run time**, not at view time. A user with broad
 access can Run, and the stored output is then readable by people whose own access
@@ -156,8 +157,8 @@ is narrower.
 
 </Warning>
 
-Take this into account when deciding who can run and publish Python reports, the
-same way you would for any other saved result shared through a workbook.
+Take this into account when deciding who can run Python analyses or publish Python
+reports, the same way you would for any other shared saved result.
 
 ## Limits
 
@@ -170,9 +171,9 @@ same way you would for any other saved result shared through a workbook.
 | stdout/stderr captured | 16 KB |
 
 Exceeding the output caps means the analysis still returns in chat but **cannot be
-saved to a report**. Aggregate or summarize inside the script so the output stays
-within the caps — analysis results such as forecasts, cohorts, and test statistics
-are small by nature.
+saved to a workbook report or exploration**. Aggregate or summarize inside the
+script so the output stays within the caps — analysis results such as forecasts,
+cohorts, and test statistics are small by nature.
 
 ## Learn more
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
@@ -33,10 +33,10 @@ and dimension definitions), the Workbook Agent can:
 ## How charts get added to a dashboard
 
 When the agent adds a chart to a dashboard, the chart widget references a
-**saved report**, not a one-off query. So to put a new chart on a dashboard, the
-agent first saves it as a report in the workbook, then adds a widget that points
-at that report. This keeps every dashboard chart backed by a reusable,
-governed report.
+**report in the workbook**, not a one-off query. So to put a new chart on a
+dashboard, the agent first saves the query as a report in the workbook, then
+adds a widget that points at that report. This keeps every dashboard chart
+backed by a reusable, governed report.
 
 ## Getting help with Cube
 

--- a/docs-mintlify/docs/integrations/agent-skills.mdx
+++ b/docs-mintlify/docs/integrations/agent-skills.mdx
@@ -75,8 +75,8 @@ The source is public under Apache 2.0 at
 | --- | --- |
 | `cube-explore-model` | Searches and inspects cubes, views, measures, dimensions, joins, and model files. |
 | `cube-build-model` | Authors cubes and views on a dev-mode branch, validates them, and prepares them to deploy. |
-| `cube-explore-content` | Browses workbooks, dashboards, reports, folders, and scheduled notifications. |
-| `cube-build-content` | Creates and updates workbooks, reports, dashboards, folders, and scheduled notifications. |
+| `cube-explore-content` | Browses workbooks, workbook reports, explorations, dashboards, folders, and scheduled notifications. |
+| `cube-build-content` | Creates and updates workbooks, workbook reports, explorations, dashboards, folders, and scheduled notifications. |
 | `cube-run-query` | Runs semantic-layer queries and interprets the results. |
 | `cube-configure-agent` | Inspects and tunes the in-product Cube agent, including rules, certified queries, and Agent Skills in Cube. |
 | `cube-admin` | Manages users, groups, attributes, access policies, tenant settings, SCIM, and OIDC. |

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -11,7 +11,7 @@ Available on [Premium and above plans](https://cube.dev/pricing).
 
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-on, you will be able to [create
-reports via pivot table](#create-reports-via-pivot-table) and work with
+explorations via pivot table](#create-explorations-via-pivot-table) and work with
 [explorations](#work-with-explorations).
 
 <iframe
@@ -64,10 +64,10 @@ Once you see the `Access Granted` message, close the modal window.
 If you want to revoke the authentication, open the add-on menu and click
 **Sign out**.
 
-## Create reports via pivot table
+## Create explorations via pivot table
 
-To create a report, go to the add-on menu and click **Create report via pivot
-table**. Then, select a Cube Cloud deployment from the drop-down. Finally,
+To create an exploration, open the add-on and click **Create exploration**.
+Then, select a Cube Cloud deployment from the drop-down. Finally,
 you can start building a query by selecting a view and its members in the UI that
 looks and feels like [Playground][ref-playground].
 
@@ -92,16 +92,16 @@ members to **Filters**. Click on **×** to remove members from a query.
 </Frame>
 
 Use **Order** and **Filters** panes below to sort and filter the
-data in the report.
+data in the exploration.
 
-If you'd like to move the report to a new location, click on the desired top-left
+If you'd like to move the exploration to a new location, click on the desired top-left
 cell and then confirm with the target button under **Result location**.
 
 <Frame>
   <img src="https://ucarecdn.com/5a8d2b6a-b415-46ee-9e03-57ea5eeb693a/" />
 </Frame>
 
-With every change to your query, Cube Cloud for Sheets will update the report on
+With every change to your query, Cube Cloud for Sheets will update the exploration on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
@@ -128,7 +128,7 @@ with **Measures on**, in the same tab) — there it's labeled **After rows** /
 
 To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
-the report and survive **Refresh**.
+the exploration and survive **Refresh**.
 
 When your exploration is ready, click **Save** to add it to your workspace.
 
@@ -167,11 +167,11 @@ targets the wrong cell.
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />
 </Frame>
 
-If a report has filters applied, an admin can turn on **Show applied filters
+If an exploration has filters applied, an admin can turn on **Show applied filters
 in reports** (Settings → Spreadsheet Add-ins) to make the filter state
 visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
-their header, both when the report is inserted and after **Refresh**.
+their header, both when the exploration is inserted and after **Refresh**.
 
 Saved explorations also appear in the Cube Cloud workspace. See
 [Saving explorations][ref-explorations] for details.

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -11,8 +11,8 @@ Available on [Premium and above plans](https://cube.dev/pricing).
 
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-on, you will be able to [create
-reports via pivot table](#create-reports-via-pivot-table) and work with [saved
-reports](#work-with-saved-reports).
+reports via pivot table](#create-reports-via-pivot-table) and work with
+[explorations](#work-with-explorations).
 
 <iframe
   width="100%"
@@ -130,10 +130,9 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the report and survive **Refresh**.
 
-When your report is ready, you can optionally move it to [saved reports](#work-with-saved-reports)
-by clicking **Save**.
+When your exploration is ready, click **Save** to add it to your workspace.
 
-## Work with saved reports
+## Work with explorations
 
 Opening the add-on shows the current spreadsheet's home: every exploration
 placed in this spreadsheet, grouped by sheet, with each placement's range and
@@ -174,8 +173,8 @@ visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
 their header, both when the report is inserted and after **Refresh**.
 
-You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
-in Cube Cloud.
+Saved explorations also appear in the Cube Cloud workspace. See
+[Saving explorations][ref-explorations] for details.
 
 
 [link-google-sheets]: https://workspace.google.com/products/sheets/
@@ -185,4 +184,4 @@ in Cube Cloud.
 [ref-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
-[ref-saved-reports]: /docs/workspace/saved-reports
+[ref-explorations]: /docs/explore-analyze/explore#saving-explorations

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -130,7 +130,8 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the exploration and survive **Refresh**.
 
-When your exploration is ready, click **Save** to add it to your workspace.
+When your exploration is ready, click **Save** to add it to your workspace. You
+can then [work with the exploration](#work-with-explorations) from the add-on.
 
 ## Work with explorations
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -220,8 +220,8 @@ Each tool is annotated as read-only or destructive. MCP clients that honor these
 annotations — including Claude — run read-only tools automatically and **always ask for
 confirmation** before any of the six destructive ones: `updateReport`, `deleteReport`,
 `updateDashboard`, `publishDashboard`, `writeDataModelFile`, and `deleteDataModelFile`.
-Nothing that changes a report, a dashboard, or your data model happens without an explicit
-approval.
+Nothing that changes a workbook report, an exploration, a dashboard, or your data model
+happens without an explicit approval.
 
 ### Deployments and chat
 
@@ -259,10 +259,10 @@ programmatically. Creating and editing workbooks requires the Explorer role or h
 | --- | --- | --- |
 | `readWorkbook` | Reads a workbook — its name and its current dashboard draft and published configs. | Read-only |
 | `createWorkbook` | Creates a new empty workbook, the container that holds reports and a dashboard. | Write |
-| `createReport` | Saves a query plus its visualization as a report. Pass `workbookId` to file it inside a workbook and get the `reportId` a chart widget references; omit `workbookId` to save a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) instead. | Write |
+| `createReport` | Saves a query plus its visualization. Pass `workbookId` to create a report inside a workbook and get the `reportId` a chart widget references; omit `workbookId` to save a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) instead. | Write |
 | `readReport` | Reads one workbook report or standalone exploration by id — its title, SQL, chart spec, placement, and a shareable URL. | Read-only |
-| `updateReport` | Edits an existing report in place, keeping its `reportId`. Send only the fields you want to change. | Destructive — prompts |
-| `deleteReport` | Deletes a report. | Destructive — prompts |
+| `updateReport` | Edits an existing workbook report or exploration in place, keeping its `reportId`. Send only the fields you want to change. | Destructive — prompts |
+| `deleteReport` | Deletes a workbook report or exploration. | Destructive — prompts |
 | `updateDashboard` | Saves the dashboard layout to the workbook **draft**. Replaces the full widget set and does not go live. | Destructive — prompts |
 | `publishDashboard` | Publishes the current draft to make it live. Idempotent — republishing an unchanged draft is a no-op. | Destructive — prompts |
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -260,7 +260,7 @@ programmatically. Creating and editing workbooks requires the Explorer role or h
 | `readWorkbook` | Reads a workbook — its name and its current dashboard draft and published configs. | Read-only |
 | `createWorkbook` | Creates a new empty workbook, the container that holds reports and a dashboard. | Write |
 | `createReport` | Saves a query plus its visualization as a report. Pass `workbookId` to file it inside a workbook and get the `reportId` a chart widget references; omit `workbookId` to save a standalone [exploration](/docs/explore-analyze/explore#saving-explorations) instead. | Write |
-| `readReport` | Reads one saved report by id — its title, SQL, chart spec, placement, and a shareable URL. | Read-only |
+| `readReport` | Reads one workbook report or standalone exploration by id — its title, SQL, chart spec, placement, and a shareable URL. | Read-only |
 | `updateReport` | Edits an existing report in place, keeping its `reportId`. Send only the fields you want to change. | Destructive — prompts |
 | `deleteReport` | Deletes a report. | Destructive — prompts |
 | `updateDashboard` | Saves the dashboard layout to the workbook **draft**. Replaces the full widget set and does not go live. | Destructive — prompts |

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -138,7 +138,8 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the exploration and survive **Refresh**.
 
-When your exploration is ready, click **Save** to add it to your workspace.
+When your exploration is ready, click **Save** to add it to your workspace. You
+can then [work with the exploration](#work-with-explorations) from the add-in.
 
 ## Work with explorations
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -17,7 +17,7 @@ Available on [Enterprise plan](https://cube.dev/pricing).
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-in, you will be able to [create
 reports via pivot table](#create-reports-via-pivot-table) and work with
-[saved reports](#work-with-saved-reports).
+[explorations](#work-with-explorations).
 
 <iframe
   width="100%"
@@ -138,10 +138,9 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the report and survive **Refresh**.
 
-When your report is ready, you can optionally move it to [saved reports](#work-with-saved-reports)
-by clicking **Save**.
+When your exploration is ready, click **Save** to add it to your workspace.
 
-## Work with saved reports
+## Work with explorations
 
 Opening the add-in shows the current workbook's home: every exploration
 placed in this workbook, grouped by sheet, with each placement's range and
@@ -182,8 +181,8 @@ visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
 their header, both when the report is inserted and after **Refresh**.
 
-You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
-in Cube Cloud.
+Saved explorations also appear in the Cube Cloud workspace. See
+[Saving explorations][ref-explorations] for details.
 
 
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
@@ -195,4 +194,4 @@ in Cube Cloud.
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
 [link-excel-addins]: https://support.microsoft.com/en-us/office/add-or-remove-add-ins-in-excel-0af570c4-5cf3-4fa9-9b88-403625a0b460
 [link-ms-appsource]: https://appsource.microsoft.com/en-us/product/office/WA200008486
-[ref-saved-reports]: /docs/workspace/saved-reports
+[ref-explorations]: /docs/explore-analyze/explore#saving-explorations

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -6,7 +6,7 @@ description: "Cube for Excel is the native Microsoft Excel add-in for Cube Cloud
 it works with Excel on all operating systems,
 including macOS, and all platforms, including web and mobile. It doesn't integrate
 with the native [PivotTable][link-pivottable] in Excel but provides a custom
-[pivot table](#create-reports-via-pivot-table) UI.
+[pivot table](#create-explorations-via-pivot-table) UI.
 
 <Note>
 
@@ -16,7 +16,7 @@ Available on [Enterprise plan](https://cube.dev/pricing).
 
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-in, you will be able to [create
-reports via pivot table](#create-reports-via-pivot-table) and work with
+explorations via pivot table](#create-explorations-via-pivot-table) and work with
 [explorations](#work-with-explorations).
 
 <iframe
@@ -72,10 +72,10 @@ Once you see the `Access Granted` message, close the modal window.
 If you want to revoke the authentication, open the add-in menu and click
 **Sign out**.
 
-## Create reports via pivot table
+## Create explorations via pivot table
 
-To create a report, go to the add-in menu and click **Create report via pivot
-table**. Then, select a Cube Cloud deployment from the drop-down. Finally,
+To create an exploration, open the add-in and click **Create exploration**.
+Then, select a Cube Cloud deployment from the drop-down. Finally,
 you can start building a query by selecting a view and its members in the UI that
 looks and feels like [Playground][ref-playground].
 
@@ -100,16 +100,16 @@ members to **Filters**. Click on **×** to remove members from a query.
 </Frame>
 
 Use **Order** and **Filters** panes below to sort and filter the
-data in the report.
+data in the exploration.
 
-If you'd like to move the report to a new location, click on the desired top-left
+If you'd like to move the exploration to a new location, click on the desired top-left
 cell and then confirm with the target button under **Result location**.
 
 <Frame>
   <img src="https://ucarecdn.com/4c3af7b9-4ef6-4f7f-8d0f-6d579609482e/" />
 </Frame>
 
-With every change to your query, Cube for Excel will update the report on
+With every change to your query, Cube for Excel will update the exploration on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
@@ -136,7 +136,7 @@ with **Measures on**, in the same tab) — there it's labeled **After rows** /
 
 To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
-the report and survive **Refresh**.
+the exploration and survive **Refresh**.
 
 When your exploration is ready, click **Save** to add it to your workspace.
 
@@ -175,11 +175,11 @@ targets the wrong cell.
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />
 </Frame>
 
-If a report has filters applied, an admin can turn on **Show applied filters
+If an exploration has filters applied, an admin can turn on **Show applied filters
 in reports** (Settings → Spreadsheet Add-ins) to make the filter state
 visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
-their header, both when the report is inserted and after **Refresh**.
+their header, both when the exploration is inserted and after **Refresh**.
 
 Saved explorations also appear in the Cube Cloud workspace. See
 [Saving explorations][ref-explorations] for details.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -36,14 +36,14 @@ See [Generate Session → Creator mode bootstrap][ref-bootstrap] for the input s
 
 ## Default dashboards
 
-You can pre-populate every embed user's workspace with ready-made content so they see useful dashboards the first time they open the embedded app, instead of an empty workspace. This is a good way to ship templates or starter reports that your users can explore and build on.
+You can pre-populate every embed user's workspace with ready-made content so they see useful dashboards the first time they open the embedded app, instead of an empty workspace. This is a good way to ship templates or starter explorations that your users can open.
 
 Default dashboards are shared from your **main workspace** with the **All embed users** (`all_embed_users`) group — a system group that Cube creates automatically once Creator Mode is enabled. Sharing is read-only: embed users can open and explore the shared content but can't edit it.
 
 To set up default dashboards:
 
-1. Build the workbooks, dashboards, folders, and reports you want everyone to see in your main workspace.
-2. Open the share dialog for a workbook or folder and share it with **All embed users**. The only available access level is **Can view**.
+1. Build the workbooks, dashboards, folders, and explorations you want everyone to see in your main workspace.
+2. Open the share dialog for a workbook, exploration, or folder and share it with **All embed users**. The only available access level is **Can view**.
 3. Embed users in Creator Mode now see the shared items at the root of their workspace as soon as they open the app.
 
 <Note>
@@ -52,15 +52,15 @@ To set up default dashboards:
 
 Keep the following behavior in mind:
 
-- **Sharing a folder** shares everything inside it — all nested folders, workbooks, and reports become available to embed users.
-- **Sharing a single workbook or report** exposes that item plus the folders above it (so users can navigate to it), but not the other contents of those folders.
+- **Sharing a folder** shares everything inside it — all nested folders, workbooks, and explorations become available to embed users.
+- **Sharing a single workbook or exploration** exposes that item plus the folders above it (so users can navigate to it), but not the other contents of those folders.
 - All embed users see the **same** default dashboards, regardless of their [groups](/admin/users-and-permissions/user-groups) or user attributes. The shared set applies across every embed tenant that belongs to your account.
 - Embed users can't edit content shared from the main workspace. Opening a shared workbook shows its published dashboard, so a workbook must have a published dashboard for users to open it.
 - Removing the share from the **All embed users** group removes those items from embed users' workspaces immediately.
 
-## Sharing workbooks, dashboards, and folders
+## Sharing workbooks, explorations, dashboards, and folders
 
-Embed users in Creator Mode can share the workbooks, dashboards, and folders they build with other users, the same way they would in the full Cube app. Sharing a folder shares everything inside it, and follows the same access levels — **Full access**, **Can edit**, **Can view** — as sharing a workbook.
+Embed users in Creator Mode can share the workbooks, explorations, dashboards, and folders they build with other users, the same way they would in the full Cube app. Sharing a folder shares everything inside it, and follows the same access levels — **Full access**, **Can edit**, **Can view** — as sharing a workbook.
 
 <Note>
   Sharing is scoped to the [embed tenant](#embed-tenant-scoping): users can only share with others in the same tenant, never across tenants.

--- a/docs-mintlify/scripts/build_old_site_redirects.py
+++ b/docs-mintlify/scripts/build_old_site_redirects.py
@@ -141,11 +141,7 @@ OVERRIDES = {
 # Legacy redirects normally take precedence over canonical page mappings. This
 # page was renamed rather than consolidated into the workspace landing, so its
 # old redirect must follow the canonical override above.
-LEGACY_REDIRECT_OVERRIDES = {
-    "/product/administration/workspace/saved-reports": OVERRIDES[
-        "/product/administration/workspace/saved-reports"
-    ],
-}
+LEGACY_SOURCE_WINS = {"/product/administration/workspace/saved-reports"}
 
 # Where to send any /product/* URL that matches nothing else.
 PRODUCT_CATCH_ALL = "/docs/introduction"
@@ -278,9 +274,8 @@ def build_redirects(old_redirects: list, page_map: dict) -> list:
     # 1. Legacy aliases from the old redirects.json.
     for r in old_redirects:
         source = r.get("source", "")
-        destination = LEGACY_REDIRECT_OVERRIDES.get(source)
-        if destination:
-            add(source, to_absolute(destination))
+        if source in LEGACY_SOURCE_WINS:
+            add(source, to_absolute(OVERRIDES[source]))
         else:
             add(source, resolve_destination(r.get("destination", ""), page_map))
 

--- a/docs-mintlify/scripts/build_old_site_redirects.py
+++ b/docs-mintlify/scripts/build_old_site_redirects.py
@@ -103,7 +103,7 @@ OVERRIDES = {
     "/product/administration/workspace/maintenance-window": "/admin",
     "/product/administration/workspace/semantic-catalog": "/admin",
     "/product/administration/workspace/integrations": "/admin/connect-to-data/visualization-tools",
-    "/product/administration/workspace/saved-reports": "/docs/explore-analyze/workbooks",
+    "/product/administration/workspace/saved-reports": "/docs/explore-analyze/explore#saving-explorations",
 
     # Auth methods moved under the Embedding tab's authentication section;
     # provider-specific pages without a dedicated new page go to the SSO/auth
@@ -136,6 +136,15 @@ OVERRIDES = {
 
     # Metabase semantic-layer sync was removed; send to the sync overview.
     "/product/apis-integrations/semantic-layer-sync/metabase": "/docs/integrations/semantic-layer-sync",
+}
+
+# Legacy redirects normally take precedence over canonical page mappings. This
+# page was renamed rather than consolidated into the workspace landing, so its
+# old redirect must follow the canonical override above.
+LEGACY_REDIRECT_OVERRIDES = {
+    "/product/administration/workspace/saved-reports": OVERRIDES[
+        "/product/administration/workspace/saved-reports"
+    ],
 }
 
 # Where to send any /product/* URL that matches nothing else.
@@ -268,7 +277,12 @@ def build_redirects(old_redirects: list, page_map: dict) -> list:
 
     # 1. Legacy aliases from the old redirects.json.
     for r in old_redirects:
-        add(r.get("source", ""), resolve_destination(r.get("destination", ""), page_map))
+        source = r.get("source", "")
+        destination = LEGACY_REDIRECT_OVERRIDES.get(source)
+        if destination:
+            add(source, to_absolute(destination))
+        else:
+            add(source, resolve_destination(r.get("destination", ""), page_map))
 
     # 2. Direct redirects for every canonical old /product page.
     for old_url, new_url in sorted(page_map.items()):

--- a/docs/redirects-new-docs.json
+++ b/docs/redirects-new-docs.json
@@ -6,7 +6,7 @@
   },
   {
     "source": "/product/administration/workspace/saved-reports",
-    "destination": "https://docs.cube.dev/admin",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/explore#saving-explorations",
     "permanent": true
   },
   {
@@ -1896,7 +1896,7 @@
   },
   {
     "source": "/product/workspace/saved-reports",
-    "destination": "https://docs.cube.dev/docs/explore-analyze/workbooks",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/explore#saving-explorations",
     "permanent": true
   },
   {


### PR DESCRIPTION
## Summary
- call standalone saved queries explorations across the current docs
- keep report terminology for items inside a workbook and clarify tools that support both forms
- align spreadsheet add-in instructions with the current Create exploration UI
- redirect historical Saved Reports URLs to the Saving explorations section

## Validation
- JSON parsing and whitespace checks pass
- targeted legacy redirect assertion passes
- terminology and legacy-anchor sweeps are clean in docs-mintlify
- yarn broken-links reaches one pre-existing broken anchor in reference/control-plane-api.mdx
- yarn mintlify validate reaches two pre-existing missing navigation pages: reference/javascript-sdk and cube-core/getting-started