### PR TITLE
docs: document alerts inbox delivery, add-in settings, detach/delete, and edit detection

### DIFF
--- a/docs-mintlify/admin/monitoring/alerts.mdx
+++ b/docs-mintlify/admin/monitoring/alerts.mdx
@@ -78,9 +78,10 @@ who were invited but never signed in do not receive alerts.
 
 ## Delivery
 
-Alerts are delivered by email only — there is no Slack, webhook, or PagerDuty delivery.
-[Scheduled refresh notifications](/docs/explore-analyze/notifications), which cover
-dashboard refresh outcomes, are a separate feature with its own delivery channels.
+Alerts are delivered by email, and a fired or resolved alert also appears in the
+recipient's in-app notification inbox — there is no Slack, webhook, or PagerDuty
+delivery. [Scheduled refresh notifications](/docs/explore-analyze/notifications), which
+cover dashboard refresh outcomes, are a separate feature with its own delivery channels.
 
 To alert from your own observability stack instead, export telemetry with [monitoring
 integrations](/admin/monitoring/monitoring-integrations).

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -168,14 +168,37 @@ targets the wrong cell.
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />
 </Frame>
 
+If a placement's written cells come back empty — for example, someone deleted
+them by hand — the spreadsheet home shows a **No data** tag next to it. Opening
+the pane also checks whether the cells it wrote still hold what was last
+written; if any have been typed over or cleared since, it shows a notice with
+an option to jump straight to the changed cells, which clears the next time you
+run the exploration. Neither check catches rows or columns inserted above the
+block — that's the anchor limitation described above.
+
+Use the row menu's **Detach** or **Delete** to stop working with an exploration
+in this document. **Detach** removes it from this spreadsheet only — it stays
+in your Cube Cloud workspace and in any other document it's placed in.
+**Delete** removes it everywhere it's been placed. Both offer to clear the
+written cells, which is checked by default.
+
 If an exploration has filters applied, an admin can turn on **Show applied filters
 in reports** (Settings → Spreadsheet Add-ins) to make the filter state
 visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
-their header, both when the exploration is inserted and after **Refresh**.
+their header, both when the exploration is inserted and after **Refresh**. Each
+user can override this for themselves from the add-on's own **Settings**.
 
 Saved explorations also appear in the Cube Cloud workspace. See
 [Saving explorations][ref-explorations] for details.
+
+## Add-on settings
+
+Open **Settings** from the add-on's menu to set personal preferences: whether
+selecting a sheet jumps the pane to its exploration and vice versa, whether an
+exploration runs automatically, whether duplicate values in the result are
+suppressed, and the per-user override of **Show applied filters in reports**
+described above.
 
 
 [link-google-sheets]: https://workspace.google.com/products/sheets/

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -176,14 +176,37 @@ targets the wrong cell.
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />
 </Frame>
 
+If a placement's written cells come back empty — for example, someone deleted
+them by hand — the workbook home shows a **No data** tag next to it. Opening
+the pane also checks whether the cells it wrote still hold what was last
+written; if any have been typed over or cleared since, it shows a notice with
+an option to jump straight to the changed cells, which clears the next time you
+run the exploration. Neither check catches rows or columns inserted above the
+block — that's the anchor limitation described above.
+
+Use the row menu's **Detach** or **Delete** to stop working with an exploration
+in this document. **Detach** removes it from this workbook only — it stays in
+your Cube Cloud workspace and in any other document it's placed in. **Delete**
+removes it everywhere it's been placed. Both offer to clear the written cells,
+which is checked by default.
+
 If an exploration has filters applied, an admin can turn on **Show applied filters
 in reports** (Settings → Spreadsheet Add-ins) to make the filter state
 visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
-their header, both when the exploration is inserted and after **Refresh**.
+their header, both when the exploration is inserted and after **Refresh**. Each
+user can override this for themselves from the add-in's own **Settings**.
 
 Saved explorations also appear in the Cube Cloud workspace. See
 [Saving explorations][ref-explorations] for details.
+
+## Add-in settings
+
+Open **Settings** from the add-in's menu to set personal preferences: whether
+selecting a sheet jumps the pane to its exploration and vice versa, whether an
+exploration runs automatically, whether duplicate values in the result are
+suppressed, and the per-user override of **Show applied filters in reports**
+described above.
 
 
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel


### PR DESCRIPTION
## Summary

Closes three documentation gaps found while cross-checking recently shipped `cubejs-enterprise` features against docs-mintlify:

- **Alerts also deliver to the in-app notification inbox now** (`cubedevinc/cubejs-enterprise#14489`), not email-only as the page previously stated. Updated `admin/monitoring/alerts.mdx`'s Delivery section.
- **Sheets/Excel add-in: Settings screen, Detach vs. Delete, and edit detection** (`cubedevinc/cubejs-enterprise#14638`, `#14697`). Added coverage to `docs/integrations/google-sheets.mdx` and `docs/integrations/microsoft-excel.mdx`:
  - The per-user **Settings** screen (sheet↔pane navigation, auto-run, duplicate suppression, a personal override of the account-wide "Show applied filters in reports" setting).
  - **Detach** (removes a placement from this document only, keeps the exploration everywhere else) vs. **Delete** (removes it everywhere), both with an option to clear written cells.
  - The **No data** tag for a placement whose written cells were deleted, and the edited-cells notice (with a locate action) for a placement whose written cells were typed over.

## Why

These shipped as plain `feat(...)` PRs in the product repo with no matching docs PR. All three are small additions to existing pages, not new capabilities that need a dedicated page.

## Test plan

- [ ] Docs build (`cd docs-mintlify && yarn dev`) renders all three pages without broken links or MDX errors.
- [ ] Spot-check wording against the merged PRs (`cubedevinc/cubejs-enterprise#14489`, `#14638`, `#14697`) for accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wnZCSqh4S55XD22NRegsL

---
_Generated by [Claude Code](https://claude.ai/code/session_018wnZCSqh4S55XD22NRegsL)_