### PR TITLE
docs(monitoring): document credentials_path for GCP sinks (CUB-4128)

### DIFF
--- a/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
@@ -43,6 +43,7 @@ inputs = [
 bucket = "your-gcs-bucket-name"
 compression = "gzip"
 credentials_base64 = "$CUBE_CLOUD_MONITORING_GCS_CREDENTIALS"
+credentials_path = "/etc/credentials/gcp-cloud-storage.json"
 
 [sinks.gcp-cloud-storage.encoding]
 codec = "json"
@@ -56,15 +57,23 @@ navigate to your bucket and watch the logs coming.
 
 ### Authentication
 
-Authenticate with the `credentials_base64` option, referencing the environment
-variable that holds the base64-encoded service account key, as in the example above.
-This is the only supported way to give the sink its credentials.
+Authenticate with the `credentials_base64` and `credentials_path` options together, as
+in the example above.
 
 `credentials_base64` is specific to Cube — it does not appear in [Vector's own sink
-reference][vector-docs-sinks-gcs]. Cube decodes the key and provides it to the Vector
-agent as a file named after the sink.
+reference][vector-docs-sinks-gcs]. Cube strips it from the configuration, decodes the
+base64-encoded service account key, and mounts it read-only at
+`/etc/credentials/<sink-name>.json`. Vector never sees the option itself, so
+`credentials_path` must point at that file — for the `gcp-cloud-storage` sink above,
+that is `/etc/credentials/gcp-cloud-storage.json`.
 
 <Warning>
+
+Both options are required, on every GCP sink — `gcp_cloud_storage`,
+`gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, `gcp_pubsub` — not just the one in
+the example above. Without `credentials_path` the sink has no credentials of its own:
+Vector falls back to the cluster's workload identity, makes requests as the node's
+service account rather than yours, and fails with authorization errors.
 
 The sink name becomes the name of a Kubernetes object that carries the credentials
 file, so it must be lowercase alphanumeric characters and dashes only — **no

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
@@ -57,9 +57,6 @@ navigate to your bucket and watch the logs coming.
 
 ### Authentication
 
-Authenticate with the `credentials_base64` and `credentials_path` options together, as
-in the example above.
-
 `credentials_base64` is specific to Cube — it does not appear in [Vector's own sink
 reference][vector-docs-sinks-gcs]. Cube strips it from the configuration, decodes the
 base64-encoded service account key, and mounts it read-only at
@@ -69,11 +66,11 @@ that is `/etc/credentials/gcp-cloud-storage.json`.
 
 <Warning>
 
-Both options are required, on every GCP sink — `gcp_cloud_storage`,
-`gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, `gcp_pubsub` — not just the one in
-the example above. Without `credentials_path` the sink has no credentials of its own:
-Vector falls back to the cluster's workload identity, makes requests as the node's
-service account rather than yours, and fails with authorization errors.
+This applies to every GCP sink — `gcp_cloud_storage`, `gcp_stackdriver_logs`,
+`gcp_stackdriver_metrics`, `gcp_pubsub` — not just the one in the example above.
+Without `credentials_path` the sink has no credentials of its own: Vector falls back to
+the cluster's workload identity, makes requests as the node's service account rather
+than yours, and fails with authorization errors.
 
 The sink name becomes the name of a Kubernetes object that carries the credentials
 file, so it must be lowercase alphanumeric characters and dashes only — **no

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -195,6 +195,9 @@ including the following ones:
   and [Azure Blob Storage][vector-docs-sinks-azureblob]
 - [Datadog][vector-docs-sinks-datadog]
 
+GCP sinks need both `credentials_base64` and `credentials_path` — see
+[Authentication][ref-monitoring-integrations-gcs-auth].
+
 Example configuration for exporting all logs, including all Cube Store logs to
 [Azure Blob Storage][vector-docs-sinks-azureblob]:
 
@@ -301,6 +304,10 @@ following sinks:
   [Prometheus][prometheus], compatible with [Mimir][mimir])
 - [`prometheus_remote_write`][vector-docs-sinks-prometheus] (compatible with
   [Grafana Cloud][grafana-cloud])
+
+The `gcp_stackdriver_metrics` sink also works, but like every GCP sink it needs both
+`credentials_base64` and `credentials_path` — see
+[Authentication][ref-monitoring-integrations-gcs-auth].
 
 Example configuration for exporting all metrics from `cubejs-server` to
 [Prometheus][vector-docs-sinks-prometheus-exporter] using the
@@ -434,6 +441,8 @@ Query History export.
   https://vector.dev/docs/reference/configuration/sinks/aws_s3/
 [vector-docs-sinks-azureblob]:
   https://vector.dev/docs/reference/configuration/sinks/azure_blob/
+[ref-monitoring-integrations-gcs-auth]:
+  /admin/monitoring/monitoring-integrations/gcs#authentication
 [vector-docs-sinks-gcs]:
   https://vector.dev/docs/reference/configuration/sinks/gcp_cloud_storage/
 [vector-docs-sinks-datadog]:


### PR DESCRIPTION
## Summary

The GCS monitoring integrations page told readers to authenticate with `credentials_base64` and
called it "the only supported way to give the sink its credentials". It never named
`credentials_path` or the directory the key is mounted in, so following the page verbatim leaves a
GCP sink with no credential of its own.

`VectorDaemonSet.getConfigData` strips `credentials_base64` from every sink and writes the decoded
key to a ConfigMap mounted read-only at `/etc/credentials/<sink-name>.json`
(`VectorDaemonSet.ts:429-432`, `:132`, `:615`). Vector never sees the option, so without
`credentials_path` it falls through its GCP credential chain to the GKE workload identity and
authenticates as the node service account. Breakthrough hit this on a `gcp_stackdriver_metrics`
sink; adding `credentials_path = "/etc/credentials/gcm-metrics.json"` fixed it, confirmed by the
customer.

## Changes

- Added `credentials_path = "/etc/credentials/gcp-cloud-storage.json"` to the example sink config.
- Rewrote **Authentication** to state that both options are required, name the mount path
  `/etc/credentials/<sink-name>.json`, and explain the workload-identity fallback and its symptom.
- Noted that this applies to every GCP sink (`gcp_cloud_storage`, `gcp_stackdriver_logs`,
  `gcp_stackdriver_metrics`, `gcp_pubsub`), not just the one in the example.
- Folded the pre-existing sink-naming warning into the same callout — it is the same mechanism
  (the sink name becomes the mounted file name), and two adjacent callouts read worse than one.

## Verification

`mintlify broken-links --check-anchors --check-redirects --check-snippets` over the whole docs tree:
`success no broken links found`. Docs-only change; no code paths touched.

Closes https://linear.app/cube-d3/issue/CUB-4128/gcs-monitoring-docs-omit-credentials-path-and-the-mounted-credentials