### PR TITLE
docs: Excel/Sheets add-in refresh-all, drag-to-Filters, and folder deletion

### DIFF
--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -84,10 +84,10 @@ their values, switch operators, or remove them.
 
 Click on members to add them to **Rows** and **Measures**, or drag a member from
 the list straight onto **Rows**, **Columns**, **Measures**, or **Filters**. You
-can also drag members between zones to rearrange them, or use the funnel
-buttons to add a member to **Filters** the same way. A member dropped onto
-**Filters** has no value yet, so it appears greyed until you set one on the
-**Filters** tab. Click on **×** to remove members from a query.
+can also drag members between zones to rearrange them, or click the funnel
+buttons to add members to **Filters**. A member dropped onto **Filters** has no
+value yet, so it appears greyed until you set one in the **Filters** pane.
+Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />
@@ -144,9 +144,10 @@ placed in this spreadsheet, grouped by sheet — a sheet isn't limited to one
 placement — with each placement's range and how long ago it last refreshed.
 A placement shows **Out of date** when its source exploration has been
 edited since that copy was written to the sheet. Running an exploration
-keeps its progress even if you close the pane before saving: it's listed as
-**Not saved** under its sheet, or under a separate **Unsaved** heading if it
-has no sheet or anchor yet. Reopening it resumes exactly where you left off.
+keeps its progress even if you close the pane before saving: it's listed
+under its sheet with a **Not saved** label; if it has no sheet or anchor
+yet, it appears under a top-level **Unsaved** heading instead. Reopening it
+resumes exactly where you left off.
 The pane can also hold more than one exploration open at once, switchable
 from a picker at the top.
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -169,12 +169,14 @@ placement in the document as a tracked run: a footer at the bottom of the
 pane tracks overall progress (**N of M refreshed**) with a **Stop** button,
 while each row shows **Queued**, **Refreshing…**, or **Not refreshed** with a
 reason if it failed. The run keeps going if you navigate away and back;
-refreshes are written one sheet at a time, so a large spreadsheet takes a
-while.
+refreshes are written one sheet at a time, so a spreadsheet with many
+sheets refreshes noticeably slower than a single placement.
 
 If you've edited a placement's cells by hand since it last refreshed, a
 banner names the affected rows and warns that the next **Refresh** will
 overwrite them — its **Locate** button jumps straight to them.
+
+{/* TODO: screenshot — the hand-edit overwrite banner with its Locate button */}
 
 A placement survives renaming the sheet it's on or the spreadsheet it's in —
 it's tracked by the sheet's and spreadsheet's own stable ids, not by name. A

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -147,9 +147,8 @@ edited since that copy was written to the sheet. Running an exploration
 keeps its progress even if you close the pane before saving: it's listed
 under its sheet with a **Not saved** label; if it has no sheet or anchor
 yet, it appears under a top-level **Unsaved** heading instead. Reopening it
-resumes exactly where you left off.
-The pane can also hold more than one exploration open at once, switchable
-from a picker at the top.
+resumes exactly where you left off. The pane can also hold more than one
+exploration open at once, switchable from a picker at the top.
 
 Click **Browse all explorations** to search by name across your whole
 deployment, not just the current folder — results are grouped by type and

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -83,9 +83,11 @@ are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
 Click on members to add them to **Rows** and **Measures**, or drag a member from
-the list straight onto **Rows**, **Columns**, or **Measures**. You can also drag
-members between zones to rearrange them. Click on the funnel buttons to add
-members to **Filters**. Click on **×** to remove members from a query.
+the list straight onto **Rows**, **Columns**, **Measures**, or **Filters**. You
+can also drag members between zones to rearrange them, or use the funnel
+buttons to add a member to **Filters** the same way. A member dropped onto
+**Filters** has no value yet, so it appears greyed until you set one on the
+**Filters** tab. Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/acc8e133-f237-4aa7-a725-f32dd4a2ebdb/" />
@@ -132,17 +134,21 @@ the exploration and survive **Refresh**.
 
 When your exploration is ready, click **Save** to add it to your workspace. You
 can then [work with the exploration](#work-with-explorations) from the add-on.
+To discard an unsaved exploration instead, choose **Delete exploration** from
+the editor's **⋮** menu.
 
 ## Work with explorations
 
 Opening the add-on shows the current spreadsheet's home: every exploration
-placed in this spreadsheet, grouped by sheet, with each placement's range and
-how long ago it last refreshed. A placement is tagged **Stale** when its
-source exploration has been edited since that copy was written to the sheet.
-Running an exploration keeps its progress even if you close the pane before
-saving — the spreadsheet home lists it under **Unsaved**, and reopening it
-resumes exactly where you left off. The pane can also hold more than one
-exploration open at once, switchable from a picker at the top.
+placed in this spreadsheet, grouped by sheet — a sheet isn't limited to one
+placement — with each placement's range and how long ago it last refreshed.
+A placement shows **Out of date** when its source exploration has been
+edited since that copy was written to the sheet. Running an exploration
+keeps its progress even if you close the pane before saving: it's listed as
+**Not saved** under its sheet, or under a separate **Unsaved** heading if it
+has no sheet or anchor yet. Reopening it resumes exactly where you left off.
+The pane can also hold more than one exploration open at once, switchable
+from a picker at the top.
 
 Click **Browse all explorations** to search by name across your whole
 deployment, not just the current folder — results are grouped by type and
@@ -156,6 +162,18 @@ Hovering a row in this list shows every placement it has in the **current**
 document under **Location** / **Locations**. Click **Refresh** to update all
 of that exploration's placements in the current document at once; click its
 title to open it and change the query, which applies to every placement.
+
+**Refresh all**, at the top of the spreadsheet home, refreshes every
+placement in the document as a tracked run: a footer at the bottom of the
+pane tracks overall progress (**N of M refreshed**) with a **Stop** button,
+while each row shows **Queued**, **Refreshing…**, or **Not refreshed** with a
+reason if it failed. The run keeps going if you navigate away and back;
+refreshes are written one sheet at a time, so a large spreadsheet takes a
+while.
+
+If you've edited a placement's cells by hand since it last refreshed, a
+banner names the affected rows and warns that the next **Refresh** will
+overwrite them — its **Locate** button jumps straight to them.
 
 A placement survives renaming the sheet it's on or the spreadsheet it's in —
 it's tracked by the sheet's and spreadsheet's own stable ids, not by name. A

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -155,9 +155,8 @@ edited since that copy was written to the sheet. Running an exploration
 keeps its progress even if you close the pane before saving: it's listed
 under its sheet with a **Not saved** label; if it has no sheet or anchor
 yet, it appears under a top-level **Unsaved** heading instead. Reopening it
-resumes exactly where you left off.
-The pane can also hold more than one exploration open at once, switchable
-from a picker at the top.
+resumes exactly where you left off. The pane can also hold more than one
+exploration open at once, switchable from a picker at the top.
 
 Click **Browse all explorations** to search by name across your whole
 deployment, not just the current folder — results are grouped by type and

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -91,9 +91,11 @@ are in workbooks. They are a starting point, not enforcement: you can change
 their values, switch operators, or remove them.
 
 Click on members to add them to **Rows** and **Measures**, or drag a member from
-the list straight onto **Rows**, **Columns**, or **Measures**. You can also drag
-members between zones to rearrange them. Click on the funnel buttons to add
-members to **Filters**. Click on **×** to remove members from a query.
+the list straight onto **Rows**, **Columns**, **Measures**, or **Filters**. You
+can also drag members between zones to rearrange them, or use the funnel
+buttons to add a member to **Filters** the same way. A member dropped onto
+**Filters** has no value yet, so it appears greyed until you set one on the
+**Filters** tab. Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />
@@ -140,17 +142,21 @@ the exploration and survive **Refresh**.
 
 When your exploration is ready, click **Save** to add it to your workspace. You
 can then [work with the exploration](#work-with-explorations) from the add-in.
+To discard an unsaved exploration instead, choose **Delete exploration** from
+the editor's **⋮** menu.
 
 ## Work with explorations
 
 Opening the add-in shows the current workbook's home: every exploration
-placed in this workbook, grouped by sheet, with each placement's range and
-how long ago it last refreshed. A placement is tagged **Stale** when its
-source exploration has been edited since that copy was written to the sheet.
-Running an exploration keeps its progress even if you close the pane before
-saving — the workbook home lists it under **Unsaved**, and reopening it
-resumes exactly where you left off. The pane can also hold more than one
-exploration open at once, switchable from a picker at the top.
+placed in this workbook, grouped by sheet — a sheet isn't limited to one
+placement — with each placement's range and how long ago it last refreshed.
+A placement shows **Out of date** when its source exploration has been
+edited since that copy was written to the sheet. Running an exploration
+keeps its progress even if you close the pane before saving: it's listed as
+**Not saved** under its sheet, or under a separate **Unsaved** heading if it
+has no sheet or anchor yet. Reopening it resumes exactly where you left off.
+The pane can also hold more than one exploration open at once, switchable
+from a picker at the top.
 
 Click **Browse all explorations** to search by name across your whole
 deployment, not just the current folder — results are grouped by type and
@@ -164,6 +170,17 @@ Hovering a row in this list shows every placement it has in the **current**
 document under **Location** / **Locations**. Click **Refresh** to update all
 of that exploration's placements in the current document at once; click its
 title to open it and change the query, which applies to every placement.
+
+**Refresh all**, at the top of the workbook home, refreshes every placement
+in the document as a tracked run: a footer at the bottom of the pane tracks
+overall progress (**N of M refreshed**) with a **Stop** button, while each
+row shows **Queued**, **Refreshing…**, or **Not refreshed** with a reason if
+it failed. The run keeps going if you navigate away and back; refreshes are
+written one sheet at a time, so a large workbook takes a while.
+
+If you've edited a placement's cells by hand since it last refreshed, a
+banner names the affected rows and warns that the next **Refresh** will
+overwrite them — its **Locate** button jumps straight to them.
 
 A placement survives renaming the sheet it's on or the workbook it's in —
 it's tracked by the sheet's and workbook's own stable ids, not by name. A

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -92,10 +92,10 @@ their values, switch operators, or remove them.
 
 Click on members to add them to **Rows** and **Measures**, or drag a member from
 the list straight onto **Rows**, **Columns**, **Measures**, or **Filters**. You
-can also drag members between zones to rearrange them, or use the funnel
-buttons to add a member to **Filters** the same way. A member dropped onto
-**Filters** has no value yet, so it appears greyed until you set one on the
-**Filters** tab. Click on **×** to remove members from a query.
+can also drag members between zones to rearrange them, or click the funnel
+buttons to add members to **Filters**. A member dropped onto **Filters** has no
+value yet, so it appears greyed until you set one in the **Filters** pane.
+Click on **×** to remove members from a query.
 
 <Frame>
   <img src="https://ucarecdn.com/670fda9d-358a-4345-9242-7888d8aaedd8/" />
@@ -152,9 +152,10 @@ placed in this workbook, grouped by sheet — a sheet isn't limited to one
 placement — with each placement's range and how long ago it last refreshed.
 A placement shows **Out of date** when its source exploration has been
 edited since that copy was written to the sheet. Running an exploration
-keeps its progress even if you close the pane before saving: it's listed as
-**Not saved** under its sheet, or under a separate **Unsaved** heading if it
-has no sheet or anchor yet. Reopening it resumes exactly where you left off.
+keeps its progress even if you close the pane before saving: it's listed
+under its sheet with a **Not saved** label; if it has no sheet or anchor
+yet, it appears under a top-level **Unsaved** heading instead. Reopening it
+resumes exactly where you left off.
 The pane can also hold more than one exploration open at once, switchable
 from a picker at the top.
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -177,11 +177,14 @@ in the document as a tracked run: a footer at the bottom of the pane tracks
 overall progress (**N of M refreshed**) with a **Stop** button, while each
 row shows **Queued**, **Refreshing…**, or **Not refreshed** with a reason if
 it failed. The run keeps going if you navigate away and back; refreshes are
-written one sheet at a time, so a large workbook takes a while.
+written one sheet at a time, so a workbook with many sheets refreshes
+noticeably slower than a single placement.
 
 If you've edited a placement's cells by hand since it last refreshed, a
 banner names the affected rows and warns that the next **Refresh** will
 overwrite them — its **Locate** button jumps straight to them.
+
+{/* TODO: screenshot — the hand-edit overwrite banner with its Locate button */}
 
 A placement survives renaming the sheet it's on or the workbook it's in —
 it's tracked by the sheet's and workbook's own stable ids, not by name. A

--- a/docs-mintlify/docs/organize-content/folders.mdx
+++ b/docs-mintlify/docs/organize-content/folders.mdx
@@ -124,15 +124,15 @@ To delete a folder:
 2. Select **Delete**.
 3. Confirm the deletion.
 
-Deleting a folder deletes everything inside it — subfolders, workbooks,
-dashboards, and reports — along with it; this cannot be undone.
-
 <Warning>
 
-If you don't have Full access to everything inside the folder, deletion is
-blocked entirely and nothing is deleted.
+Deleting a folder deletes everything inside it — subfolders, workbooks,
+dashboards, and explorations — along with it; this cannot be undone.
 
 </Warning>
+
+If a subfolder inside it has its own permissions and you don't have Full
+access there too, deletion is blocked entirely and nothing is deleted.
 
 ## Folder permissions
 

--- a/docs-mintlify/docs/organize-content/folders.mdx
+++ b/docs-mintlify/docs/organize-content/folders.mdx
@@ -122,11 +122,15 @@ To delete a folder:
 
 1. Open the folder's action menu.
 2. Select **Delete**.
+3. Confirm the deletion.
+
+Deleting a folder deletes everything inside it — subfolders, workbooks,
+dashboards, and reports — along with it; this cannot be undone.
 
 <Warning>
 
-A folder can only be deleted if it contains no subfolders. Move or delete
-any subfolders first.
+If you don't have Full access to everything inside the folder, deletion is
+blocked entirely and nothing is deleted.
 
 </Warning>
 

--- a/docs-mintlify/docs/organize-content/folders.mdx
+++ b/docs-mintlify/docs/organize-content/folders.mdx
@@ -131,7 +131,7 @@ dashboards, and explorations — along with it; this cannot be undone.
 
 </Warning>
 
-If a subfolder inside it has its own permissions and you don't have Full
+If anything inside the folder has its own permissions and you don't have Full
 access there too, deletion is blocked entirely and nothing is deleted.
 
 ## Folder permissions


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

A batch of documentation updates to the Excel/Google Sheets add-in pages and the folders page, catching up to recently shipped product behavior:

- The pivot builder's drag-and-drop now also accepts the **Filters** zone (previously Rows/Columns/Measures only); a member dropped there with no value yet shows greyed until you give it one.
- An unsaved exploration can be deleted straight from the editor's own actions menu, not only from a list view.
- The workbook/spreadsheet home explicitly documents that a sheet isn't limited to one placed exploration.
- **Refresh all** is now a tracked run with a progress footer (count + Stop button) and per-row states, rather than a single spinner-and-toast action.
- A banner now warns before **Refresh** overwrites cells that were edited by hand since the last write, with a button to jump to them.
- Workbook-home placement-state labels updated to match the current UI: "Out of date" (previously described as a "Stale" tag) and "Not saved" (previously "Unsaved"); they're no longer shown as colored tags.
- Deleting a non-empty folder now deletes its contents (with a confirmation step) instead of being blocked until it's emptied first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuYqSYDJ9NP1xSsSuFyC7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuYqSYDJ9NP1xSsSuFyC7c)_