### PR TITLE
docs: update Cube naming in integrations

### DIFF
--- a/docs-mintlify/admin/connect-to-data/visualization-tools/google-sheets.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/google-sheets.mdx
@@ -18,7 +18,7 @@ application.
 
 ## Connect from Cube Cloud
 
-Cube Cloud provides [Cube Cloud for Sheets][ref-cube-cloud-for-sheets], a native
+Cube provides [Cube for Sheets][ref-cube-cloud-for-sheets], a native
 Google Sheets add-on.
 
 Navigate to the [Integrations](/admin/connect-to-data/visualization-tools)
@@ -33,13 +33,13 @@ There's no way to connect a Cube Core deployment to Google Sheets.
 
 ## Connecting from Google Sheets
 
-First, install Cube Cloud for Sheets from its [page in the Google Workspace
+First, install Cube for Sheets from its [page in the Google Workspace
 Marketplace][link-marketplace-listing].
 
 Then, in Google Sheets, open the **Extensions** menu, choose **Cube
 Cloud for Sheets → Show Sidebar**, and click **Sign in**.
 
-For additional guidance, check the [Cube Cloud for Sheets][ref-cube-cloud-for-sheets]
+For additional guidance, check the [Cube for Sheets][ref-cube-cloud-for-sheets]
 page.
 
 

--- a/docs-mintlify/docs/getting-started/databricks/query-from-bi.mdx
+++ b/docs-mintlify/docs/getting-started/databricks/query-from-bi.mdx
@@ -1,6 +1,6 @@
 ---
 title: Query from a BI tool
-description: Use the SQL API and Semantic Layer Sync from a Databricks-oriented Cube Cloud setup so BI tools consume your semantic layer.
+description: Use the SQL API and Semantic Layer Sync from a Databricks-oriented Cube setup so BI tools consume your semantic layer.
 ---
 
 You can query Cube using a BI or visualization tool through the Cube SQL API. To
@@ -101,7 +101,7 @@ model.
 ## Manual Setup
 
 Alternatively, you can connect to Cube and create all the mappings manually. To
-do this, navigate to your Apache Superset instance and connect to Cube Cloud as
+do this, navigate to your Apache Superset instance and connect to Cube as
 if it were a Postgres database.
 
 You can find the credentials to connect to Cube on the **BI

--- a/docs-mintlify/docs/getting-started/databricks/query-from-bi.mdx
+++ b/docs-mintlify/docs/getting-started/databricks/query-from-bi.mdx
@@ -61,7 +61,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'user': 'mail@example.com',
         'password': '4dceae-606a03-93ae6dc7',
         'url': 'superset.example.com',
-        'database': 'Cube Cloud: production-deployment'
+        'database': 'Cube: production-deployment'
       }
     }
   ]
@@ -78,7 +78,7 @@ module.exports = {
           user: "mail@example.com",
           password: "4dceae-606a03-93ae6dc7",
           url: "superset.example.com",
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -41,7 +41,7 @@ Marketplace][link-marketplace-listing] and click **Install**:
 
 To verify that the add-on is successfully installed, go to any Google Sheets
 document, open the **Extensions** menu, and check that there is the
-**Cube for Sheets** menu item:
+**Cube Cloud for Sheets** menu item:
 
 <Frame>
   <img src="https://ucarecdn.com/90f3a9d0-abde-4eb4-9222-27e4ebc46c6c/" />
@@ -51,7 +51,7 @@ document, open the **Extensions** menu, and check that there is the
 
 You need to authenticate Cube for Sheets to retrieve data from Cube.
 To do so, open the sidebar by going to the **Extensions** menu and choosing
-**Cube for Sheets → Open Sidebar**. Then, click **Sign in**.
+**Cube Cloud for Sheets → Open Sidebar**. Then, click **Sign in**.
 
 <Frame>
   <img src="https://ucarecdn.com/d47c8faa-97ed-4ce1-ba0e-99b7add1ab61/" />

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -51,7 +51,7 @@ document, open the **Extensions** menu, and check that there is the
 
 You need to authenticate Cube for Sheets to retrieve data from Cube.
 To do so, open the sidebar by going to the **Extensions** menu and choosing
-**Cube Cloud for Sheets → Open Sidebar**. Then, click **Sign in**.
+**Cube Cloud for Sheets → Show Sidebar**. Then, click **Sign in**.
 
 <Frame>
   <img src="https://ucarecdn.com/d47c8faa-97ed-4ce1-ba0e-99b7add1ab61/" />

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -1,6 +1,6 @@
 ---
-title: Cube Cloud for Sheets
-description: "Cube Cloud for Sheets is the native Google Sheets add-on for Cube Cloud."
+title: Cube for Sheets
+description: "Cube for Sheets is the native Google Sheets add-on for Cube."
 ---
 
 <Note>
@@ -26,12 +26,12 @@ explorations via pivot table](#create-explorations-via-pivot-table) and work wit
 
 ## Configuration
 
-Cube Cloud for Sheets uses the SQL API internally. So, the SQL API has to be
-[enabled][ref-sql-api-enabled] in the Cube Cloud deployment settings.
+Cube for Sheets uses the SQL API internally. So, the SQL API has to be
+[enabled][ref-sql-api-enabled] in the Cube deployment settings.
 
 ## Installation
 
-You have to install Cube Cloud for Sheets into your Google Workspace organization.
+You have to install Cube for Sheets into your Google Workspace organization.
 To do so, navigate to its [page in the Google Workspace
 Marketplace][link-marketplace-listing] and click **Install**:
 
@@ -41,7 +41,7 @@ Marketplace][link-marketplace-listing] and click **Install**:
 
 To verify that the add-on is successfully installed, go to any Google Sheets
 document, open the **Extensions** menu, and check that there is the
-**Cube Cloud for Sheets** menu item:
+**Cube for Sheets** menu item:
 
 <Frame>
   <img src="https://ucarecdn.com/90f3a9d0-abde-4eb4-9222-27e4ebc46c6c/" />
@@ -49,9 +49,9 @@ document, open the **Extensions** menu, and check that there is the
 
 ## Authentication
 
-You need to authenticate Cube Cloud for Sheets to retrieve data from Cube Cloud.
+You need to authenticate Cube for Sheets to retrieve data from Cube.
 To do so, open the sidebar by going to the **Extensions** menu and choosing
-**Cube Cloud for Sheets → Open Sidebar**. Then, click **Sign in**.
+**Cube for Sheets → Open Sidebar**. Then, click **Sign in**.
 
 <Frame>
   <img src="https://ucarecdn.com/d47c8faa-97ed-4ce1-ba0e-99b7add1ab61/" />
@@ -67,13 +67,13 @@ If you want to revoke the authentication, open the add-on menu and click
 ## Create explorations via pivot table
 
 To create an exploration, open the add-on and click **Create exploration**.
-Then, select a Cube Cloud deployment from the drop-down. Finally,
+Then, select a Cube deployment from the drop-down. Finally,
 you can start building a query by selecting a view and its members in the UI that
 looks and feels like [Playground][ref-playground].
 
 <Info>
 
-Cube Cloud for Sheets works only with [views][ref-views], not cubes.
+Cube for Sheets works only with [views][ref-views], not cubes.
 
 </Info>
 
@@ -103,7 +103,7 @@ cell and then confirm with the target button under **Result location**.
   <img src="https://ucarecdn.com/5a8d2b6a-b415-46ee-9e03-57ea5eeb693a/" />
 </Frame>
 
-With every change to your query, Cube Cloud for Sheets will update the exploration on
+With every change to your query, Cube for Sheets will update the exploration on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
@@ -194,7 +194,7 @@ visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
 their header, both when the exploration is inserted and after **Refresh**.
 
-Saved explorations also appear in the Cube Cloud workspace. See
+Saved explorations also appear in the Cube workspace. See
 [Saving explorations][ref-explorations] for details.
 
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cube for Excel
-description: "Cube for Excel is the native Microsoft Excel add-in for Cube Cloud."
+description: "Cube for Excel is the native Microsoft Excel add-in for Cube."
 ---
 
 it works with Excel on all operating systems,
@@ -32,7 +32,7 @@ explorations via pivot table](#create-explorations-via-pivot-table) and work wit
 ## Configuration
 
 Cube for Excel uses the SQL API internally. So, the SQL API has to be
-[enabled][ref-sql-api-enabled] in the Cube Cloud deployment settings.
+[enabled][ref-sql-api-enabled] in the Cube deployment settings.
 
 ## Installation
 
@@ -57,8 +57,8 @@ Search for `Cube for Excel (add-in)` and click **Add**:
 
 ## Authentication
 
-You need to authenticate Cube for Excel to retrieve data from Cube Cloud.
-To do so, open the sidebar by clicking on the **Cube Cloud** button in
+You need to authenticate Cube for Excel to retrieve data from Cube.
+To do so, open the sidebar by clicking on the **Cube** button in
 the **Home** ribbon. Then, click **Sign in**.
 
 <Frame>
@@ -75,7 +75,7 @@ If you want to revoke the authentication, open the add-in menu and click
 ## Create explorations via pivot table
 
 To create an exploration, open the add-in and click **Create exploration**.
-Then, select a Cube Cloud deployment from the drop-down. Finally,
+Then, select a Cube deployment from the drop-down. Finally,
 you can start building a query by selecting a view and its members in the UI that
 looks and feels like [Playground][ref-playground].
 
@@ -202,7 +202,7 @@ visible on the sheet itself. When enabled, a summary of active filters is
 added above the table, and filtered columns are marked "(filtered)" in
 their header, both when the exploration is inserted and after **Refresh**.
 
-Saved explorations also appear in the Cube Cloud workspace. See
+Saved explorations also appear in the Cube workspace. See
 [Saving explorations][ref-explorations] for details.
 
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -58,7 +58,7 @@ Search for `Cube for Excel (add-in)` and click **Add**:
 ## Authentication
 
 You need to authenticate Cube for Excel to retrieve data from Cube.
-To do so, open the sidebar by clicking on the **Cube** button in
+To do so, open the sidebar by clicking on the **Cube Cloud** button in
 the **Home** ribbon. Then, click **Sign in**.
 
 <Frame>

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -58,7 +58,7 @@ Search for `Cube for Excel (add-in)` and click **Add**:
 ## Authentication
 
 You need to authenticate Cube for Excel to retrieve data from Cube.
-To do so, open the sidebar by clicking on the **Cube Cloud** button in
+To do so, open the sidebar by clicking on the **Cube** button in
 the **Home** ribbon. Then, click **Sign in**.
 
 <Frame>

--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -21,7 +21,7 @@ If you're using Power BI Service, you need to set up an [on-premises data gatewa
 
 ## Connect to the DAX API
 
-Cube provides the [DAX API][ref-dax-api] for the native Power BI connectivity.
+The Cube cloud platform provides the [DAX API][ref-dax-api] for the native Power BI connectivity.
 
 
 In Power BI Desktop, choose the **SQL Server Analysis Services database** option

--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -6,7 +6,7 @@ hidden: true
 
 [Microsoft Power BI][link-powerbi] is a popular business intelligence tool.
 
-Cube Cloud works with both [Power BI Desktop and Power BI Service][link-powerbi-desktop-vs-service].
+Cube works with both [Power BI Desktop and Power BI Service][link-powerbi-desktop-vs-service].
 If you're using Power BI Service, you need to set up an [on-premises data gateway][link-powerbi-gateway].
 
 <iframe
@@ -21,7 +21,7 @@ If you're using Power BI Service, you need to set up an [on-premises data gatewa
 
 ## Connect to the DAX API
 
-Cube Cloud provides the [DAX API][ref-dax-api] for the native Power BI connectivity.
+Cube provides the [DAX API][ref-dax-api] for the native Power BI connectivity.
 
 
 In Power BI Desktop, choose the **SQL Server Analysis Services database** option
@@ -40,7 +40,7 @@ Kerberos assets — is configured on the **Settings → Power BI** page of your 
 
 ### Authentication methods
 
-Cube Cloud supports the following authentication methods for Power BI:
+Cube supports the following authentication methods for Power BI:
 
 | Application | Authentication | Notes |
 | --- | --- | --- |

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
@@ -85,7 +85,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'user': 'mail@example.com',
         'password': '4dceae-606a03-93ae6dc7',
         'url': 'superset.example.com',
-        'database': 'Cube Cloud: staging-deployment'
+        'database': 'Cube: staging-deployment'
       }
     }
   ]
@@ -103,7 +103,7 @@ module.exports = {
           user: "mail@example.com",
           password: "4dceae-606a03-93ae6dc7",
           url: "superset.example.com",
-          database: "Cube Cloud: staging-deployment"
+          database: "Cube: staging-deployment"
         }
       }
     ]
@@ -123,7 +123,7 @@ If multiple security contexts are defined via the
 
 By default, multitenancy support in `semanticLayerSync` is disabled. Please
 contact support to enable multitenancy support in `semanticLayerSync` for your
-Cube Cloud account.
+Cube account.
 
 </Warning>
 
@@ -151,7 +151,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'user': 'mail@example.com',
         'password': '4dceae-606a03-93ae6dc7',
         'url': 'superset.example.com',
-        'database': f"Cube Cloud: {department}",
+        'database': f"Cube: {department}",
       }
     }
   ]
@@ -170,7 +170,7 @@ module.exports = {
           user: "mail@example.com",
           password: "4dceae-606a03-93ae6dc7",
           url: "superset.example.com",
-          database: `Cube Cloud: ${department}`
+          database: `Cube: ${department}`
         }
       }
     ]
@@ -199,7 +199,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
           'user': 'mail@example.com',
           'password': '4dceae-606a03-93ae6dc7',
           'url': 'superset.example.com',
-          'database': 'Cube Cloud: sls-test (admin)'
+          'database': 'Cube: sls-test (admin)'
         }
       },
       {
@@ -209,7 +209,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
           'api_token': '07988f63-c200-499e-97c9-ba137d8918aa',
           'api_secret': 'c19fbab4fd4945899795d32898f2e1165bef8e5ee653',
           'workspace_url': '12345678.us1a.app.preset.io',
-          'database': 'Cube Cloud: sls-test (admin)'
+          'database': 'Cube: sls-test (admin)'
         }
       }
     ]
@@ -231,7 +231,7 @@ module.exports = {
             user: "mail@example.com",
             password: "4dceae-606a03-93ae6dc7",
             url: "superset.example.com",
-            database: "Cube Cloud: sls-test (admin)"
+            database: "Cube: sls-test (admin)"
           }
         },
         {
@@ -241,7 +241,7 @@ module.exports = {
             api_token: "07988f63-c200-499e-97c9-ba137d8918aa",
             api_secret: "c19fbab4fd4945899795d32898f2e1165bef8e5ee653",
             workspace_url: "12345678.us1a.app.preset.io",
-            database: "Cube Cloud: sls-test (admin)"
+            database: "Cube: sls-test (admin)"
           }
         }
             ]
@@ -276,7 +276,7 @@ If data model is updated dynamically and the
 [`schema_version`][ref-config-schemaversion] configuration option is used to
 track data model changes, syncs will not automatically run. This behavior is
 disabled by default. Please contact support to enable running syncs when the
-data model is updated dynamically for your Cube Cloud account.
+data model is updated dynamically for your Cube account.
 
 </Warning>
 
@@ -303,7 +303,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'user': 'mail@example.com',
         'password': '4dceae-606a03-93ae6dc7',
         'url': 'superset.example.com',
-        'database': 'Cube Cloud: staging-deployment',
+        'database': 'Cube: staging-deployment',
         'scheduleInterval': 'every 10 minutes'
       }
     }
@@ -322,7 +322,7 @@ module.exports = {
           user: "mail@example.com",
           password: "4dceae-606a03-93ae6dc7",
           url: "superset.example.com",
-          database: "Cube Cloud: staging-deployment",
+          database: "Cube: staging-deployment",
           scheduleInterval: "every 10 minutes"
         }
       }

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/preset.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/preset.mdx
@@ -42,7 +42,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'api_token': '07988f63-c200-499e-97c9-ba137d8918aa',
         'api_secret': 'c19fbab4fd4945899795d32898f2e1165bef8e5ee653499e92f083b3d088aecb',
         'workspace_url': '12345678.us1a.app.preset.io',
-        'database': 'Cube Cloud: production-deployment'
+        'database': 'Cube: production-deployment'
       }
     }
   ]
@@ -59,7 +59,7 @@ module.exports = {
           api_token: "07988f63-c200-499e-97c9-ba137d8918aa",
           api_secret: "c19fbab4fd4945899795d32898f2e1165bef8e5ee653499e92f083b3d088aecb",
           workspace_url: "12345678.us1a.app.preset.io",
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/superset.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/superset.mdx
@@ -38,7 +38,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'user': 'mail@example.com',
         'password': '4dceae-606a03-93ae6dc7',
         'url': 'superset.example.com',
-        'database': 'Cube Cloud: production-deployment'
+        'database': 'Cube: production-deployment'
       }
     }
   ]
@@ -55,7 +55,7 @@ module.exports = {
           user: "mail@example.com",
           password: "4dceae-606a03-93ae6dc7",
           url: "superset.example.com",
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
@@ -68,7 +68,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'site': 'mytableausite',
         'personalAccessToken': 'cube-cloud',
         'personalAccessTokenSecret': os.environ['CUBEJS_TABLEAU_PAT_SECRET'],
-        'database': 'Cube Cloud: production-deployment',
+        'database': 'Cube: production-deployment',
       },
     },
   ]
@@ -86,7 +86,7 @@ module.exports = {
           site: "mytableausite",
           personalAccessToken: "cube-cloud",
           personalAccessTokenSecret: process.env.CUBEJS_TABLEAU_PAT_SECRET,
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]
@@ -103,7 +103,7 @@ For Tableau Server, you need to specify a `hostname`, `site`, and `apiVersion`.
 To find your site name, look at your Tableau Server URL: the site name is
 the value that follows `/site/` in the URL. If there is no `/site/` segment in
 the URL, you are using the Default site — leave the `site` field blank
-in the Cube Cloud configuration.
+in the Cube configuration.
 
 Example configuration for Tableau Server:
 
@@ -125,7 +125,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'apiVersion': '3.19',
         'personalAccessToken': 'cube-cloud',
         'personalAccessTokenSecret': os.environ['CUBEJS_TABLEAU_PAT_SECRET'],
-        'database': 'Cube Cloud: production-deployment',
+        'database': 'Cube: production-deployment',
       },
     },
   ]
@@ -144,7 +144,7 @@ module.exports = {
           apiVersion: "3.19",
           personalAccessToken: "cube-cloud",
           personalAccessTokenSecret: process.env.CUBEJS_TABLEAU_PAT_SECRET,
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]
@@ -164,9 +164,9 @@ or `process.env.CUBEJS_TABLEAU_PAT_SECRET` in JavaScript.
 
 </Tip>
 
-When connecting a Cube Cloud data source to your Tableau workbook, you will be prompted
-to enter the user name and password for Cube Cloud. You can find them at the&nbsp;**SQL
-API Connection** tab on the&nbsp;**IDE → Integrations** page in Cube Cloud.
+When connecting a Cube data source to your Tableau workbook, you will be prompted
+to enter the user name and password for Cube. You can find them at the&nbsp;**SQL
+API Connection** tab on the&nbsp;**IDE → Integrations** page in Cube.
 
 ### Least-privilege mode
 

--- a/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
+++ b/docs-mintlify/docs/integrations/snowflake-semantic-views.mdx
@@ -63,7 +63,7 @@ recommended approach for straightforward table access (e.g., `sql_table: MY_SCHE
 The push integration uses the SQL Runner to execute DDL statements in Snowflake. To
 successfully create semantic views, ensure the following:
 
-- **Enable DDL operations** for your Cube deployment. In the Cube Cloud UI, go to
+- **Enable DDL operations** for your Cube deployment. In the Cube UI, go to
   **Deployment Settings** → **Configuration** and turn on **Enable DDL operations**.
   Without this setting, the SQL Runner will reject the DDL statements that the push
   integration generates.

--- a/docs-mintlify/docs/integrations/tableau.mdx
+++ b/docs-mintlify/docs/integrations/tableau.mdx
@@ -76,7 +76,7 @@ def semantic_layer_sync(ctx: dict) -> list[dict]:
         'site': 'mytableausite',
         'personalAccessToken': 'cube-cloud',
         'personalAccessTokenSecret': 'HW8TFrBfJyen+JQleh0/bw==:1BvJLIti9Fud04rN021EfHMnh4yYD3p4',
-        'database': 'Cube Cloud: production-deployment',
+        'database': 'Cube: production-deployment',
       },
     },
   ]
@@ -94,7 +94,7 @@ module.exports = {
           site: "mytableausite",
           personalAccessToken: "cube-cloud",
           personalAccessTokenSecret: "HW8TFrBfJyen+JQleh0/bw==:1BvJLIti9Fud04rN021EfHMnh4yYD3p4",
-          database: "Cube Cloud: production-deployment"
+          database: "Cube: production-deployment"
         }
       }
     ]
@@ -104,9 +104,9 @@ module.exports = {
 
 </CodeGroup>
 
-When connecting a Cube Cloud data source to your Tableau workbook, you will be prompted
-to enter the user name and password for Cube Cloud. You can find them at the&nbsp;**SQL
-API Connection** tab on the&nbsp;**IDE → Integrations** page in Cube Cloud.
+When connecting a Cube data source to your Tableau workbook, you will be prompted
+to enter the user name and password for Cube. You can find them at the&nbsp;**SQL
+API Connection** tab on the&nbsp;**IDE → Integrations** page in Cube.
 
 ### Tableau Desktop
 

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -12,7 +12,7 @@ Core Data APIs enable you to query and retrieve data from your Cube semantic lay
 
 * To connect to [Microsoft Excel][ref-excel], use [Cube for Excel][ref-cube-cloud-for-excel]
 
-* To connect to [Google Sheets][ref-sheets], use [Cube Cloud for Sheets][ref-cube-cloud-for-sheets]
+* To connect to [Google Sheets][ref-sheets], use [Cube for Sheets][ref-cube-cloud-for-sheets]
 
 * To connect to AI assistants, use the [Model Context Protocol (MCP) server][ref-mcp-server]
 
@@ -36,8 +36,8 @@ tools][ref-viz-tools]. Some of the features with partial support are listed belo
 
 | Feature | ✅ Supported in |
 | --- | --- |
-| [Hierarchies][ref-hierarchies] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
-| Flat [folders][ref-folders] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
+| [Hierarchies][ref-hierarchies] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
+| Flat [folders][ref-folders] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
 | [Custom time formats][ref-custom-time-formats] | [Playground][ref-playground] and [Workbooks][ref-workbooks] |
 
 ## Personal Core Data API Token
@@ -68,7 +68,7 @@ tools][ref-viz-tools]:
 | --- | --- |
 | [User name and password][ref-auth-user-pass] | [MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
 | Kerberos and NTLM | [MDX API][ref-mdx-api] |
-| [Identity provider][ref-auth-idp] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
+| [Identity provider][ref-auth-idp] | [Cube for Excel][ref-cube-cloud-for-excel]<br/>[Cube for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
 | [Personal Core Data API Token](#personal-core-data-api-token) | [SQL API][ref-sql-api]<br/>[REST (JSON) API][ref-rest-api] |
 


### PR DESCRIPTION
## Summary

- replace legacy Cube Cloud product naming across the integration docs with Cube
- rename prose references to Cube for Sheets and align related cross-page labels and examples
- preserve the current Cube Cloud for Sheets menu labels where readers must match Google Sheets UI; use the planned Cube naming for the Excel add-in
- use Cube cloud platform where the Power BI page explicitly distinguishes DAX API availability from Cube Core

## Validation

- git diff --check
- verified the only remaining Cube Cloud matches under docs-mintlify/docs/integrations are two literal Google Sheets UI labels
- yarn mintlify validate (blocked by two pre-existing missing navigation pages: reference/javascript-sdk and cube-core/getting-started)