### PR TITLE
docs: describe the outcome messages after a manual pre-aggregation refresh

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -334,6 +334,8 @@ Two indicators next to each result describe the data behind it.
 - **Freshness** — a leaf icon shows how recently the underlying data was refreshed. Hover over it to see the last refresh time (for example, "Refreshed 5 minutes ago"); its color shifts as the data ages, so you can tell fresh from stale results at a glance. If the refresh time can't be determined, the leaf turns gray with a "Data age unknown" label. When you have access to [Query History](/admin/monitoring/query-history), clicking the leaf opens the underlying request for that result.
 - **Pre-aggregation** — for those same users, a lightning-bolt icon appears next to the leaf with a "Served from a pre-aggregation" label whenever the result was served from a [pre-aggregation](/docs/pre-aggregations). If no icon is shown, the query ran directly against your data source.
 
+Manually refreshing a result served from a pre-aggregation (a chart's **Refresh**, a dashboard's **Refresh all**, or a workbook's **Run all**) reports what actually happened, since a pre-aggregation rebuild can take longer than the request itself waits for: **Refreshed successfully** once the rebuild is confirmed complete, **Refresh requested** when Cube can't yet confirm whether a rebuild finished, or a message noting the rebuild is still running if it takes more than a few minutes.
+
 ## Editing Semantic SQL by hand
 
 You can edit the Semantic SQL directly in the editor to refine a query — for example, to add a `WHERE` clause, change `GROUP BY` order, or apply a different sort. After making changes, click **Save and Run** to apply them to the query and refresh the results, or **Discard** to revert.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

`cubejs-enterprise#14657` (CUB-3373) changed what a manual refresh reports: instead of
always claiming "Refreshed successfully", Cube now distinguishes a confirmed rebuild
from one it can't yet confirm ("Refresh requested") or one still running past a few
minutes. This adds a short paragraph to the "Result freshness and provenance" section
of the querying-data page describing those three outcomes, since the existing text
only covered the passive freshness/pre-aggregation indicators, not what a manual
Refresh / Refresh all / Run all reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oxbph2zZPPPv8NCMRofH4


---
_Generated by [Claude Code](https://claude.ai/code/session_011oxbph2zZPPPv8NCMRofH4)_