### PR TITLE
docs: update Excel/Sheets add-in sign-in instructions for the new button label

### DIFF
--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -51,11 +51,9 @@ document, open the **Extensions** menu, and check that there is the
 
 You need to authenticate Cube for Sheets to retrieve data from Cube.
 To do so, open the sidebar by going to the **Extensions** menu and choosing
-**Cube Cloud for Sheets → Show Sidebar**. Then, click **Sign in**.
+**Cube Cloud for Sheets → Show Sidebar**. Then, click **Log in to Cube**.
 
-<Frame>
-  <img src="https://ucarecdn.com/d47c8faa-97ed-4ce1-ba0e-99b7add1ab61/" />
-</Frame>
+{/* TODO: screenshot — sign-in screen redesign, headline "Log in to continue" and a "Log in to Cube" button */}
 
 A modal window with an authentication prompt will appear. Choose the deployments
 that you want to work with in Google Sheets and click **Authorize**.

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -59,11 +59,9 @@ Search for `Cube for Excel (add-in)` and click **Add**:
 
 You need to authenticate Cube for Excel to retrieve data from Cube.
 To do so, open the sidebar by clicking on the **Cube** button in
-the **Home** ribbon. Then, click **Sign in**.
+the **Home** ribbon. Then, click **Log in to Cube**.
 
-<Frame>
-  <img src="https://ucarecdn.com/bdf82477-02d3-4686-9c8f-8d6384c3e7f3/" />
-</Frame>
+{/* TODO: screenshot — sign-in screen redesign, headline "Log in to continue" and a "Log in to Cube" button */}
 
 A modal window with an authentication prompt will appear. Choose the deployments
 that you want to work with in Microsoft Excel and click **Authorize**.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

The Excel and Google Sheets add-ins' signed-out screen was redesigned. The primary
action is now labeled **Log in to Cube** instead of **Sign in**. This updates the
authentication instructions on both integration pages (`microsoft-excel.mdx`,
`google-sheets.mdx`) to reference the new button label, and replaces the screenshot
below each with a placeholder noting it needs to be recaptured against the new
screen design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUpDQ17DugCRZ8UxpsKQkg


---
_Generated by [Claude Code](https://claude.ai/code/session_01AUpDQ17DugCRZ8UxpsKQkg)_