### PR TITLE
docs: document dashboard stack containers

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, swap which field the charts are built on, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
+- [Layout](/docs/explore-analyze/dashboards/widgets/layout) — A stack container for grouping widgets, plus a spacer and divider for whitespace and section breaks
 
 ## Adding widgets
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,9 +1,22 @@
 ---
-title: Spacer & Divider
-description: Non-data layout elements — a spacer for whitespace and a divider line — that help you structure a dashboard.
+title: Layout widgets
+description: Non-data layout elements — a stack container, spacer, and divider — that help you structure a dashboard.
 ---
 
-Spacer and divider are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace and visual structure to a dashboard.
+Stack, spacer, and divider are non-data **layout** widgets. Stack carries other widgets; spacer and divider carry no data of their own. Place them on the canvas alongside charts, text, and controls to structure a dashboard.
+
+## Stack
+
+A stack is a container that groups other widgets and lays them out along one axis:
+
+- **Horizontal stack** — arranges its children side by side.
+- **Vertical stack** — stacks its children on top of each other.
+
+A stack's children share the space evenly along that axis and have no size of their own — only a position in the line. Resizing the stack resizes every child with it.
+
+Drag a widget onto a stack to add it — an empty stack prompts you to **Drag widgets here**. As you drag over the stack, it opens a slot under the pointer showing exactly where the widget will land. A stack can hold other stacks too, nested up to 4 levels deep.
+
+Controls placed inside a stack ([filters](/docs/explore-analyze/dashboards/widgets/controls#filter), [time granularity switchers](/docs/explore-analyze/dashboards/widgets/controls#time-granularity-switcher), [field switchers](/docs/explore-analyze/dashboards/widgets/controls#field-switcher), and [parent controls](/docs/explore-analyze/dashboards/widgets/controls#parent)) drive the dashboard the same as controls placed directly on the canvas.
 
 ## Spacer
 
@@ -17,11 +30,11 @@ A divider is a horizontal separator line that breaks up the layout flow — a li
 
 ## Adding a layout widget
 
-In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer** or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer) resize it.
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Horizontal stack**, **Vertical stack**, **Spacer**, or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer or stack) resize it.
 
 ## Styling
 
-Both widgets follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
+The spacer and divider follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
 
 - The **divider** draws its line using the widget **border** width, style, and color.
 - A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see.


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Cube Cloud shipped a new dashboard widget — horizontal and vertical **stack containers** (CUB-4271) — that had no documentation yet. This PR:

- Renames the "Spacer & Divider" widget page to **Layout widgets** and adds a **Stack** section covering: the two orientations, even space distribution among children, drag-to-add with the slot preview, the 4-level nesting limit, and that controls (filter, time granularity, field switcher, parent) keep driving the dashboard when placed inside a stack.
- Updates the widget type list on the widgets index page and the "Adding a layout widget" instructions to include the new stack options.

Facts were verified against the source PR (cubedevinc/cubejs-enterprise#14632) and the shipped UI copy (`horizontalStack`/`verticalStack`/`dragWidgetsIntoStack` strings, `MAX_CONTAINER_DEPTH = 4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tvjJd9nhs2pffpqEwYXXw

---
_Generated by [Claude Code](https://claude.ai/code/session_016tvjJd9nhs2pffpqEwYXXw)_