### PR TITLE
docs: document the write-progress indicator in Excel/Sheets explorations

### DIFF
--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -105,6 +105,11 @@ With every change to your query, Cube for Sheets will update the exploration on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
+Writing a large result to the sheet can take a few seconds. When it does, a
+thin progress bar appears above the run controls to track the write itself
+(not the query) — it only shows up for an explicit run, not for auto-run's
+own updates or for **Refresh**.
+
 ### Measure position and order
 
 By default, measures nest under each value of the dimension they're paired

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -106,9 +106,8 @@ the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
 Writing a large result to the sheet can take a few seconds. When it does, a
-thin progress bar appears above the run controls to track the write itself
-(not the query) — it only shows up for an explicit run, not for auto-run's
-own updates or for **Refresh**.
+progress bar appears above the run controls, tracking the write itself rather
+than the query.
 
 ### Measure position and order
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -114,9 +114,8 @@ the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
 Writing a large result to the sheet can take a few seconds. When it does, a
-thin progress bar appears above the run controls to track the write itself
-(not the query) — it only shows up for an explicit run, not for auto-run's
-own updates or for **Refresh**.
+progress bar appears above the run controls, tracking the write itself rather
+than the query.
 
 ### Measure position and order
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -113,6 +113,11 @@ With every change to your query, Cube for Excel will update the exploration on
 the sheet after a slight delay. If you'd like to minimize it, consider
 implementing [pre-aggregations][ref-pre-aggs].
 
+Writing a large result to the sheet can take a few seconds. When it does, a
+thin progress bar appears above the run controls to track the write itself
+(not the query) — it only shows up for an explicit run, not for auto-run's
+own updates or for **Refresh**.
+
 ### Measure position and order
 
 By default, measures nest under each value of the dimension they're paired


### PR DESCRIPTION
## Summary

- Cube for Excel and Cube for Sheets now show a progress bar above the run controls while a large exploration's result is being written to the sheet.
- Documents the one fact that matters to a reader: the bar tracks the write itself, not the query.

## Test plan

- [x] Verified the added text against the shipped behavior
- [x] Confirmed no links were added or moved (nothing to break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj91UbpMpaE98tUiTM2F46

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj91UbpMpaE98tUiTM2F46)_