### PR TITLE
fix(api-gateway): guard root orderBy cube name capitalization

### DIFF
--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -377,8 +377,10 @@ export function getJsonQuery(metaConfig: any, args: Record<string, any>, infos: 
 
   if (orderBy) {
     Object.entries<any>(orderBy).forEach(([cubeName, members]) => {
+      const cubeExists = metaConfig.find((cube) => cube.config.name === cubeName);
+      const normalizedCubeName = cubeExists ? cubeName : capitalize(cubeName);
       Object.entries<any>(members).forEach(([member, value]) => {
-        order.push([`${capitalize(cubeName)}.${member}`, value]);
+        order.push([`${normalizedCubeName}.${member}`, value]);
       });
     });
   }

--- a/packages/cubejs-api-gateway/test/graphql.test.ts
+++ b/packages/cubejs-api-gateway/test/graphql.test.ts
@@ -9,7 +9,7 @@ import { GraphQLObjectType } from 'graphql';
 import fs from 'fs-extra';
 import request from 'supertest';
 
-import { makeSchema } from '../src/graphql';
+import { makeSchema, getJsonQueryFromGraphQLQuery } from '../src/graphql';
 
 const metaConfig = [
   {
@@ -266,6 +266,30 @@ describe('GraphQL Schema', () => {
 
         expect((<any>error)?.text).toBeUndefined();
       });
+    });
+  });
+
+  describe('root orderBy casing', () => {
+    test('preserves lowercase-first cube name when cube exists in metaConfig', () => {
+      const query = `query CubeQuery {
+        cube(orderBy: { orders: { count: desc } }) {
+          orders { count }
+        }
+      }`;
+
+      const jsonQuery = getJsonQueryFromGraphQLQuery(query, metaConfigSnakeCase);
+      expect(jsonQuery.order).toEqual([['orders.count', 'desc']]);
+    });
+
+    test('capitalizes cube name when cube exists under capitalized name', () => {
+      const query = `query CubeQuery {
+        cube(orderBy: { orders: { count: desc } }) {
+          orders { count }
+        }
+      }`;
+
+      const jsonQuery = getJsonQueryFromGraphQLQuery(query, metaConfig);
+      expect(jsonQuery.order).toEqual([['Orders.count', 'desc']]);
     });
   });
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Closes #11700

**Description of Changes Made**

In `packages/cubejs-api-gateway/src/graphql.ts` (`getJsonQuery`), the root `orderBy` handler was unconditionally capitalizing the cube name (`capitalize(cubeName)`). When querying a cube declared with a lowercase-first or snake_case name (e.g. `orders`, `lowercaseOrders`), this resulted in non-existent order paths (such as `Orders.count`) causing query resolution errors under the Tesseract planner.

This change checks whether the cube already exists in `metaConfig` under its un-capitalized name before falling back to `capitalize(cubeName)`, aligning with the existing pattern used in `whereArgToQueryFilters`, `getMemberType`, and the per-cube `orderBy` handler.