### PR TITLE
docs: document refresh feedback for pre-aggregation rebuilds

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -26,6 +26,8 @@ definitions in Git — see [Dashboards as code](/docs/explore-analyze/dashboards
 
 Each widget shows a [freshness](/docs/explore-analyze/workbooks/querying-data#result-freshness-and-provenance) leaf indicating how recently its data was refreshed. The dashboard's own leaf reflects its least-recently-refreshed widget, so you can see at a glance whether everything on the dashboard is up to date.
 
+Use a chart's **Refresh** action, or **Refresh all charts** for the whole dashboard, to force new data. If a chart is served from a [pre-aggregation](/docs/pre-aggregations) that needs to rebuild first, Cube tracks the rebuild and reports what actually happened once it can confirm it, rather than declaring success while the rebuild is still running: **Refreshed successfully** once the new data has landed, **Refresh requested** when Cube can't yet confirm whether a rebuild finished, or **Still rebuilding pre-aggregations** if it's taking longer than a few minutes. Refreshing several charts at once shows a single combined notification for the whole batch.
+
 ## Linking between dashboards
 
 Dashboards can link to one another. When a table widget shows a dimension that


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Cube Cloud's dashboard **Refresh** / **Refresh all charts** actions now wait on a pre-aggregation rebuild they trigger and report the real outcome — **Refreshed successfully**, **Refresh requested** (when the rebuild's completion can't yet be confirmed), or **Still rebuilding pre-aggregations** (if it's taking longer than a few minutes) — instead of always reporting success while a rebuild might still be running in the background. This was undocumented; adds a short paragraph to the dashboards **Data freshness** section covering the new feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGo4bUUWt579vThh4CTWYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGo4bUUWt579vThh4CTWYz)_