### PR TITLE
docs(dashboards): document stack containers and how their children are managed

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -130,6 +130,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
           - Layout
             - Spacer
             - Divider
+            - Stack
     - **Dashboard**
       - Scheduled refresh
     - **Semantic Model**

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -3,7 +3,7 @@ title: Widgets
 description: Building blocks for dashboards — charts, text, controls, AI summaries, and layout elements that you arrange on the canvas to tell your data story.
 ---
 
-Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, an AI-generated summary, or a layout element such as a spacer or divider. Combine them to assemble polished, interactive views of your data.
+Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, an AI-generated summary, or a layout element such as a spacer, divider, or stack. Combine them to assemble polished, interactive views of your data.
 
 ## Widget types
 
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, swap which field the charts are built on, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer & Divider](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace and section breaks
+- [Spacer, Divider & Stack](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace, section breaks, and grouping widgets
 
 ## Adding widgets
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,5 +1,5 @@
 ---
-title: Spacer, Divider & Stacks
+title: Spacer, Divider & Stack
 description: Non-data layout elements — a spacer for whitespace, a divider line, and stack containers that group widgets — to help you structure a dashboard.
 ---
 
@@ -15,13 +15,18 @@ A spacer is only visible while you are editing in the [dashboard builder][ref-wo
 
 A divider is a horizontal separator line that breaks up the layout flow — a lightweight way to signal the boundary between sections of a dashboard. Unlike other widgets, a divider is a fixed height and **cannot be resized** vertically.
 
-## Stacks
+## Stack
 
 A **horizontal stack** or **vertical stack** is a container that groups several widgets and lays them out evenly — side by side in a horizontal stack, or top to bottom in a vertical stack. Use a stack to keep a set of related widgets aligned and sized together, instead of positioning each one on the grid by hand.
 
-Place a stack on the canvas and resize it to any width and height; its children always share that space evenly. In a horizontal stack each child takes the full height and an equal share of the width; in a vertical stack each child takes the full width and an equal share of the height. Add a widget to a stack by dragging it in — from the canvas, the **Add Widgets** menu, or another stack — and remove one by dragging it back out; the remaining children redistribute to fill the space. Stacks can be nested inside one another.
+Place a stack on the canvas and resize it to any width and height; its children always share that space evenly:
 
-Because a stack owns its children's layout, you work with the **container as a unit**: select, move, resize, or delete the stack itself and it carries its children with it. Individual widgets inside a stack are not separately selectable on the board — to rearrange them, drag a child to a new position **within** the stack; to take one out, drag it onto the canvas or into another container.
+- In a **horizontal stack**, each child takes the full height and an equal share of the width.
+- In a **vertical stack**, each child takes the full width and an equal share of the height.
+
+Add a widget to a stack by dragging it in — from the canvas, the **Add Widgets** menu, or another stack — and remove one by dragging it back out; the remaining children redistribute to fill the space. Stacks can be nested inside one another.
+
+Because a stack owns its children's layout, you work with the **container as a unit**: select, move, resize, or delete the stack itself and it carries its children with it. Individual widgets inside a stack are not separately selectable on the board — a marquee drawn over a stack selects the container, not its children. To rearrange children, drag one to a new position **within** the stack; to take one out, drag it onto the canvas or into another container.
 
 ## Adding a layout widget
 
@@ -29,9 +34,11 @@ In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the 
 
 ## Styling
 
-Both widgets follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
+The **spacer** and **divider** follow the dashboard's [widget styling settings](/docs/explore-analyze/dashboards/styling):
 
 - The **divider** draws its line using the widget **border** width, style, and color.
 - A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see.
+
+A **stack** draws no card of its own — it only groups and sizes its children, each of which keeps its own styling.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,9 +1,9 @@
 ---
-title: Spacer & Divider
-description: Non-data layout elements — a spacer for whitespace and a divider line — that help you structure a dashboard.
+title: Spacer, Divider & Stacks
+description: Non-data layout elements — a spacer for whitespace, a divider line, and stack containers that group widgets — to help you structure a dashboard.
 ---
 
-Spacer and divider are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace and visual structure to a dashboard.
+Spacers, dividers, and stacks are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace, visual structure, and grouping to a dashboard.
 
 ## Spacer
 
@@ -15,9 +15,17 @@ A spacer is only visible while you are editing in the [dashboard builder][ref-wo
 
 A divider is a horizontal separator line that breaks up the layout flow — a lightweight way to signal the boundary between sections of a dashboard. Unlike other widgets, a divider is a fixed height and **cannot be resized** vertically.
 
+## Stacks
+
+A **horizontal stack** or **vertical stack** is a container that groups several widgets and lays them out evenly — side by side in a horizontal stack, or top to bottom in a vertical stack. Use a stack to keep a set of related widgets aligned and sized together, instead of positioning each one on the grid by hand.
+
+Place a stack on the canvas and resize it to any width and height; its children always share that space evenly. In a horizontal stack each child takes the full height and an equal share of the width; in a vertical stack each child takes the full width and an equal share of the height. Add a widget to a stack by dragging it in — from the canvas, the **Add Widgets** menu, or another stack — and remove one by dragging it back out; the remaining children redistribute to fill the space. Stacks can be nested inside one another.
+
+Because a stack owns its children's layout, you work with the **container as a unit**: select, move, resize, or delete the stack itself and it carries its children with it. Individual widgets inside a stack are not separately selectable on the board — to rearrange them, drag a child to a new position **within** the stack; to take one out, drag it onto the canvas or into another container.
+
 ## Adding a layout widget
 
-In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer** or **Divider**. The widget is added to the canvas, where you can drag it into place and (for a spacer) resize it.
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer**, **Divider**, **Horizontal Stack**, or **Vertical Stack**. The widget is added to the canvas, where you can drag it into place and resize it (a divider resizes horizontally only).
 
 ## Styling
 


### PR DESCRIPTION
## What

Adds a **Stacks** section to the dashboard layout-widgets page (`docs/explore-analyze/dashboards/widgets/layout.mdx`). Horizontal and vertical stack containers shipped in the dashboard builder but had no public docs at all.

The section covers:
- what a horizontal / vertical stack is and when to use it
- how children are distributed evenly, and how to add / remove / nest them
- **the behavior users most often read as a bug**: a stack owns its children's layout, so you select and move the *container* as a unit, and rearrange children by dragging *within* the stack rather than selecting them individually

## Why

Came out of a cross-feature dashboard interaction audit. We deliberately keep stack children non-individually-selectable (the container is the unit of selection/movement); documenting it prevents that from being misread as broken.

## Notes

- Frontmatter title updated `Spacer & Divider` → `Spacer, Divider & Stacks`; the sidebar label is derived from the page title (nav references the page by path), so no `docs.json` change is needed.
- Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)