### PR TITLE
docs: document IANA timezone validation and cube.ts removal

### DIFF
--- a/docs-mintlify/configuration/overview.mdx
+++ b/docs-mintlify/configuration/overview.mdx
@@ -36,6 +36,10 @@ module.exports = {
 ```
 </CodeGroup>
 
+<Note>
+A `cube.ts` configuration file is not supported. Use `cube.py` or `cube.js` instead.
+</Note>
+
 ## Environment variables
 
 All Cube environment variables start with `CUBEJS_`:

--- a/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/calculated-fields.mdx
@@ -148,9 +148,10 @@ and last buckets instead of extending them.
 </Info>
 
 To change a bucketed field, choose **Edit bins…** or **Edit groups…** from its
-menu—either in the sidebar or on its column header in the results. Only fields
-this panel generated offer the action; a `CASE` expression written by hand does
-not.
+menu—either in the sidebar or on its column header in the results. This opens
+the structured bucket editor only for fields it generated; a `CASE` expression
+written by hand, a custom aggregation, or another hand-written field opens a
+SQL-only editor instead.
 
 ### Editing a calculated field
 

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -62,6 +62,10 @@ or [GraphQL API][ref-ref-graphql-api-args] to specify the time zone for a query.
 Also, you can use the [`SQL_UTILS` context variable][ref-sql-utils] to apply the
 time zone conversion to dimensions that are not used as time dimensions in a query.
 
+The `timezone` value must be a valid [IANA time zone name][wiki-tz-database]
+(e.g., `America/Los_Angeles`); fixed UTC offsets (e.g., `+05:00`) and unrecognized
+names are rejected with a validation error.
+
 Additionally, note that time zones have impact on [pre-aggregation
 matching][ref-matching-preaggs-time-dimensions].
 
@@ -400,6 +404,7 @@ called `count` to be defined in the cube or view. Please add one to resolve this
 
 
 [wiki-utc-time-zone]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[wiki-tz-database]: https://en.wikipedia.org/wiki/Tz_database
 [ref-data-model]: /docs/data-modeling/overview
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference


### PR DESCRIPTION
## Summary

Found via a routine scan of recent Cube core + Cube Cloud changes against docs-mintlify. Three small, undocumented, customer-facing changes from the last few weeks:

- **`timezone` query parameter is now validated against IANA time zones** (cube-js/cube#11575). The REST/GraphQL/SQL API `timezone` field (and the pre-aggregation jobs `timezones` selector) now rejects fixed UTC offsets (e.g. `+05:00`) and unrecognized zone names with a validation error, instead of silently accepting them. Documented in the canonical "Time zone" section (`reference/core-data-apis/queries.mdx`), which the REST/GraphQL API reference pages already link to.
- **`cube.ts` configuration file is no longer supported** (cube-js/cube#11763). The server previously loaded `cube.ts` via an in-process TypeScript compiler; it now throws an explicit error directing users to `cube.js`/`cube.py`. Added a short note to `configuration/overview.mdx` (which already only documented `cube.py`/`cube.js`).
- **Hand-written calculated fields can now be edited via a SQL fallback editor** (cubedevinc/cubejs-enterprise#14322). Previously, only calculated fields generated by the **Create bins…**/**Group values…** panel could be edited (a hand-written `CASE` expression, custom aggregation, or saved workbook field could not). `docs/explore-analyze/workbooks/calculated-fields.mdx` stated the old, now-stale behavior — updated to describe the new SQL-only editor opened for those fields.

Each change verified directly against the shipped diff/PR, not just the commit subject.

## Test plan

- [x] Content-only `.mdx` edits in `docs-mintlify`; no build/test impact.
- [x] Verified against the actual merged diffs/PRs (`d1ba22a31c`, `2da5a6a879`, cubejs-enterprise#14322), not just titles.
- [ ] Mintlify preview render (reviewer/CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhEweJtDuuv9jhPSVTvDUv