### PR TITLE
docs: note the single-Google-account limitation for Cube for Sheets

### DIFF
--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -65,12 +65,12 @@ If you want to revoke the authentication, open the add-on menu and click
 <Warning>
 
 Google Apps Script authenticates the add-on as whichever Google account you
-signed in to first in the browser, not necessarily the one that owns the open
-spreadsheet. If they differ, the add-on can't reach the spreadsheet and the
-cursor status reads **Cannot read your selection**. Sign in to only one
-Google account per Chrome profile (or use an incognito window) to avoid
-this — or sign out of every Google account and sign back in with the file's
-owner account first.
+signed in to first in the browser, not necessarily one with access to the
+open spreadsheet. If they differ, the add-on can't reach the spreadsheet and
+the cursor status reads **Cannot read your selection**. Sign in to only one
+Google account per browser profile (or use a private/incognito window) to
+avoid this — or sign out of every Google account and sign back in with an
+account that has access to the file first.
 
 </Warning>
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -62,6 +62,18 @@ Once you see the `Access Granted` message, close the modal window.
 If you want to revoke the authentication, open the add-on menu and click
 **Sign out**.
 
+<Warning>
+
+Google Apps Script authenticates the add-on as whichever Google account you
+signed in to first in the browser, not necessarily the one that owns the open
+spreadsheet. If they differ, the add-on can't reach the spreadsheet and the
+cursor status reads **Cannot read your selection**. Sign in to only one
+Google account per Chrome profile (or use an incognito window) to avoid
+this — or sign out of every Google account and sign back in with the file's
+owner account first.
+
+</Warning>
+
 ## Create explorations via pivot table
 
 To create an exploration, open the add-on and click **Create exploration**.

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -59,9 +59,6 @@ A modal window with an authentication prompt will appear. Choose the deployments
 that you want to work with in Google Sheets and click **Authorize**.
 Once you see the `Access Granted` message, close the modal window.
 
-If you want to revoke the authentication, open the add-on menu and click
-**Sign out**.
-
 <Warning>
 
 Google Apps Script authenticates the add-on as whichever Google account you
@@ -73,6 +70,9 @@ avoid this — or sign out of every Google account and sign back in with an
 account that has access to the file first.
 
 </Warning>
+
+If you want to revoke the authentication, open the add-on menu and click
+**Sign out**.
 
 ## Create explorations via pivot table
 


### PR DESCRIPTION
## Summary

- Google Sheets authenticates the Cube for Sheets add-on as whichever Google account is signed in first in the browser, not necessarily an account with access to the currently open spreadsheet. When they differ, the add-on can't reach the spreadsheet.
- Documents this limitation next to the authentication instructions, along with the workarounds: keep one Google account per browser profile (or use a private/incognito window), or sign out of every account and sign back in with an account that has access to the file first.

## Test plan

- [x] Verified the added text against the shipped behavior
- [x] Confirmed no links were added or moved (nothing to break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFr6FLepvNhXYoEET9a396

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFr6FLepvNhXYoEET9a396)_