### PR TITLE
chore(cross): Upgrade x86_64-unknown-linux-gnu bookworm (08092026)

### DIFF
--- a/.github/workflows/drivers-tests.yml
+++ b/.github/workflows/drivers-tests.yml
@@ -113,7 +113,7 @@ jobs:
         target: [ "x86_64-unknown-linux-gnu" ]
       fail-fast: false
     container:
-      image: cubejs/rust-cross:${{ matrix.target }}-31072025
+      image: cubejs/rust-cross:${{ matrix.target }}-08092026
 
     steps:
       - name: Checkout

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 60
     name: Build Linux Native backend for Dev image
     container:
-      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025-python-3.13
+      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026-python-3.13
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
             package_target_libc: glibc
       fail-fast: false
     container:
-      image: cubejs/rust-cross:${{ matrix.target }}-31072025${{ matrix.python-version != 'fallback' && format('-python-{0}', matrix.python-version) || '' }}
+      image: cubejs/rust-cross:${{ matrix.target }}-08092026${{ matrix.python-version != 'fallback' && format('-python-{0}', matrix.python-version) || '' }}
     permissions:
       contents: write
     steps:
@@ -600,13 +600,13 @@ jobs:
           # Please use minimal possible version of ubuntu, because it produces constraint on glibc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026
             executable_name: cubestored
             strip: true
             compress: false
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-            image: cubejs/rust-cross:x86_64-unknown-linux-musl-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-musl-08092026
             executable_name: cubestored
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 60
     if: (needs['latest-tag-sha'].outputs.sha != github.sha)
     container:
-      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025
+      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -278,7 +278,7 @@ jobs:
         python-version: [ 3.13 ]
       fail-fast: false
     container:
-      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025-python-${{ matrix.python-version }}
+      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026-python-${{ matrix.python-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 20
     name: Check fmt/clippy
     container:
-      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025
+      image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026
 
     steps:
       - name: Checkout
@@ -137,7 +137,7 @@ jobs:
             target: "aarch64-unknown-linux-gnu"
       fail-fast: false
     container:
-      image: cubejs/rust-cross:${{ matrix.target }}-31072025${{ matrix.python-version != 'fallback' && format('-python-{0}', matrix.python-version) || '' }}
+      image: cubejs/rust-cross:${{ matrix.target }}-08092026${{ matrix.python-version != 'fallback' && format('-python-{0}', matrix.python-version) || '' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust-cubestore-master.yml
+++ b/.github/workflows/rust-cubestore-master.yml
@@ -266,13 +266,13 @@ jobs:
           # Please use minimal possible version of ubuntu, because it produces constraint on glibc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026
             executable_name: cubestored
             strip: true
             compress: false
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-            image: cubejs/rust-cross:x86_64-unknown-linux-musl-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-musl-08092026
             executable_name: cubestored
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890

--- a/.github/workflows/rust-cubestore.yml
+++ b/.github/workflows/rust-cubestore.yml
@@ -205,13 +205,13 @@ jobs:
           # Please use minimal possible version of ubuntu, because it produces constraint on glibc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026
             executable_name: cubestored
             strip: true
             compress: false
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
-            image: cubejs/rust-cross:x86_64-unknown-linux-musl-31072025
+            image: cubejs/rust-cross:x86_64-unknown-linux-musl-08092026
             executable_name: cubestored
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890

--- a/rust/cubestore/Cross.toml
+++ b/rust/cubestore/Cross.toml
@@ -1,11 +1,11 @@
 [target.x86_64-unknown-linux-gnu]
-image = "cubejs/rust-cross:x86_64-unknown-linux-gnu-31072025"
+image = "cubejs/rust-cross:x86_64-unknown-linux-gnu-08092026"
 xargo = false
 
 [target.x86_64-unknown-linux-musl]
-image = "cubejs/rust-cross:x86_64-unknown-linux-musl-31072025"
+image = "cubejs/rust-cross:x86_64-unknown-linux-musl-08092026"
 xargo = false
 
 [target.aarch64-unknown-linux-gnu]
-image = "cubejs/rust-cross:aarch64-unknown-linux-gnu-31072025"
+image = "cubejs/rust-cross:aarch64-unknown-linux-gnu-08092026"
 xargo = false

--- a/rust/cubestore/cross/README.md
+++ b/rust/cubestore/cross/README.md
@@ -12,18 +12,20 @@ For all another, we are using Cross.
 
 Keep in mind:
 
-- Don't use modern unix*, which ship newest `libc` (current used 2.31)
-- Better to use one clang/gcc version across images (`clang-14`)
+- Don't use modern unix*, which ship newest `libc`. The `libc` of the image becomes the
+  minimum requirement for the binaries we publish: 2.36 for `x86_64-unknown-linux-gnu`
+  (debian bookworm), 2.31 for `aarch64-unknown-linux-gnu` (ubuntu focal)
+- Better to use one clang/gcc version across images (`clang-18`)
 - Try to use one OS for all images (`debian`) for unix*
 
 ```sh
 export DOCKER_BUILDKIT_MAX_PARALLELISM=2
 docker buildx bake x86_64-unknown-linux-gnu-python --push
 docker buildx bake aarch64-unknown-linux-gnu-python --push
-docker buildx bake x86_64-unknown-linux-musl-python --push
+docker buildx bake x86_64-unknown-linux-musl --push
 
 # dmY
-export CROSS_VERSION=31072025
+export CROSS_VERSION=08092026
 
 # Verify versions
 docker run --platform linux/amd64 --rm -it cubejs/rust-cross:x86_64-unknown-linux-gnu-$CROSS_VERSION cc --version

--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -38,8 +38,8 @@ ENV ARCH=arm \
     LD=aarch64-linux-gnu-ld \
     RUNLIB=aarch64-linux-gnu-ranlib
 
-ENV ZLIB_VERSION=1.3.1
-RUN wget https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz -O - | tar -xz && \
+ENV ZLIB_VERSION=1.3.2
+RUN wget https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz -O - | tar -xz && \
     cd zlib-${ZLIB_VERSION} && \
     ./configure --prefix=/usr/aarch64-linux-gnu && \
     make -j $(nproc) && \

--- a/rust/cubestore/cross/docker-bake.hcl
+++ b/rust/cubestore/cross/docker-bake.hcl
@@ -1,6 +1,6 @@
 variable "CROSS_VERSION" {
   // dmY
-  default = "31072025"
+  default = "08092026"
 }
 
 variable "LLVM_VERSION" {

--- a/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -5,8 +5,8 @@ ARG LLVM_VERSION=18
 
 RUN apt-get update && apt-get -y upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config wget curl git ca-certificates \
-    && wget -O /etc/apt/trusted.gpg.d/llvm-snapshot.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
+    && wget -O /etc/apt/keyrings/llvm-snapshot.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.asc] https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y llvm-${LLVM_VERSION} lld-${LLVM_VERSION} clang-${LLVM_VERSION} libclang-${LLVM_VERSION}-dev make cmake \
       lzma-dev liblzma-dev libpython3-dev \

--- a/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,14 +1,14 @@
-# libc 2.31 python 3.9
-FROM debian:bullseye-slim
+# libc 2.36 python 3.11
+FROM debian:bookworm-slim
 
 ARG LLVM_VERSION=18
 
 RUN apt-get update && apt-get -y upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common pkg-config wget curl gnupg git apt-transport-https ca-certificates \
-    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && add-apt-repository "deb https://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-$LLVM_VERSION main"  \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config wget curl git ca-certificates \
+    && wget -O /etc/apt/trusted.gpg.d/llvm-snapshot.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y llvm-${LLVM_VERSION} lld-${LLVM_VERSION} clang-$LLVM_VERSION libclang-${LLVM_VERSION}-dev make cmake \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y llvm-${LLVM_VERSION} lld-${LLVM_VERSION} clang-${LLVM_VERSION} libclang-${LLVM_VERSION}-dev make cmake \
       lzma-dev liblzma-dev libpython3-dev \
     && rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Rebuilds the `cubejs/rust-cross` cross-compilation images and repoints every workflow, `Cross.toml` and the bake file at the new `08092026` tag. The aarch64 image was failing to build because zlib.net only serves the latest release, so the pinned 1.3.1 tarball 404s — it now fetches zlib 1.3.2 from GitHub releases. The `x86_64-unknown-linux-gnu` image moves from debian bullseye to bookworm (glibc 2.31 → 2.36, python 3.9 → 3.11), replacing the deprecated `apt-key`/`add-apt-repository` pair with a keyring drop-in plus an explicit sources list entry. Note this raises the minimum glibc for the published `x86_64-unknown-linux-gnu` binaries to 2.36. Also fixes stale bits in `cross/README.md`: the publish snippet referenced a non-existent `x86_64-unknown-linux-musl-python` bake target, and the glibc/clang notes were out of date.