### PR TITLE
chore(cross): Support Python 3.14

### DIFF
--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
@@ -9,7 +9,7 @@ ARG PYTHON_VERSION_SUFFIX
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y build-essential wget ca-certificates \
+    && apt-get install -y build-essential wget ca-certificates zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*;
 
 RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \

--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
@@ -1,15 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# Cross compiling python needs a build interpreter of the exact same version :D
+FROM ubuntu:20.04 AS build-python
+
+ARG PYTHON_VERSION
+ARG PYTHON_VERSION_SUFFIX
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y build-essential wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*;
+
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
+    && cd Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX} \
+    && ./configure --prefix=/opt/build-python --disable-test-modules --without-ensurepip \
+    && make -j $(nproc) \
+    && make install \
+    && cd .. && rm -rf Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX};
+
 FROM base
 
 ARG PYTHON_VERSION
 ARG PYTHON_VERSION_SUFFIX
 ARG PYTHON_RELEASE
 
-# python  is required for cross compiling python :D
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${PYTHON_RELEASE} \
-    && rm -rf /var/lib/apt/lists/*;
-
 # --enable-optimizations is disabled, because it's not supported with CROSS
-RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
+RUN --mount=type=bind,from=build-python,source=/opt/build-python,target=/opt/build-python \
+    wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
     && cd Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX} \
     && touch config.site-aarch64 \
     && echo "ac_cv_buggy_getaddrinfo=no" >> config.site-aarch64 \
@@ -19,13 +37,13 @@ RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VER
       --enable-shared \
       --disable-ipv6 \
       --prefix=/usr/aarch64-linux-gnu \
+      --without-ensurepip \
       --build=aarch64-unknown-linux-gnu \
       --host=x86_64-linux-gnu \
-      --with-build-python=/usr/bin/python${PYTHON_RELEASE} \
+      --with-build-python=/opt/build-python/bin/python${PYTHON_RELEASE} \
     && make -j $(nproc) \
     && make install \
-    && cd .. && rm -rf Python-${PYTHON_VERSION} \
-    && rm -rf /var/lib/apt/lists/*;
+    && cd .. && rm -rf Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX};
 
 ENV PYO3_CROSS_PYTHON_VERSION=${PYTHON_RELEASE} \
     PYO3_CROSS_INCLUDE_DIR=/usr/aarch64-linux-gnu/include \

--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
@@ -26,8 +26,11 @@ ARG PYTHON_VERSION_SUFFIX
 ARG PYTHON_RELEASE
 
 # --enable-optimizations is disabled, because it's not supported with CROSS
+# 3.9/3.10 ignore --with-build-python and instead search PATH for python$VERSION, so the build
+# interpreter has to be reachable both ways
 RUN --mount=type=bind,from=build-python,source=/opt/build-python,target=/opt/build-python \
-    wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
+    export PATH="/opt/build-python/bin:${PATH}" \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
     && cd Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX} \
     && touch config.site-aarch64 \
     && echo "ac_cv_buggy_getaddrinfo=no" >> config.site-aarch64 \

--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu.Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common pkg-config wget curl apt-transport-https ca-certificates \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-$LLVM_VERSION main"  \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y libffi-dev binutils-multiarch binutils-aarch64-linux-gnu gcc-multilib g++-multilib \
     # llvm14-dev will install python 3.8 as bin/python3

--- a/rust/cubestore/cross/docker-bake.hcl
+++ b/rust/cubestore/cross/docker-bake.hcl
@@ -9,12 +9,11 @@ variable "LLVM_VERSION" {
 
 variable "PYTHON_VERSIONS" {
   default = [
-    # TODO: Enable after release.
-    # {
-    #   python_version = "3.14.0"
-    #   python_version_sufix = "rc1"
-    #   python_release = "3.14"
-    # },
+    {
+      python_version = "3.14.7"
+      python_version_sufix = ""
+      python_release = "3.14"
+    },
     {
       python_version = "3.13.5"
       python_version_sufix = ""

--- a/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
+++ b/rust/cubestore/cross/x86_64-unknown-linux-gnu.Dockerfile
@@ -4,9 +4,9 @@ FROM debian:bookworm-slim
 ARG LLVM_VERSION=18
 
 RUN apt-get update && apt-get -y upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config wget curl git ca-certificates \
-    && wget -O /etc/apt/keyrings/llvm-snapshot.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
-    && echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.asc] https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config wget curl git gnupg ca-certificates \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y llvm-${LLVM_VERSION} lld-${LLVM_VERSION} clang-${LLVM_VERSION} libclang-${LLVM_VERSION}-dev make cmake \
       lzma-dev liblzma-dev libpython3-dev \


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Adds Python 3.14.7 to the cross image matrix, replacing the commented-out 3.14.0rc1 TODO. aarch64 could not build it because `--with-build-python` needs a build interpreter of the same version and that came from `ppa:deadsnakes`, which has no `python3.14` for focal — so the aarch64 python image now builds that interpreter from source in a separate `build-python` stage and bind-mounts it, dropping the PPA entirely. This also restores `gnupg` in the x86_64 base image and dearmors the LLVM key into `/usr/share/keyrings`: apt is fine with an ASCII-armored `.asc` key, but removing the package left no `gpg` binary in the image and consumers of it failed with `Unable to locate executable file: gpg`.

Verified by building and pushing all `x86_64-unknown-linux-gnu` images (base plus python 3.9–3.14) to `cubejs/rust-cross` at tag `08092026`; `gpg` is present in every variant and `_ssl` still builds against the base's OpenSSL 1.1.1w on 3.14. The aarch64 images are **not** built or published yet — the new `build-python` stage runs for the first time when this lands on master, since `cross-images.yml` only pushes from master.