### PR TITLE
fix(cubesql): Build a pushed down union over its queries' classes, not their forms

### DIFF
--- a/rust/cubesql/CLAUDE.md
+++ b/rust/cubesql/CLAUDE.md
@@ -130,6 +130,15 @@ that match the list node itself — never by a transform that walks it.
   takes `top_level_elem_vars`, which is how a fact that must hold across every element —
   all queries reaching the same data source — is enforced: name the variable there and
   unification does the rest, with no comparison of your own.
+- When the elements of a list each have many alternatives (the pulled up forms of a
+  query) and the rewrite builds one list node from them, the combinations of the
+  alternatives are the product of their counts, and so is the number of list nodes; every
+  rule above the list multiplies it again. Use
+  `transforming_list_rewrite_per_elem_with_lists_and_vars` there, with the searcher's own
+  element pattern as the applier's element pattern: each element then resolves to the class
+  it was matched in, whichever alternative matched, so the list is one node and extraction
+  picks between the alternatives. Where that class also holds forms the parent cannot use,
+  the cost model has to rule them out in the parent's state (`plan_nodes_inside_wrapper`).
 - Generate the traversal with the existing helpers rather than by hand:
   `WrapperRules::list_pushdown_pullup_rules` / `flat_list_pushdown_pullup_rules`
   (or `replacer_push_down_node` / `replacer_pull_up_node` underneath them). They emit

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -845,6 +845,9 @@ impl CubeScanWrapperNode {
                         .inputs
                         .iter()
                         .any(|input| Self::has_ungrouped_wrapped_node(input))
+                } else if let Some(wrapper) = node.as_any().downcast_ref::<CubeScanWrapperNode>() {
+                    // A query of a pushed down union
+                    Self::has_ungrouped_wrapped_node(wrapper.wrapped_plan.as_ref())
                 } else {
                     false
                 }
@@ -1222,6 +1225,20 @@ impl CubeScanWrapperNode {
                             parent_data_source,
                         )
                         .await
+                } else if let Some(wrapper) = node_any.downcast_ref::<CubeScanWrapperNode>() {
+                    // The queries of a pushed down union are the wrappers they were pulled
+                    // up into, and each renders as the query it holds
+                    Self::generate_sql_for_node_rec(
+                        meta,
+                        transport,
+                        load_request_meta,
+                        state,
+                        wrapper.wrapped_plan.clone(),
+                        can_rename_columns,
+                        values,
+                        parent_data_source,
+                    )
+                    .await
                 } else {
                     return Err(CubeError::internal(format!(
                         "Can't generate SQL for node: {node:?}"

--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -253,6 +253,8 @@ impl BestCubePlan {
         CubePlanCost {
             replacers: this_replacers,
             // Will be filled in finalize
+            plan_nodes_inside_wrapper: 0,
+            // Will be filled in finalize
             penalized_ast_size_outside_wrapper: 0,
             table_scans,
             filters,
@@ -328,6 +330,7 @@ pub struct CubePlanCostOptions {
 
 /// This cost struct maintains following structural relationships:
 /// - `replacers` > other nodes - having replacers in structure means not finished processing
+/// - `plan_nodes_inside_wrapper` > other nodes - a DataFusion node under a wrapper cannot be rendered as SQL, which matters where a wrapper reads a class that also holds plain forms (the queries of a pushed down union)
 /// - `penalized_ast_size_outside_wrapper` > other nodes - this is used to force "no post processing" mode, only CubeScan and CubeScanWrapped are expected as result
 /// - `table_scans` > other nodes - having table scan means not detected cube scan
 /// - `empty_wrappers` > `non_detected_cube_scans` - we don't want empty wrapper to hide non detected cube scan errors
@@ -347,6 +350,9 @@ pub struct CubePlanCostOptions {
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CubePlanCost {
     replacers: i64,
+    // A DataFusion plan node under a `CubeScanWrapper` has no SQL to render, so a plan
+    // with one is not an answer, however cheap the rest of it is
+    plan_nodes_inside_wrapper: usize,
     penalized_ast_size_outside_wrapper: usize,
     table_scans: i64,
     empty_wrappers: i64,
@@ -420,6 +426,8 @@ impl CubePlanCost {
     pub fn add_child(&self, other: &Self) -> Self {
         Self {
             replacers: self.replacers + other.replacers,
+            plan_nodes_inside_wrapper: self.plan_nodes_inside_wrapper
+                + other.plan_nodes_inside_wrapper,
             // Will be filled in finalize
             penalized_ast_size_outside_wrapper: 0,
             table_scans: self.table_scans + other.table_scans,
@@ -479,9 +487,16 @@ impl CubePlanCost {
         state: &CubePlanState,
         sort_state: &SortState,
         under_limit: bool,
+        wrapper_depth: usize,
         enode: &LogicalPlanLanguage,
         options: CubePlanCostOptions,
     ) -> Self {
+        // `wrapper_depth` counts this node, so a wrapper is inside another at depth two
+        let plan_node_inside_wrapper = wrapper_depth > 0 && is_post_processing_node(enode);
+        // A wrapper inside a wrapper is how a pushed down union reads its queries: it
+        // renders as the query it holds, not as another wrapper, so it costs like none
+        let nested_wrapper =
+            wrapper_depth > 1 && matches!(enode, LogicalPlanLanguage::CubeScanWrapper(_));
         let ast_size_outside_wrapper = match state {
             CubePlanState::Wrapped => 0,
             CubePlanState::Unwrapped(size) => *size,
@@ -495,6 +510,8 @@ impl CubePlanCost {
 
         Self {
             replacers: self.replacers,
+            plan_nodes_inside_wrapper: self.plan_nodes_inside_wrapper
+                + if plan_node_inside_wrapper { 1 } else { 0 },
             penalized_ast_size_outside_wrapper,
             table_scans: self.table_scans,
             filters: self.filters,
@@ -593,7 +610,7 @@ impl CubePlanCost {
                 _ => 0,
             } + self.limitless_post_processing,
             unwrapped_subqueries: self.unwrapped_subqueries,
-            wrapper_nodes: self.wrapper_nodes,
+            wrapper_nodes: self.wrapper_nodes - if nested_wrapper { 1 } else { 0 },
             wrapped_select_non_push_to_cube: self.wrapped_select_non_push_to_cube,
             wrapped_select_ungrouped_scan: self.wrapped_select_ungrouped_scan,
             cube_scan_nodes: self.cube_scan_nodes,
@@ -625,6 +642,38 @@ impl CubePlanCost {
             ),
         }
     }
+}
+
+/// A DataFusion plan node the wrapper cannot render, so one that runs as post processing
+/// when it is outside a wrapper and makes the plan invalid when it is inside one. Every
+/// plan variant of the language is here except the ones SQL generation handles: the Cube
+/// nodes (`CubeScan`, `CubeScanWrapper`, `WrappedSelect`, `WrappedUnion`) and
+/// `EmptyRelation`.
+///
+/// One list serves both directions: it is what `plan_nodes_inside_wrapper` rejects and
+/// what `ast_size_outside_wrapper` counts, so a variant added or removed here changes the
+/// post processing penalty as much as the wrapper check.
+fn is_post_processing_node(node: &LogicalPlanLanguage) -> bool {
+    matches!(
+        node,
+        LogicalPlanLanguage::Projection(_)
+            | LogicalPlanLanguage::Filter(_)
+            | LogicalPlanLanguage::Window(_)
+            | LogicalPlanLanguage::Aggregate(_)
+            | LogicalPlanLanguage::Sort(_)
+            | LogicalPlanLanguage::Join(_)
+            | LogicalPlanLanguage::CrossJoin(_)
+            | LogicalPlanLanguage::Repartition(_)
+            | LogicalPlanLanguage::Subquery(_)
+            | LogicalPlanLanguage::Union(_)
+            | LogicalPlanLanguage::TableScan(_)
+            | LogicalPlanLanguage::Limit(_)
+            | LogicalPlanLanguage::TableUDFs(_)
+            | LogicalPlanLanguage::CreateExternalTable(_)
+            | LogicalPlanLanguage::Values(_)
+            | LogicalPlanLanguage::Distinct(_)
+            | LogicalPlanLanguage::Extension(_)
+    )
 }
 
 pub trait TopDownCost: Clone + Debug + PartialOrd {
@@ -914,6 +963,11 @@ pub struct CubePlanTopDownState {
     limit: SortState,
     /// Whether a select above bounds the rows every scan below it can return
     under_limit: bool,
+    /// How many `CubeScanWrapper` nodes are above, this node included: 0 outside any, 1 in
+    /// one, 2 in a wrapper nested in another. Saturates at 2, both because deeper nesting
+    /// changes nothing and because the state is part of the extraction memo key: the
+    /// e-graph has cycles, and a state that kept growing along one would never repeat
+    wrapper_depth: usize,
     max_row_limit: usize,
 }
 
@@ -923,6 +977,7 @@ impl CubePlanTopDownState {
             wrapped: CubePlanState::Unwrapped(0),
             limit: SortState::None,
             under_limit: false,
+            wrapper_depth: 0,
             max_row_limit,
         }
     }
@@ -1001,19 +1056,7 @@ impl TopDownState<LogicalPlanLanguage> for CubePlanTopDownState {
                 CubePlanState::Wrapped
             }
             _ => {
-                let ast_size_outside_wrapper = match node {
-                    LogicalPlanLanguage::Aggregate(_) => 1,
-                    LogicalPlanLanguage::Projection(_) => 1,
-                    LogicalPlanLanguage::Limit(_) => 1,
-                    LogicalPlanLanguage::Sort(_) => 1,
-                    LogicalPlanLanguage::Filter(_) => 1,
-                    LogicalPlanLanguage::Join(_) => 1,
-                    LogicalPlanLanguage::CrossJoin(_) => 1,
-                    LogicalPlanLanguage::Union(_) => 1,
-                    LogicalPlanLanguage::Window(_) => 1,
-                    LogicalPlanLanguage::Subquery(_) => 1,
-                    _ => 0,
-                };
+                let ast_size_outside_wrapper = if is_post_processing_node(node) { 1 } else { 0 };
                 CubePlanState::Unwrapped(ast_size_outside_wrapper)
             }
         };
@@ -1028,10 +1071,16 @@ impl TopDownState<LogicalPlanLanguage> for CubePlanTopDownState {
 
         let under_limit = self.under_limit || self.introduces_limit(node, egraph);
 
+        let wrapper_depth = match node {
+            LogicalPlanLanguage::CubeScanWrapper(_) => (self.wrapper_depth + 1).min(2),
+            _ => self.wrapper_depth,
+        };
+
         Self {
             wrapped,
             limit,
             under_limit,
+            wrapper_depth,
             max_row_limit: self.max_row_limit,
         }
     }
@@ -1053,6 +1102,7 @@ impl TopDownCostFunction<LogicalPlanLanguage, CubePlanTopDownState, CubePlanCost
             &state.wrapped,
             &state.limit,
             state.under_limit,
+            state.wrapper_depth,
             node,
             CubePlanCostOptions {
                 penalize_post_processing: self.penalize_post_processing,

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -894,6 +894,10 @@ where
     .unwrap()
 }
 
+/// Every combination of one match per element of a list. `substs` holds the matches of
+/// every element back to back, `prevs` links each match to a match of the previous element
+/// that agrees with it on the top level variables, and `start` marks the last element's range,
+/// so walking `prevs` from there spells out a combination.
 struct ListMatches {
     len: usize,
     substs: Vec<Subst>,
@@ -918,6 +922,14 @@ impl ListMatches {
             f(&substs);
         }
     }
+}
+
+/// Every match of every element of a list, kept apart per element rather than combined,
+/// for an applier that builds each element from all of its matches at once: the
+/// combinations are not needed there, and their count is the product of the alternatives.
+/// One group per assignment of the top level variables, an element's matches at its index.
+struct ListElemMatches {
+    groups: Vec<Vec<Vec<Subst>>>,
 }
 
 #[derive(Clone, PartialEq)]
@@ -981,6 +993,9 @@ struct ListNodeSearcher {
     /// union, and folding a `Distinct` into a single-query one would drop the deduplication
     /// with no operator to render it on.
     min_elements: usize,
+    /// Report the matches of every element as [`ListElemMatches`] instead of combining them
+    /// into [`ListMatches`]. Only for an applier that consumes them per element.
+    per_elem: bool,
 }
 
 impl ListNodeSearcher {
@@ -992,7 +1007,13 @@ impl ListNodeSearcher {
             elem_pattern: elem_pattern.parse().unwrap(),
             top_level_elem_vars: vec![],
             min_elements: 1,
+            per_elem: false,
         }
+    }
+
+    fn with_per_elem_matches(mut self) -> Self {
+        self.per_elem = true;
+        self
     }
 
     fn with_min_elements(mut self, min_elements: usize) -> Self {
@@ -1080,6 +1101,11 @@ impl ListNodeSearcher {
                 continue;
             }
 
+            if self.per_elem {
+                self.search_elem_matches(egraph, limit, list_children, list_subst, output);
+                continue;
+            }
+
             let mut list_matches = ListMatches {
                 len: list_children.len(),
                 substs: vec![],
@@ -1125,6 +1151,57 @@ impl ListNodeSearcher {
                 subst.data = Some(Arc::new(list_matches));
                 output.push(subst);
             }
+        }
+    }
+
+    /// Collect the matches of every element into [`ListElemMatches`]: grouped by the values
+    /// of the top level variables, so a group holds only matches that agree on them, and
+    /// dropped when any element has no match in it. `limit` caps the matches of every
+    /// element and ends its search there; the combining path caps only its first element.
+    fn search_elem_matches(
+        &self,
+        egraph: &CubeEGraph,
+        limit: usize,
+        list_children: &[Id],
+        list_subst: &Subst,
+        output: &mut Vec<Subst>,
+    ) {
+        let mut groups: Vec<(Vec<Option<Id>>, Vec<Vec<Subst>>)> = vec![];
+        for (index, &list_child) in list_children.iter().enumerate() {
+            let mut kept = 0;
+            self.elem_pattern
+                .search_eclass_with_fn(egraph, list_child, |subst| {
+                    if kept >= limit {
+                        return Err(());
+                    }
+                    kept += 1;
+                    let key = self
+                        .top_level_elem_vars
+                        .iter()
+                        .map(|&v| subst.get(v).copied())
+                        .collect::<Vec<_>>();
+                    let group = match groups.iter_mut().find(|(k, _)| *k == key) {
+                        Some((_, group)) => group,
+                        None => {
+                            groups.push((key, vec![vec![]; list_children.len()]));
+                            &mut groups.last_mut().unwrap().1
+                        }
+                    };
+                    group[index].push(subst.clone());
+                    Ok(())
+                })
+                .unwrap_or_default();
+        }
+
+        let groups = groups
+            .into_iter()
+            .map(|(_, group)| group)
+            .filter(|group| group.iter().all(|substs| !substs.is_empty()))
+            .collect::<Vec<_>>();
+        if !groups.is_empty() {
+            let mut subst = list_subst.clone();
+            subst.data = Some(Arc::new(ListElemMatches { groups }));
+            output.push(subst);
         }
     }
 }
@@ -1249,12 +1326,23 @@ struct ListNodeApplier {
     /// searcher binds every variable the applier uses, so a typo anywhere else in the
     /// applier still fails when the rule is built rather than when it first matches.
     transform_vars: Vec<Var>,
+    /// Build every list element from the class all of the element's matches resolve to,
+    /// instead of building one list per combination of matches. The searcher has to report
+    /// [`ListElemMatches`] for this. Every list gets one node per group of matches, so the
+    /// elements' alternatives never multiply the nodes of the list or of anything built on
+    /// top of it.
+    per_elem: bool,
 }
 
 impl ListNodeApplier {
     fn with_transform(mut self, transform: ListNodeTransform, transform_vars: &[&str]) -> Self {
         self.transform = Some(transform);
         self.transform_vars = transform_vars.iter().map(|v| v.parse().unwrap()).collect();
+        self
+    }
+
+    fn with_per_elem_matches(mut self) -> Self {
+        self.per_elem = true;
         self
     }
 }
@@ -1283,6 +1371,7 @@ impl ListNodeApplier {
         Self {
             transform: None,
             transform_vars: vec![],
+            per_elem: false,
             list_pattern: list_pattern.parse().unwrap(),
             lists: lists
                 .into_iter()
@@ -1309,6 +1398,14 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
             .data
             .as_ref()
             .expect("no data, did you use ListNodeSearcher?");
+
+        if self.per_elem {
+            let elem_matches = data
+                .downcast_ref::<ListElemMatches>()
+                .expect("wrong data type, did you use ListNodeSearcher::with_per_elem_matches?");
+            return self.apply_per_elem(egraph, eclass, subst, elem_matches);
+        }
+
         let list_matches = data.downcast_ref::<ListMatches>().expect("wrong data type");
 
         let mut subst = subst.clone();
@@ -1351,6 +1448,71 @@ impl Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for ListNodeApplier {
         }
         vars.retain(|v| !self.transform_vars.contains(v)); // and these by the transform
         vars
+    }
+}
+
+impl ListNodeApplier {
+    /// Instantiate every list once per group. An element's node is instantiated from each of
+    /// its matches and all of them have to resolve to one class, which is what the list
+    /// holds: that is the case with the searcher's own element pattern, where every match
+    /// maps back to the class the element was matched in, and anything else would put
+    /// unrelated plans into one class, so it is asserted. The transform and the list pattern
+    /// see the top level variables and the element variables of the first match of the
+    /// first element, so they must not depend on which alternative of an element that is.
+    fn apply_per_elem(
+        &self,
+        egraph: &mut CubeEGraph,
+        mut eclass: Id,
+        subst: &Subst,
+        elem_matches: &ListElemMatches,
+    ) -> Vec<Id> {
+        let mut result_ids = vec![];
+        for group in &elem_matches.groups {
+            let mut subst = subst.clone();
+            for list in &self.lists {
+                let new_list = group
+                    .iter()
+                    .map(|elem_substs| {
+                        let instantiate = |egraph: &mut CubeEGraph, elem_subst: &Subst| {
+                            let mut subst = subst.clone();
+                            subst.extend(elem_subst.iter());
+                            egraph.add_instantiation(&list.elem_pattern, &subst)
+                        };
+                        let elem = instantiate(egraph, &elem_substs[0]);
+                        let elem = egraph.find(elem);
+                        // The other alternatives are instantiated only to be checked, so
+                        // only where the check runs
+                        if cfg!(debug_assertions) {
+                            for elem_subst in &elem_substs[1..] {
+                                let id = instantiate(egraph, elem_subst);
+                                assert_eq!(
+                                    egraph.find(id),
+                                    elem,
+                                    "the applier's element pattern must be the searcher's, \
+                                     so every alternative resolves to the element's class"
+                                );
+                            }
+                        }
+                        elem
+                    })
+                    .collect();
+
+                subst.insert(list.new_list_var, egraph.add(list.make_node(new_list)));
+            }
+            subst.extend(group[0][0].iter());
+            if let Some(transform) = &self.transform {
+                if !transform(egraph, &mut subst) {
+                    continue;
+                }
+            }
+            let new_id = egraph.add_instantiation(&self.list_pattern, &subst);
+            if egraph.union(eclass, new_id) {
+                result_ids.push(new_id);
+                eclass = new_id;
+            }
+        }
+
+        result_ids
     }
 }
 
@@ -2562,6 +2724,41 @@ where
     .with_min_elements(min_elements);
     let applier = ListNodeApplier::from_lists(applier_pattern, lists)
         .with_transform(Box::new(transform_fn), transform_vars);
+    Rewrite::new(name.to_string(), searcher, applier).unwrap()
+}
+
+/// `transforming_list_rewrite_with_lists_and_vars` for a list whose elements have many
+/// alternatives each: rather than one list per combination of alternatives, their product,
+/// every list element is built from all of the element's alternatives at once, so the list,
+/// and everything the rewrite builds on it, is a single node no matter how many forms each
+/// element takes. See [`ListNodeApplier::apply_per_elem`] for what the element pattern of
+/// an applier list may be.
+pub fn transforming_list_rewrite_per_elem_with_lists_and_vars<T>(
+    name: &str,
+    list_type: ListType,
+    searcher: ListPattern,
+    applier_pattern: &str,
+    lists: impl IntoIterator<Item = ListApplierListPattern>,
+    top_level_elem_vars: &[&str],
+    min_elements: usize,
+    transform_vars: &[&str],
+    transform_fn: T,
+) -> CubeRewrite
+where
+    T: Fn(&mut CubeEGraph, &mut Subst) -> bool + Sync + Send + 'static,
+{
+    let searcher = ListNodeSearcher::new(
+        list_type,
+        &searcher.list_var,
+        &searcher.pattern,
+        &searcher.elem,
+    )
+    .with_top_level_elem_vars(top_level_elem_vars)
+    .with_min_elements(min_elements)
+    .with_per_elem_matches();
+    let applier = ListNodeApplier::from_lists(applier_pattern, lists)
+        .with_transform(Box::new(transform_fn), transform_vars)
+        .with_per_elem_matches();
     Rewrite::new(name.to_string(), searcher, applier).unwrap()
 }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/union.rs
@@ -3,7 +3,7 @@ use crate::{
         cube_scan_wrapper, distinct, rewrite,
         rewriter::{CubeEGraph, CubeRewrite},
         rules::wrapper::WrapperRules,
-        transforming_list_rewrite_with_lists_and_vars, union, wrapped_union,
+        transforming_list_rewrite_per_elem_with_lists_and_vars, union, wrapped_union,
         wrapper_pullup_replacer, wrapper_replacer_context, ListApplierListPattern, ListPattern,
         ListType, LogicalPlanLanguage, UnionAlias, WrappedUnionAlias,
         WrapperReplacerContextAliasToCube, WrapperReplacerContextGroupedSubqueries,
@@ -16,34 +16,42 @@ use egg::Subst;
 
 impl WrapperRules {
     pub fn union_rules(&self, rules: &mut Vec<CubeRewrite>) {
+        // A query of the union, pulled up and ready: there is nothing left to push into it
+        let query = cube_scan_wrapper(
+            wrapper_pullup_replacer(
+                "?elem",
+                wrapper_replacer_context(
+                    "?elem_alias_to_cube",
+                    "?elem_push_to_cube",
+                    "?elem_in_projection",
+                    "?elem_cube_members",
+                    "?elem_grouped_subqueries",
+                    "?elem_ungrouped_scan",
+                    "?input_data_source",
+                ),
+            ),
+            "CubeScanWrapperFinalized:false",
+        );
         rules.extend(vec![
             // The queries of a union arrive already pulled up, so there is nothing to push
-            // into them: the whole list is matched at once and every query is unwrapped into
-            // the set operation. `?input_data_source` is a top level element variable, so
-            // every query has to reach the same data source for this to match at all — a
-            // union spanning two of them is left to post processing without a check of its
-            // own.
-            transforming_list_rewrite_with_lists_and_vars(
+            // into them: the whole list is matched at once and the set operation is built
+            // over them. `?input_data_source` is a top level element variable, so every
+            // query has to reach the same data source for this to match at all: a union
+            // spanning two of them is left to post processing without a check of its own.
+            //
+            // The element pattern of the new list is the matched query itself, so each
+            // element resolves to the query's class whichever of its pulled up forms
+            // matched, and the union is one node rather than one per combination of forms.
+            // Extraction picks the form of each query, in the wrapper's state (see
+            // `plan_nodes_inside_wrapper` in `cost.rs`), and SQL generation reads the
+            // nested wrapper as the query it holds.
+            transforming_list_rewrite_per_elem_with_lists_and_vars(
                 "wrapper-pull-up-union",
                 ListType::UnionInputs,
                 ListPattern {
                     pattern: union("?list", "?union_alias"),
                     list_var: "?list".to_string(),
-                    elem: cube_scan_wrapper(
-                        wrapper_pullup_replacer(
-                            "?elem",
-                            wrapper_replacer_context(
-                                "?elem_alias_to_cube",
-                                "?elem_push_to_cube",
-                                "?elem_in_projection",
-                                "?elem_cube_members",
-                                "?elem_grouped_subqueries",
-                                "?elem_ungrouped_scan",
-                                "?input_data_source",
-                            ),
-                        ),
-                        "CubeScanWrapperFinalized:false",
-                    ),
+                    elem: query.clone(),
                 },
                 &cube_scan_wrapper(
                     wrapper_pullup_replacer(
@@ -69,7 +77,7 @@ impl WrapperRules {
                 [ListApplierListPattern {
                     list_type: ListType::WrappedUnionInputs,
                     new_list_var: "?new_list".to_string(),
-                    elem_pattern: "?elem".to_string(),
+                    elem_pattern: query,
                 }],
                 &["?input_data_source"],
                 // One query is not a union, and folding a `Distinct` into a single query

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -4202,3 +4202,97 @@ async fn test_wrapper_multi_arg_aggregate_function_without_template() {
         error
     );
 }
+
+/// A pivot with subtotals on both axes: a four-way union of
+/// aggregations, one per grouping set, each filtered before and after aggregating and
+/// projected with literals, under a grouping, sort and limit that read the union. Every
+/// query has several pushed down forms, and a union that spelled out every combination of
+/// them would blow past the node limit of the rewrite before rules on top of the union even
+/// start multiplying it.
+#[tokio::test]
+async fn test_wrapper_union_of_many_form_queries_stays_within_node_limit() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query = |gender: bool, note: bool| {
+        let group_by = match (gender, note) {
+            (true, true) => "GROUP BY 1, 2",
+            (true, false) | (false, true) => "GROUP BY 1",
+            (false, false) => "",
+        };
+        format!(
+            "SELECT {gender_expr} AS market, {note_expr} AS note, \
+             {gender_total} AS is_market_total, {note_total} AS is_note_total, s AS total \
+             FROM (\
+               SELECT {gender_col}{note_col}SUM(sumPrice) AS s FROM KibanaSampleDataEcommerce \
+               WHERE order_date >= '2024-01-01' {group_by}\
+             ) q WHERE s IS NOT NULL",
+            gender_expr = if gender {
+                "customer_gender"
+            } else {
+                "CAST(NULL AS TEXT)"
+            },
+            note_expr = if note { "notes" } else { "CAST(NULL AS TEXT)" },
+            gender_total = if gender { "FALSE" } else { "TRUE" },
+            note_total = if note { "FALSE" } else { "TRUE" },
+            gender_col = if gender { "customer_gender, " } else { "" },
+            note_col = if note { "notes, " } else { "" },
+        )
+    };
+    let sql = format!(
+        "SELECT note, is_note_total FROM ({} UNION ALL {} UNION ALL {} UNION ALL {}) core \
+         GROUP BY 1, 2 ORDER BY 2, 1 LIMIT 102",
+        query(true, true),
+        query(true, false),
+        query(false, true),
+        query(false, false),
+    );
+
+    let sql = convert_select_to_query_plan(sql, DatabaseProtocol::PostgreSQL)
+        .await
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+
+    assert_eq!(
+        sql.matches("UNION ALL").count(),
+        3,
+        "all four queries are pushed down in one union: {}",
+        sql
+    );
+    // Each query keeps its own grouping: the subtotal queries stand in a NULL for the
+    // column they roll up, two for each column and none twice over
+    assert_eq!(
+        sql.matches("CAST(NULL AS STRING) \"market\"").count(),
+        2,
+        "two queries roll up the market: {}",
+        sql
+    );
+    assert_eq!(
+        sql.matches("CAST(NULL AS STRING) \"note\"").count(),
+        2,
+        "two queries roll up the note: {}",
+        sql
+    );
+    // Each query keeps both of its filters: the one before aggregating and the one after
+    assert_eq!(
+        sql.matches("afterOrOnDate").count(),
+        4,
+        "every query filters by date before aggregating: {}",
+        sql
+    );
+    assert_eq!(
+        sql.matches("\"operator\": \"set\"").count(),
+        4,
+        "every query drops empty totals after aggregating: {}",
+        sql
+    );
+    assert!(
+        sql.contains("GROUP BY 1, 2") && sql.contains("LIMIT 102"),
+        "the grouping and limit above the union are pushed down with it: {}",
+        sql
+    );
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR makes `wrapper-pull-up-union` build one `WrappedUnion` over the classes of its queries instead of one per combination of their pulled up forms, which grew as k^n and ran a four-way union of aggregations past any node limit. Related test is included.
