### PR TITLE
fix(cubesql): Allow SQL pushdown for views spanning several data sources

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -491,6 +491,8 @@ crate::plan_to_language! {
             // Data source restriction for SQL generation imposed by `input` of LP node being rewritten
             // Will be provided from top, when wrapping new LP node, and for initial CubeScan wrap
             // `None` means it is not restricted yet, any data source could work here
+            // A scan over a view spanning data sources gets one context per data source it
+            // reaches, and only members of that data source are pushed into each of them
             input_data_source: Option<String>,
         },
         WrapperPushdownReplacer {
@@ -823,6 +825,27 @@ where
         TransformingPattern::new(applier.as_str(), move |egraph, _, subst| {
             transform_fn(egraph, subst)
         }),
+    )
+    .unwrap()
+}
+
+/// [`transforming_rewrite`] whose transform yields any number of substitutions, each applied
+/// as its own instance of the applier pattern and unioned with the matched class. For a
+/// match that has several valid outcomes at once, like a scan over a view spanning data
+/// sources that gets one wrapper context per data source.
+pub fn transforming_rewrite_multi<T>(
+    name: &str,
+    searcher: String,
+    applier: String,
+    transform_fn: T,
+) -> CubeRewrite
+where
+    T: Fn(&mut CubeEGraph, &Subst) -> Vec<Subst> + Sync + Send + 'static,
+{
+    Rewrite::new(
+        name.to_string(),
+        searcher.parse::<Pattern<LogicalPlanLanguage>>().unwrap(),
+        MultiTransformingPattern::new(applier.as_str(), transform_fn),
     )
     .unwrap()
 }
@@ -2693,6 +2716,48 @@ where
         } else {
             Vec::new()
         }
+    }
+}
+
+pub struct MultiTransformingPattern<T>
+where
+    T: Fn(&mut CubeEGraph, &Subst) -> Vec<Subst>,
+{
+    pattern: Pattern<LogicalPlanLanguage>,
+    substitutions: T,
+}
+
+impl<T> MultiTransformingPattern<T>
+where
+    T: Fn(&mut CubeEGraph, &Subst) -> Vec<Subst>,
+{
+    pub fn new(pattern: &str, substitutions: T) -> Self {
+        Self {
+            pattern: pattern.parse().unwrap(),
+            substitutions,
+        }
+    }
+}
+
+impl<T> Applier<LogicalPlanLanguage, LogicalPlanAnalysis> for MultiTransformingPattern<T>
+where
+    T: Fn(&mut CubeEGraph, &Subst) -> Vec<Subst>,
+{
+    fn apply_one(
+        &self,
+        egraph: &mut CubeEGraph,
+        eclass: Id,
+        subst: &Subst,
+        searcher_ast: Option<&PatternAst<LogicalPlanLanguage>>,
+        rule_name: Symbol,
+    ) -> Vec<Id> {
+        (self.substitutions)(egraph, subst)
+            .iter()
+            .flat_map(|subst| {
+                self.pattern
+                    .apply_one(egraph, eclass, subst, searcher_ast, rule_name)
+            })
+            .collect()
     }
 }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
@@ -292,6 +292,7 @@ impl WrapperRules {
                         "?out_measure_expr",
                         "?out_measure_alias",
                         "?alias_to_cube",
+                        "?input_data_source",
                     ),
                 )
             },
@@ -400,6 +401,7 @@ impl WrapperRules {
                     "?fun",
                     "?distinct",
                     "?cube_members",
+                    "?input_data_source",
                     "?replace_agg_type",
                     "?out_measure_alias",
                 ),
@@ -461,6 +463,7 @@ impl WrapperRules {
                     "?fun",
                     "?distinct",
                     "?cube_members",
+                    "?input_data_source",
                     "?replace_agg_type",
                     "?out_measure_alias",
                 ),
@@ -1161,10 +1164,17 @@ impl WrapperRules {
         out_expr_var: Var,
         out_alias_var: Var,
         alias_to_cube_var: Var,
+        input_data_source_var: Var,
         meta: &MetaContext,
         disable_strict_agg_type_match: bool,
     ) -> bool {
         let Some(alias) = original_expr_name(egraph, subst[original_expr_var]) else {
+            return false;
+        };
+        // Read before members are resolved, which holds the e-graph mutably
+        let Ok(context_data_source) =
+            Self::context_data_source(egraph, subst, input_data_source_var, meta)
+        else {
             return false;
         };
 
@@ -1225,6 +1235,10 @@ impl WrapperRules {
                                     &column.name,
                                 )
                             {
+                                if !Self::member_fits_data_source(context_data_source, meta, member)
+                                {
+                                    continue;
+                                }
                                 if let Some(measure) = meta.find_measure_with_name(member) {
                                     let Some(call_agg_type) = &call_agg_type else {
                                         // call_agg_type is None, rewrite as is
@@ -1296,6 +1310,7 @@ impl WrapperRules {
         out_expr_var: &'static str,
         out_alias_var: &'static str,
         alias_to_cube_var: &'static str,
+        input_data_source_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let original_expr_var = var!(original_expr_var);
         let column_var = column_var.map(|v| var!(v));
@@ -1306,6 +1321,7 @@ impl WrapperRules {
         let out_expr_var = var!(out_expr_var);
         let out_alias_var = var!(out_alias_var);
         let alias_to_cube_var = var!(alias_to_cube_var);
+        let input_data_source_var = var!(input_data_source_var);
         let meta = self.meta_context.clone();
         let disable_strict_agg_type_match = self.config_obj.disable_strict_agg_type_match();
         move |egraph, subst| {
@@ -1320,6 +1336,7 @@ impl WrapperRules {
                 out_expr_var,
                 out_alias_var,
                 alias_to_cube_var,
+                input_data_source_var,
                 &meta,
                 disable_strict_agg_type_match,
             )
@@ -1403,6 +1420,7 @@ impl WrapperRules {
         fun_name_var: &'static str,
         distinct_var: &'static str,
         cube_members_var: &'static str,
+        input_data_source_var: &'static str,
         replace_agg_type_var: &'static str,
         out_measure_alias_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
@@ -1412,6 +1430,7 @@ impl WrapperRules {
         let fun_name_var = var!(fun_name_var);
         let distinct_var = var!(distinct_var);
         let cube_members_var = var!(cube_members_var);
+        let input_data_source_var = var!(input_data_source_var);
         let replace_agg_type_var = var!(replace_agg_type_var);
         let out_measure_alias_var = var!(out_measure_alias_var);
 
@@ -1431,6 +1450,12 @@ impl WrapperRules {
             };
 
             let Some(alias) = original_expr_name(egraph, subst[aggr_expr_var]) else {
+                return false;
+            };
+            // Read before members are resolved, which holds the e-graph mutably
+            let Ok(context_data_source) =
+                Self::context_data_source(egraph, subst, input_data_source_var, &meta)
+            else {
                 return false;
             };
 
@@ -1466,6 +1491,10 @@ impl WrapperRules {
                         else {
                             continue;
                         };
+
+                        if !Self::member_fits_data_source(context_data_source, &meta, member) {
+                            continue;
+                        }
 
                         let Some(measure) = meta.find_measure_with_name(member) else {
                             continue;

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/column.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/column.rs
@@ -70,7 +70,7 @@ impl WrapperRules {
                         "?input_data_source",
                     ),
                 ),
-                self.pushdown_simple_measure("?name", "?cube_members"),
+                self.pushdown_simple_measure("?name", "?cube_members", "?input_data_source"),
             ),
             // TODO time dimension support
             transforming_rewrite(
@@ -105,6 +105,7 @@ impl WrapperRules {
                     "?cube_members",
                     "?dimension",
                     "?grouped_subqueries",
+                    "?input_data_source",
                 ),
             ),
         ]);
@@ -117,16 +118,25 @@ impl WrapperRules {
         members_var: &'static str,
         dimension_var: &'static str,
         grouped_subqueries_var: &'static str,
+        input_data_source_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let alias_to_cube_var = var!(alias_to_cube_var);
         let column_name_var = var!(column_name_var);
         let members_var = var!(members_var);
         let dimension_var = var!(dimension_var);
         let grouped_subqueries_var = var!(grouped_subqueries_var);
+        let input_data_source_var = var!(input_data_source_var);
+        let meta = self.meta_context.clone();
         move |egraph, subst| {
             let columns: Vec<_> = var_iter!(egraph[subst[column_name_var]], ColumnExprColumn)
                 .cloned()
                 .collect();
+            let Ok(context_data_source) =
+                Self::context_data_source(egraph, subst, input_data_source_var, &meta)
+            else {
+                return false;
+            };
+
             for column in columns.iter() {
                 for alias_to_cube in var_iter!(
                     egraph[subst[alias_to_cube_var]],
@@ -188,6 +198,17 @@ impl WrapperRules {
                             | Member::VirtualField { .. }
                             | Member::LiteralMember { .. }
                     ) {
+                        // A member with a name reaches a data source; the rest (literal
+                        // members, the change user) fit any context
+                        if let Some(member_name) = member.1.name() {
+                            if !Self::member_fits_data_source(
+                                context_data_source,
+                                &meta,
+                                member_name,
+                            ) {
+                                continue;
+                            }
+                        }
                         let column_expr_column = egraph.add(LogicalPlanLanguage::ColumnExprColumn(
                             ColumnExprColumn(column.clone()),
                         ));
@@ -207,19 +228,29 @@ impl WrapperRules {
         &self,
         column_name_var: &'static str,
         members_var: &'static str,
+        input_data_source_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let column_name_var = var!(column_name_var);
         let members_var = var!(members_var);
+        let input_data_source_var = var!(input_data_source_var);
         let meta = self.meta_context.clone();
         move |egraph, subst| {
             let columns: Vec<_> = var_iter!(egraph[subst[column_name_var]], ColumnExprColumn)
                 .cloned()
                 .collect();
+            let Ok(context_data_source) =
+                Self::context_data_source(egraph, subst, input_data_source_var, &meta)
+            else {
+                return false;
+            };
             for column in columns {
                 if let Some(((Some(member), _, _), _)) = egraph[subst[members_var]]
                     .data
                     .find_member_by_alias(&column.name)
                 {
+                    if !Self::member_fits_data_source(context_data_source, &meta, member) {
+                        continue;
+                    }
                     if let Some(measure) = meta.find_measure_with_name(member) {
                         if measure.agg_type != Some("number".to_string()) {
                             return true;

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/cube_scan_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/cube_scan_wrapper.rs
@@ -3,22 +3,20 @@ use crate::{
         cube_scan, cube_scan_wrapper, rewrite,
         rewriter::{CubeEGraph, CubeRewrite},
         rules::wrapper::WrapperRules,
-        transforming_rewrite, wrapper_pullup_replacer, wrapper_replacer_context,
+        transforming_rewrite_multi, wrapper_pullup_replacer, wrapper_replacer_context,
         CubeScanAliasToCube, CubeScanLimit, CubeScanOffset, CubeScanUngrouped, LogicalPlanLanguage,
         WrapperReplacerContextAliasToCube, WrapperReplacerContextGroupedSubqueries,
         WrapperReplacerContextInputDataSource, WrapperReplacerContextPushToCube,
         WrapperReplacerContextUngroupedScan,
     },
-    copy_flag,
-    transport::DataSource,
-    var, var_iter,
+    copy_flag, var, var_iter,
 };
 use egg::Subst;
 
 impl WrapperRules {
     pub fn cube_scan_wrapper_rules(&self, rules: &mut Vec<CubeRewrite>) {
         rules.extend(vec![
-            transforming_rewrite(
+            transforming_rewrite_multi(
                 "wrapper-cube-scan-wrap",
                 cube_scan(
                     "?alias_to_cube",
@@ -96,7 +94,7 @@ impl WrapperRules {
         grouped_subqueries_out_var: &'static str,
         ungrouped_scan_out_var: &'static str,
         input_data_source_out_var: &'static str,
-    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+    ) -> impl Fn(&mut CubeEGraph, &Subst) -> Vec<Subst> {
         let members_var = var!(members_var);
         let alias_to_cube_var = var!(alias_to_cube_var);
         let limit_var = var!(limit_var);
@@ -109,6 +107,8 @@ impl WrapperRules {
         let input_data_source_out_var = var!(input_data_source_out_var);
         let meta = self.meta_context.clone();
         move |egraph, subst| {
+            let mut subst = subst.clone();
+
             let mut has_no_limit_or_offset = true;
             for limit in var_iter!(egraph[subst[limit_var]], CubeScanLimit).cloned() {
                 has_no_limit_or_offset &= limit.is_none();
@@ -125,25 +125,33 @@ impl WrapperRules {
                 ungrouped_scan_out_var,
                 WrapperReplacerContextUngroupedScan
             ) {
-                return false;
+                return vec![];
             }
+
+            let Some(alias_to_cube) =
+                var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube)
+                    .next()
+                    .cloned()
+            else {
+                return vec![];
+            };
+            let Some(ungrouped) = var_iter!(egraph[subst[ungrouped_cube_var]], CubeScanUngrouped)
+                .next()
+                .cloned()
+            else {
+                return vec![];
+            };
+            // When CubeScan already has limit or offset, it's unsafe to allow to push
+            // anything on top to Cube.
+            // Especially aggregation: aggregate does not commute with limit,
+            // so it would be incorrect to join them to single CubeScan
+            let push_to_cube_out = ungrouped && has_no_limit_or_offset;
 
             // This rule would wrap CubeScan, which would try to generate data source SQL for it
             // This means that CubeScan should allow for this
-            // View can reference cubes from different data sources, and should be disallowed here
-            // But
-            // During rewrites we can generate representations like CubeScan(AllMembers(view))
-            // And that would be an issue for representations like this: Aggregate(CSW(CubeScan(AllMembers(view), ungrouped=true)))
-            // In this plan aggregate can be pushed into wrapper, and it would limit members
-            // that would be actually referenced later, during SQL generation
-            // But this rule would see only AllMembers, and disallow SQL pushdown for views like that
-            // Rewriting views like this would require further limiting data sources during later rewrtie stages
-            // And, probably, penalizing multi-datasource representations in cost
-            // TODO find a clever-er way to allow SQL pushdown for multi-datasource views
-
-            let data_source = {
+            let data_sources = {
                 let Some(members) = &egraph[subst[members_var]].data.member_name_to_expr else {
-                    return false;
+                    return vec![];
                 };
 
                 let member_names = members
@@ -153,61 +161,60 @@ impl WrapperRules {
                 // TODO get all referenced members (from members, filters, order etc.)
                 let every_member_name = member_names;
 
-                meta.data_source_for_member_names(every_member_name)
+                let Ok(data_sources) = meta.data_sources_for_member_names(every_member_name) else {
+                    return vec![];
+                };
+                data_sources
             };
-            // See comment above about wrapping CubeScan(AllMembers(view), ungrouped=true)
-            let Ok(data_source) = data_source else {
-                return false;
+            // A scan that nothing is pushed into is rendered as is, so several data sources
+            // among its members cannot be resolved to one. A scan that is pushed into is
+            // narrowed later, so each data source gets its own context (`member_fits_data_source`)
+            if data_sources.len() > 1 && !push_to_cube_out {
+                return vec![];
+            }
+            let data_sources_out: Vec<Option<String>> = if data_sources.is_empty() {
+                vec![None]
+            } else {
+                data_sources
+                    .iter()
+                    .map(|data_source| Some(data_source.to_string()))
+                    .collect()
             };
 
-            for alias_to_cube in
-                var_iter!(egraph[subst[alias_to_cube_var]], CubeScanAliasToCube).cloned()
-            {
-                for ungrouped in
-                    var_iter!(egraph[subst[ungrouped_cube_var]], CubeScanUngrouped).cloned()
-                {
-                    // When CubeScan already has limit or offset, it's unsafe to allow to push
-                    // anything on top to Cube.
-                    // Especially aggregation: aggregate does not commute with limit,
-                    // so it would be incorrect to join them to single CubeScan
-                    let push_to_cube_out = ungrouped && has_no_limit_or_offset;
+            subst.insert(
+                push_to_cube_out_var,
+                egraph.add(LogicalPlanLanguage::WrapperReplacerContextPushToCube(
+                    WrapperReplacerContextPushToCube(push_to_cube_out),
+                )),
+            );
+            subst.insert(
+                alias_to_cube_var_out,
+                egraph.add(LogicalPlanLanguage::WrapperReplacerContextAliasToCube(
+                    WrapperReplacerContextAliasToCube(alias_to_cube),
+                )),
+            );
+            subst.insert(
+                grouped_subqueries_out_var,
+                egraph.add(
+                    LogicalPlanLanguage::WrapperReplacerContextGroupedSubqueries(
+                        WrapperReplacerContextGroupedSubqueries(vec![]),
+                    ),
+                ),
+            );
 
-                    let data_source_out = match data_source {
-                        DataSource::Unrestricted => None,
-                        DataSource::Specific(data_source) => Some(data_source.to_string()),
-                    };
-
+            data_sources_out
+                .into_iter()
+                .map(|data_source_out| {
+                    let mut subst = subst.clone();
                     subst.insert(
                         input_data_source_out_var,
                         egraph.add(LogicalPlanLanguage::WrapperReplacerContextInputDataSource(
                             WrapperReplacerContextInputDataSource(data_source_out),
                         )),
                     );
-                    subst.insert(
-                        push_to_cube_out_var,
-                        egraph.add(LogicalPlanLanguage::WrapperReplacerContextPushToCube(
-                            WrapperReplacerContextPushToCube(push_to_cube_out),
-                        )),
-                    );
-                    subst.insert(
-                        alias_to_cube_var_out,
-                        egraph.add(LogicalPlanLanguage::WrapperReplacerContextAliasToCube(
-                            WrapperReplacerContextAliasToCube(alias_to_cube),
-                        )),
-                    );
-                    subst.insert(
-                        grouped_subqueries_out_var,
-                        egraph.add(
-                            LogicalPlanLanguage::WrapperReplacerContextGroupedSubqueries(
-                                WrapperReplacerContextGroupedSubqueries(vec![]),
-                            ),
-                        ),
-                    );
-                    return true;
-                }
-            }
-
-            false
+                    subst
+                })
+                .collect()
         }
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -211,6 +211,48 @@ impl WrapperRules {
         })
     }
 
+    /// The data source a wrapper context is bound to, `None` when unrestricted. Borrowed from
+    /// `meta` rather than the e-graph, so a transform can hold it while resolving members,
+    /// which borrows the e-graph mutably. `Err` when the context cannot be read, or names a
+    /// data source `meta` does not know.
+    fn context_data_source<'meta>(
+        egraph: &CubeEGraph,
+        subst: &mut Subst,
+        input_data_source_var: Var,
+        meta: &'meta MetaContext,
+    ) -> Result<Option<&'meta str>, ()> {
+        let data_source =
+            Self::get_data_source(egraph, subst, input_data_source_var).map_err(|_| ())?;
+        let Some(data_source) = data_source.specific() else {
+            return Ok(None);
+        };
+        meta.data_source_to_sql_generator
+            .get_key_value(data_source)
+            .map(|(data_source, _)| Some(data_source.as_str()))
+            .ok_or(())
+    }
+
+    /// Whether `member` may be pushed into a wrapper context bound to `data_source`, as read
+    /// with [`Self::context_data_source`] (`None` is unrestricted). A scan over a view spanning
+    /// data sources gets one context per data source it reaches, so a pushed down select is
+    /// complete only when every member it references shares one, and that is the data source
+    /// SQL generation resolves to. A member reaching no data source of its own, like a
+    /// synthetic field, fits any.
+    fn member_fits_data_source(
+        data_source: Option<&str>,
+        meta: &MetaContext,
+        member: &str,
+    ) -> bool {
+        let Some(data_source) = data_source else {
+            return true;
+        };
+        match meta.data_source_for_member_name(member) {
+            Ok(DataSource::Unrestricted) => true,
+            Ok(DataSource::Specific(member_data_source)) => member_data_source == data_source,
+            Err(_) => false,
+        }
+    }
+
     fn can_rewrite_template(data_source: &DataSource, meta: &MetaContext, template: &str) -> bool {
         let sql_generator = match data_source {
             DataSource::Specific(data_source) => {

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -889,6 +889,113 @@ pub fn get_test_tenant_ctx_with_cube_data_sources(
     ))
 }
 
+/// The standard test meta plus `MultiSourceView`, a view over `KibanaSampleDataEcommerce`
+/// and `Logs` with `Logs` reaching a second data source. Every view member reaches the data
+/// source of the member it aliases, so the view as a whole spans two data sources.
+pub fn get_test_tenant_ctx_with_multi_data_source_view() -> Arc<MetaContext> {
+    get_test_tenant_ctx_with_multi_data_source_view_and_templates(vec![])
+}
+
+/// [`get_test_tenant_ctx_with_multi_data_source_view`] with custom templates per data source
+/// (`default` and `other`), so an empty template removes it from that data source only.
+pub fn get_test_tenant_ctx_with_multi_data_source_view_and_templates(
+    custom_templates: Vec<(&str, Vec<(String, String)>)>,
+) -> Arc<MetaContext> {
+    let view_dimension = |name: &str, alias_member: &str, r#type: &str| CubeMetaDimension {
+        name: format!("MultiSourceView.{name}"),
+        r#type: r#type.to_string(),
+        alias_member: Some(alias_member.to_string()),
+        ..CubeMetaDimension::default()
+    };
+    let view_measure = |name: &str, alias_member: &str, agg_type: &str| CubeMetaMeasure {
+        name: format!("MultiSourceView.{name}"),
+        title: None,
+        short_title: None,
+        description: None,
+        r#type: "number".to_string(),
+        agg_type: Some(agg_type.to_string()),
+        meta: None,
+        alias_member: Some(alias_member.to_string()),
+        format: None,
+        format_description: None,
+        currency: None,
+    };
+
+    let mut meta = get_test_meta();
+    meta.push(CubeMeta {
+        name: "MultiSourceView".to_string(),
+        description: None,
+        title: None,
+        r#type: V1CubeMetaType::View,
+        dimensions: vec![
+            view_dimension(
+                "customer_gender",
+                "KibanaSampleDataEcommerce.customer_gender",
+                "string",
+            ),
+            view_dimension("order_date", "KibanaSampleDataEcommerce.order_date", "time"),
+            view_dimension("content", "Logs.content", "string"),
+        ],
+        measures: vec![
+            view_measure("sumPrice", "KibanaSampleDataEcommerce.sumPrice", "sum"),
+            view_measure("agentCount", "Logs.agentCount", "countDistinct"),
+        ],
+        segments: vec![],
+        joins: None,
+        folders: None,
+        nested_folders: None,
+        hierarchies: None,
+        meta: None,
+    });
+
+    let data_source_for_cube = |cube: &str| if cube == "Logs" { "other" } else { "default" };
+    // A member reaches the data source of the cube that owns it, which for a view member
+    // is the cube of the member it aliases
+    let data_source_for_member = |name: &String, alias_member: Option<&String>| {
+        let owner = alias_member.unwrap_or(name);
+        let cube = owner
+            .split_once('.')
+            .map_or(owner.as_str(), |(cube, _)| cube);
+        (name.clone(), data_source_for_cube(cube).to_string())
+    };
+    let member_to_data_source: HashMap<_, _> = meta
+        .iter()
+        .flat_map(|cube| {
+            cube.dimensions
+                .iter()
+                .map(|d| data_source_for_member(&d.name, d.alias_member.as_ref()))
+                .chain(
+                    cube.measures
+                        .iter()
+                        .map(|m| data_source_for_member(&m.name, m.alias_member.as_ref())),
+                )
+                .chain(
+                    cube.segments
+                        .iter()
+                        .map(|s| data_source_for_member(&s.name, None)),
+                )
+        })
+        .collect();
+
+    let data_source_to_sql_generator = member_to_data_source
+        .values()
+        .map(|data_source| {
+            let templates = custom_templates
+                .iter()
+                .find(|(name, _)| *name == data_source)
+                .map_or_else(Vec::new, |(_, templates)| templates.clone());
+            (data_source.clone(), sql_generator(templates))
+        })
+        .collect();
+
+    Arc::new(MetaContext::new(
+        meta,
+        member_to_data_source,
+        data_source_to_sql_generator,
+        Uuid::new_v4(),
+    ))
+}
+
 pub async fn get_test_session(
     protocol: DatabaseProtocol,
     meta_context: Arc<MetaContext>,

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1,6 +1,6 @@
 use cubeclient::models::{V1LoadRequestQuery, V1LoadRequestQueryTimeDimension};
 use datafusion::{
-    logical_plan::{JoinType, LogicalPlan, PlanVisitor},
+    logical_plan::{plan::Extension, JoinType, LogicalPlan, PlanVisitor},
     physical_plan::displayable,
     scalar::ScalarValue,
 };
@@ -11,14 +11,16 @@ use std::sync::Arc;
 
 use crate::{
     compile::{
-        engine::df::scan::MemberField,
+        engine::df::scan::{CubeScanNode, MemberField},
         rewrite::rewriter::Rewriter,
         test::{
             convert_select_to_query_plan, convert_select_to_query_plan_customized,
             convert_select_to_query_plan_with_config, convert_sql_to_cube_query, get_test_session,
             get_test_session_with_config, get_test_tenant_ctx,
-            get_test_tenant_ctx_with_cube_data_sources, init_testing_logger, member_expression_sql,
-            LogicalPlanTestUtils, TestContext,
+            get_test_tenant_ctx_with_cube_data_sources,
+            get_test_tenant_ctx_with_multi_data_source_view,
+            get_test_tenant_ctx_with_multi_data_source_view_and_templates, init_testing_logger,
+            member_expression_sql, LogicalPlanTestUtils, TestContext,
         },
         DatabaseProtocol,
     },
@@ -4295,4 +4297,331 @@ async fn test_wrapper_union_of_many_form_queries_stays_within_node_limit() {
         "the grouping and limit above the union are pushed down with it: {}",
         sql
     );
+}
+
+/// A view can include cubes from different data sources. Until a rewrite narrows a scan over
+/// it to the members a query references, the scan names every member of the view and their
+/// data sources conflict. That used to deny SQL pushdown to every query over such a view,
+/// even one that reads a single data source. A filtered measure, the shape a DAX `CALCULATE`
+/// with a column filter produces, has no plan without pushdown, so it has to keep it.
+#[tokio::test]
+async fn test_wrapper_filtered_measure_over_multi_data_source_view() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let query_plan = convert_sql_to_cube_query(
+        &"SELECT SUM(CASE WHEN customer_gender = 'female' THEN sumPrice END) AS filtered \
+          FROM MultiSourceView"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a query over one data source of the view should compile");
+
+    let request = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .request;
+    let measures = request
+        .measures
+        .expect("the filtered measure is pushed to Cube");
+    assert_eq!(measures.len(), 1, "unexpected measures: {:?}", measures);
+    let measure: serde_json::Value = serde_json::from_str(&measures[0]).unwrap();
+    assert_eq!(measure["expr"]["type"], "PatchMeasure", "{}", measures[0]);
+    assert_eq!(
+        measure["expr"]["sourceMeasure"], "MultiSourceView.sumPrice",
+        "{}",
+        measures[0]
+    );
+    assert_eq!(
+        measure["expr"]["addFilters"].as_array().map(Vec::len),
+        Some(1),
+        "{}",
+        measures[0]
+    );
+}
+
+/// The view's data sources are visited in a stable order, and every other test here reads the
+/// first one. A query over the second one alone pins that it gets its own context too, and
+/// that the filtered measure resolves to its own member.
+#[tokio::test]
+async fn test_wrapper_filtered_measure_over_multi_data_source_view_second_source() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let query_plan = convert_sql_to_cube_query(
+        &"SELECT COUNT(DISTINCT CASE WHEN content = 'error' THEN agentCount END) AS filtered \
+          FROM MultiSourceView"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a query over the view's second data source should compile");
+
+    let request = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .request;
+    let measures = request
+        .measures
+        .expect("the filtered measure is pushed to Cube");
+    assert_eq!(measures.len(), 1, "unexpected measures: {:?}", measures);
+    let measure: serde_json::Value = serde_json::from_str(&measures[0]).unwrap();
+    assert_eq!(measure["expr"]["type"], "PatchMeasure", "{}", measures[0]);
+    assert_eq!(
+        measure["expr"]["sourceMeasure"], "MultiSourceView.agentCount",
+        "{}",
+        measures[0]
+    );
+    assert_eq!(
+        measure["expr"]["addFilters"].as_array().map(Vec::len),
+        Some(1),
+        "{}",
+        measures[0]
+    );
+}
+
+/// The same view read across both of its data sources has no single data source to run on.
+/// Each data source has its own wrapper context and only takes members of its own, so no
+/// pushed down form of the query completes, and it is refused like any other query without
+/// a plan.
+#[tokio::test]
+async fn test_wrapper_multi_data_source_view_across_data_sources_fails() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let error = convert_sql_to_cube_query(
+        &"SELECT SUM(CASE WHEN content = 'error' THEN sumPrice END) AS filtered \
+          FROM MultiSourceView"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect_err("a query across two data sources should not compile");
+
+    assert!(
+        error.to_string().contains("Can't detect Cube query"),
+        "unexpected error: {}",
+        error
+    );
+}
+
+/// Plain members over a view spanning data sources need no pushdown, and keep going to Cube
+/// as a regular scan.
+#[tokio::test]
+async fn test_wrapper_multi_data_source_view_plain_query_not_wrapped() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT customer_gender, SUM(sumPrice) AS total FROM MultiSourceView GROUP BY 1"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a plain query over the view should compile")
+    .as_logical_plan();
+
+    let root_is_plain_scan = match &logical_plan {
+        LogicalPlan::Extension(Extension { node }) => {
+            node.as_any().downcast_ref::<CubeScanNode>().is_some()
+        }
+        _ => false,
+    };
+    assert!(
+        root_is_plain_scan,
+        "plain members should not need SQL pushdown: {:?}",
+        logical_plan
+    );
+}
+
+/// A wrapper context over a view spanning data sources is bound to the data source of the
+/// members the query references, and a template it cannot render keeps the expression in
+/// post processing. A window function is a shape the cost model always prefers to push down.
+#[tokio::test]
+async fn test_wrapper_multi_data_source_view_missing_template_stays_post_processed() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let no_window_function = vec![("expressions/window_function".to_string(), "".to_string())];
+    let meta = get_test_tenant_ctx_with_multi_data_source_view_and_templates(vec![
+        ("default", no_window_function.clone()),
+        ("other", no_window_function),
+    ]);
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT g, ROW_NUMBER() OVER (ORDER BY g) AS rn \
+          FROM (SELECT customer_gender AS g, SUM(sumPrice) AS s FROM MultiSourceView GROUP BY 1) q"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a window function without a template should compile through post processing")
+    .as_logical_plan();
+
+    assert!(
+        matches!(logical_plan, LogicalPlan::Projection(_)),
+        "the window function is left to post processing: {:?}",
+        logical_plan
+    );
+}
+
+/// The wrapper context of a query over a view spanning data sources is bound to the data
+/// source of the members it references, so a template check is exact: the window function
+/// here lands on `default`, which can render it, and only `other` cannot.
+#[tokio::test]
+async fn test_wrapper_multi_data_source_view_template_missing_in_other_source_pushes_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view_and_templates(vec![(
+        "other",
+        vec![("expressions/window_function".to_string(), "".to_string())],
+    )]);
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT f, ROW_NUMBER() OVER (ORDER BY f) AS rn \
+          FROM (SELECT SUM(CASE WHEN customer_gender = 'female' THEN sumPrice END) AS f \
+                FROM MultiSourceView) q"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a window function over a filtered measure should compile")
+    .as_logical_plan();
+
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("OVER"),
+        "the window function is pushed down to the data source that renders it: {}",
+        sql
+    );
+}
+
+/// Queries over a view spanning data sources are each bound to the data source of the members
+/// they reference. Two of them on the same data source push down as one set operation.
+#[tokio::test]
+async fn test_wrapper_union_over_multi_data_source_view_same_source_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT SUM(CASE WHEN customer_gender = 'female' THEN sumPrice END) AS f \
+          FROM MultiSourceView \
+          UNION ALL \
+          SELECT SUM(CASE WHEN customer_gender = 'male' THEN sumPrice END) AS f \
+          FROM MultiSourceView"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a union over the view should compile")
+    .as_logical_plan();
+
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("UNION ALL"),
+        "the union is pushed down: {}",
+        sql
+    );
+}
+
+/// Two queries over the same view bound to different data sources cannot be rendered by one
+/// of them, so the union stays in post processing.
+#[tokio::test]
+async fn test_wrapper_union_over_multi_data_source_view_across_sources_not_pushed_down() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let meta = get_test_tenant_ctx_with_multi_data_source_view();
+    let logical_plan = convert_sql_to_cube_query(
+        &"SELECT SUM(CASE WHEN customer_gender = 'female' THEN sumPrice END) AS f \
+          FROM MultiSourceView \
+          UNION ALL \
+          SELECT COUNT(DISTINCT CASE WHEN content = 'error' THEN agentCount END) AS f \
+          FROM MultiSourceView"
+            .to_string(),
+        meta.clone(),
+        get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+    )
+    .await
+    .expect("a union across the view's data sources should compile")
+    .as_logical_plan();
+
+    assert!(
+        matches!(logical_plan, LogicalPlan::Union(_)),
+        "the union is left to post processing: {:?}",
+        logical_plan
+    );
+    assert_eq!(
+        logical_plan.find_cube_scans().len(),
+        2,
+        "every query keeps its own scan: {:?}",
+        logical_plan
+    );
+}
+
+/// A query grouping members from both data sources of the view has no pushed down form, but
+/// Cube can still serve it as a plain scan (a rollup join pre-aggregation, for one). Shapes
+/// the cost model likes to push down, a window function or a limit with an ordering
+/// expression, must keep that plain scan under post processing rather than pick a pushed
+/// down form that SQL generation cannot render.
+#[tokio::test]
+async fn test_wrapper_multi_data_source_view_cross_source_query_stays_plain() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    for sql in [
+        "SELECT g, c, ROW_NUMBER() OVER (ORDER BY g) AS rn \
+         FROM (SELECT customer_gender AS g, content AS c, SUM(sumPrice) AS s \
+               FROM MultiSourceView GROUP BY 1, 2) q",
+        "SELECT customer_gender, content, SUM(sumPrice) AS s FROM MultiSourceView \
+         GROUP BY 1, 2 ORDER BY LOWER(content) LIMIT 5",
+    ] {
+        let meta = get_test_tenant_ctx_with_multi_data_source_view();
+        let logical_plan = convert_sql_to_cube_query(
+            &sql.to_string(),
+            meta.clone(),
+            get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
+        )
+        .await
+        .expect("a query across the view's data sources should compile as a plain scan")
+        .as_logical_plan();
+
+        let cube_scan = logical_plan.find_cube_scan();
+        assert_eq!(
+            cube_scan.request.dimensions.as_deref().map(<[String]>::len),
+            Some(2),
+            "both dimensions go to Cube in one plain scan: {:?}",
+            logical_plan
+        );
+    }
 }

--- a/rust/cubesql/cubesql/src/transport/ctx.rs
+++ b/rust/cubesql/cubesql/src/transport/ctx.rs
@@ -56,6 +56,14 @@ pub enum DataSourceError {
 }
 
 impl<'meta> DataSource<'meta> {
+    /// The data source when there is a specific one, `None` when unrestricted.
+    pub fn specific(&self) -> Option<&'meta str> {
+        match self {
+            DataSource::Unrestricted => None,
+            DataSource::Specific(data_source) => Some(data_source),
+        }
+    }
+
     pub fn specific_or<E>(self, err: E) -> Result<&'meta str, E> {
         match self {
             DataSource::Unrestricted => Err(err),
@@ -148,6 +156,27 @@ impl MetaContext {
             .into_iter()
             .map(|member| self.data_source_for_member_name(member))
             .try_fold(DataSource::Unrestricted, |l, r| l.merge(&r?))
+    }
+
+    /// Every data source reached by `members`, sorted and without duplicates. Unlike
+    /// [`Self::data_source_for_member_names`] this does not treat several data sources as
+    /// a conflict: members of a view can come from different data sources, and a caller
+    /// that does not know yet which of them a query will use keeps them all as the bound.
+    /// Synthetic fields reach no data source of their own and add nothing.
+    pub fn data_sources_for_member_names<'mem>(
+        &self,
+        members: impl IntoIterator<Item = &'mem str>,
+    ) -> Result<Vec<&str>, DataSourceError> {
+        // This runs inside rewrite transforms, so it stays a single allocation
+        let mut data_sources: Vec<&str> = Vec::new();
+        for member in members {
+            if let DataSource::Specific(data_source) = self.data_source_for_member_name(member)? {
+                data_sources.push(data_source);
+            }
+        }
+        data_sources.sort_unstable();
+        data_sources.dedup();
+        Ok(data_sources)
     }
 
     /// Data source for a cube or a view as a whole.
@@ -479,6 +508,46 @@ mod tests {
         assert!(matches!(
             ctx.data_source_for_cube_name("everything"),
             Ok(DataSource::Specific("analytics"))
+        ));
+    }
+
+    /// Members on several data sources are all kept, once each and in a stable order, so
+    /// that a caller can carry them as a bound; a member without a data source is still
+    /// an error, and synthetic fields add nothing.
+    #[test]
+    fn test_data_sources_for_member_names() {
+        let ctx = MetaContext::new(
+            vec![
+                cube_with_members("orders", &["orders.status"]),
+                cube_with_members("visits", &["visits.url"]),
+                cube_with_members("logs", &["logs.line"]),
+            ],
+            HashMap::from([
+                ("orders.status".to_string(), "warehouse".to_string()),
+                ("visits.url".to_string(), "analytics".to_string()),
+            ]),
+            HashMap::new(),
+            Uuid::new_v4(),
+        );
+
+        assert_eq!(
+            ctx.data_sources_for_member_names(vec![
+                "visits.url",
+                "orders.status",
+                "orders.__user",
+                "visits.url",
+            ])
+            .unwrap(),
+            vec!["analytics", "warehouse"]
+        );
+        assert_eq!(
+            ctx.data_sources_for_member_names(vec!["orders.__user"])
+                .unwrap(),
+            Vec::<&str>::new()
+        );
+        assert!(matches!(
+            ctx.data_sources_for_member_names(vec!["orders.status", "logs.line"]),
+            Err(DataSourceError::Missing(member)) if member == "logs.line"
         ));
     }
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR allows SQL pushdown for queries over views whose cubes span several data sources, giving such a scan one wrapper context per data source it reaches and pushing a member only into the context of its own data source, so a pushed down select completes only when everything it references shares one.

**Notes**

- A scan over a view spanning data sources is now explored under one wrapper context per data source it reaches, so planning for such views costs somewhat more than before, when they were never wrapped at all. A select referencing members of another data source stops at the first one, so the extra work is bounded.
- Queries that reference members of two data sources are unchanged: grouped ones stay a plain scan, which a rollup join can still serve, and ones that need pushdown are still refused at rewrite with "Can't detect Cube query".
- Single data source deployments are unaffected: the scan reaches one data source, one context is produced, and every member fits it.
