### PR TITLE
docs: rollup join index best practice for partition pruning

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
@@ -1043,8 +1043,9 @@ filter on the second column of an index prunes nothing unless a partition
 happens to cover a single value of the first column.
 
 **When queries filter the joined rollup by a highly selective, single-value
-dimension, define an index that puts that dimension before the join key.** In
-the example above, if queries commonly filter users by `alt_key`, add:
+dimension, define an index that puts that dimension before the join key.**
+Suppose `users` has such a dimension, `alt_key`, and queries commonly filter on
+it. Add it to `users_rollup` and index it ahead of the join key:
 
 <CodeGroup>
 
@@ -1089,9 +1090,13 @@ cube(`users`, {
 
 Cube Store will pick `alt_key_index` for the joined side of such a query — the
 join key is still covered by the index's leading columns, it just doesn't come
-first — and prune every partition whose range excludes the filtered value. This
-pays off twice over, because the joined rollup's partitions are not split across
-workers: each worker processing the query receives all of them.
+first — and prune every partition whose range excludes the filtered value.
+
+This pays off twice over, because the joined rollup's partitions are never split
+up: only the left-most rollup is divided into batches, and every batch carries
+all partitions of the joined one. Those partitions also consume the per-batch
+join budget that bounds how large the right side of a rollup join can be, so
+pruning them can be what keeps a query planning at all.
 
 A few things to keep in mind:
 

--- a/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
@@ -1095,11 +1095,16 @@ workers: each worker processing the query receives all of them.
 
 A few things to keep in mind:
 
-- Only single-value (equality) filters prune this way. Range filters, including
-  time dimension filters, do not.
+- Only single-value (equality) filters let the filtered dimension sit ahead of
+  the join key. A range filter, including a time dimension filter, won't make
+  such an index eligible for the join — though a range filter on an index's
+  leading column does prune partitions normally.
 - The join key must still be part of the index's leading columns, together with
   the filtered dimension. Listing the filtered dimension alone, without the join
   key, makes the index unusable for the join.
+- Queries that hit the rollup join without the equality filter are planned on a
+  join-key-leading scan instead, so keep one available — the default index
+  serves that as long as the join key is the rollup's first dimension.
 - The other side of the join — typically the large rollup carrying the time
   dimension — still needs to be scanned in join-key order, and its time
   dimension filter will not prune partitions there.

--- a/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
@@ -1033,13 +1033,14 @@ With all of the above set up, making a query such as the following will now use
 
 ### Indexing the joined rollup for partition pruning
 
-A `rollup_join` can only be planned if the rollup on each side of the join has
-an index whose leading columns cover the join key — that's what `user_index`
-above is for. However, an index that *starts* with the join key gives you no
-partition pruning: Cube Store partitions are ranged by index order, so a filter
-only prunes partitions when it constrains the index's leading column. A filter
-on the second column of an index prunes nothing unless a partition happens to
-cover a single value of the first column.
+A `rollup_join` can only be planned if each side of the join can be scanned in
+join-key order — either from the rollup's default index, where dimensions come
+first, or from an explicit index whose leading columns cover the join key, like
+`user_index` above. However, an index that *starts* with the join key gives you
+no partition pruning: Cube Store partitions are ranged by index order, so a
+filter only prunes partitions when it constrains the index's leading column. A
+filter on the second column of an index prunes nothing unless a partition
+happens to cover a single value of the first column.
 
 **When queries filter the joined rollup by a highly selective, single-value
 dimension, define an index that puts that dimension before the join key.** In
@@ -1100,7 +1101,7 @@ A few things to keep in mind:
   the filtered dimension. Listing the filtered dimension alone, without the join
   key, makes the index unusable for the join.
 - The other side of the join — typically the large rollup carrying the time
-  dimension — still needs an index that starts with the join key, and its time
+  dimension — still needs to be scanned in join-key order, and its time
   dimension filter will not prune partitions there.
 - Each extra index adds build time and storage, so add one when the filter is
   both common and selective.

--- a/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx
@@ -1031,6 +1031,84 @@ With all of the above set up, making a query such as the following will now use
 }
 ```
 
+### Indexing the joined rollup for partition pruning
+
+A `rollup_join` can only be planned if the rollup on each side of the join has
+an index whose leading columns cover the join key — that's what `user_index`
+above is for. However, an index that *starts* with the join key gives you no
+partition pruning: Cube Store partitions are ranged by index order, so a filter
+only prunes partitions when it constrains the index's leading column. A filter
+on the second column of an index prunes nothing unless a partition happens to
+cover a single value of the first column.
+
+**When queries filter the joined rollup by a highly selective, single-value
+dimension, define an index that puts that dimension before the join key.** In
+the example above, if queries commonly filter users by `alt_key`, add:
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: users
+    # ...
+
+    pre_aggregations:
+      - name: users_rollup
+        dimensions:
+          - CUBE.id
+          - CUBE.name
+          - CUBE.alt_key
+
+        indexes:
+          - name: alt_key_index
+            columns:
+              - CUBE.alt_key
+              - CUBE.id
+```
+
+```javascript title="JavaScript"
+cube(`users`, {
+  // ...
+
+  pre_aggregations: {
+    users_rollup: {
+      dimensions: [CUBE.id, CUBE.name, CUBE.alt_key],
+
+      indexes: {
+        alt_key_index: {
+          columns: [CUBE.alt_key, CUBE.id]
+        }
+      }
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+Cube Store will pick `alt_key_index` for the joined side of such a query — the
+join key is still covered by the index's leading columns, it just doesn't come
+first — and prune every partition whose range excludes the filtered value. This
+pays off twice over, because the joined rollup's partitions are not split across
+workers: each worker processing the query receives all of them.
+
+A few things to keep in mind:
+
+- Only single-value (equality) filters prune this way. Range filters, including
+  time dimension filters, do not.
+- The join key must still be part of the index's leading columns, together with
+  the filtered dimension. Listing the filtered dimension alone, without the join
+  key, makes the index unusable for the join.
+- The other side of the join — typically the large rollup carrying the time
+  dimension — still needs an index that starts with the join key, and its time
+  dimension filter will not prune partitions there.
+- Each extra index adds build time and storage, so add one when the filter is
+  both common and selective.
+
+As always,
+[use `EXPLAIN` and `EXPLAIN ANALYZE`][ref-cubestore-sql-commands] to confirm
+which index was picked and how many partitions were scanned.
+
 ## Pre-Aggregation build strategies
 
 <Info>

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -471,6 +471,16 @@ cube(`orders`, {
 
 </CodeGroup>
 
+<Info>
+
+Each referenced rollup needs an [index][self-indexes] whose leading columns
+cover the join key. For queries that also filter the joined rollup by a
+selective, single-value dimension, put that dimension before the join key in
+the index so that Cube Store can prune partitions — see
+[indexing the joined rollup for partition pruning][ref-rollup-join-indexing].
+
+</Info>
+
 #### `rollup_lambda`
 
 <Warning>
@@ -1828,6 +1838,7 @@ cube(`orders`, {
 [self-refreshkey-sql]: #sql
 [self-rollup]: #rollup
 [self-rollupjoin]: #rollup_join
+[self-indexes]: #indexes
 [self-rolluplambda]: #rollup_lambda
 [self-timedimension]: #time_dimension
 [self-buildrange]: #build_range_start-and-build_range_end
@@ -1840,3 +1851,4 @@ cube(`orders`, {
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-env-allow-non-strict]: /reference/configuration/environment-variables#cubejs-pre-aggregations-allow-non-strict-date-range-match
+[ref-rollup-join-indexing]: /docs/pre-aggregations/using-pre-aggregations#indexing-the-joined-rollup-for-partition-pruning


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available — docs-only change; `yarn broken-links --check-anchors` passes (the one reported break, `reference/control-plane-api.mdx#apiv1deploymentsdeployment_idenvironments`, pre-exists on `master`)
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet — n/a, docs only
- [x] Docs have been added / updated if required

**Description of Changes Made**

Documents how to index the joined rollup of a `rollup_join` so that Cube Store can actually prune partitions.

Cube Store ranges partitions by index order, so a filter only prunes partitions when it constrains the index's *leading* column. An index that starts with the join key therefore yields no pruning from the query's filters on the joined rollup: a filter on the second index column prunes only in the degenerate case where a partition happens to cover a single value of the first column.

The planner does accept an index whose leading columns cover the join key alongside a single-value filter column in any order — a `Filter` node with a single-value predicate prepends the filter column to `sort_on` and downgrades `required` to false (`planning.rs:629-655`), which is what makes the `join_columns_indices.sort()` relaxation at `planning.rs:1424-1426` accept it — and `optimal_index_by_score` prefers the one where the filter column comes first. So putting a selective, equality-filtered dimension *before* the join key keeps the join plannable and prunes partitions.

That matters doubly because the joined rollup's partitions are never split up: `distribute_join_partitions` (`query_executor.rs:1716-1763`) chunks only the left-most table and appends *all* right-side partitions to every batch. Its budget is `max_joined_partitions - right_active`, and a right side that exceeds it fails the query outright — the same limit as the existing `<Warning>` about the right side being bounded by partition count.

Verified against the planner with throwaway tests in `queryplanner/planning.rs`: with 4 catalog partitions and an equality filter on the non-join-key dimension, an index of `(filter_col, join_key)` pruned to 2 partitions while `(join_key, filter_col)` kept all 4. A separate test confirmed the default index remains a valid candidate for a join — `pick_index`'s `skip(1)` drops the duplicate copy that `get_tables_with_indexes` prepends, not the default index itself.

Changes:
- `docs-mintlify/docs/pre-aggregations/using-pre-aggregations.mdx` — new "Indexing the joined rollup for partition pruning" subsection under "Joins between pre-aggregations", with a YAML/JS example and the caveats: equality filters buy index *eligibility* (a range filter on a leading column still prunes normally); the join key must stay within the leading columns; queries without the equality filter fall back to a join-key-leading scan, so one must stay available; the other side of the join gets no pruning from its time filter; index build/storage cost.
- `docs-mintlify/reference/data-modeling/pre-aggregations.mdx` — short `<Info>` in the `rollup_join` section linking to the new guidance.

Review feedback from `claude[bot]` is addressed in d0f445d, 8303998 and a662a33; see the resolved threads for which suggestions were applied and which rested on the `skip(1)` reading above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpiEwkcFEAEQoc1ifzyzBM