### PR TITLE
docs(dashboards): document the Grid container widget

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -131,6 +131,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
             - Spacer
             - Divider
             - Stack
+            - Grid
     - **Dashboard**
       - Scheduled refresh
     - **Semantic Model**

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -3,7 +3,7 @@ title: Widgets
 description: Building blocks for dashboards — charts, text, controls, AI summaries, and layout elements that you arrange on the canvas to tell your data story.
 ---
 
-Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, an AI-generated summary, or a layout element such as a spacer, divider, or stack. Combine them to assemble polished, interactive views of your data.
+Widgets are the building blocks of a dashboard. Each tile placed on the canvas in the [dashboard builder][ref-workbooks] is a widget — a chart, a block of text, a control that viewers interact with, an AI-generated summary, or a layout element such as a spacer, divider, stack, or grid. Combine them to assemble polished, interactive views of your data.
 
 ## Widget types
 
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, swap which field the charts are built on, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer, Divider & Stack](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace, section breaks, and grouping widgets
+- [Spacer, Divider, Stack & Grid](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace, section breaks, and grouping widgets, including a grid container that gives widgets a fixed position
 
 ## Adding widgets
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,9 +1,9 @@
 ---
-title: Spacer, Divider & Stack
-description: Non-data layout elements — a spacer for whitespace, a divider line, and stack containers that group widgets — to help you structure a dashboard.
+title: Spacer, Divider, Stack & Grid
+description: Non-data layout elements — a spacer for whitespace, a divider line, stack containers that group widgets evenly, and grid containers that give widgets their own fixed position — to help you structure a dashboard.
 ---
 
-Spacers, dividers, and stacks are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace, visual structure, and grouping to a dashboard.
+Spacers, dividers, stacks, and grids are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace, visual structure, and grouping to a dashboard.
 
 ## Spacer
 
@@ -28,9 +28,23 @@ Add a widget to a stack by dragging it in — from the canvas, the **Add Widgets
 
 Because a stack owns its children's layout, you work with the **container as a unit**: select, move, resize, or delete the stack itself and it carries its children with it. Individual widgets inside a stack are not separately selectable on the board — a marquee drawn over a stack selects the container, not its children. To rearrange children, drag one to a new position **within** the stack; to take one out, drag it onto the canvas or into another container.
 
+## Grid
+
+A **grid** is a container whose children each keep their own fixed cell position and size, arranged in the container's own `columns × rows` grid — unlike a stack, a grid never redistributes, resizes, or moves a child to make room for another. Use a grid when you want to group widgets and arrange them precisely relative to one another, independent of the rest of the dashboard.
+
+A grid is added at a square footprint matching the board's column count (for example, `12 × 12` on a 12-column dashboard), and its inner grid always uses the same cell size as the board that holds it — a widget keeps the exact same footprint whether it sits on the root canvas or inside a grid.
+
+Drag a widget into a grid from the canvas, the **Add Widgets** menu, or another container. A widget keeps its size on arrival, landing in the cell you drop it on if that cell is free. Dragging, resizing, or dropping a widget onto a cell that is already occupied is refused rather than pushing, swapping, or resizing anything else — you'll need to make room first.
+
+Click a grid's header (or open its **⋯** menu and choose **Resize**) to select it and reveal its own resize grip. A grid can only be shrunk down to the cells its children already occupy — it crops empty rows off the bottom and empty columns off the right, down to a minimum of 2 × 2 cells.
+
+Give a grid a name by clicking its header once it's selected and typing a title; the title is shown on the published dashboard.
+
+Grids can be nested inside the root canvas or inside another grid, but not inside a stack.
+
 ## Adding a layout widget
 
-In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer**, **Divider**, **Horizontal Stack**, or **Vertical Stack**. The widget is added to the canvas, where you can drag it into place and resize it (a divider resizes horizontally only).
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer**, **Divider**, **Horizontal Stack**, **Vertical Stack**, or **Grid**. The widget is added to the canvas, where you can drag it into place and resize it (a divider resizes horizontally only).
 
 ## Styling
 
@@ -39,6 +53,6 @@ The **spacer** and **divider** follow the dashboard's [widget styling settings](
 - The **divider** draws its line using the widget **border** width, style, and color.
 - A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see.
 
-A **stack** draws no card of its own — it only groups and sizes its children, each of which keeps its own styling.
+A **stack** or **grid** draws no card of its own on the published dashboard — it only arranges its children, each of which keeps its own styling.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] N/A — Tests / linter (docs-only change)

## What

Adds a **Grid** section to the dashboard layout-widgets page (`docs/explore-analyze/dashboards/widgets/layout.mdx`). The Grid container (CUB-3811) shipped in cubejs-enterprise#14769, alongside the existing Spacer/Divider/Stack layout widgets, but had no public docs.

The section covers:
- what a grid is and how it differs from a stack (children keep a fixed cell position/size instead of being redistributed)
- how a grid is sized on add, and how children are placed (drag-in, refuse-on-collision — no pushing/swapping/resizing of anyone else)
- resizing the grid itself (select via header or **⋯ → Resize**; crop-only, down to the cells its children occupy, floored at 2 × 2)
- the editable title
- the nesting rule: a grid nests inside the root canvas or another grid, never inside a stack

Also updates the widgets index page's widget-type list and this repo's `docs-mintlify/CLAUDE.md` widget taxonomy (`Layout: Spacer, Divider, Stack, **Grid**`).

## Why

An earlier attempt at this ([#11556](https://github.com/cube-js/cube/pull/11556)) was written against the feature's pre-final design (auto `cols × rows` grid, a "Distribute evenly" action, swap-on-collision) and was closed once the shipped implementation diverged (free-position cells, collisions revert rather than swap, crop-only resize, no distribute action). This PR documents the interaction model as it actually shipped, read directly from `packages/console-ui/src/modules/d3/components/Workbook/DashboardBuilder/{Preview/GridContainerWidget.tsx,utils/grid-container.ts}` in cubejs-enterprise.

## Notes

- Frontmatter title updated `Spacer, Divider & Stack` → `Spacer, Divider, Stack & Grid`; the sidebar label is derived from the page title, so no `docs.json` change is needed.
- Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jko3RdVikXS2NEvBqEAcB

---
_Generated by [Claude Code](https://claude.ai/code/session_019jko3RdVikXS2NEvBqEAcB)_