### PR TITLE
docs: document that Cube Core development mode bypasses authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ docker run -p 4000:4000 \
 
 Then open http://localhost:4000 in your browser to continue setup.
 
-> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, so
-> anyone who can reach the instance can read all of your data, and the SQL API accepts
-> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
-> connected data sources. This is intentional — development mode is designed to run on a developer's
+> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
+> supporting endpoints are served with no authentication, so anyone who can reach the
+> instance can mint an API token carrying any security context (signed with your API
+> secret), read and overwrite your data model and `.env`, and — unless
+> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly
 > discouraged, as it bypasses the platform's security model. See

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ docker run -p 4000:4000 \
 Then open http://localhost:4000 in your browser to continue setup.
 
 > **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, and
-> anyone who can reach the instance can execute arbitrary SQL against connected data
-> sources. This is intentional — development mode is designed to run on a developer's
+> endpoints are served without any authentication or authorization verification, so
+> anyone who can reach the instance can read all of your data, and the SQL API accepts
+> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
+> connected data sources. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly
 > discouraged, as it bypasses the platform's security model. See

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ docker run -p 4000:4000 \
 
 Then open http://localhost:4000 in your browser to continue setup.
 
-> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
+> **Development mode is an authentication bypass.** In the official images — whose
+> entrypoint is the `cubejs` CLI — `CUBEJS_DEV_MODE=true` also forces
 > `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
 > GraphQL APIs, so they accept requests with no token at all. Playground and its
 > supporting endpoints are served with no authentication either, so anyone who can

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ docker run -p 4000:4000 \
 
 Then open http://localhost:4000 in your browser to continue setup.
 
-> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
-> supporting endpoints are served with no authentication, so anyone who can reach the
-> instance is handed a ready-to-use API token (and can mint others carrying any
-> security context, signed with your API secret), read your data model, overwrite it
-> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> **Development mode is an authentication bypass.** Cube is in development mode with
+> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
+> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
+> and its supporting endpoints are served with no authentication, so anyone who can
+> reach the instance is handed a ready-to-use API token (and can mint others carrying
+> any security context, signed with your API secret), read your data model, overwrite
+> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
 > through the SQL API. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly

--- a/README.md
+++ b/README.md
@@ -46,18 +46,21 @@ docker run -p 4000:4000 \
 
 Then open http://localhost:4000 in your browser to continue setup.
 
-> **Development mode is an authentication bypass.** Cube is in development mode with
-> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
-> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
-> and its supporting endpoints are served with no authentication, so anyone who can
+> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
+> `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
+> GraphQL APIs, so they accept requests with no token at all. Playground and its
+> supporting endpoints are served with no authentication either, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
-> any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
-> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
-> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
-> developer's local machine for ease of use and debugging. Never expose it to the internet or use
-> it in production. Using development mode in the Cube cloud platform is highly
-> discouraged, as it bypasses the platform's security model. See
+> any security context, signed with your API secret), can read your data model, and can
+> overwrite it and your `.env`. With no `CUBEJS_SQL_PASSWORD` set, the SQL API accepts
+> any credentials as well, allowing arbitrary SQL against connected data sources.
+>
+> This is intentional — development mode is designed to run on a developer's local
+> machine for ease of use and debugging. Never expose it to the internet or use it in
+> production. Using development mode in the Cube cloud platform is highly discouraged,
+> as it bypasses the platform's security model. Cube is also in development mode
+> whenever `NODE_ENV` is not `production`, but `cubejs server` and the official images
+> already set it to `production`. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
 
 For a step-by-step guide, [see the docs](https://docs.cube.dev/cube-core/getting-started/create-a-project?ref=github-readme).

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Then open http://localhost:4000 in your browser to continue setup.
 
 > **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
 > supporting endpoints are served with no authentication, so anyone who can reach the
-> instance can mint an API token carrying any security context (signed with your API
-> secret), read and overwrite your data model and `.env`, and — unless
-> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
+> instance is handed a ready-to-use API token (and can mint others carrying any
+> security context, signed with your API secret), read your data model, overwrite it
+> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly
 > discouraged, as it bypasses the platform's security model. See

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Then open http://localhost:4000 in your browser to continue setup.
 > instance is handed a ready-to-use API token (and can mint others carrying any
 > security context, signed with your API secret), read your data model, overwrite it
 > and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a developer's
-> local machine for ease of use and debugging. Never expose it to the internet or use
+> through the SQL API. This is intentional — development mode is designed to run on a
+> developer's local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly
 > discouraged, as it bypasses the platform's security model. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Then open http://localhost:4000 in your browser to continue setup.
 > and its supporting endpoints are served with no authentication, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
 > any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a
+> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
+> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
+> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never expose it to the internet or use
 > it in production. Using development mode in the Cube cloud platform is highly
 > discouraged, as it bypasses the platform's security model. See

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ docker run -p 4000:4000 \
 
 Then open http://localhost:4000 in your browser to continue setup.
 
+> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
+> endpoints are served without any authentication or authorization verification, and
+> anyone who can reach the instance can execute arbitrary SQL against connected data
+> sources. This is intentional — development mode is designed to run on a developer's
+> local machine for ease of use and debugging. Never expose it to the internet or use
+> it in production. Using development mode in the Cube cloud platform is highly
+> discouraged, as it bypasses the platform's security model. See
+> [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
+
 For a step-by-step guide, [see the docs](https://docs.cube.dev/cube-core/getting-started/create-a-project?ref=github-readme).
 
 ## Cube Core vs. Cube

--- a/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
@@ -43,6 +43,16 @@ services:
       - "8812:8812"
 ```
 
+<Warning>
+
+Development mode disables authentication completely: data access endpoints are served
+without any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. Use it only on a
+local development machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>
+
 Within your project directory, create an `.env` file:
 
 ```dotenv

--- a/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
@@ -45,13 +45,13 @@ services:
 
 <Warning>
 
-Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, so anyone who can reach the
-instance can read all of your data. Unless
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources. Use it only on a local development machine, never in
-production. See
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
@@ -3,6 +3,8 @@ title: QuestDB
 description: "QuestDB is a high-performance time-series database which helps you overcome ingestion bottlenecks."
 ---
 
+import DevModeWarningShort from '/snippets/dev-mode-warning-short.mdx';
+
 [QuestDB][questdb] is a high-performance [time-series database][time-series-database-glossary] which helps you overcome ingestion bottlenecks.
 
 <Warning>
@@ -43,19 +45,6 @@ services:
       - "8812:8812"
 ```
 
-<Warning>
-
-Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
-
-</Warning>
-
 Within your project directory, create an `.env` file:
 
 ```dotenv
@@ -74,6 +63,8 @@ docker-compose up -d
 ```
 
 Access Cube at http://localhost:4000 & QuestDB at http://localhost:9000
+
+<DevModeWarningShort />
 
 ## Environment Variables
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/questdb.mdx
@@ -46,9 +46,12 @@ services:
 <Warning>
 
 Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. Use it only on a
-local development machine, never in production. See
+without any authentication or authorization verification, so anyone who can reach the
+instance can read all of your data. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -3,6 +3,8 @@ title: Deploying Cube Core with Docker
 description: This guide walks you through deploying Cube with Docker.
 ---
 
+import DevModeWarning from '/snippets/dev-mode-warning.mdx';
+
 <Warning>
 
 This is an example of a production-ready deployment, but real-world deployments
@@ -388,39 +390,10 @@ deployment.
 ### Disable Development Mode
 
 When running Cube in production environments, make sure development mode is
-disabled both on API Instances and Refresh Worker. You can read more on the
-differences between [production and development mode
-here][link-cubejs-dev-vs-prod].
+disabled both on API Instances and Refresh Worker. You can read more about what
+development mode changes [here][link-cubejs-dev-vs-prod].
 
-<Warning>
-
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
-
-This is intentional. Development mode is designed to run on a developer's local
-machine for ease of use and debugging. Never run it where anyone else can reach it,
-never expose it to the internet, and never use it in production. Using development
-mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
-security model.
-
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
-
-</Warning>
+<DevModeWarning />
 
 <Info>
 
@@ -554,7 +527,7 @@ data source usage.
 [blog-migrate-to-cube-cloud]:
   https://cube.dev/blog/migrating-from-self-hosted-to-cube-cloud/
 [link-cube-cloud]: https://cubecloud.dev
-[link-cubejs-dev-vs-prod]: /docs/data-modeling/dev-mode
+[link-cubejs-dev-vs-prod]: /reference/configuration/environment-variables#cubejs_dev_mode
 [link-k8s-healthcheck-api]:
   https://kubernetes.io/docs/reference/using-api/health-checks/
 [ref-config-connect-db]: /admin/connect-to-data/data-sources

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -404,11 +404,12 @@ official Docker images already set `NODE_ENV=production`.
 </Info>
 
 ```dotenv
-# Set this to false or leave unset to disable development mode
+# Both are required: Cube is in development mode unless NODE_ENV is
+# production AND this flag is not true, so setting this alone is not enough
 CUBEJS_DEV_MODE=false
 
-# Required to enforce JWT verification on the REST (JSON) and GraphQL APIs;
-# without it those APIs accept unauthenticated requests
+# Takes the instance out of development mode, which is also what enables JWT
+# verification on the REST (JSON) and GraphQL APIs
 NODE_ENV=production
 ```
 

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -397,19 +397,21 @@ development mode changes [here][link-cubejs-dev-vs-prod].
 
 <Info>
 
-`CUBEJS_DEV_MODE` defaults to `false`, but Cube also treats any environment where
-`NODE_ENV` is not `production` as development mode. Set both variables below. The
-official Docker images already set `NODE_ENV=production`.
+`CUBEJS_DEV_MODE` defaults to `false`, and the official Docker images already set
+`NODE_ENV=production` — as does `cubejs server` itself — so on a Docker deployment
+leaving the flag unset is enough. Setting `NODE_ENV` below as well is belt-and-braces;
+it matters only if you embed `@cubejs-backend/server-core` directly, where an unset
+`NODE_ENV` puts the instance in development mode whatever the flag says.
 
 </Info>
 
 ```dotenv
-# Both are required: Cube is in development mode unless NODE_ENV is
-# production AND this flag is not true, so setting this alone is not enough
+# Keep development mode off. Note that setting this to `true` would also force
+# NODE_ENV=development, switching off JWT verification on the data APIs
 CUBEJS_DEV_MODE=false
 
-# Takes the instance out of development mode, which is also what enables JWT
-# verification on the REST (JSON) and GraphQL APIs
+# Already set by the official images and by `cubejs server`; set it explicitly if
+# you start Cube some other way
 NODE_ENV=production
 ```
 

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -400,11 +400,14 @@ data access endpoint of the Cube instance — the
 [GraphQL API](/reference/core-data-apis/graphql-api),
 [SQL API](/reference/core-data-apis/sql-api), and
 [Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: no JWT is required and
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The data model and configuration are also readable and writable
-through those unauthenticated endpoints, so anyone who can reach the instance can
-execute arbitrary SQL against every connected data source.
+or authorization verification: requests with a missing or invalid token are accepted,
+and [member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The SQL API additionally accepts any user name and password unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, so anyone who can reach the instance can execute arbitrary SQL against every
+connected data source. Playground's own endpoints are unauthenticated as well: they
+read and write your data model files and `.env`, and mint tokens carrying any security
+context, signed with your API secret.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -406,8 +406,9 @@ it matters only if you embed `@cubejs-backend/server-core` directly, where an un
 </Info>
 
 ```dotenv
-# Keep development mode off. Note that setting this to `true` would also force
-# NODE_ENV=development, switching off JWT verification on the data APIs
+# Keep development mode off. Under the `cubejs` CLI and the official images,
+# setting this to `true` also forces NODE_ENV=development, switching off JWT
+# verification on the data APIs
 CUBEJS_DEV_MODE=false
 
 # Already set by the official images and by `cubejs server`; set it explicitly if

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -388,11 +388,31 @@ deployment.
 ### Disable Development Mode
 
 When running Cube in production environments, make sure development mode is
-disabled both on API Instances and Refresh Worker. Running Cube in development
-mode in a production environment can lead to security vulnerabilities. Enabling
-Development Mode in Cube Cloud is not recommended. Development Mode will expose
-your data to the internet. You can read more on the differences between
-[production and development mode here][link-cubejs-dev-vs-prod].
+disabled both on API Instances and Refresh Worker. You can read more on the
+differences between [production and development mode
+here][link-cubejs-dev-vs-prod].
+
+<Warning>
+
+**Development mode disables authentication completely.** While it is enabled, every
+data access endpoint of the Cube instance — the
+[REST (JSON) API](/reference/core-data-apis/rest-api),
+[GraphQL API](/reference/core-data-apis/graphql-api),
+[SQL API](/reference/core-data-apis/sql-api), and
+[Playground](/docs/explore-analyze/playground) — is served without any authentication
+or authorization verification: no JWT is required and
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The data model and configuration are also readable and writable
+through those unauthenticated endpoints, so anyone who can reach the instance can
+execute arbitrary SQL against every connected data source.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+</Warning>
 
 <Info>
 

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -394,20 +394,18 @@ here][link-cubejs-dev-vs-prod].
 
 <Warning>
 
-**Development mode disables authentication completely.** While it is enabled, every
-data access endpoint of the Cube instance — the
-[REST (JSON) API](/reference/core-data-apis/rest-api),
-[GraphQL API](/reference/core-data-apis/graphql-api),
-[SQL API](/reference/core-data-apis/sql-api), and
-[Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: requests with a missing or invalid token are accepted,
-and [member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The SQL API additionally accepts any user name and password unless
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, so anyone who can reach the instance can execute arbitrary SQL against every
-connected data source. Playground's own endpoints are unauthenticated as well: they
-read and write your data model files and `.env`, and mint tokens carrying any security
-context, signed with your API secret.
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
@@ -415,17 +413,30 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
+
 </Warning>
 
 <Info>
 
-Development mode is disabled by default.
+`CUBEJS_DEV_MODE` defaults to `false`, but Cube also treats any environment where
+`NODE_ENV` is not `production` as development mode. Set both variables below. The
+official Docker images already set `NODE_ENV=production`.
 
 </Info>
 
 ```dotenv
 # Set this to false or leave unset to disable development mode
 CUBEJS_DEV_MODE=false
+
+# Required to enforce JWT verification on the REST (JSON) and GraphQL APIs;
+# without it those APIs accept unauthenticated requests
+NODE_ENV=production
 ```
 
 ### Set up Refresh Worker

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -183,20 +183,18 @@ Cube Cloud automatically installs dependencies from `requirements.txt` and
 
 <Warning>
 
-**Development mode disables authentication completely.** While it is enabled, every
-data access endpoint of the Cube instance — the
-[REST (JSON) API](/reference/core-data-apis/rest-api),
-[GraphQL API](/reference/core-data-apis/graphql-api),
-[SQL API](/reference/core-data-apis/sql-api), and
-[Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: requests with a missing or invalid token are accepted,
-and [member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The SQL API additionally accepts any user name and password unless
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, so anyone who can reach the instance can execute arbitrary SQL against every
-connected data source. Playground's own endpoints are unauthenticated as well: they
-read and write your data model files and `.env`, and mint tokens carrying any security
-context, signed with your API secret.
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
@@ -204,15 +202,24 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
+
 </Warning>
 
 Cube can be run in an insecure, development mode by setting the
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true`. Putting Cube in development
 mode does the following:
 
-- Disables authentication checks completely, serving all data access endpoints
-  without any authentication or authorization verification.
-- Disables [member-level access control][ref-mls].
+- Serves Playground and its supporting endpoints with no authentication, which lets
+  anyone who can reach the instance mint an API token carrying any security context,
+  and read or overwrite the data model and `.env`.
+- Skips the SQL API password check when no `CUBEJS_SQL_PASSWORD` is configured.
+- Disables [member-level access control][ref-mls] when listing the data model.
 - Enables Cube Store in single instance mode.
 - Enables background refresh for in-memory cache and [scheduled
   pre-aggregations][link-scheduled-refresh].

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -181,11 +181,34 @@ Cube Cloud automatically installs dependencies from `requirements.txt` and
 
 ## Development mode
 
+<Warning>
+
+**Development mode disables authentication completely.** While it is enabled, every
+data access endpoint of the Cube instance — the
+[REST (JSON) API](/reference/core-data-apis/rest-api),
+[GraphQL API](/reference/core-data-apis/graphql-api),
+[SQL API](/reference/core-data-apis/sql-api), and
+[Playground](/docs/explore-analyze/playground) — is served without any authentication
+or authorization verification: no JWT is required and
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The data model and configuration are also readable and writable
+through those unauthenticated endpoints, so anyone who can reach the instance can
+execute arbitrary SQL against every connected data source.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+</Warning>
+
 Cube can be run in an insecure, development mode by setting the
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true`. Putting Cube in development
 mode does the following:
 
-- Disables authentication checks.
+- Disables authentication checks completely, serving all data access endpoints
+  without any authentication or authorization verification.
 - Disables [member-level access control][ref-mls].
 - Enables Cube Store in single instance mode.
 - Enables background refresh for in-memory cache and [scheduled

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -189,11 +189,6 @@ Cube can be run in an insecure, development mode by setting the
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true`. Putting Cube in development
 mode does the following:
 
-- Serves Playground and its supporting endpoints with no authentication, which hands
-  anyone who can reach the instance a signed API token (and the ability to mint others
-  carrying any security context), lets them read the data model, and lets them
-  overwrite the data model and `.env`.
-- Skips the SQL API password check when no `CUBEJS_SQL_PASSWORD` is configured.
 - Disables [member-level access control][ref-mls] when listing the data model.
 - Enables Cube Store in single instance mode.
 - Enables background refresh for in-memory cache and [scheduled

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -3,6 +3,8 @@ title: Administration
 description: TODO
 ---
 
+import DevModeWarning from '/snippets/dev-mode-warning.mdx';
+
 Cube is configured via [environment variables][link-env-vars] and
 [configuration options][link-config] in a configuration file. Usually,
 both would be used to configure a Cube deployment in production.
@@ -181,35 +183,7 @@ Cube Cloud automatically installs dependencies from `requirements.txt` and
 
 ## Development mode
 
-<Warning>
-
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
-
-This is intentional. Development mode is designed to run on a developer's local
-machine for ease of use and debugging. Never run it where anyone else can reach it,
-never expose it to the internet, and never use it in production. Using development
-mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
-security model.
-
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
-
-</Warning>
+<DevModeWarning />
 
 Cube can be run in an insecure, development mode by setting the
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true`. Putting Cube in development

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -189,9 +189,10 @@ Cube can be run in an insecure, development mode by setting the
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true`. Putting Cube in development
 mode does the following:
 
-- Serves Playground and its supporting endpoints with no authentication, which lets
-  anyone who can reach the instance mint an API token carrying any security context,
-  and read or overwrite the data model and `.env`.
+- Serves Playground and its supporting endpoints with no authentication, which hands
+  anyone who can reach the instance a signed API token (and the ability to mint others
+  carrying any security context), lets them read the data model, and lets them
+  overwrite the data model and `.env`.
 - Skips the SQL API password check when no `CUBEJS_SQL_PASSWORD` is configured.
 - Disables [member-level access control][ref-mls] when listing the data model.
 - Enables Cube Store in single instance mode.

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -189,11 +189,14 @@ data access endpoint of the Cube instance — the
 [GraphQL API](/reference/core-data-apis/graphql-api),
 [SQL API](/reference/core-data-apis/sql-api), and
 [Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: no JWT is required and
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The data model and configuration are also readable and writable
-through those unauthenticated endpoints, so anyone who can reach the instance can
-execute arbitrary SQL against every connected data source.
+or authorization verification: requests with a missing or invalid token are accepted,
+and [member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The SQL API additionally accepts any user name and password unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, so anyone who can reach the instance can execute arbitrary SQL against every
+connected data source. Playground's own endpoints are unauthenticated as well: they
+read and write your data model files and `.env`, and mint tokens carrying any security
+context, signed with your API secret.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -3,6 +3,8 @@ title: Deploying Cube Core with Docker
 description: This guide walks you through deploying Cube with Docker.
 ---
 
+import DevModeWarning from '/snippets/dev-mode-warning.mdx';
+
 <Warning>
 
 This is an example of a production-ready deployment, but real-world deployments
@@ -388,39 +390,10 @@ deployment.
 ### Disable Development Mode
 
 When running Cube in production environments, make sure development mode is
-disabled both on API Instances and Refresh Worker. You can read more on the
-differences between [production and development mode
-here][link-cubejs-dev-vs-prod].
+disabled both on API Instances and Refresh Worker. You can read more about what
+development mode changes [here][link-cubejs-dev-vs-prod].
 
-<Warning>
-
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
-
-This is intentional. Development mode is designed to run on a developer's local
-machine for ease of use and debugging. Never run it where anyone else can reach it,
-never expose it to the internet, and never use it in production. Using development
-mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
-security model.
-
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
-
-</Warning>
+<DevModeWarning />
 
 <Info>
 
@@ -554,7 +527,7 @@ data source usage.
 [blog-migrate-to-cube-cloud]:
   https://cube.dev/blog/migrating-from-self-hosted-to-cube-cloud/
 [link-cube-cloud]: https://cubecloud.dev
-[link-cubejs-dev-vs-prod]: /docs/data-modeling/dev-mode
+[link-cubejs-dev-vs-prod]: /reference/configuration/environment-variables#cubejs_dev_mode
 [link-k8s-healthcheck-api]:
   https://kubernetes.io/docs/reference/using-api/health-checks/
 [ref-config-connect-db]: /admin/connect-to-data/data-sources

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -404,11 +404,12 @@ official Docker images already set `NODE_ENV=production`.
 </Info>
 
 ```dotenv
-# Set this to false or leave unset to disable development mode
+# Both are required: Cube is in development mode unless NODE_ENV is
+# production AND this flag is not true, so setting this alone is not enough
 CUBEJS_DEV_MODE=false
 
-# Required to enforce JWT verification on the REST (JSON) and GraphQL APIs;
-# without it those APIs accept unauthenticated requests
+# Takes the instance out of development mode, which is also what enables JWT
+# verification on the REST (JSON) and GraphQL APIs
 NODE_ENV=production
 ```
 

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -397,19 +397,21 @@ development mode changes [here][link-cubejs-dev-vs-prod].
 
 <Info>
 
-`CUBEJS_DEV_MODE` defaults to `false`, but Cube also treats any environment where
-`NODE_ENV` is not `production` as development mode. Set both variables below. The
-official Docker images already set `NODE_ENV=production`.
+`CUBEJS_DEV_MODE` defaults to `false`, and the official Docker images already set
+`NODE_ENV=production` — as does `cubejs server` itself — so on a Docker deployment
+leaving the flag unset is enough. Setting `NODE_ENV` below as well is belt-and-braces;
+it matters only if you embed `@cubejs-backend/server-core` directly, where an unset
+`NODE_ENV` puts the instance in development mode whatever the flag says.
 
 </Info>
 
 ```dotenv
-# Both are required: Cube is in development mode unless NODE_ENV is
-# production AND this flag is not true, so setting this alone is not enough
+# Keep development mode off. Note that setting this to `true` would also force
+# NODE_ENV=development, switching off JWT verification on the data APIs
 CUBEJS_DEV_MODE=false
 
-# Takes the instance out of development mode, which is also what enables JWT
-# verification on the REST (JSON) and GraphQL APIs
+# Already set by the official images and by `cubejs server`; set it explicitly if
+# you start Cube some other way
 NODE_ENV=production
 ```
 

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -400,11 +400,14 @@ data access endpoint of the Cube instance — the
 [GraphQL API](/reference/core-data-apis/graphql-api),
 [SQL API](/reference/core-data-apis/sql-api), and
 [Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: no JWT is required and
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The data model and configuration are also readable and writable
-through those unauthenticated endpoints, so anyone who can reach the instance can
-execute arbitrary SQL against every connected data source.
+or authorization verification: requests with a missing or invalid token are accepted,
+and [member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The SQL API additionally accepts any user name and password unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, so anyone who can reach the instance can execute arbitrary SQL against every
+connected data source. Playground's own endpoints are unauthenticated as well: they
+read and write your data model files and `.env`, and mint tokens carrying any security
+context, signed with your API secret.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -406,8 +406,9 @@ it matters only if you embed `@cubejs-backend/server-core` directly, where an un
 </Info>
 
 ```dotenv
-# Keep development mode off. Note that setting this to `true` would also force
-# NODE_ENV=development, switching off JWT verification on the data APIs
+# Keep development mode off. Under the `cubejs` CLI and the official images,
+# setting this to `true` also forces NODE_ENV=development, switching off JWT
+# verification on the data APIs
 CUBEJS_DEV_MODE=false
 
 # Already set by the official images and by `cubejs server`; set it explicitly if

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -388,11 +388,31 @@ deployment.
 ### Disable Development Mode
 
 When running Cube in production environments, make sure development mode is
-disabled both on API Instances and Refresh Worker. Running Cube in development
-mode in a production environment can lead to security vulnerabilities. Enabling
-Development Mode in Cube Cloud is not recommended. Development Mode will expose
-your data to the internet. You can read more on the differences between
-[production and development mode here][link-cubejs-dev-vs-prod].
+disabled both on API Instances and Refresh Worker. You can read more on the
+differences between [production and development mode
+here][link-cubejs-dev-vs-prod].
+
+<Warning>
+
+**Development mode disables authentication completely.** While it is enabled, every
+data access endpoint of the Cube instance — the
+[REST (JSON) API](/reference/core-data-apis/rest-api),
+[GraphQL API](/reference/core-data-apis/graphql-api),
+[SQL API](/reference/core-data-apis/sql-api), and
+[Playground](/docs/explore-analyze/playground) — is served without any authentication
+or authorization verification: no JWT is required and
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The data model and configuration are also readable and writable
+through those unauthenticated endpoints, so anyone who can reach the instance can
+execute arbitrary SQL against every connected data source.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+</Warning>
 
 <Info>
 

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -394,20 +394,18 @@ here][link-cubejs-dev-vs-prod].
 
 <Warning>
 
-**Development mode disables authentication completely.** While it is enabled, every
-data access endpoint of the Cube instance — the
-[REST (JSON) API](/reference/core-data-apis/rest-api),
-[GraphQL API](/reference/core-data-apis/graphql-api),
-[SQL API](/reference/core-data-apis/sql-api), and
-[Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: requests with a missing or invalid token are accepted,
-and [member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The SQL API additionally accepts any user name and password unless
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, so anyone who can reach the instance can execute arbitrary SQL against every
-connected data source. Playground's own endpoints are unauthenticated as well: they
-read and write your data model files and `.env`, and mint tokens carrying any security
-context, signed with your API secret.
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
@@ -415,17 +413,30 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
+
 </Warning>
 
 <Info>
 
-Development mode is disabled by default.
+`CUBEJS_DEV_MODE` defaults to `false`, but Cube also treats any environment where
+`NODE_ENV` is not `production` as development mode. Set both variables below. The
+official Docker images already set `NODE_ENV=production`.
 
 </Info>
 
 ```dotenv
 # Set this to false or leave unset to disable development mode
 CUBEJS_DEV_MODE=false
+
+# Required to enforce JWT verification on the REST (JSON) and GraphQL APIs;
+# without it those APIs accept unauthenticated requests
+NODE_ENV=production
 ```
 
 ### Set up Refresh Worker

--- a/docs-mintlify/cube-core/getting-started/create-a-project.mdx
+++ b/docs-mintlify/cube-core/getting-started/create-a-project.mdx
@@ -36,26 +36,31 @@ handy for local development but not suitable for
 
 <Warning>
 
-**Development mode disables authentication completely.** While it is enabled, every
-data access endpoint of the Cube instance — the
-[REST (JSON) API](/reference/core-data-apis/rest-api),
-[GraphQL API](/reference/core-data-apis/graphql-api),
-[SQL API](/reference/core-data-apis/sql-api), and
-[Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: requests with a missing or invalid token are accepted,
-and [member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The SQL API additionally accepts any user name and password unless
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, so anyone who can reach the instance can execute arbitrary SQL against every
-connected data source. Playground's own endpoints are unauthenticated as well: they
-read and write your data model files and `.env`, and mint tokens carrying any security
-context, signed with your API secret.
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
 never expose it to the internet, and never use it in production. Using development
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
+
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
 
 </Warning>
 

--- a/docs-mintlify/cube-core/getting-started/create-a-project.mdx
+++ b/docs-mintlify/cube-core/getting-started/create-a-project.mdx
@@ -34,6 +34,28 @@ enable the [Development Mode](/docs/data-modeling/dev-mode). This is
 handy for local development but not suitable for
 [production](/cube-core/running-in-production).
 
+<Warning>
+
+**Development mode disables authentication completely.** While it is enabled, every
+data access endpoint of the Cube instance — the
+[REST (JSON) API](/reference/core-data-apis/rest-api),
+[GraphQL API](/reference/core-data-apis/graphql-api),
+[SQL API](/reference/core-data-apis/sql-api), and
+[Playground](/docs/explore-analyze/playground) — is served without any authentication
+or authorization verification: no JWT is required and
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The data model and configuration are also readable and writable
+through those unauthenticated endpoints, so anyone who can reach the instance can
+execute arbitrary SQL against every connected data source.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+</Warning>
+
 <Info>
 
 If you're using Linux as the Docker host OS, you'll also need to add

--- a/docs-mintlify/cube-core/getting-started/create-a-project.mdx
+++ b/docs-mintlify/cube-core/getting-started/create-a-project.mdx
@@ -3,6 +3,8 @@ title: Create a project
 description: In this step, we will create a Cube Core project on your computer, connect a data source, and generate data models.
 ---
 
+import DevModeWarning from '/snippets/dev-mode-warning.mdx';
+
 ## Scaffold a project
 
 Start by opening your terminal to create a new folder for the project, then
@@ -30,39 +32,11 @@ services:
 ```
 
 Note that we're setting the [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) environment variable to `true` to
-enable the [Development Mode](/docs/data-modeling/dev-mode). This is
+enable [development mode](/reference/configuration/environment-variables#cubejs_dev_mode). This is
 handy for local development but not suitable for
 [production](/cube-core/running-in-production).
 
-<Warning>
-
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
-
-This is intentional. Development mode is designed to run on a developer's local
-machine for ease of use and debugging. Never run it where anyone else can reach it,
-never expose it to the internet, and never use it in production. Using development
-mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
-security model.
-
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
-
-</Warning>
+<DevModeWarning />
 
 <Info>
 

--- a/docs-mintlify/cube-core/getting-started/create-a-project.mdx
+++ b/docs-mintlify/cube-core/getting-started/create-a-project.mdx
@@ -42,11 +42,14 @@ data access endpoint of the Cube instance — the
 [GraphQL API](/reference/core-data-apis/graphql-api),
 [SQL API](/reference/core-data-apis/sql-api), and
 [Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: no JWT is required and
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The data model and configuration are also readable and writable
-through those unauthenticated endpoints, so anyone who can reach the instance can
-execute arbitrary SQL against every connected data source.
+or authorization verification: requests with a missing or invalid token are accepted,
+and [member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The SQL API additionally accepts any user name and password unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, so anyone who can reach the instance can execute arbitrary SQL against every
+connected data source. Playground's own endpoints are unauthenticated as well: they
+read and write your data model files and `.env`, and mint tokens carrying any security
+context, signed with your API secret.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -12,13 +12,13 @@ this is to use the official Docker images for Cube and Cube Store.
 
 <Warning>
 
-Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, so anyone who can reach the
-instance can read all of your data. Unless
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources. Use it only on a local development machine, never in
-production. See
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -10,6 +10,16 @@ Cube Store is enabled by default when running Cube in development mode. In
 production, Cube Store **must** run as a separate process. The easiest way to do
 this is to use the official Docker images for Cube and Cube Store.
 
+<Warning>
+
+Development mode disables authentication completely: data access endpoints are served
+without any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. Use it only on a
+local development machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>
+
 <Info>
 
 Using Windows? We **strongly** recommend using [WSL2 for Windows 10][link-wsl2]

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -3,6 +3,8 @@ title: Running in production
 description: "Cube makes use of two different kinds of cache:"
 ---
 
+import DevModeWarningShort from '/snippets/dev-mode-warning-short.mdx';
+
 - In-memory storage of query results
 - Pre-aggregations
 
@@ -10,18 +12,7 @@ Cube Store is enabled by default when running Cube in development mode. In
 production, Cube Store **must** run as a separate process. The easiest way to do
 this is to use the official Docker images for Cube and Cube Store.
 
-<Warning>
-
-Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
-
-</Warning>
+<DevModeWarningShort />
 
 <Info>
 

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -13,9 +13,12 @@ this is to use the official Docker images for Cube and Cube Store.
 <Warning>
 
 Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. Use it only on a
-local development machine, never in production. See
+without any authentication or authorization verification, so anyone who can reach the
+instance can read all of your data. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -12,8 +12,9 @@ This page describes development mode in the Cube cloud platform. It is unrelated
 Cube Core's development mode — which is on when
 [`CUBEJS_DEV_MODE=true`](/reference/configuration/environment-variables#cubejs_dev_mode)
 or whenever `NODE_ENV` is not `production` — and which is an **authentication bypass**.
-Setting the flag also forces `NODE_ENV=development`, switching off JWT verification on
-the data APIs, and Playground's endpoints are served with no authentication at all, so
+Under the `cubejs` CLI and the official Docker images, setting the flag also forces
+`NODE_ENV=development`, switching off JWT verification on the data APIs. Playground's
+endpoints are served with no authentication at all, so
 anyone who can reach the instance can mint an API token carrying any security context
 (signed with the API secret), read the data model, and overwrite it and `.env`. With
 `CUBEJS_DEV_MODE=true` and no

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -9,15 +9,16 @@ Development mode allows to test and debug the data model in an isolated
 <Warning>
 
 This page describes development mode in the Cube cloud platform. It is unrelated to
-Cube Core's development mode — which is on whenever `NODE_ENV` is not `production` or
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) is
-`true` — and which is an **authentication bypass**: it serves Playground's endpoints with no
-authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with the API secret), read the data model, overwrite it
-and `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
+Cube Core's development mode — which is on when
+[`CUBEJS_DEV_MODE=true`](/reference/configuration/environment-variables#cubejs_dev_mode)
+or whenever `NODE_ENV` is not `production` — and which is an **authentication bypass**.
+Setting the flag also forces `NODE_ENV=development`, switching off JWT verification on
+the data APIs, and Playground's endpoints are served with no authentication at all, so
+anyone who can reach the instance can mint an API token carrying any security context
+(signed with the API secret), read the data model, and overwrite it and `.env`. With
+`CUBEJS_DEV_MODE=true` and no
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-set, the SQL API also accepts any credentials, allowing arbitrary SQL. That is
-intentional — it is designed
+set, the SQL API accepts any credentials as well. That is intentional — it is designed
 to run on a developer's local machine for ease of use and debugging. Never use it in
 production, and using it in the Cube cloud platform is highly discouraged because it
 bypasses the platform's security model.

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -11,14 +11,15 @@ Development mode allows to test and debug the data model in an isolated
 This page describes development mode in the Cube cloud platform. It is unrelated to
 Cube Core's development mode, which is enabled with
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) and
-**disables authentication completely**: all data access endpoints are served without
-any authentication or authorization verification, so anyone who can reach the instance
-can read all of the data, and the SQL API accepts any credentials unless
+is an **authentication bypass**: it serves Playground's endpoints with no
+authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with the API secret), read and overwrite the data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, allowing arbitrary SQL against connected data sources. That is
-intentional — it is designed to run on a developer's local machine for ease of use and
-debugging. Never use it in production, and using it in the Cube cloud platform is
-highly discouraged because it bypasses the platform's security model.
+is set — run arbitrary SQL through the SQL API. That is intentional — it is designed to
+run on a developer's local machine for ease of use and debugging. Never use it in
+production, and using it in the Cube cloud platform is highly discouraged because it
+bypasses the platform's security model.
 
 </Warning>
 

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -14,9 +14,10 @@ Cube Core's development mode — which is on whenever `NODE_ENV` is not `product
 `true` — and which is an **authentication bypass**: it serves Playground's endpoints with no
 authentication, so anyone who can reach the instance can mint an API token carrying
 any security context (signed with the API secret), read the data model, overwrite it
-and `.env`, and — unless
+and `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. That is intentional — it is designed
+set, the SQL API also accepts any credentials, allowing arbitrary SQL. That is
+intentional — it is designed
 to run on a developer's local machine for ease of use and debugging. Never use it in
 production, and using it in the Cube cloud platform is highly discouraged because it
 bypasses the platform's security model.

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -6,6 +6,20 @@ description: Outlines development mode in Cube Cloud—branch-scoped APIs, save 
 Development mode allows to test and debug the data model in an isolated
 [development environment][ref-environments-dev] before releasing any changes to production.
 
+<Warning>
+
+This page describes development mode in the Cube cloud platform. It is unrelated to
+Cube Core's development mode, which is enabled with
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) and
+**disables authentication completely**: all data access endpoints are served without
+any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. That is
+intentional — it is designed to run on a developer's local machine for ease of use and
+debugging. Never use it in production, and using it in the Cube cloud platform is
+highly discouraged because it bypasses the platform's security model.
+
+</Warning>
+
 When you enter the development mode, you'll have access to your personal API endpoints
 that will track the branch you're on and will be updated automatically when you make
 changes to the data model.

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -16,8 +16,8 @@ authentication, so anyone who can reach the instance can mint an API token carry
 any security context (signed with the API secret), read the data model, overwrite it
 and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. That is intentional — it is designed to
-run on a developer's local machine for ease of use and debugging. Never use it in
+is set — run arbitrary SQL through the SQL API. That is intentional — it is designed
+to run on a developer's local machine for ease of use and debugging. Never use it in
 production, and using it in the Cube cloud platform is highly discouraged because it
 bypasses the platform's security model.
 

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -13,7 +13,7 @@ Cube Core's development mode, which is enabled with
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) and
 is an **authentication bypass**: it serves Playground's endpoints with no
 authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with the API secret), read and overwrite the data model
+any security context (signed with the API secret), read the data model, overwrite it
 and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
 is set — run arbitrary SQL through the SQL API. That is intentional — it is designed to

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -9,9 +9,9 @@ Development mode allows to test and debug the data model in an isolated
 <Warning>
 
 This page describes development mode in the Cube cloud platform. It is unrelated to
-Cube Core's development mode, which is enabled with
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) and
-is an **authentication bypass**: it serves Playground's endpoints with no
+Cube Core's development mode — which is on whenever `NODE_ENV` is not `production` or
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) is
+`true` — and which is an **authentication bypass**: it serves Playground's endpoints with no
 authentication, so anyone who can reach the instance can mint an API token carrying
 any security context (signed with the API secret), read the data model, overwrite it
 and `.env`, and — unless

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -12,8 +12,10 @@ This page describes development mode in the Cube cloud platform. It is unrelated
 Cube Core's development mode, which is enabled with
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) and
 **disables authentication completely**: all data access endpoints are served without
-any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. That is
+any authentication or authorization verification, so anyone who can reach the instance
+can read all of the data, and the SQL API accepts any credentials unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, allowing arbitrary SQL against connected data sources. That is
 intentional — it is designed to run on a developer's local machine for ease of use and
 debugging. Never use it in production, and using it in the Cube cloud platform is
 highly discouraged because it bypasses the platform's security model.

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -22,9 +22,12 @@ when it's run in the [development mode][ref-dev-mode].
 <Warning>
 
 Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. Use it only on a
-local development machine, never in production. See
+without any authentication or authorization verification, so anyone who can reach the
+instance can read all of your data. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -3,6 +3,8 @@ title: Playground
 description: Browser-based workspace to inspect cubes and views, run ad hoc queries, and copy API-ready examples while developing the semantic model.
 ---
 
+import DevModeWarningShort from '/snippets/dev-mode-warning-short.mdx';
+
 Playground is a web-based tool that helps validate the data model by executing
 [queries][ref-queries] and previewing their results. It is supposed to be used
 by data engineers and developers while building the [data model][ref-data-modeling].
@@ -19,18 +21,7 @@ when it's run in the [development mode][ref-dev-mode].
 
 </Info>
 
-<Warning>
-
-Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
-
-</Warning>
+<DevModeWarningShort />
 
 You can [view](#viewing-the-data-model) the data model entities or [search](#searching-the-data-model)
 for them, [compose](#composing-queries) a query from scratch or [paste](#pasting-a-query)
@@ -204,7 +195,7 @@ manually.
 
 */}
 
-[ref-dev-mode]: /docs/data-modeling/dev-mode
+[ref-dev-mode]: /reference/configuration/environment-variables#cubejs_dev_mode
 [ref-dataviz-tools]: /admin/connect-to-data/visualization-tools
 [ref-js-sdk]: /reference/javascript-sdk
 [ref-data-model]: /docs/data-modeling/data-model-ide#generating-data-model-files

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -21,13 +21,13 @@ when it's run in the [development mode][ref-dev-mode].
 
 <Warning>
 
-Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, so anyone who can reach the
-instance can read all of your data. Unless
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources. Use it only on a local development machine, never in
-production. See
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -19,6 +19,16 @@ when it's run in the [development mode][ref-dev-mode].
 
 </Info>
 
+<Warning>
+
+Development mode disables authentication completely: data access endpoints are served
+without any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. Use it only on a
+local development machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>
+
 You can [view](#viewing-the-data-model) the data model entities or [search](#searching-the-data-model)
 for them, [compose](#composing-queries) a query from scratch or [paste](#pasting-a-query)
 an exsiting query, view [results](#viewing-results), check a [generated

--- a/docs-mintlify/docs/pre-aggregations/index.mdx
+++ b/docs-mintlify/docs/pre-aggregations/index.mdx
@@ -23,6 +23,8 @@ users. [Pre-aggregations](#pre-aggregations) are designed to provide the
 right balance between time to insight and querying performance.
 
 To reset the **in-memory** cache in development mode, just restart the server.
+Note that [development mode][ref-development-mode] disables authentication
+completely and is meant for local development machines only.
 
 The second level of caching is called **pre-aggregations**, and requires
 explicit configuration to activate.
@@ -186,7 +188,8 @@ cube(`orders`, {
 By default, Cube will check and invalidate the cache in the background when in
 [development mode][ref-development-mode]. In production environments, we
 recommend [running a Refresh Worker as a separate
-instance][ref-production-checklist-refresh].
+instance][ref-production-checklist-refresh] — development mode disables
+authentication completely and must never be used in production.
 
 We recommend enabling background cache invalidation in a separate Cube worker
 for production deployments. Please consult the [Production

--- a/docs-mintlify/docs/pre-aggregations/index.mdx
+++ b/docs-mintlify/docs/pre-aggregations/index.mdx
@@ -23,8 +23,8 @@ users. [Pre-aggregations](#pre-aggregations) are designed to provide the
 right balance between time to insight and querying performance.
 
 To reset the **in-memory** cache in development mode, just restart the server.
-Note that [development mode][ref-development-mode] disables authentication
-completely and is meant for local development machines only.
+Note that [development mode][ref-development-mode] bypasses authentication and is
+meant for local development machines only.
 
 The second level of caching is called **pre-aggregations**, and requires
 explicit configuration to activate.
@@ -188,8 +188,8 @@ cube(`orders`, {
 By default, Cube will check and invalidate the cache in the background when in
 [development mode][ref-development-mode]. In production environments, we
 recommend [running a Refresh Worker as a separate
-instance][ref-production-checklist-refresh] — development mode disables
-authentication completely and must never be used in production.
+instance][ref-production-checklist-refresh] — development mode bypasses
+authentication and must never be used in production.
 
 We recommend enabling background cache invalidation in a separate Cube worker
 for production deployments. Please consult the [Production

--- a/docs-mintlify/docs/pre-aggregations/index.mdx
+++ b/docs-mintlify/docs/pre-aggregations/index.mdx
@@ -22,9 +22,8 @@ when there's a burst of requests hitting the same data from multiple concurrent
 users. [Pre-aggregations](#pre-aggregations) are designed to provide the
 right balance between time to insight and querying performance.
 
-To reset the **in-memory** cache in development mode, just restart the server.
-Note that [development mode][ref-development-mode] bypasses authentication and is
-meant for local development machines only.
+To reset the **in-memory** cache in [development mode][ref-development-mode], just
+restart the server.
 
 The second level of caching is called **pre-aggregations**, and requires
 explicit configuration to activate.
@@ -188,8 +187,7 @@ cube(`orders`, {
 By default, Cube will check and invalidate the cache in the background when in
 [development mode][ref-development-mode]. In production environments, we
 recommend [running a Refresh Worker as a separate
-instance][ref-production-checklist-refresh] — development mode bypasses
-authentication and must never be used in production.
+instance][ref-production-checklist-refresh].
 
 We recommend enabling background cache invalidation in a separate Cube worker
 for production deployments. Please consult the [Production
@@ -294,7 +292,7 @@ cache types.
 [link-cube-cloud]: https://cube.dev/cloud
 [ref-config-preagg-schema]: /reference/configuration/config#preaggregationsschema
 [ref-dev-playground]: /docs/explore-analyze/playground
-[ref-development-mode]: /docs/data-modeling/dev-mode
+[ref-development-mode]: /reference/configuration/environment-variables#cubejs_dev_mode
 [ref-production-checklist]: /cube-core/running-in-production
 [ref-production-checklist-refresh]: /cube-core/running-in-production#set-up-refresh-worker
 [ref-schema-ref-cube-refresh-key]: /reference/data-modeling/cube#refresh_key

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -12,13 +12,13 @@ this is to use the official Docker images for Cube and Cube Store.
 
 <Warning>
 
-Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, so anyone who can reach the
-instance can read all of your data. Unless
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources. Use it only on a local development machine, never in
-production. See
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -10,6 +10,16 @@ Cube Store is enabled by default when running Cube in development mode. In
 production, Cube Store **must** run as a separate process. The easiest way to do
 this is to use the official Docker images for Cube and Cube Store.
 
+<Warning>
+
+Development mode disables authentication completely: data access endpoints are served
+without any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. Use it only on a
+local development machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>
+
 <Info>
 
 Using Windows? We **strongly** recommend using [WSL2 for Windows 10][link-wsl2]

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -3,6 +3,8 @@ title: Running in production
 description: "Cube makes use of two different kinds of cache:"
 ---
 
+import DevModeWarningShort from '/snippets/dev-mode-warning-short.mdx';
+
 - In-memory storage of query results
 - Pre-aggregations
 
@@ -10,18 +12,7 @@ Cube Store is enabled by default when running Cube in development mode. In
 production, Cube Store **must** run as a separate process. The easiest way to do
 this is to use the official Docker images for Cube and Cube Store.
 
-<Warning>
-
-Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
-
-</Warning>
+<DevModeWarningShort />
 
 <Info>
 

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -13,9 +13,12 @@ this is to use the official Docker images for Cube and Cube Store.
 <Warning>
 
 Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. Use it only on a
-local development machine, never in production. See
+without any authentication or authorization verification, so anyone who can reach the
+instance can read all of your data. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -43,17 +43,18 @@ A typical use case would be:
 
 <Warning>
 
-**In development mode, the token is not required for authorization.** Cube Core
-disables authentication completely when
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode)
-is enabled: all data access endpoints are served without any authentication or
-authorization verification, so anyone who can reach the instance can read all of your
-data, and the SQL API accepts any credentials unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, allowing arbitrary SQL against connected data sources. This is intentional — development mode
-is designed for local development machines only. Never use it in production, and
-using it in the Cube cloud platform is highly discouraged because it bypasses the
-platform's security model.
+**In development mode, the token is not required for authorization.** JWT
+verification on this API is enforced only when `NODE_ENV=production` or a custom
+[`check_auth`](/reference/configuration/config#check_auth) is configured, so with
+`NODE_ENV` unset the API accepts requests with no token at all — regardless of
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+Enabling `CUBEJS_DEV_MODE` bypasses authentication even under
+`NODE_ENV=production`, because Playground's unauthenticated endpoints will mint a
+valid token carrying any security context, signed with your API secret. This is
+intentional — development mode is designed for local development machines only. Never
+use it in production, and using it in the Cube cloud platform is highly discouraged
+because it bypasses the platform's security model.
 
 You can still pass a token in development mode to [set a security
 context][ref-sec-ctx].

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -46,9 +46,9 @@ A typical use case would be:
 **In development mode, the token is not required for authorization.** Cube is in
 development mode whenever `NODE_ENV` is not `production`, whatever
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) is
-set to — and in that state this API accepts requests with no token at all. Setting
-`NODE_ENV=production` both takes the instance out of development mode and turns JWT
-verification on; a custom
+set to — and in that state this API accepts requests with no token at all.
+`NODE_ENV=production` turns JWT verification on, and — unless `CUBEJS_DEV_MODE=true` —
+also takes the instance out of development mode; a custom
 [`check_auth`](/reference/configuration/config#check_auth) that rejects
 unauthenticated requests enforces it too, whatever `NODE_ENV` is.
 

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -45,9 +45,10 @@ A typical use case would be:
 
 **In development mode, the token is not required for authorization.** JWT
 verification on this API is enabled by `NODE_ENV=production`, so it is off whenever
-`NODE_ENV` is anything else — and setting
+`NODE_ENV` is anything else. Under the `cubejs` CLI and the official Docker images,
+setting
 [`CUBEJS_DEV_MODE=true`](/reference/configuration/environment-variables#cubejs_dev_mode)
-forces `NODE_ENV=development`, which switches verification off even where it was
+also forces `NODE_ENV=development`, which switches verification off even where it was
 otherwise on. A custom [`check_auth`](/reference/configuration/config#check_auth) that
 rejects unauthenticated requests enforces it whatever `NODE_ENV` is.
 

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -41,12 +41,22 @@ A typical use case would be:
 5.  Once decoded, the token claims are injected into the [security
     context][ref-sec-ctx].
 
-<Info>
+<Warning>
 
-**In development mode, the token is not required for authorization**, but you
-can still use it to [pass a security context][ref-sec-ctx].
+**In development mode, the token is not required for authorization.** Cube Core
+disables authentication completely when
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode)
+is enabled: all data access endpoints are served without any authentication or
+authorization verification, and anyone who can reach the instance can execute
+arbitrary SQL against connected data sources. This is intentional — development mode
+is designed for local development machines only. Never use it in production, and
+using it in the Cube cloud platform is highly discouraged because it bypasses the
+platform's security model.
 
-</Info>
+You can still pass a token in development mode to [set a security
+context][ref-sec-ctx].
+
+</Warning>
 
 ## Generating JSON Web Tokens
 

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -43,18 +43,18 @@ A typical use case would be:
 
 <Warning>
 
-**In development mode, the token is not required for authorization.** Cube is in
-development mode whenever `NODE_ENV` is not `production`, whatever
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) is
-set to — and in that state this API accepts requests with no token at all.
-`NODE_ENV=production` turns JWT verification on, and — unless `CUBEJS_DEV_MODE=true` —
-also takes the instance out of development mode; a custom
-[`check_auth`](/reference/configuration/config#check_auth) that rejects
-unauthenticated requests enforces it too, whatever `NODE_ENV` is.
+**In development mode, the token is not required for authorization.** JWT
+verification on this API is enabled by `NODE_ENV=production`, so it is off whenever
+`NODE_ENV` is anything else — and setting
+[`CUBEJS_DEV_MODE=true`](/reference/configuration/environment-variables#cubejs_dev_mode)
+forces `NODE_ENV=development`, which switches verification off even where it was
+otherwise on. A custom [`check_auth`](/reference/configuration/config#check_auth) that
+rejects unauthenticated requests enforces it whatever `NODE_ENV` is.
 
-Enabling `CUBEJS_DEV_MODE` bypasses authentication even under
-`NODE_ENV=production`, because Playground's unauthenticated endpoints will mint a
-valid token carrying any security context, signed with your API secret. This is
+`cubejs server` and the official Docker images set `NODE_ENV=production`, so
+verification is on there unless you enable development mode. Development mode also
+exposes Playground's unauthenticated endpoints, which hand out and mint valid tokens
+carrying any security context, signed with your API secret. This is
 intentional — development mode is designed for local development machines only. Never
 use it in production, and using it in the Cube cloud platform is highly discouraged
 because it bypasses the platform's security model.

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -44,9 +44,10 @@ A typical use case would be:
 <Warning>
 
 **In development mode, the token is not required for authorization.** JWT
-verification on this API is enforced only when `NODE_ENV=production` or a custom
-[`check_auth`](/reference/configuration/config#check_auth) is configured, so with
-`NODE_ENV` unset the API accepts requests with no token at all — regardless of
+verification on this API is enforced only when `NODE_ENV=production`, or when a custom
+[`check_auth`](/reference/configuration/config#check_auth) itself rejects
+unauthenticated requests. With `NODE_ENV` unset and no such `check_auth`, the API
+accepts requests with no token at all — regardless of
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 Enabling `CUBEJS_DEV_MODE` bypasses authentication even under

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -43,12 +43,14 @@ A typical use case would be:
 
 <Warning>
 
-**In development mode, the token is not required for authorization.** JWT
-verification on this API is enforced only when `NODE_ENV=production`, or when a custom
-[`check_auth`](/reference/configuration/config#check_auth) itself rejects
-unauthenticated requests. With `NODE_ENV` unset and no such `check_auth`, the API
-accepts requests with no token at all — regardless of
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+**In development mode, the token is not required for authorization.** Cube is in
+development mode whenever `NODE_ENV` is not `production`, whatever
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode) is
+set to — and in that state this API accepts requests with no token at all. Setting
+`NODE_ENV=production` both takes the instance out of development mode and turns JWT
+verification on; a custom
+[`check_auth`](/reference/configuration/config#check_auth) that rejects
+unauthenticated requests enforces it too, whatever `NODE_ENV` is.
 
 Enabling `CUBEJS_DEV_MODE` bypasses authentication even under
 `NODE_ENV=production`, because Playground's unauthenticated endpoints will mint a

--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -47,8 +47,10 @@ A typical use case would be:
 disables authentication completely when
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode)
 is enabled: all data access endpoints are served without any authentication or
-authorization verification, and anyone who can reach the instance can execute
-arbitrary SQL against connected data sources. This is intentional — development mode
+authorization verification, so anyone who can reach the instance can read all of your
+data, and the SQL API accepts any credentials unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, allowing arbitrary SQL against connected data sources. This is intentional — development mode
 is designed for local development machines only. Never use it in production, and
 using it in the Cube cloud platform is highly discouraged because it bypasses the
 platform's security model.

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -629,7 +629,9 @@ Either string or function can be passed. Providing a function allows to set
 the schema name dynamically depending on the security context.
 
 Defaults to `dev_pre_aggregations` in [development mode][ref-development-mode]
-and `prod_pre_aggregations` in production.
+and `prod_pre_aggregations` in production. Development mode [disables
+authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode)
+and is intended for local development machines only.
 
 <Info>
 
@@ -1511,9 +1513,11 @@ See also the [`CUBEJS_LOG_LEVEL`](/reference/configuration/environment-variables
 ### `telemetry`
 
 Cube collects high-level anonymous usage statistics for servers started in
-development mode. It doesn't track any credentials, data model contents or
-queries issued. This statistics is used solely for the purpose of constant
-cube.js improvement.
+[development mode][ref-development-mode] (which [disables authentication
+completely](/reference/configuration/environment-variables#cubejs_dev_mode) and is
+intended for local development machines only). It doesn't track any credentials,
+data model contents or queries issued. This statistics is used solely for the
+purpose of constant cube.js improvement.
 
 You can opt out of it any time by setting `telemetry` option to `False` or,
 alternatively, by setting [`CUBEJS_TELEMETRY`](/reference/configuration/environment-variables#cubejs_telemetry) environment variable to `false`.

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -629,8 +629,8 @@ Either string or function can be passed. Providing a function allows to set
 the schema name dynamically depending on the security context.
 
 Defaults to `dev_pre_aggregations` in [development mode][ref-development-mode]
-and `prod_pre_aggregations` in production. Development mode [disables
-authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode)
+and `prod_pre_aggregations` in production. Development mode [bypasses
+authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
 and is intended for local development machines only.
 
 <Info>
@@ -1513,8 +1513,8 @@ See also the [`CUBEJS_LOG_LEVEL`](/reference/configuration/environment-variables
 ### `telemetry`
 
 Cube collects high-level anonymous usage statistics for servers started in
-[development mode][ref-development-mode] (which [disables authentication
-completely](/reference/configuration/environment-variables#cubejs_dev_mode) and is
+[development mode][ref-development-mode] (which [bypasses
+authentication](/reference/configuration/environment-variables#cubejs_dev_mode) and is
 intended for local development machines only). It doesn't track any credentials,
 data model contents or queries issued. This statistics is used solely for the
 purpose of constant cube.js improvement.

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -629,9 +629,7 @@ Either string or function can be passed. Providing a function allows to set
 the schema name dynamically depending on the security context.
 
 Defaults to `dev_pre_aggregations` in [development mode][ref-development-mode]
-and `prod_pre_aggregations` in production. Development mode [bypasses
-authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
-and is intended for local development machines only.
+and `prod_pre_aggregations` in production.
 
 <Info>
 
@@ -1513,11 +1511,9 @@ See also the [`CUBEJS_LOG_LEVEL`](/reference/configuration/environment-variables
 ### `telemetry`
 
 Cube collects high-level anonymous usage statistics for servers started in
-[development mode][ref-development-mode] (which [bypasses
-authentication](/reference/configuration/environment-variables#cubejs_dev_mode) and is
-intended for local development machines only). It doesn't track any credentials,
-data model contents or queries issued. This statistics is used solely for the
-purpose of constant cube.js improvement.
+[development mode][ref-development-mode]. It doesn't track any credentials, data
+model contents or queries issued. This statistics is used solely for the purpose of
+constant cube.js improvement.
 
 You can opt out of it any time by setting `telemetry` option to `False` or,
 alternatively, by setting [`CUBEJS_TELEMETRY`](/reference/configuration/environment-variables#cubejs_telemetry) environment variable to `false`.
@@ -1547,7 +1543,7 @@ module.exports = {
 [link-jwt-ref-sub]: https://tools.ietf.org/html/rfc7519#section-4.1.2
 [link-jwt-ref-aud]: https://tools.ietf.org/html/rfc7519#section-4.1.3
 [link-wiki-tz]: https://en.wikipedia.org/wiki/Tz_database
-[ref-development-mode]: /docs/data-modeling/dev-mode
+[ref-development-mode]: /reference/configuration/environment-variables#cubejs_dev_mode
 [ref-multitenancy]: /embedding/multitenancy
 [ref-preagg-data-source]: /docs/pre-aggregations/refreshing-pre-aggregations#pre-aggregation-data-source
 [ref-rest-api]: /reference/core-data-apis/rest-api

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1204,11 +1204,14 @@ data access endpoint of the Cube instance — the
 [GraphQL API](/reference/core-data-apis/graphql-api),
 [SQL API](/reference/core-data-apis/sql-api), and
 [Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: no JWT is required and
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The data model and configuration are also readable and writable
-through those unauthenticated endpoints, so anyone who can reach the instance can
-execute arbitrary SQL against every connected data source.
+or authorization verification: requests with a missing or invalid token are accepted,
+and [member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The SQL API additionally accepts any user name and password unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, so anyone who can reach the instance can execute arbitrary SQL against every
+connected data source. Playground's own endpoints are unauthenticated as well: they
+read and write your data model files and `.env`, and mint tokens carrying any security
+context, signed with your API secret.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -3,6 +3,8 @@ title: Environment variables
 description: "To see a complete list of environment variables for a specific data source, please check the relevant page on Connecting to Data Sources."
 ---
 
+import DevModeWarning from '/snippets/dev-mode-warning.mdx';
+
 <Info>
 
 To see a complete list of environment variables for a specific data source,
@@ -1196,35 +1198,7 @@ If `true`, enables [development mode](/docs/data-modeling/dev-mode).
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true`                 | `false`               |
 
-<Warning>
-
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
-
-This is intentional. Development mode is designed to run on a developer's local
-machine for ease of use and debugging. Never run it where anyone else can reach it,
-never expose it to the internet, and never use it in production. Using development
-mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
-security model.
-
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
-
-</Warning>
+<DevModeWarning />
 
 ## `CUBEJS_DROP_PRE_AGG_WITHOUT_TOUCH`
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1198,26 +1198,31 @@ If `true`, enables [development mode](/docs/data-modeling/dev-mode).
 
 <Warning>
 
-**Development mode disables authentication completely.** While it is enabled, every
-data access endpoint of the Cube instance — the
-[REST (JSON) API](/reference/core-data-apis/rest-api),
-[GraphQL API](/reference/core-data-apis/graphql-api),
-[SQL API](/reference/core-data-apis/sql-api), and
-[Playground](/docs/explore-analyze/playground) — is served without any authentication
-or authorization verification: requests with a missing or invalid token are accepted,
-and [member-level access control](/docs/data-modeling/access-control/member-level-security)
-is not enforced. The SQL API additionally accepts any user name and password unless
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, so anyone who can reach the instance can execute arbitrary SQL against every
-connected data source. Playground's own endpoints are unauthenticated as well: they
-read and write your data model files and `.env`, and mint tokens carrying any security
-context, signed with your API secret.
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
 never expose it to the internet, and never use it in production. Using development
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
+
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
 
 </Warning>
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1196,6 +1196,28 @@ If `true`, enables [development mode](/docs/data-modeling/dev-mode).
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true`                 | `false`               |
 
+<Warning>
+
+**Development mode disables authentication completely.** While it is enabled, every
+data access endpoint of the Cube instance — the
+[REST (JSON) API](/reference/core-data-apis/rest-api),
+[GraphQL API](/reference/core-data-apis/graphql-api),
+[SQL API](/reference/core-data-apis/sql-api), and
+[Playground](/docs/explore-analyze/playground) — is served without any authentication
+or authorization verification: no JWT is required and
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+is not enforced. The data model and configuration are also readable and writable
+through those unauthenticated endpoints, so anyone who can reach the instance can
+execute arbitrary SQL against every connected data source.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+</Warning>
+
 ## `CUBEJS_DROP_PRE_AGG_WITHOUT_TOUCH`
 
 If `true`, it enables dropping pre-aggregations that Refresh Worker doesn't

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -56,8 +56,7 @@ Response
   including browsers holding a public embedding token. Fields that describe
   storage layout or query results stay behind
   [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode)
-  (a local-development-only setting that [bypasses
-  authentication](/reference/configuration/environment-variables#cubejs_dev_mode))
+  (a local-development-only setting that bypasses authentication)
   and the Playground: `targetTableName` (the physical table of one specific build,
   version hashes included) and `refreshKeyValues`.
 

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -59,6 +59,11 @@ Response
   and the Playground: `targetTableName` (the physical table of one specific build,
   version hashes included) and `refreshKeyValues`.
 
+  Development mode itself disables authentication completely — all data access
+  endpoints are served without any authentication or authorization verification, and
+  anyone who can reach the instance can execute arbitrary SQL against connected data
+  sources — so use it only on local development machines, never in production.
+
   </Note>
 - `total` - The total number of rows returned for the query. Useful for
   paginating results.

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -56,13 +56,10 @@ Response
   including browsers holding a public embedding token. Fields that describe
   storage layout or query results stay behind
   [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode)
+  (a local-development-only setting that [bypasses
+  authentication](/reference/configuration/environment-variables#cubejs_dev_mode))
   and the Playground: `targetTableName` (the physical table of one specific build,
   version hashes included) and `refreshKeyValues`.
-
-  Development mode itself disables authentication completely — all data access
-  endpoints are served without any authentication or authorization verification, so
-  anyone who can reach the instance can read all of your data — so use it only on
-  local development machines, never in production.
 
   </Note>
 - `total` - The total number of rows returned for the query. Useful for

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -60,9 +60,9 @@ Response
   version hashes included) and `refreshKeyValues`.
 
   Development mode itself disables authentication completely — all data access
-  endpoints are served without any authentication or authorization verification, and
-  anyone who can reach the instance can execute arbitrary SQL against connected data
-  sources — so use it only on local development machines, never in production.
+  endpoints are served without any authentication or authorization verification, so
+  anyone who can reach the instance can read all of your data — so use it only on
+  local development machines, never in production.
 
   </Note>
 - `total` - The total number of rows returned for the query. Useful for

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -181,9 +181,12 @@ an [example request](#transport).
 <Warning>
 
 Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, and anyone who can reach the
-instance can execute arbitrary SQL against connected data sources. Use it only on a
-local development machine, never in production. See
+without any authentication or authorization verification, so anyone who can reach the
+instance can read all of your data. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -3,6 +3,8 @@ title: Cube Core
 description: "Connect any Postgres-compatible client or BI tool to Cube using the Postgres-protocol SQL API."
 ---
 
+import DevModeWarningShort from '/snippets/dev-mode-warning-short.mdx';
+
  SQL API
 
 The SQL API enables Cube to deliver data over the [Postgres-compatible
@@ -178,18 +180,7 @@ services:
 After running it with `docker compose up`, you can finally connect and execute
 an [example request](#transport).
 
-<Warning>
-
-Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
-[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
-
-</Warning>
+<DevModeWarningShort />
 
 ### Cube Cloud
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -178,6 +178,16 @@ services:
 After running it with `docker compose up`, you can finally connect and execute
 an [example request](#transport).
 
+<Warning>
+
+Development mode disables authentication completely: data access endpoints are served
+without any authentication or authorization verification, and anyone who can reach the
+instance can execute arbitrary SQL against connected data sources. Use it only on a
+local development machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>
+
 ### Cube Cloud
 
 **SQL API is enabled by default.** To find your SQL API endpoint and credentials

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -180,13 +180,13 @@ an [example request](#transport).
 
 <Warning>
 
-Development mode disables authentication completely: data access endpoints are served
-without any authentication or authorization verification, so anyone who can reach the
-instance can read all of your data. Unless
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources. Use it only on a local development machine, never in
-production. See
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -1285,10 +1285,9 @@ starting with most recent ones in time and checks if the
 [`refresh_key`][self-refreshkey] has changed. If a change was detected, then
 that partition will be refreshed.
 
-In development mode, Cube runs the background refresh by default and will
-refresh all pre-aggregations which have `scheduled_refresh: true`. Development
-mode [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
-and is intended for local development machines only.
+In [development mode](/reference/configuration/environment-variables#cubejs_dev_mode),
+Cube runs the background refresh by default and will refresh all pre-aggregations
+which have `scheduled_refresh: true`.
 
 Please consult [Production Checklist][ref-production-checklist-refresh] for best
 practices on running background refresh in production environments.

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -1286,7 +1286,9 @@ starting with most recent ones in time and checks if the
 that partition will be refreshed.
 
 In development mode, Cube runs the background refresh by default and will
-refresh all pre-aggregations which have `scheduled_refresh: true`.
+refresh all pre-aggregations which have `scheduled_refresh: true`. Development
+mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode)
+and is intended for local development machines only.
 
 Please consult [Production Checklist][ref-production-checklist-refresh] for best
 practices on running background refresh in production environments.

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -1287,7 +1287,7 @@ that partition will be refreshed.
 
 In development mode, Cube runs the background refresh by default and will
 refresh all pre-aggregations which have `scheduled_refresh: true`. Development
-mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode)
+mode [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
 and is intended for local development machines only.
 
 Please consult [Production Checklist][ref-production-checklist-refresh] for best

--- a/docs-mintlify/reference/javascript-sdk/angular.mdx
+++ b/docs-mintlify/reference/javascript-sdk/angular.mdx
@@ -61,10 +61,10 @@ Here are the typical steps to query and visualize analytical data in Angular:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production): development
-  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
-  serving data access endpoints without any authentication or authorization
-  verification, so it's intended for local development machines only.
+  takes effect only in [production](/cube-core/running-in-production): with
+  `NODE_ENV` unset the API accepts requests with no token, and development mode
+  [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
+  outright, so both are intended for local development machines only.
 - **Query data from Cube Backend and Transform data for visualization.** Use
   [`CubeClient`](/reference/javascript-sdk/reference/cubejs-client-ngx#api) to load data. The
   client accepts a query, which is a plain JavaScript object. See

--- a/docs-mintlify/reference/javascript-sdk/angular.mdx
+++ b/docs-mintlify/reference/javascript-sdk/angular.mdx
@@ -61,7 +61,10 @@ Here are the typical steps to query and visualize analytical data in Angular:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production).
+  takes effect only in [production](/cube-core/running-in-production): development
+  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
+  serving data access endpoints without any authentication or authorization
+  verification, so it's intended for local development machines only.
 - **Query data from Cube Backend and Transform data for visualization.** Use
   [`CubeClient`](/reference/javascript-sdk/reference/cubejs-client-ngx#api) to load data. The
   client accepts a query, which is a plain JavaScript object. See

--- a/docs-mintlify/reference/javascript-sdk/index.mdx
+++ b/docs-mintlify/reference/javascript-sdk/index.mdx
@@ -56,7 +56,10 @@ Here are the typical steps to query and visualize analytical data:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production).
+  takes effect only in [production](/cube-core/running-in-production): development
+  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
+  serving data access endpoints without any authentication or authorization
+  verification, so it's intended for local development machines only.
 - **Query data from Cube Backend.** The client accepts a query, which is a plain
   JavaScript object. See
   [Query Format](/reference/core-data-apis/rest-api/query-format) for details.

--- a/docs-mintlify/reference/javascript-sdk/index.mdx
+++ b/docs-mintlify/reference/javascript-sdk/index.mdx
@@ -56,10 +56,10 @@ Here are the typical steps to query and visualize analytical data:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production): development
-  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
-  serving data access endpoints without any authentication or authorization
-  verification, so it's intended for local development machines only.
+  takes effect only in [production](/cube-core/running-in-production): with
+  `NODE_ENV` unset the API accepts requests with no token, and development mode
+  [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
+  outright, so both are intended for local development machines only.
 - **Query data from Cube Backend.** The client accepts a query, which is a plain
   JavaScript object. See
   [Query Format](/reference/core-data-apis/rest-api/query-format) for details.

--- a/docs-mintlify/reference/javascript-sdk/react.mdx
+++ b/docs-mintlify/reference/javascript-sdk/react.mdx
@@ -68,7 +68,10 @@ Here are the typical steps to query and visualize analytical data in React:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production).
+  takes effect only in [production](/cube-core/running-in-production): development
+  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
+  serving data access endpoints without any authentication or authorization
+  verification, so it's intended for local development machines only.
 - **Query data from Cube Backend.** In functional React components, use the
   `useCubeQuery` hook to execute a query, which is a plain JavaScript object.
   See [Query Format](/reference/core-data-apis/rest-api/query-format) for

--- a/docs-mintlify/reference/javascript-sdk/react.mdx
+++ b/docs-mintlify/reference/javascript-sdk/react.mdx
@@ -68,10 +68,10 @@ Here are the typical steps to query and visualize analytical data in React:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production): development
-  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
-  serving data access endpoints without any authentication or authorization
-  verification, so it's intended for local development machines only.
+  takes effect only in [production](/cube-core/running-in-production): with
+  `NODE_ENV` unset the API accepts requests with no token, and development mode
+  [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
+  outright, so both are intended for local development machines only.
 - **Query data from Cube Backend.** In functional React components, use the
   `useCubeQuery` hook to execute a query, which is a plain JavaScript object.
   See [Query Format](/reference/core-data-apis/rest-api/query-format) for

--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -52,7 +52,7 @@ const cubeApi = cube(
 
 Name | Type | Description |
 ------ | ------ | ------ |
-apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube will print the API token to the console on startup. In case of async function `authorization` is updated for `options.transport` on each request. |
+apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube will print the API token to the console on startup; note that development mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode) and is intended for local development machines only. In case of async function `authorization` is updated for `options.transport` on each request. |
 options | [CubeApiOptions](#cubeapioptions) | - |
 
 >  **cube**(**options**: [CubeApiOptions](#cubeapioptions)): *[CubeApi](#cubeapi)*

--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -52,7 +52,7 @@ const cubeApi = cube(
 
 Name | Type | Description |
 ------ | ------ | ------ |
-apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube will print the API token to the console on startup; note that development mode [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode) and is intended for local development machines only. In case of async function `authorization` is updated for `options.transport` on each request. |
+apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In [development mode](/reference/configuration/environment-variables#cubejs_dev_mode) (local use only — it bypasses authentication), Cube will print the API token to the console on startup. In case of async function `authorization` is updated for `options.transport` on each request. |
 options | [CubeApiOptions](#cubeapioptions) | - |
 
 >  **cube**(**options**: [CubeApiOptions](#cubeapioptions)): *[CubeApi](#cubeapi)*

--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -52,7 +52,7 @@ const cubeApi = cube(
 
 Name | Type | Description |
 ------ | ------ | ------ |
-apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube will print the API token to the console on startup; note that development mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode) and is intended for local development machines only. In case of async function `authorization` is updated for `options.transport` on each request. |
+apiToken | string &#124;  () => *Promise‹string›* | [API token][ref-security] is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube will print the API token to the console on startup; note that development mode [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode) and is intended for local development machines only. In case of async function `authorization` is updated for `options.transport` on each request. |
 options | [CubeApiOptions](#cubeapioptions) | - |
 
 >  **cube**(**options**: [CubeApiOptions](#cubeapioptions)): *[CubeApi](#cubeapi)*

--- a/docs-mintlify/reference/javascript-sdk/vue.mdx
+++ b/docs-mintlify/reference/javascript-sdk/vue.mdx
@@ -60,10 +60,10 @@ Here are the typical steps to query and visualize analytical data in Vue:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production): development
-  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
-  serving data access endpoints without any authentication or authorization
-  verification, so it's intended for local development machines only.
+  takes effect only in [production](/cube-core/running-in-production): with
+  `NODE_ENV` unset the API accepts requests with no token, and development mode
+  [bypasses authentication](/reference/configuration/environment-variables#cubejs_dev_mode)
+  outright, so both are intended for local development machines only.
 - **Query data from Cube Backend.** Use
   [`QueryBuilder`](/reference/javascript-sdk/reference/cubejs-client-vue#querybuilder) or
   [`QueryRenderer`](/reference/javascript-sdk/reference/cubejs-client-vue#queryrenderer) and

--- a/docs-mintlify/reference/javascript-sdk/vue.mdx
+++ b/docs-mintlify/reference/javascript-sdk/vue.mdx
@@ -60,7 +60,10 @@ Here are the typical steps to query and visualize analytical data in Vue:
   with Cube API URL. In development mode, the default URL is
   [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1).
   The client is also initialized with an [API token](/docs/data-modeling/access-control), but it
-  takes effect only in [production](/cube-core/running-in-production).
+  takes effect only in [production](/cube-core/running-in-production): development
+  mode [disables authentication completely](/reference/configuration/environment-variables#cubejs_dev_mode),
+  serving data access endpoints without any authentication or authorization
+  verification, so it's intended for local development machines only.
 - **Query data from Cube Backend.** Use
   [`QueryBuilder`](/reference/javascript-sdk/reference/cubejs-client-vue#querybuilder) or
   [`QueryRenderer`](/reference/javascript-sdk/reference/cubejs-client-vue#queryrenderer) and

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -7,7 +7,11 @@ REST (JSON) and GraphQL APIs — and whenever `NODE_ENV` is not
 `production`. Playground's endpoints are served with no authentication too: anyone who
 can reach the instance is handed a ready-to-use API token, can mint others carrying any
 security context, can read your data model files, and can overwrite your data model and
-your `.env`. Use it only on a local development machine, never in production. See
+your `.env`. With `CUBEJS_DEV_MODE=true` and no
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+set, the SQL API accepts any credentials as well, allowing arbitrary SQL against
+connected data sources. Use it only on a local development machine, never in
+production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,14 +1,12 @@
 <Warning>
 
-Development mode is an authentication bypass, and Cube is in development mode whenever
-`NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`. Playground's endpoints are
-then served with no authentication: anyone who can reach the instance is handed a
-ready-to-use API token, can mint others carrying any security context, can read your
-data model files, and can overwrite your data model and your `.env`. With
-`CUBEJS_DEV_MODE=true` specifically and no
-[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-set, the SQL API also accepts any credentials, allowing arbitrary SQL against connected
-data sources. Use it only on a local development machine, never in production. See
+Development mode is an authentication bypass. Cube is in development mode when
+`CUBEJS_DEV_MODE=true` — which also forces `NODE_ENV=development` and so switches off
+JWT verification on the REST (JSON) and GraphQL APIs — and whenever `NODE_ENV` is not
+`production`. Playground's endpoints are served with no authentication too: anyone who
+can reach the instance is handed a ready-to-use API token, can mint others carrying any
+security context, can read your data model files, and can overwrite your data model and
+your `.env`. Use it only on a local development machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,14 +1,14 @@
 <Warning>
 
-Development mode is an authentication bypass — and Cube is in development mode
-whenever `NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`. Playground's
-endpoints are then served with
-no authentication, so anyone who can reach the instance is handed a ready-to-use API
-token (and can mint others carrying any security context), read your data model,
-overwrite it and your `.env`, and — unless
+Development mode is an authentication bypass, and Cube is in development mode whenever
+`NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`. Playground's endpoints are
+then served with no authentication: anyone who can reach the instance is handed a
+ready-to-use API token, can mint others carrying any security context, can read your
+data model files, and can overwrite your data model and your `.env`. With
+`CUBEJS_DEV_MODE=true` specifically and no
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set — run arbitrary SQL through the SQL API. Use it only on a local development
-machine, never in production. See
+set, the SQL API also accepts any credentials, allowing arbitrary SQL against connected
+data sources. Use it only on a local development machine, never in production. See
 [`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,0 +1,12 @@
+<Warning>
+
+Development mode is an authentication bypass: Playground's endpoints are served with
+no authentication, so anyone who can reach the instance can mint an API token carrying
+any security context (signed with your API secret), read and overwrite your data model
+and `.env`, and — unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set — run arbitrary SQL through the SQL API. Use it only on a local development
+machine, never in production. See
+[`CUBEJS_DEV_MODE`](/reference/configuration/environment-variables#cubejs_dev_mode).
+
+</Warning>

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,9 +1,9 @@
 <Warning>
 
 Development mode is an authentication bypass: Playground's endpoints are served with
-no authentication, so anyone who can reach the instance can mint an API token carrying
-any security context (signed with your API secret), read and overwrite your data model
-and `.env`, and — unless
+no authentication, so anyone who can reach the instance is handed a ready-to-use API
+token (and can mint others carrying any security context), read your data model,
+overwrite it and your `.env`, and — unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
 is set — run arbitrary SQL through the SQL API. Use it only on a local development
 machine, never in production. See

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,8 +1,9 @@
 <Warning>
 
 Development mode is an authentication bypass. Cube is in development mode when
-`CUBEJS_DEV_MODE=true` — which also forces `NODE_ENV=development` and so switches off
-JWT verification on the REST (JSON) and GraphQL APIs — and whenever `NODE_ENV` is not
+`CUBEJS_DEV_MODE=true` — which, under the `cubejs` CLI and the official Docker images,
+also forces `NODE_ENV=development` and so switches off JWT verification on the
+REST (JSON) and GraphQL APIs — and whenever `NODE_ENV` is not
 `production`. Playground's endpoints are served with no authentication too: anyone who
 can reach the instance is handed a ready-to-use API token, can mint others carrying any
 security context, can read your data model files, and can overwrite your data model and

--- a/docs-mintlify/snippets/dev-mode-warning-short.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning-short.mdx
@@ -1,6 +1,8 @@
 <Warning>
 
-Development mode is an authentication bypass: Playground's endpoints are served with
+Development mode is an authentication bypass — and Cube is in development mode
+whenever `NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`. Playground's
+endpoints are then served with
 no authentication, so anyone who can reach the instance is handed a ready-to-use API
 token (and can mint others carrying any security context), read your data model,
 overwrite it and your `.env`, and — unless

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -9,10 +9,12 @@ with your API secret — and so query every data API as any user, bypassing
 [member-level access control](/docs/data-modeling/access-control/member-level-security)
 and [row-level security](/docs/data-modeling/access-control/row-level-security). The
 same endpoints also read your data model files and the table schema of every connected
-data source, and overwrite your data model and your `.env`. Unless
+data source, and overwrite your data model and your `.env`. On top of that, with
+`CUBEJS_DEV_MODE=true` specifically — the SQL API's password check follows that flag
+alone, not `NODE_ENV` — and no
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
-connected data sources.
+set, the SQL API accepts any credentials, allowing arbitrary SQL against connected
+data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -1,0 +1,29 @@
+<Warning>
+
+**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
+mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
+with no authentication whatsoever, so anyone who can reach the instance can mint a
+valid API token carrying any security context — signed with your API secret — and then
+query every data API as any user, bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read and overwrite your data model files and your `.env` (secrets included), and read
+the table schema of every connected data source. Unless
+[`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
+is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
+connected data sources.
+
+This is intentional. Development mode is designed to run on a developer's local
+machine for ease of use and debugging. Never run it where anyone else can reach it,
+never expose it to the internet, and never use it in production. Using development
+mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
+security model.
+
+Disabling development mode is necessary but not sufficient. JWT verification on the
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) — **not** by
+`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
+even when `CUBEJS_DEV_MODE=false`. The official Docker images set
+`NODE_ENV=production`.
+
+</Warning>

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -19,11 +19,13 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
-Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production`, or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) that rejects unauthenticated
-requests — **not** by `CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept
-unauthenticated requests even when `CUBEJS_DEV_MODE=false`. The official Docker images
-set `NODE_ENV=production`.
+`CUBEJS_DEV_MODE` is not the only switch. Cube treats any instance where `NODE_ENV`
+is not `production` as being in development mode, whatever the flag is set to, so
+`CUBEJS_DEV_MODE=false` on its own does not turn it off — set `NODE_ENV=production`
+too. Once development mode is genuinely off, JWT verification on the REST (JSON) and
+GraphQL APIs is enforced, because `NODE_ENV=production` is exactly what enables it. A
+custom [`check_auth`](/reference/configuration/config#check_auth) that rejects
+unauthenticated requests enforces it as well, whatever `NODE_ENV` is. The official
+Docker images set `NODE_ENV=production`.
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -2,13 +2,13 @@
 
 **Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
 mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever, so anyone who can reach the instance can mint a
-valid API token carrying any security context — signed with your API secret — and then
-query every data API as any user, bypassing [member-level access
-control](/docs/data-modeling/access-control/member-level-security) and [row-level
-security](/docs/data-modeling/access-control/row-level-security). The same endpoints
-read and overwrite your data model files and your `.env` (secrets included), and read
-the table schema of every connected data source. Unless
+with no authentication whatsoever. Anyone who can reach the instance is handed a
+ready-to-use API token, and can mint further ones carrying any security context signed
+with your API secret — and so query every data API as any user, bypassing
+[member-level access control](/docs/data-modeling/access-control/member-level-security)
+and [row-level security](/docs/data-modeling/access-control/row-level-security). The
+same endpoints also read your data model files and the table schema of every connected
+data source, and overwrite your data model and your `.env`. Unless
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
 is set, the SQL API also accepts any credentials, allowing arbitrary SQL against
 connected data sources.
@@ -20,10 +20,10 @@ mode in the Cube cloud platform is highly discouraged — it bypasses the platfo
 security model.
 
 Disabling development mode is necessary but not sufficient. JWT verification on the
-REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production` or by a custom
-[`check_auth`](/reference/configuration/config#check_auth) — **not** by
-`CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept unauthenticated requests
-even when `CUBEJS_DEV_MODE=false`. The official Docker images set
-`NODE_ENV=production`.
+REST (JSON) and GraphQL APIs is turned on by `NODE_ENV=production`, or by a custom
+[`check_auth`](/reference/configuration/config#check_auth) that rejects unauthenticated
+requests — **not** by `CUBEJS_DEV_MODE`. With `NODE_ENV` unset, those APIs accept
+unauthenticated requests even when `CUBEJS_DEV_MODE=false`. The official Docker images
+set `NODE_ENV=production`.
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -1,8 +1,9 @@
 <Warning>
 
-**Development mode is an authentication bypass.** With `CUBEJS_DEV_MODE=true`, Cube
-mounts [Playground](/docs/explore-analyze/playground) and its supporting endpoints
-with no authentication whatsoever. Anyone who can reach the instance is handed a
+**Development mode is an authentication bypass.** Cube is in development mode whenever
+`NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`, and in that state it mounts
+[Playground](/docs/explore-analyze/playground) and its supporting endpoints with no
+authentication whatsoever. Anyone who can reach the instance is handed a
 ready-to-use API token, and can mint further ones carrying any security context signed
 with your API secret — and so query every data API as any user, bypassing
 [member-level access control](/docs/data-modeling/access-control/member-level-security)
@@ -19,13 +20,13 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
-`CUBEJS_DEV_MODE` is not the only switch. Cube treats any instance where `NODE_ENV`
-is not `production` as being in development mode, whatever the flag is set to, so
-`CUBEJS_DEV_MODE=false` on its own does not turn it off — set `NODE_ENV=production`
-too. Once development mode is genuinely off, JWT verification on the REST (JSON) and
-GraphQL APIs is enforced, because `NODE_ENV=production` is exactly what enables it. A
-custom [`check_auth`](/reference/configuration/config#check_auth) that rejects
-unauthenticated requests enforces it as well, whatever `NODE_ENV` is. The official
-Docker images set `NODE_ENV=production`.
+Turning development mode off takes both: `CUBEJS_DEV_MODE` not set to `true` (its
+default) **and** `NODE_ENV=production`. Setting the flag alone leaves you in
+development mode, with everything above still exposed. Once it is genuinely off, JWT
+verification on the REST (JSON) and GraphQL APIs is enforced, because
+`NODE_ENV=production` is exactly what enables it; a custom
+[`check_auth`](/reference/configuration/config#check_auth) that rejects unauthenticated
+requests enforces it as well, whatever `NODE_ENV` is. The official Docker images set
+`NODE_ENV=production`.
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -1,20 +1,24 @@
 <Warning>
 
-**Development mode is an authentication bypass.** Cube is in development mode whenever
-`NODE_ENV` is not `production` or `CUBEJS_DEV_MODE=true`, and in that state it mounts
-[Playground](/docs/explore-analyze/playground) and its supporting endpoints with no
-authentication whatsoever. Anyone who can reach the instance is handed a
-ready-to-use API token, and can mint further ones carrying any security context signed
-with your API secret — and so query every data API as any user, bypassing
-[member-level access control](/docs/data-modeling/access-control/member-level-security)
-and [row-level security](/docs/data-modeling/access-control/row-level-security). The
-same endpoints also read your data model files and the table schema of every connected
-data source, and overwrite your data model and your `.env`. On top of that, with
-`CUBEJS_DEV_MODE=true` specifically — the SQL API's password check follows that flag
-alone, not `NODE_ENV` — and no
+**Development mode is an authentication bypass.** Cube is in development mode when
+`CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production`. Setting
+`CUBEJS_DEV_MODE=true` additionally forces `NODE_ENV=development`, which switches off
+JWT verification on the [REST (JSON)](/reference/core-data-apis/rest-api) and
+[GraphQL](/reference/core-data-apis/graphql-api) APIs — they then accept requests with
+no token at all.
+
+Development mode also mounts [Playground](/docs/explore-analyze/playground) and its
+supporting endpoints with no authentication whatsoever. Anyone who can reach the
+instance is handed a ready-to-use API token, and can mint further ones carrying any
+security context signed with your API secret — and so query every data API as any user,
+bypassing [member-level access
+control](/docs/data-modeling/access-control/member-level-security) and [row-level
+security](/docs/data-modeling/access-control/row-level-security). The same endpoints
+read your data model files and the table schema of every connected data source, and
+overwrite your data model and your `.env`. With `CUBEJS_DEV_MODE=true` and no
 [`CUBEJS_SQL_PASSWORD`](/reference/configuration/environment-variables#cubejs_sql_password)
-set, the SQL API accepts any credentials, allowing arbitrary SQL against connected
-data sources.
+set, the SQL API accepts any credentials as well, allowing arbitrary SQL against
+connected data sources.
 
 This is intentional. Development mode is designed to run on a developer's local
 machine for ease of use and debugging. Never run it where anyone else can reach it,
@@ -22,13 +26,10 @@ never expose it to the internet, and never use it in production. Using developme
 mode in the Cube cloud platform is highly discouraged — it bypasses the platform's
 security model.
 
-Turning development mode off takes both: `CUBEJS_DEV_MODE` not set to `true` (its
-default) **and** `NODE_ENV=production`. Setting the flag alone leaves you in
-development mode, with everything above still exposed. Once it is genuinely off, JWT
-verification on the REST (JSON) and GraphQL APIs is enforced, because
-`NODE_ENV=production` is exactly what enables it; a custom
-[`check_auth`](/reference/configuration/config#check_auth) that rejects unauthenticated
-requests enforces it as well, whatever `NODE_ENV` is. The official Docker images set
-`NODE_ENV=production`.
+To keep it off: `cubejs server` and the official Docker images already set
+`NODE_ENV=production`, so leaving `CUBEJS_DEV_MODE` unset — its default — is enough
+there. If you embed `@cubejs-backend/server-core` directly rather than starting Cube
+through the `cubejs` CLI, set `NODE_ENV=production` yourself, since an unset `NODE_ENV`
+puts the instance in development mode whatever the flag says.
 
 </Warning>

--- a/docs-mintlify/snippets/dev-mode-warning.mdx
+++ b/docs-mintlify/snippets/dev-mode-warning.mdx
@@ -1,10 +1,12 @@
 <Warning>
 
 **Development mode is an authentication bypass.** Cube is in development mode when
-`CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production`. Setting
-`CUBEJS_DEV_MODE=true` additionally forces `NODE_ENV=development`, which switches off
-JWT verification on the [REST (JSON)](/reference/core-data-apis/rest-api) and
-[GraphQL](/reference/core-data-apis/graphql-api) APIs — they then accept requests with
+`CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production`. When Cube
+is started through the `cubejs` CLI — which is what the official Docker images run —
+setting `CUBEJS_DEV_MODE=true` additionally forces `NODE_ENV=development`, which
+switches off JWT verification on the
+[REST (JSON)](/reference/core-data-apis/rest-api) and
+[GraphQL](/reference/core-data-apis/graphql-api) APIs: they then accept requests with
 no token at all.
 
 Development mode also mounts [Playground](/docs/explore-analyze/playground) and its

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -32,8 +32,9 @@ if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 > and its supporting endpoints are served with no authentication, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
 > any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a
+> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
+> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
+> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -26,11 +26,11 @@ use env instead.
 ```
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
-> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, so
-> anyone who can reach the instance can read all of your data, and the SQL API accepts
-> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
-> connected data sources. This is intentional — development mode is designed to run on a developer's
+> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
+> supporting endpoints are served with no authentication, so anyone who can reach the
+> instance can mint an API token carrying any security context (signed with your API
+> secret), read and overwrite your data model and `.env`, and — unless
+> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -27,9 +27,10 @@ use env instead.
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
 > **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, and
-> anyone who can reach the instance can execute arbitrary SQL against connected data
-> sources. This is intentional — development mode is designed to run on a developer's
+> endpoints are served without any authentication or authorization verification, so
+> anyone who can reach the instance can read all of your data, and the SQL API accepts
+> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
+> connected data sources. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -26,6 +26,15 @@ use env instead.
 ```
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
+> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
+> endpoints are served without any authentication or authorization verification, and
+> anyone who can reach the instance can execute arbitrary SQL against connected data
+> sources. This is intentional — development mode is designed to run on a developer's
+> local machine for ease of use and debugging. Never use it in production, and using it
+> in the Cube cloud platform is highly discouraged, as it bypasses the platform's
+> security model. See
+> [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
+
 ### License
 
 Cube.js Vertica Database Driver is [Apache 2.0 licensed](./LICENSE).

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -28,9 +28,10 @@ if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
 > **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
 > supporting endpoints are served with no authentication, so anyone who can reach the
-> instance can mint an API token carrying any security context (signed with your API
-> secret), read and overwrite your data model and `.env`, and — unless
-> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
+> instance is handed a ready-to-use API token (and can mint others carrying any
+> security context, signed with your API secret), read your data model, overwrite it
+> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -26,18 +26,21 @@ use env instead.
 ```
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
-> **Development mode is an authentication bypass.** Cube is in development mode with
-> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
-> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
-> and its supporting endpoints are served with no authentication, so anyone who can
+> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
+> `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
+> GraphQL APIs, so they accept requests with no token at all. Playground and its
+> supporting endpoints are served with no authentication either, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
-> any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
-> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
-> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
-> developer's local machine for ease of use and debugging. Never use it in production, and using it
-> in the Cube cloud platform is highly discouraged, as it bypasses the platform's
-> security model. See
+> any security context, signed with your API secret), can read your data model, and can
+> overwrite it and your `.env`. With no `CUBEJS_SQL_PASSWORD` set, the SQL API accepts
+> any credentials as well, allowing arbitrary SQL against connected data sources.
+>
+> This is intentional — development mode is designed to run on a developer's local
+> machine for ease of use and debugging. Never expose it to the internet or use it in
+> production. Using development mode in the Cube cloud platform is highly discouraged,
+> as it bypasses the platform's security model. Cube is also in development mode
+> whenever `NODE_ENV` is not `production`, but `cubejs server` and the official images
+> already set it to `production`. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
 
 ### License

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -26,23 +26,6 @@ use env instead.
 ```
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
-> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
-> `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
-> GraphQL APIs, so they accept requests with no token at all. Playground and its
-> supporting endpoints are served with no authentication either, so anyone who can
-> reach the instance is handed a ready-to-use API token (and can mint others carrying
-> any security context, signed with your API secret), can read your data model, and can
-> overwrite it and your `.env`. With no `CUBEJS_SQL_PASSWORD` set, the SQL API accepts
-> any credentials as well, allowing arbitrary SQL against connected data sources.
->
-> This is intentional — development mode is designed to run on a developer's local
-> machine for ease of use and debugging. Never expose it to the internet or use it in
-> production. Using development mode in the Cube cloud platform is highly discouraged,
-> as it bypasses the platform's security model. Cube is also in development mode
-> whenever `NODE_ENV` is not `production`, but `cubejs server` and the official images
-> already set it to `production`. See
-> [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
-
 ### License
 
 Cube.js Vertica Database Driver is [Apache 2.0 licensed](./LICENSE).

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -31,8 +31,8 @@ if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 > instance is handed a ready-to-use API token (and can mint others carrying any
 > security context, signed with your API secret), read your data model, overwrite it
 > and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a developer's
-> local machine for ease of use and debugging. Never use it in production, and using it
+> through the SQL API. This is intentional — development mode is designed to run on a
+> developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).

--- a/packages/cubejs-vertica-driver/README.md
+++ b/packages/cubejs-vertica-driver/README.md
@@ -26,11 +26,13 @@ use env instead.
 ```
 if `CUBEJS_DB_TYPE=vertica` then the vertica driver is loaded automatically.
 
-> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
-> supporting endpoints are served with no authentication, so anyone who can reach the
-> instance is handed a ready-to-use API token (and can mint others carrying any
-> security context, signed with your API secret), read your data model, overwrite it
-> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> **Development mode is an authentication bypass.** Cube is in development mode with
+> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
+> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
+> and its supporting endpoints are served with no authentication, so anyone who can
+> reach the instance is handed a ready-to-use API token (and can mint others carrying
+> any security context, signed with your API secret), read your data model, overwrite
+> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
 > through the SQL API. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -73,11 +73,13 @@ Starting with `v0.26.48`, Cube.js ships with Cube Store enabled when `CUBEJS_DEV
 You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
-> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
-> supporting endpoints are served with no authentication, so anyone who can reach the
-> instance is handed a ready-to-use API token (and can mint others carrying any
-> security context, signed with your API secret), read your data model, overwrite it
-> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> **Development mode is an authentication bypass.** Cube is in development mode with
+> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
+> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
+> and its supporting endpoints are served with no authentication, so anyone who can
+> reach the instance is handed a ready-to-use API token (and can mint others carrying
+> any security context, signed with your API secret), read your data model, overwrite
+> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
 > through the SQL API. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -79,8 +79,9 @@ You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 > and its supporting endpoints are served with no authentication, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
 > any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a
+> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
+> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
+> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
 > developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -73,11 +73,11 @@ Starting with `v0.26.48`, Cube.js ships with Cube Store enabled when `CUBEJS_DEV
 You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
-> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, so
-> anyone who can reach the instance can read all of your data, and the SQL API accepts
-> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
-> connected data sources. This is intentional — development mode is designed to run on a developer's
+> **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
+> supporting endpoints are served with no authentication, so anyone who can reach the
+> instance can mint an API token carrying any security context (signed with your API
+> secret), read and overwrite your data model and `.env`, and — unless
+> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -75,9 +75,10 @@ You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 
 > **`CUBEJS_DEV_MODE=true` is an authentication bypass.** Playground and its
 > supporting endpoints are served with no authentication, so anyone who can reach the
-> instance can mint an API token carrying any security context (signed with your API
-> secret), read and overwrite your data model and `.env`, and — unless
-> `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL through the SQL API. This is intentional — development mode is designed to run on a developer's
+> instance is handed a ready-to-use API token (and can mint others carrying any
+> security context, signed with your API secret), read your data model, overwrite it
+> and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
+> through the SQL API. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -73,23 +73,6 @@ Starting with `v0.26.48`, Cube.js ships with Cube Store enabled when `CUBEJS_DEV
 You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
-> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
-> `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
-> GraphQL APIs, so they accept requests with no token at all. Playground and its
-> supporting endpoints are served with no authentication either, so anyone who can
-> reach the instance is handed a ready-to-use API token (and can mint others carrying
-> any security context, signed with your API secret), can read your data model, and can
-> overwrite it and your `.env`. With no `CUBEJS_SQL_PASSWORD` set, the SQL API accepts
-> any credentials as well, allowing arbitrary SQL against connected data sources.
->
-> This is intentional — development mode is designed to run on a developer's local
-> machine for ease of use and debugging. Never expose it to the internet or use it in
-> production. Using development mode in the Cube cloud platform is highly discouraged,
-> as it bypasses the platform's security model. Cube is also in development mode
-> whenever `NODE_ENV` is not `production`, but `cubejs server` and the official images
-> already set it to `production`. See
-> [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
-
 For versions prior to `v0.26.48`, you should upgrade your project to the latest
 version and install the Cube Store driver:
 

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -73,18 +73,21 @@ Starting with `v0.26.48`, Cube.js ships with Cube Store enabled when `CUBEJS_DEV
 You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
-> **Development mode is an authentication bypass.** Cube is in development mode with
-> `CUBEJS_DEV_MODE=true`, and also whenever `NODE_ENV` is not `production` — so
-> `CUBEJS_DEV_MODE=false` alone does not take you out of it. In that state Playground
-> and its supporting endpoints are served with no authentication, so anyone who can
+> **Development mode is an authentication bypass.** `CUBEJS_DEV_MODE=true` also forces
+> `NODE_ENV=development`, which switches off JWT verification on the REST (JSON) and
+> GraphQL APIs, so they accept requests with no token at all. Playground and its
+> supporting endpoints are served with no authentication either, so anyone who can
 > reach the instance is handed a ready-to-use API token (and can mint others carrying
-> any security context, signed with your API secret), read your data model, overwrite
-> it and your `.env`. With `CUBEJS_DEV_MODE=true` specifically and no
-> `CUBEJS_SQL_PASSWORD` set, the SQL API also accepts any credentials, allowing
-> arbitrary SQL against connected data sources. This is intentional — development mode is designed to run on a
-> developer's local machine for ease of use and debugging. Never use it in production, and using it
-> in the Cube cloud platform is highly discouraged, as it bypasses the platform's
-> security model. See
+> any security context, signed with your API secret), can read your data model, and can
+> overwrite it and your `.env`. With no `CUBEJS_SQL_PASSWORD` set, the SQL API accepts
+> any credentials as well, allowing arbitrary SQL against connected data sources.
+>
+> This is intentional — development mode is designed to run on a developer's local
+> machine for ease of use and debugging. Never expose it to the internet or use it in
+> production. Using development mode in the Cube cloud platform is highly discouraged,
+> as it bypasses the platform's security model. Cube is also in development mode
+> whenever `NODE_ENV` is not `production`, but `cubejs server` and the official images
+> already set it to `production`. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
 
 For versions prior to `v0.26.48`, you should upgrade your project to the latest

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -74,9 +74,10 @@ You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
 > **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
-> endpoints are served without any authentication or authorization verification, and
-> anyone who can reach the instance can execute arbitrary SQL against connected data
-> sources. This is intentional — development mode is designed to run on a developer's
+> endpoints are served without any authentication or authorization verification, so
+> anyone who can reach the instance can read all of your data, and the SQL API accepts
+> any credentials unless `CUBEJS_SQL_PASSWORD` is set, allowing arbitrary SQL against
+> connected data sources. This is intentional — development mode is designed to run on a developer's
 > local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -78,8 +78,8 @@ You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 > instance is handed a ready-to-use API token (and can mint others carrying any
 > security context, signed with your API secret), read your data model, overwrite it
 > and your `.env`, and — unless `CUBEJS_SQL_PASSWORD` is set — run arbitrary SQL
-> through the SQL API. This is intentional — development mode is designed to run on a developer's
-> local machine for ease of use and debugging. Never use it in production, and using it
+> through the SQL API. This is intentional — development mode is designed to run on a
+> developer's local machine for ease of use and debugging. Never use it in production, and using it
 > in the Cube cloud platform is highly discouraged, as it bypasses the platform's
 > security model. See
 > [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).

--- a/rust/cubestore/README.md
+++ b/rust/cubestore/README.md
@@ -73,6 +73,15 @@ Starting with `v0.26.48`, Cube.js ships with Cube Store enabled when `CUBEJS_DEV
 You don't need to set up any `CUBEJS_EXT_DB_*` environment variables or
 `externalDriverFactory` inside your `cube.js` configuration file.
 
+> **`CUBEJS_DEV_MODE=true` disables authentication completely.** All data access
+> endpoints are served without any authentication or authorization verification, and
+> anyone who can reach the instance can execute arbitrary SQL against connected data
+> sources. This is intentional — development mode is designed to run on a developer's
+> local machine for ease of use and debugging. Never use it in production, and using it
+> in the Cube cloud platform is highly discouraged, as it bypasses the platform's
+> security model. See
+> [`CUBEJS_DEV_MODE`](https://docs.cube.dev/reference/configuration/environment-variables#cubejs_dev_mode).
+
 For versions prior to `v0.26.48`, you should upgrade your project to the latest
 version and install the Cube Store driver:
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available — n/a, documentation-only change (24 files, all `.mdx`/`.md`; Codecov reports a zero code diff)
- [x] Linter has been run for changed code — n/a, only `.mdx`/`.md`; verified callout tags balance in every edited page, all 10 snippet imports resolve, and the duplicate page pairs stay byte-identical
- [x] Tests for the changes have been added if not covered yet — n/a, documentation-only change
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Cube Core development mode was under-documented: `admin/deployment/core.mdx` said only that it "can lead to security vulnerabilities" and "will expose your data to the internet", and `admin/index.mdx` listed "Disables authentication checks" as one bullet among nine behavioural changes. Neither conveyed what an exposed dev-mode instance actually gives away.

Every place that documents `CUBEJS_DEV_MODE` now says that development mode is an authentication bypass, that this is intentional and meant for a developer's local machine, and that using it in the Cube cloud platform is highly discouraged because it bypasses the platform's security model.

### Three independent gates

Getting this right took several rounds, because "development mode" is not one switch. The docs now name the applicable condition in each sentence rather than letting a paragraph inherit the section's:

| Behaviour | Gate |
| --- | --- |
| REST/GraphQL JWT verification | `enforceSecurityChecks` = `options.enforceSecurityChecks \|\| NODE_ENV === 'production'` (`gateway.ts:285`), and `cubejs-server-core` never passes the option. Under the `cubejs` CLI, `CUBEJS_DEV_MODE=true` forces `NODE_ENV=development` (`container.ts:250-253`), so the flag switches verification off |
| Playground / dev-server mount | `devServer: this.isDevMode()` (`OptsHandler.ts:392`), where `isDevMode()` is `NODE_ENV !== 'production' \|\| getEnv('devMode')` (`:485-489`) |
| SQL API password skip | `skipPasswordCheck: getEnv('devMode') && !allowedPassword` (`sql-server.ts:371`) — the flag alone, no `NODE_ENV` term, and only when no `sqlPassword` is configured |

What that means in practice:

- **Development mode exposes the Playground endpoints with no authentication at all.** `GET /playground/context` hands out a ready-to-use API-secret-signed JWT (`DevServer.ts:52`, `:116`) and `POST /playground/token` mints further ones from `req.body.payload` (`:607`), so anyone who can reach the instance can query every data API as any user, bypassing member-level access control and row-level security. The same endpoints read the data model files (`GET /playground/files`) and every connected data source's table schema (`GET /playground/db-schema`, called with `securityContext: null`), and overwrite the data model (`POST /playground/generate-schema`) and `.env` (`POST /playground/env`).
- **Under the `cubejs` CLI, the flag also turns off JWT verification outright**, because `ServerContainer.lookupConfiguration()` rewrites `NODE_ENV` to `development` before the gateway reads it. `start()` calls it at `:336`, ahead of `runServerInstance()` at `:344`. Nothing rewrites `NODE_ENV` if you construct `CubejsServer`/`CubejsServerCore` yourself, so the docs scope this to the CLI and the official images (whose `CMD` is `["cubejs", "server"]`).
- **With `CUBEJS_DEV_MODE=true` and no `CUBEJS_SQL_PASSWORD`, the SQL API accepts any credentials**, allowing arbitrary SQL against connected data sources. Scoped to the flag deliberately: with it unset, `sql-server.ts:345-361` forces `allowedUser = 'cube'` and generates a random password, so credentials are enforced even though the instance may still be in development mode.
- **Turning it off:** `cubejs server` and the official images already set `NODE_ENV=production`, so leaving `CUBEJS_DEV_MODE` unset is sufficient there. An unset `NODE_ENV` only matters when embedding `@cubejs-backend/server-core` directly, where it puts the instance in development mode whatever the flag says — the warning says so rather than implying everyone must set `NODE_ENV`.

The pre-existing "Development mode is disabled by default" note held only because the images set `ENV NODE_ENV=production` (`latest.Dockerfile:41`); it now explains that.

### Structure

The warning lives in two Mintlify snippets — `docs-mintlify/snippets/dev-mode-warning.mdx` (long) and `dev-mode-warning-short.mdx` (condensed) — imported by 10 pages. `yarn broken-links` already runs with `--check-snippets`. It was originally pasted into every page; extracting it came out of review after an accuracy fix had to be applied 11 times by hand, and every correction since has been a single edit.

The long form goes on the `CUBEJS_DEV_MODE` reference, the Administration and Cube Core deployment pages, and the Cube Core getting-started guide; the short form on the production/Cube Store pages, Playground, and the SQL API and QuestDB Docker examples. `embedding/authentication/jwt.mdx` had its "token is not required in development mode" `<Info>` promoted to a `<Warning>`. Both production checklists gained `NODE_ENV=production` with an accurate comment.

Incidental mentions (pre-aggregations, `config.mdx`, the JavaScript SDK pages) just link "development mode" to the canonical warning rather than carrying a security aside — and those links were repointed from `/docs/data-modeling/dev-mode`, which documents the *cloud platform's* branch-based development mode, a different feature. That page now carries a callout distinguishing the two, since several Cube Core pages linked to it as "Development Mode".

The root `README.md` carries the warning inline next to its `docker run -e CUBEJS_DEV_MODE=true` snippet, since it can't import a Mintlify snippet. It was also added to the Vertica driver and Cube Store READMEs and then removed as disproportionate for those documents; both are back to their state on master.

Only `docs-mintlify` is touched; the deprecated `/docs` Nextra site is left alone per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7RGv1SFGTWjRUSaarhE88