### PR TITLE
fix(cubestore): refresh S3 web identity credentials before STS expiry

### DIFF
--- a/rust/cubestore/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/cubestore/src/remotefs/s3.rs
@@ -92,6 +92,8 @@ impl S3RemoteFs {
             .map_err(|e| CubeError::internal(format!("Failed to create S3 credentials: {}", e)))?
         };
 
+        let initial_expiration = credentials_expiration(&credentials);
+
         let region = region.parse::<Region>().map_err(|e| {
             CubeError::internal(format!("Failed to parse Region '{}': {}", region, e))
         })?;
@@ -111,7 +113,14 @@ impl S3RemoteFs {
             web_identity_role_arn: role_arn,
             server_side_encryption,
         });
-        spawn_creds_refresh_loop(access_key, secret_key, bucket_name, region, &fs);
+        spawn_creds_refresh_loop(
+            access_key,
+            secret_key,
+            bucket_name,
+            region,
+            initial_expiration,
+            &fs,
+        );
 
         Ok(fs)
     }
@@ -150,11 +159,46 @@ fn new_bucket(
     Ok(bucket)
 }
 
+/// How long before the STS expiration timestamp credentials are considered
+/// stale, so a request never starts with a nearly-dead session token.
+const WEB_IDENTITY_EXPIRY_MARGIN: Duration = Duration::from_secs(5 * 60);
+
+/// STS `Expiration` of the credentials, if the issuer reported one.
+fn credentials_expiration(credentials: &Credentials) -> Option<SystemTime> {
+    let unix_seconds = credentials.expiration.as_ref()?.unix_timestamp();
+    if unix_seconds < 0 {
+        return None;
+    }
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(unix_seconds as u64))
+}
+
+/// State the web identity refresh loop carries between iterations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WebIdentityCredsState {
+    token_file_modified: Option<SystemTime>,
+    expiration: Option<SystemTime>,
+    last_refreshed: SystemTime,
+}
+
+/// Whether web identity credentials have to be exchanged again, and why.
+fn web_identity_refresh_reason(
+    state: &WebIdentityCredsState,
+    token_file_modified: Option<SystemTime>,
+    _now: SystemTime,
+    _expiry_margin: Duration,
+) -> Option<&'static str> {
+    if token_file_modified != state.token_file_modified {
+        return Some("web identity token file changed");
+    }
+    None
+}
+
 fn spawn_creds_refresh_loop(
     access_key: Option<String>,
     secret_key: Option<String>,
     bucket_name: String,
     region: Region,
+    initial_expiration: Option<SystemTime>,
     fs: &Arc<S3RemoteFs>,
 ) {
     let token_file = fs.web_identity_token_file.clone();
@@ -178,10 +222,16 @@ fn spawn_creds_refresh_loop(
         return;
     }
 
+    let expiry_margin = std::cmp::max(WEB_IDENTITY_EXPIRY_MARGIN, refresh_every);
+
     let fs = Arc::downgrade(fs);
-    let mut last_modified = token_file
-        .as_ref()
-        .and_then(|f| std::fs::metadata(f).ok()?.modified().ok());
+    let mut state = WebIdentityCredsState {
+        token_file_modified: token_file
+            .as_ref()
+            .and_then(|f| std::fs::metadata(f).ok()?.modified().ok()),
+        expiration: initial_expiration,
+        last_refreshed: SystemTime::now(),
+    };
 
     std::thread::spawn(move || {
         log::debug!(
@@ -198,14 +248,21 @@ fn spawn_creds_refresh_loop(
                 Some(fs) => fs,
             };
 
-            // In web identity mode, only refresh when the token file changed.
             if let (Some(ref file), Some(_)) = (&token_file, &role_arn) {
-                let current_modified = std::fs::metadata(file).ok().and_then(|m| m.modified().ok());
-                if current_modified == last_modified {
-                    continue;
+                let token_file_modified =
+                    std::fs::metadata(file).ok().and_then(|m| m.modified().ok());
+                match web_identity_refresh_reason(
+                    &state,
+                    token_file_modified,
+                    SystemTime::now(),
+                    expiry_margin,
+                ) {
+                    None => continue,
+                    Some(reason) => {
+                        info!("Refreshing S3 credentials: {}", reason);
+                        state.token_file_modified = token_file_modified;
+                    }
                 }
-                last_modified = current_modified;
-                info!("Web identity token file changed, refreshing S3 credentials");
             }
 
             let c = if let (Some(ref file), Some(ref arn)) = (&token_file, &role_arn) {
@@ -233,6 +290,7 @@ fn spawn_creds_refresh_loop(
                     continue;
                 }
             };
+            state.expiration = credentials_expiration(&c);
             let b = match new_bucket(&bucket_name, region.clone(), c, &server_side_encryption) {
                 Ok(b) => b,
                 Err(e) => {
@@ -241,6 +299,7 @@ fn spawn_creds_refresh_loop(
                 }
             };
             fs.bucket.swap(Arc::new(b));
+            state.last_refreshed = SystemTime::now();
             log::debug!("Successfully refreshed S3 credentials")
         }
     });
@@ -564,6 +623,141 @@ impl S3RemoteFs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const NOW: Duration = Duration::from_secs(1_800_000_000);
+    const TOKEN_FILE_MTIME: Duration = Duration::from_secs(1_000);
+
+    fn now() -> SystemTime {
+        SystemTime::UNIX_EPOCH + NOW
+    }
+
+    /// Credentials exchanged just now, expiring in a full STS session.
+    fn fresh_state() -> WebIdentityCredsState {
+        WebIdentityCredsState {
+            token_file_modified: Some(SystemTime::UNIX_EPOCH + TOKEN_FILE_MTIME),
+            expiration: Some(now() + Duration::from_secs(60 * 60)),
+            last_refreshed: now(),
+        }
+    }
+
+    #[test]
+    fn refresh_not_needed_while_credentials_are_fresh() {
+        let state = fresh_state();
+        assert_eq!(
+            web_identity_refresh_reason(
+                &state,
+                state.token_file_modified,
+                now(),
+                WEB_IDENTITY_EXPIRY_MARGIN
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_needed_when_token_file_changed() {
+        let state = fresh_state();
+        let touched = Some(SystemTime::UNIX_EPOCH + TOKEN_FILE_MTIME + Duration::from_secs(1));
+        assert!(
+            web_identity_refresh_reason(&state, touched, now(), WEB_IDENTITY_EXPIRY_MARGIN)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn refresh_needed_near_expiry_with_unchanged_token_file() {
+        let state = WebIdentityCredsState {
+            expiration: Some(now() + Duration::from_secs(60)),
+            ..fresh_state()
+        };
+        assert!(web_identity_refresh_reason(
+            &state,
+            state.token_file_modified,
+            now(),
+            WEB_IDENTITY_EXPIRY_MARGIN
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn refresh_needed_after_expiry_with_unchanged_token_file() {
+        let state = WebIdentityCredsState {
+            expiration: Some(now() - Duration::from_secs(60)),
+            ..fresh_state()
+        };
+        assert!(web_identity_refresh_reason(
+            &state,
+            state.token_file_modified,
+            now(),
+            WEB_IDENTITY_EXPIRY_MARGIN
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn refresh_needed_when_expiry_is_unknown() {
+        let state = WebIdentityCredsState {
+            expiration: None,
+            last_refreshed: now() - WEB_IDENTITY_EXPIRY_MARGIN,
+            ..fresh_state()
+        };
+        assert!(web_identity_refresh_reason(
+            &state,
+            state.token_file_modified,
+            now(),
+            WEB_IDENTITY_EXPIRY_MARGIN
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn unknown_expiry_does_not_re_exchange_on_every_poll() {
+        let state = WebIdentityCredsState {
+            expiration: None,
+            last_refreshed: now() - Duration::from_secs(30),
+            ..fresh_state()
+        };
+        assert_eq!(
+            web_identity_refresh_reason(
+                &state,
+                state.token_file_modified,
+                now(),
+                WEB_IDENTITY_EXPIRY_MARGIN
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_needed_when_token_file_disappeared() {
+        // An unreadable token file reads as "no mtime", which must not look
+        // like an unchanged file and silence the refresh.
+        let state = fresh_state();
+        assert!(
+            web_identity_refresh_reason(&state, None, now(), WEB_IDENTITY_EXPIRY_MARGIN).is_some()
+        );
+    }
+
+    #[test]
+    fn expiry_margin_scales_with_a_long_poll_interval() {
+        // Credentials that die within one poll interval must be refreshed on
+        // the current wake-up, not on the next one.
+        let poll_every = Duration::from_secs(60 * 60);
+        let state = WebIdentityCredsState {
+            expiration: Some(now() + Duration::from_secs(30 * 60)),
+            ..fresh_state()
+        };
+        let margin = std::cmp::max(WEB_IDENTITY_EXPIRY_MARGIN, poll_every);
+        assert!(
+            web_identity_refresh_reason(&state, state.token_file_modified, now(), margin).is_some()
+        );
+    }
+
+    #[test]
+    fn credentials_expiration_is_none_for_static_credentials() {
+        let credentials = Credentials::new(Some("key"), Some("secret"), None, None, None).unwrap();
+        assert_eq!(credentials_expiration(&credentials), None);
+    }
 
     #[test]
     fn parse_sse_value_accepts_allowed_values() {

--- a/rust/cubestore/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/cubestore/src/remotefs/s3.rs
@@ -159,11 +159,10 @@ fn new_bucket(
     Ok(bucket)
 }
 
-/// How long before the STS expiration timestamp credentials are considered
-/// stale, so a request never starts with a nearly-dead session token.
+/// Headroom kept on top of one poll interval, so a refresh never starts with a
+/// nearly-dead session token.
 const WEB_IDENTITY_EXPIRY_MARGIN: Duration = Duration::from_secs(5 * 60);
 
-/// STS `Expiration` of the credentials, if the issuer reported one.
 fn credentials_expiration(credentials: &Credentials) -> Option<SystemTime> {
     let unix_seconds = credentials.expiration.as_ref()?.unix_timestamp();
     if unix_seconds < 0 {
@@ -172,24 +171,18 @@ fn credentials_expiration(credentials: &Credentials) -> Option<SystemTime> {
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(unix_seconds as u64))
 }
 
-/// State the web identity refresh loop carries between iterations. Only a
-/// refresh that actually reached the live bucket updates it, so a failed STS
-/// exchange is retried on the next poll instead of being treated as done.
+/// `token_file_modified` and `expiration` are committed only after the rebuilt
+/// bucket is live, so a failed exchange retries. `last_attempted` moves either way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WebIdentityCredsState {
     token_file_modified: Option<SystemTime>,
     expiration: Option<SystemTime>,
-    last_refreshed: SystemTime,
+    last_attempted: SystemTime,
 }
 
-/// Whether web identity credentials have to be exchanged again, and why.
-///
-/// The token file mtime is only one of the triggers: Kubernetes rotates the
-/// projected service account token on its own schedule, which is unrelated to
-/// the STS session TTL, and some projected volume implementations keep the
-/// mtime when rewriting the contents. Expiry therefore has to be checked
-/// independently, and credentials with an unknown expiry cannot be assumed
-/// valid either.
+/// The mtime alone is not sufficient: Kubernetes rotates the projected token on a
+/// schedule unrelated to the STS session TTL, and some projected volumes keep the
+/// mtime while rewriting the contents.
 fn web_identity_refresh_reason(
     state: &WebIdentityCredsState,
     token_file_modified: Option<SystemTime>,
@@ -200,9 +193,8 @@ fn web_identity_refresh_reason(
         return Some("web identity token file changed");
     }
     match state.expiration {
-        // Nothing says how long these are good for, so re-exchange them, but
-        // no more often than the margin to keep STS calls bounded.
-        None if now >= state.last_refreshed + expiry_margin => {
+        // Speculative, so throttled by attempt rather than by success.
+        None if now >= state.last_attempted + expiry_margin => {
             Some("credentials expiration is unknown")
         }
         None => None,
@@ -242,9 +234,8 @@ fn spawn_creds_refresh_loop(
         return;
     }
 
-    // A refresh has to be triggered at least one poll before the credentials
-    // actually expire, otherwise the loop wakes up when they are already dead.
-    let expiry_margin = std::cmp::max(WEB_IDENTITY_EXPIRY_MARGIN, refresh_every);
+    // The next wake-up is the last chance to react, so one poll plus the headroom.
+    let expiry_margin = refresh_every + WEB_IDENTITY_EXPIRY_MARGIN;
 
     let fs = Arc::downgrade(fs);
     let mut state = WebIdentityCredsState {
@@ -252,7 +243,7 @@ fn spawn_creds_refresh_loop(
             .as_ref()
             .and_then(|f| std::fs::metadata(f).ok()?.modified().ok()),
         expiration: initial_expiration,
-        last_refreshed: SystemTime::now(),
+        last_attempted: SystemTime::now(),
     };
 
     std::thread::spawn(move || {
@@ -283,7 +274,8 @@ fn spawn_creds_refresh_loop(
                     None => continue,
                     Some(reason) => {
                         info!("Refreshing S3 credentials: {}", reason);
-                        observed_token_file_modified = Some(token_file_modified);
+                        observed_token_file_modified = token_file_modified;
+                        state.last_attempted = SystemTime::now();
                     }
                 }
             }
@@ -323,11 +315,8 @@ fn spawn_creds_refresh_loop(
             };
             fs.bucket.swap(Arc::new(b));
             if is_web_identity {
-                if let Some(token_file_modified) = observed_token_file_modified {
-                    state.token_file_modified = token_file_modified;
-                }
+                state.token_file_modified = observed_token_file_modified;
                 state.expiration = expiration;
-                state.last_refreshed = SystemTime::now();
             }
             log::debug!("Successfully refreshed S3 credentials")
         }
@@ -660,12 +649,12 @@ mod tests {
         SystemTime::UNIX_EPOCH + NOW
     }
 
-    /// Credentials exchanged just now, expiring in a full STS session.
+    // Exchanged just now, expiring in a full STS session.
     fn fresh_state() -> WebIdentityCredsState {
         WebIdentityCredsState {
             token_file_modified: Some(SystemTime::UNIX_EPOCH + TOKEN_FILE_MTIME),
             expiration: Some(now() + Duration::from_secs(60 * 60)),
-            last_refreshed: now(),
+            last_attempted: now(),
         }
     }
 
@@ -727,7 +716,7 @@ mod tests {
     fn refresh_needed_when_expiry_is_unknown() {
         let state = WebIdentityCredsState {
             expiration: None,
-            last_refreshed: now() - WEB_IDENTITY_EXPIRY_MARGIN,
+            last_attempted: now() - WEB_IDENTITY_EXPIRY_MARGIN,
             ..fresh_state()
         };
         assert!(web_identity_refresh_reason(
@@ -743,7 +732,7 @@ mod tests {
     fn unknown_expiry_does_not_re_exchange_on_every_poll() {
         let state = WebIdentityCredsState {
             expiration: None,
-            last_refreshed: now() - Duration::from_secs(30),
+            last_attempted: now() - Duration::from_secs(30),
             ..fresh_state()
         };
         assert_eq!(
@@ -758,9 +747,27 @@ mod tests {
     }
 
     #[test]
+    fn unknown_expiry_throttle_survives_failed_exchanges() {
+        // A failing exchange advances the attempt but never the expiration.
+        let state = WebIdentityCredsState {
+            expiration: None,
+            last_attempted: now() - Duration::from_secs(30),
+            ..fresh_state()
+        };
+        assert_eq!(
+            web_identity_refresh_reason(
+                &state,
+                state.token_file_modified,
+                now(),
+                Duration::from_secs(30) + WEB_IDENTITY_EXPIRY_MARGIN
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn refresh_needed_when_token_file_disappeared() {
-        // An unreadable token file reads as "no mtime", which must not look
-        // like an unchanged file and silence the refresh.
+        // An unreadable token file reads as "no mtime", not as "unchanged".
         let state = fresh_state();
         assert!(
             web_identity_refresh_reason(&state, None, now(), WEB_IDENTITY_EXPIRY_MARGIN).is_some()
@@ -768,15 +775,53 @@ mod tests {
     }
 
     #[test]
+    fn refresh_not_needed_just_outside_the_margin() {
+        let margin = Duration::from_secs(5 * 60);
+        let state = WebIdentityCredsState {
+            expiration: Some(now() + margin + Duration::from_secs(1)),
+            ..fresh_state()
+        };
+        assert_eq!(
+            web_identity_refresh_reason(&state, state.token_file_modified, now(), margin),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_needed_just_inside_the_margin() {
+        let margin = Duration::from_secs(5 * 60);
+        let state = WebIdentityCredsState {
+            expiration: Some(now() + margin),
+            ..fresh_state()
+        };
+        assert!(
+            web_identity_refresh_reason(&state, state.token_file_modified, now(), margin).is_some()
+        );
+    }
+
+    #[test]
+    fn margin_keeps_full_headroom_on_top_of_a_poll_interval() {
+        // The margin must not collapse to the poll interval.
+        let poll_every = WEB_IDENTITY_EXPIRY_MARGIN;
+        let margin = poll_every + WEB_IDENTITY_EXPIRY_MARGIN;
+        let state = WebIdentityCredsState {
+            expiration: Some(now() + poll_every + WEB_IDENTITY_EXPIRY_MARGIN),
+            ..fresh_state()
+        };
+        assert!(
+            web_identity_refresh_reason(&state, state.token_file_modified, now(), margin).is_some()
+        );
+    }
+
+    #[test]
     fn expiry_margin_scales_with_a_long_poll_interval() {
-        // Credentials that die within one poll interval must be refreshed on
-        // the current wake-up, not on the next one.
+        // Refresh on the current wake-up, not on the next one.
         let poll_every = Duration::from_secs(60 * 60);
         let state = WebIdentityCredsState {
             expiration: Some(now() + Duration::from_secs(30 * 60)),
             ..fresh_state()
         };
-        let margin = std::cmp::max(WEB_IDENTITY_EXPIRY_MARGIN, poll_every);
+        let margin = poll_every + WEB_IDENTITY_EXPIRY_MARGIN;
         assert!(
             web_identity_refresh_reason(&state, state.token_file_modified, now(), margin).is_some()
         );

--- a/rust/cubestore/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/cubestore/src/remotefs/s3.rs
@@ -172,7 +172,9 @@ fn credentials_expiration(credentials: &Credentials) -> Option<SystemTime> {
     Some(SystemTime::UNIX_EPOCH + Duration::from_secs(unix_seconds as u64))
 }
 
-/// State the web identity refresh loop carries between iterations.
+/// State the web identity refresh loop carries between iterations. Only a
+/// refresh that actually reached the live bucket updates it, so a failed STS
+/// exchange is retried on the next poll instead of being treated as done.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WebIdentityCredsState {
     token_file_modified: Option<SystemTime>,
@@ -181,16 +183,34 @@ struct WebIdentityCredsState {
 }
 
 /// Whether web identity credentials have to be exchanged again, and why.
+///
+/// The token file mtime is only one of the triggers: Kubernetes rotates the
+/// projected service account token on its own schedule, which is unrelated to
+/// the STS session TTL, and some projected volume implementations keep the
+/// mtime when rewriting the contents. Expiry therefore has to be checked
+/// independently, and credentials with an unknown expiry cannot be assumed
+/// valid either.
 fn web_identity_refresh_reason(
     state: &WebIdentityCredsState,
     token_file_modified: Option<SystemTime>,
-    _now: SystemTime,
-    _expiry_margin: Duration,
+    now: SystemTime,
+    expiry_margin: Duration,
 ) -> Option<&'static str> {
     if token_file_modified != state.token_file_modified {
         return Some("web identity token file changed");
     }
-    None
+    match state.expiration {
+        // Nothing says how long these are good for, so re-exchange them, but
+        // no more often than the margin to keep STS calls bounded.
+        None if now >= state.last_refreshed + expiry_margin => {
+            Some("credentials expiration is unknown")
+        }
+        None => None,
+        Some(expiration) if now + expiry_margin >= expiration => {
+            Some("credentials are about to expire")
+        }
+        Some(_) => None,
+    }
 }
 
 fn spawn_creds_refresh_loop(
@@ -222,6 +242,8 @@ fn spawn_creds_refresh_loop(
         return;
     }
 
+    // A refresh has to be triggered at least one poll before the credentials
+    // actually expire, otherwise the loop wakes up when they are already dead.
     let expiry_margin = std::cmp::max(WEB_IDENTITY_EXPIRY_MARGIN, refresh_every);
 
     let fs = Arc::downgrade(fs);
@@ -248,6 +270,7 @@ fn spawn_creds_refresh_loop(
                 Some(fs) => fs,
             };
 
+            let mut observed_token_file_modified = None;
             if let (Some(ref file), Some(_)) = (&token_file, &role_arn) {
                 let token_file_modified =
                     std::fs::metadata(file).ok().and_then(|m| m.modified().ok());
@@ -260,7 +283,7 @@ fn spawn_creds_refresh_loop(
                     None => continue,
                     Some(reason) => {
                         info!("Refreshing S3 credentials: {}", reason);
-                        state.token_file_modified = token_file_modified;
+                        observed_token_file_modified = Some(token_file_modified);
                     }
                 }
             }
@@ -290,7 +313,7 @@ fn spawn_creds_refresh_loop(
                     continue;
                 }
             };
-            state.expiration = credentials_expiration(&c);
+            let expiration = credentials_expiration(&c);
             let b = match new_bucket(&bucket_name, region.clone(), c, &server_side_encryption) {
                 Ok(b) => b,
                 Err(e) => {
@@ -299,7 +322,13 @@ fn spawn_creds_refresh_loop(
                 }
             };
             fs.bucket.swap(Arc::new(b));
-            state.last_refreshed = SystemTime::now();
+            if is_web_identity {
+                if let Some(token_file_modified) = observed_token_file_modified {
+                    state.token_file_modified = token_file_modified;
+                }
+                state.expiration = expiration;
+                state.last_refreshed = SystemTime::now();
+            }
             log::debug!("Successfully refreshed S3 credentials")
         }
     });


### PR DESCRIPTION
Fixes #11622

## Problem

In web identity mode `S3RemoteFs` re-exchanged the projected service account
token with STS **only when the mtime of the token file changed**. The
`Expiration` that `AssumeRoleWithWebIdentity` returns was never looked at.

CubeStore does not use a self-refreshing AWS credentials provider — it uses a
fork of `rust-s3`, whose `s3::creds::Credentials` is a plain struct with no
auto-refresh, and does the refreshing by hand in a background thread
(`spawn_creds_refresh_loop`).

## Cause

Kubernetes rotates a projected service account token on a schedule of its own,
which is not required to line up with the ~1h TTL of an STS session, and some
projected volume implementations keep the mtime while rewriting the file
contents. With the mtime as the only gate, a node kept signing S3 requests with
a dead session token — `ExpiredToken` / `InvalidAccessKeyId` — until the file
happened to change. This has been the behaviour since the web identity path was
introduced; it is not a regression.

## What was done

- The "do the credentials have to be exchanged again" decision is extracted
  into a pure function, `web_identity_refresh_reason`. The loop sleeps on a
  timer and cannot be tested as is; the decision can.
- The STS `Expiration` is recorded in the loop state and forces a refresh once
  it is within the margin, independently of the mtime. The mtime stays as an
  additional trigger, it is no longer the only gate.
- The margin is `poll interval + 5min`. The next wake-up is the last chance to
  react, so one poll interval is the minimum; the 5 minutes on top are the
  headroom that keeps a refresh from starting against a nearly-dead token. A
  `max` of the two would let the headroom collapse whenever the interval is the
  longer of the two.
- An unknown expiry counts as a reason to re-exchange, throttled on the last
  *attempt* rather than the last success — a failing exchange advances the
  attempt, so the speculative refresh cannot turn into one STS call per poll.
  Genuinely expired credentials still retry at the poll rate, since that arm
  compares against the recorded expiration. `from_sts` always reports an
  expiration, so the unknown case is a fallback rather than an expected path.
- `token_file_modified` and `expiration` are committed only after the rebuilt
  bucket reaches the live `ArcSwap`. A failed token read, a failed STS exchange
  or a failed bucket build is therefore retried on the next poll instead of
  being recorded as done — previously a transient failure right after a token
  rotation could suppress the retry.

Static credentials mode is untouched: the decision is consulted, and the state
it reads is recorded, only when both the token file and the role ARN are set.

## How it was verified

`cargo test -p cubestore --lib remotefs::s3` — 17 tests, covering: fresh
credentials need no refresh; a changed mtime triggers one; nearing expiry,
passed expiry and unknown expiry each trigger one with the mtime unchanged; an
unreadable token file does not read as "unchanged"; unknown expiry does not
re-exchange on every poll, including across failed exchanges; expiry just
outside the margin does not trigger and just inside does; the margin keeps its
headroom on top of a poll interval and scales with a long one.

The four expiry tests were confirmed to fail against the previous mtime-only
gate:

```
failures:
    remotefs::s3::tests::expiry_margin_scales_with_a_long_poll_interval
    remotefs::s3::tests::refresh_needed_after_expiry_with_unchanged_token_file
    remotefs::s3::tests::refresh_needed_near_expiry_with_unchanged_token_file
    remotefs::s3::tests::refresh_needed_when_expiry_is_unknown

test result: FAILED. 9 passed; 4 failed
```

Full `cargo test -p cubestore --lib`: 355 passed. Two unrelated failures in this
environment — `sql::tests::table_partition_split_threshold` downloads a CSV
fixture from an external host that now answers `403 Forbidden`, and
`metastore::tests::delete_old_snapshots` passes in isolation and fails only
under the parallel run.

## Risks

- No live AWS in the loop, so this is not verified end to end against STS. The
  tests cover the decision logic only; the surrounding thread is unchanged in
  shape.
- With a poll interval at or above the session TTL, a refresh happens on every
  poll. That is one exchange per poll interval — the rate is bounded by the poll
  interval by construction — and it is what keeps the credentials alive at that
  cadence, but the accompanying `info!` line will appear once per poll.
- A refresh that keeps failing against a recorded expiry retries once per poll
  interval with no backoff. That is the same cadence the static credentials path
  in this loop has always used, and suppressing the retry is the defect being
  fixed, but under a misconfigured role trust policy or an STS outage it means
  one error line per poll per node.
- Credentials from the instance metadata / ECS chain also carry an
  `Expiration`, and the static path still ignores it and polls blindly every 3
  hours. Out of scope here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)