### PR TITLE
fix(ci): Unbreak release, yarn fails on ${NODE_AUTH_TOKEN} in setup-node@v7 npmrc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org/'
+      # Publishing goes through OIDC trusted publishing, so no token is needed, but
+      # setup-node still writes _authToken=${NODE_AUTH_TOKEN} and since v7 no longer
+      # exports a placeholder value for it, which makes every yarn 1 command fail
+      # TODO: drop this once we move to a modern package manager (yarn 4 / pnpm)
+      - name: Drop unused _authToken from generated .npmrc
+        run: sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@11.7.0
       - name: Get yarn cache directory path


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

`actions/setup-node` with `registry-url` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and points `NPM_CONFIG_USERCONFIG` at it; up to v6 it also exported a placeholder value for that variable, while v7 exports it only when the caller supplied one. We publish via OIDC trusted publishing and set no token, so since #11792 bumped the action to v7 every yarn 1 command in the `npm` job fails with `Failed to replace env in config: ${NODE_AUTH_TOKEN}` — that is what killed the [v1.7.36 release](https://github.com/cube-js/cube/actions/runs/34341760131/job/102433927031) at `yarn policies set-version`, and it had already been silently emptying the yarn cache key, since `yarn cache dir` failed inside a command substitution. The auth line is unused with OIDC, so this drops it right after `setup-node` and keeps the `registry=` one; verified locally against yarn 1.22.22 with the same `.npmrc` (fails before, resolves the cache dir after).

Note: the aarch64 `native` jobs in that same run fail for an unrelated reason (#11800 removed the host `python$VERSION` from the cross images while the workflow still sets `PYO3_PYTHON`) and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)