### PR TITLE
fix(schema-compiler): keep a view's independent join_path root off its own longer paths

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -419,7 +419,7 @@ export class BaseQuery {
    * @return {import('../compiler/JoinGraph').FinishedJoinTree}
    */
   joinTreeForHints(hints, skipQueryJoinMap = false) {
-    const queryJoinMaps = skipQueryJoinMap ? { joinMaps: {}, rootCubes: new Set() } : this.queryJoinMap();
+    const queryJoinMaps = skipQueryJoinMap ? {} : this.queryJoinMap();
     let newCollectedHints = [];
 
     const constructJH = () => R.uniq(this.enrichHintsWithJoinMap([
@@ -516,26 +516,27 @@ export class BaseQuery {
   }
 
   /**
-   * Join paths and root cubes declared by the views the query's members belong to.
+   * How the views the query's members belong to reach the cubes they include:
+   * the join paths they declare, and the cubes they include at the root of
+   * their join tree, per view.
    * @private
-   * @return {{ joinMaps: Record<string, string[][]>, rootCubes: Set<string> }}
+   * @return { Record<string, { paths: string[][], rootCubes: Set<string> }>}
    */
   queryJoinMap() {
     const queryMembers = this.allMembersConcat(false);
     const joinMaps = {};
-    const rootCubes = new Set();
 
     for (const member of queryMembers) {
       const memberCube = member.cube?.();
       if (memberCube?.isView && !joinMaps[memberCube.name] && memberCube.joinMap) {
-        joinMaps[memberCube.name] = memberCube.joinMap;
-        for (const rootCube of memberCube.rootCubes ?? []) {
-          rootCubes.add(rootCube);
-        }
+        joinMaps[memberCube.name] = {
+          paths: memberCube.joinMap,
+          rootCubes: new Set(memberCube.rootCubes ?? []),
+        };
       }
     }
 
-    return { joinMaps, rootCubes };
+    return joinMaps;
   }
 
   /**
@@ -569,29 +570,30 @@ export class BaseQuery {
   /**
    * @private
    * @param { (string|string[])[] } hints
-   * @param {{ joinMaps: Record<string, string[][]>, rootCubes: Set<string> }} queryJoinMap
+   * @param { Record<string, { paths: string[][], rootCubes: Set<string> }>} joinMap
    * @return {(string|string[])[]}
    */
-  enrichHintsWithJoinMap(hints, queryJoinMap) {
-    // Potentially, if joins between views would take place, we need to distinguish
-    // join maps on per view basis.
-    const allPaths = Object.values(queryJoinMap.joinMaps).flat();
+  enrichHintsWithJoinMap(hints, joinMap) {
+    const views = Object.values(joinMap);
 
     return hints.map(hint => {
       if (Array.isArray(hint)) {
         return hint;
       }
 
-      for (const path of allPaths) {
-        const hintIndex = path.indexOf(hint);
-        if (hintIndex !== -1) {
-          // A cube the view also includes at the root of its join tree is
-          // reachable on its own, so a bare hint into it must not be moved onto
-          // a longer path - that path serves the members included under it.
-          if (hintIndex > 0 && queryJoinMap.rootCubes.has(hint)) {
-            return hint;
+      for (const { paths, rootCubes } of views) {
+        for (const path of paths) {
+          const hintIndex = path.indexOf(hint);
+          if (hintIndex !== -1) {
+            // A cube this view also includes at the root of its join tree is
+            // reachable on its own, so a bare hint into it must not be moved
+            // onto a longer path - that path serves the members included
+            // under it.
+            if (hintIndex > 0 && rootCubes.has(hint)) {
+              return hint;
+            }
+            return path.slice(0, hintIndex + 1);
           }
-          return path.slice(0, hintIndex + 1);
         }
       }
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -419,7 +419,7 @@ export class BaseQuery {
    * @return {import('../compiler/JoinGraph').FinishedJoinTree}
    */
   joinTreeForHints(hints, skipQueryJoinMap = false) {
-    const queryJoinMaps = skipQueryJoinMap ? {} : this.queryJoinMap();
+    const queryJoinMaps = skipQueryJoinMap ? { joinMaps: {}, rootCubes: new Set() } : this.queryJoinMap();
     let newCollectedHints = [];
 
     const constructJH = () => R.uniq(this.enrichHintsWithJoinMap([
@@ -516,21 +516,26 @@ export class BaseQuery {
   }
 
   /**
+   * Join paths and root cubes declared by the views the query's members belong to.
    * @private
-   * @return { Record<string, string[][]>}
+   * @return {{ joinMaps: Record<string, string[][]>, rootCubes: Set<string> }}
    */
   queryJoinMap() {
     const queryMembers = this.allMembersConcat(false);
     const joinMaps = {};
+    const rootCubes = new Set();
 
     for (const member of queryMembers) {
       const memberCube = member.cube?.();
       if (memberCube?.isView && !joinMaps[memberCube.name] && memberCube.joinMap) {
         joinMaps[memberCube.name] = memberCube.joinMap;
+        for (const rootCube of memberCube.rootCubes ?? []) {
+          rootCubes.add(rootCube);
+        }
       }
     }
 
-    return joinMaps;
+    return { joinMaps, rootCubes };
   }
 
   /**
@@ -564,13 +569,13 @@ export class BaseQuery {
   /**
    * @private
    * @param { (string|string[])[] } hints
-   * @param { Record<string, string[][]>} joinMap
+   * @param {{ joinMaps: Record<string, string[][]>, rootCubes: Set<string> }} queryJoinMap
    * @return {(string|string[])[]}
    */
-  enrichHintsWithJoinMap(hints, joinMap) {
+  enrichHintsWithJoinMap(hints, queryJoinMap) {
     // Potentially, if joins between views would take place, we need to distinguish
     // join maps on per view basis.
-    const allPaths = Object.values(joinMap).flat();
+    const allPaths = Object.values(queryJoinMap.joinMaps).flat();
 
     return hints.map(hint => {
       if (Array.isArray(hint)) {
@@ -580,6 +585,12 @@ export class BaseQuery {
       for (const path of allPaths) {
         const hintIndex = path.indexOf(hint);
         if (hintIndex !== -1) {
+          // A cube the view also includes at the root of its join tree is
+          // reachable on its own, so a bare hint into it must not be moved onto
+          // a longer path - that path serves the members included under it.
+          if (hintIndex > 0 && queryJoinMap.rootCubes.has(hint)) {
+            return hint;
+          }
           return path.slice(0, hintIndex + 1);
         }
       }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -230,6 +230,12 @@ export interface CubeDefinition {
   isSplitView?: boolean;
   includedMembers?: ViewIncludedMember[];
   joinMap?: string[][];
+  /**
+   * Cubes the view includes at the root of its join tree, i.e. declared with a
+   * single-segment `join_path`. Such a cube is reachable on its own, no matter
+   * what other join paths of the view walk through it.
+   */
+  rootCubes?: string[];
   fileName?: string;
 }
 
@@ -806,6 +812,7 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
     const types = ['hierarchies', 'dimensions', 'measures', 'segments'];
 
     const joinMap: string[][] = [];
+    const rootCubes: string[] = [];
 
     const viewAllMembers: ViewResolvedMember[] = [];
 
@@ -822,6 +829,8 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
         // No need to keep a simple direct cube joins in join map
         if (split.length > 1) {
           joinMap.push(split);
+        } else {
+          rootCubes.push(cubeRef);
         }
 
         if (it.includes === '*') {
@@ -901,6 +910,7 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
     }
 
     cube.joinMap = joinMap;
+    cube.rootCubes = rootCubes;
 
     [...memberSets.allMembers].filter(it => !memberSets.resolvedMembers.has(it)).forEach(it => {
       errorReporter.error(`Member '${it}' is included in '${cube.name}' but not defined in any cube`);

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -1894,6 +1894,9 @@ Object {
   "preAggregations": Object {},
   "rawCubes": [Function],
   "rawFolders": [Function],
+  "rootCubes": Array [
+    "orders",
+  ],
   "segments": Object {},
 }
 `;

--- a/packages/cubejs-schema-compiler/test/unit/view-independent-join-path-roots.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/view-independent-join-path-roots.test.ts
@@ -1,0 +1,167 @@
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { PreAggregations } from '../../src/adapter/PreAggregations';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+// `locations` fans out over `boards` (2 location rows per board), and `boards`
+// carries a ratio measure plus a rollup that covers it. A query that touches
+// only members declared under the view's independent `boards` root should be
+// planned against `boards` alone - `locations` is never referenced by it.
+const cubes = `
+cubes:
+  - name: locations
+    sql: >
+      SELECT 1 AS id, 'A' AS board_id, 'x' AS pos UNION ALL
+      SELECT 2 AS id, 'A' AS board_id, 'y' AS pos UNION ALL
+      SELECT 3 AS id, 'B' AS board_id, 'x' AS pos UNION ALL
+      SELECT 4 AS id, 'B' AS board_id, 'y' AS pos
+    joins:
+      - name: boards
+        relationship: many_to_one
+        sql: "{CUBE}.board_id = {boards}.board_id"
+    measures:
+      - name: count
+        type: count
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: board_id
+        sql: "{CUBE}.board_id"
+        type: string
+      - name: pos
+        sql: "{CUBE}.pos"
+        type: string
+
+  - name: boards
+    sql: >
+      SELECT 'A' AS board_id, 'p1' AS product, 1 AS good, 2 AS total UNION ALL
+      SELECT 'B' AS board_id, 'p2' AS product, 2 AS good, 2 AS total
+    measures:
+      - name: good_count
+        sql: "{CUBE}.good"
+        type: sum
+      - name: total_count
+        sql: "{CUBE}.total"
+        type: sum
+      - name: yield_pct
+        sql: "{good_count} / NULLIF({total_count}, 0) * 100"
+        type: number
+    dimensions:
+      - name: board_id
+        sql: "{CUBE}.board_id"
+        type: string
+        primary_key: true
+      - name: product
+        sql: "{CUBE}.product"
+        type: string
+    pre_aggregations:
+      # A rollup on \`boards\` alone. It carries one dimension more than the
+      # query asks for, which only the additive matching path allows. Once the
+      # query is considered to have multiplied measures, matching switches to
+      # the strict path that requires exact dimension equality, and this rollup
+      # stops being usable.
+      - name: daily
+        type: rollup
+        measures:
+          - good_count
+          - total_count
+        dimensions:
+          - board_id
+          - product
+`;
+
+// Two independent roots, no dotted paths.
+const independentRootsOnly = `${cubes}
+views:
+  - name: kpi
+    cubes:
+      - join_path: locations
+        includes:
+          - count
+          - pos
+      - join_path: boards
+        includes:
+          - yield_pct
+          - board_id
+`;
+
+// Same independent \`boards\` root, but the view additionally declares a dotted
+// path that walks locations -> boards for an unrelated member.
+const withDottedPath = `${cubes}
+views:
+  - name: kpi
+    cubes:
+      - join_path: locations
+        includes:
+          - count
+          - pos
+      - join_path: locations.boards
+        includes:
+          - name: product
+            alias: loc_product
+      - join_path: boards
+        includes:
+          - yield_pct
+          - board_id
+`;
+
+const viewQuery = { measures: ['kpi.yield_pct'], dimensions: ['kpi.board_id'], timezone: 'UTC' };
+
+async function compile(model: string, queryDef: any) {
+  const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(model);
+  await compiler.compile();
+  const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, queryDef);
+  return { query, transformed: PreAggregations.transformQueryToCanUseForm(query) as any };
+}
+
+describe('View with independent join_path roots', () => {
+  // Baseline: querying the cube directly, without any view.
+  it('matches the rollup when boards is queried directly', async () => {
+    const { query, transformed } = await compile(independentRootsOnly, {
+      measures: ['boards.yield_pct'],
+      dimensions: ['boards.board_id'],
+      timezone: 'UTC',
+    });
+
+    expect(transformed.leafMeasuresFullPaths).toEqual(['boards.good_count', 'boards.total_count']);
+    expect(transformed.hasMultipliedMeasures).toBe(false);
+    expect(query.buildSqlAndParams()[0]).toContain('boards_daily');
+  });
+
+  it('matches the rollup through a view with independent roots', async () => {
+    const { query, transformed } = await compile(independentRootsOnly, viewQuery);
+
+    expect(transformed.leafMeasuresFullPaths).toEqual(['boards.good_count', 'boards.total_count']);
+    expect(transformed.hasMultipliedMeasures).toBe(false);
+    expect(query.buildSqlAndParams()[0]).toContain('boards_daily');
+  });
+
+  // A dotted `locations.boards` entry in the same view must not move the join
+  // hint of the independent `boards` root onto that path. Planned as if it
+  // needed the fan-out join, the query resolves its leaf measures to the dotted
+  // form, counts as having multiplied measures, and gets the rollup on `boards`
+  // rejected in favour of a `SELECT DISTINCT ... FROM locations LEFT JOIN
+  // boards` plan - even though it never references `locations`.
+  it('matches the rollup through a view that also declares a dotted path', async () => {
+    const { query, transformed } = await compile(withDottedPath, viewQuery);
+
+    expect(transformed.leafMeasuresFullPaths).toEqual(['boards.good_count', 'boards.total_count']);
+    expect(transformed.hasMultipliedMeasures).toBe(false);
+    expect(query.buildSqlAndParams()[0]).toContain('boards_daily');
+  });
+
+  // The other side of the same rule: the member the view declares under
+  // `locations.boards` still reaches `boards` by walking that path.
+  it('still walks the dotted path for the member declared under it', async () => {
+    const { query } = await compile(withDottedPath, {
+      measures: ['kpi.count'],
+      dimensions: ['kpi.loc_product'],
+      timezone: 'UTC',
+    });
+
+    const sql = query.buildSqlAndParams()[0];
+    expect(sql).toContain('AS board_id, \'p1\' AS product');
+    expect(sql).toContain('AS id, \'A\' AS board_id');
+  });
+});

--- a/packages/cubejs-schema-compiler/test/unit/view-independent-join-path-roots.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/view-independent-join-path-roots.test.ts
@@ -100,6 +100,8 @@ views:
         includes:
           - name: product
             alias: loc_product
+          - name: yield_pct
+            alias: loc_yield_pct
       - join_path: boards
         includes:
           - yield_pct
@@ -151,17 +153,24 @@ describe('View with independent join_path roots', () => {
     expect(query.buildSqlAndParams()[0]).toContain('boards_daily');
   });
 
-  // The other side of the same rule: the member the view declares under
-  // `locations.boards` still reaches `boards` by walking that path.
+  // The other side of the same rule. `loc_yield_pct` is declared under
+  // `locations.boards`, and its own components resolve to bare `boards` hints -
+  // exactly the hints the rule above leaves alone. They must not pull the
+  // member off the path it is declared on: it still fans out over `locations`,
+  // still counts as multiplied, and still resolves to the dotted leaves.
   it('still walks the dotted path for the member declared under it', async () => {
-    const { query } = await compile(withDottedPath, {
-      measures: ['kpi.count'],
-      dimensions: ['kpi.loc_product'],
+    const { query, transformed } = await compile(withDottedPath, {
+      measures: ['kpi.loc_yield_pct'],
+      dimensions: ['kpi.board_id'],
       timezone: 'UTC',
     });
 
-    const sql = query.buildSqlAndParams()[0];
-    expect(sql).toContain('AS board_id, \'p1\' AS product');
-    expect(sql).toContain('AS id, \'A\' AS board_id');
+    expect(query.allJoinHints).toEqual([['locations'], ['locations', 'boards'], 'boards']);
+    expect(query.join.root).toBe('locations');
+    expect(transformed.leafMeasuresFullPaths).toEqual([
+      'locations.boards.good_count',
+      'locations.boards.total_count',
+    ]);
+    expect(transformed.hasMultipliedMeasures).toBe(true);
   });
 });

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/cube_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/cube_definition.rs
@@ -22,6 +22,10 @@ pub struct CubeDefinitionStatic {
     pub is_calendar: Option<bool>,
     #[serde(rename = "joinMap")]
     pub join_map: Option<Vec<Vec<String>>>,
+    /// Cubes the view includes at the root of its join tree, i.e. declared with
+    /// a single-segment `join_path`.
+    #[serde(rename = "rootCubes")]
+    pub root_cubes: Option<Vec<String>>,
 }
 
 impl CubeDefinitionStatic {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/join_hints_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/join_hints_collector.rs
@@ -101,18 +101,13 @@ pub fn collect_join_hints(node: &Rc<MemberSymbol>) -> Result<JoinHints, CubeErro
     visitor.apply(node, &())?;
     let mut collected_hints = visitor.extract_result();
 
-    let join_map = node.join_map();
-
-    if let Some(join_map) = join_map {
+    if let Some(join_map) = node.join_map() {
         for hint in collected_hints.iter_mut() {
             match hint {
                 // If hints array has single element, check if it can be enriched with join hints
-                JoinHintItem::Single(hints) => {
-                    for path in join_map.iter() {
-                        if let Some(hint_index) = path.iter().position(|p| p == hints) {
-                            *hint = JoinHintItem::Vector(path[0..=hint_index].to_vec());
-                            break;
-                        }
+                JoinHintItem::Single(cube_name) => {
+                    if let Some(path) = join_map.path_to(cube_name) {
+                        *hint = JoinHintItem::Vector(path.to_vec());
                     }
                 }
                 // If hints is an array with multiple elements, it means it already

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/compiled_member_path.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/compiled_member_path.rs
@@ -1,4 +1,4 @@
-use crate::planner::{CubeNameSymbol, CubeTableSymbol};
+use crate::planner::{CubeNameSymbol, CubeTableSymbol, ViewJoinMap};
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
@@ -40,7 +40,7 @@ impl CompiledMemberPath {
         &self.cube
     }
 
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         self.cube.join_map()
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/cube_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/cube_symbol.rs
@@ -9,6 +9,7 @@ use crate::planner::{Compiler, SqlCall};
 use cubenativeutils::CubeError;
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 /// Symbol for a cube referenced as an identifier (`{CUBE}` /
@@ -72,6 +73,42 @@ impl CubeNameSymbolFactory {
     }
 }
 
+/// How a view reaches the cubes it includes: the join paths it declares for the
+/// cubes it walks to, and the cubes it includes at the root of its join tree.
+#[derive(Debug, Default)]
+pub struct ViewJoinMap {
+    paths: Vec<Vec<String>>,
+    root_cubes: HashSet<String>,
+}
+
+impl ViewJoinMap {
+    pub fn new(paths: Vec<Vec<String>>, root_cubes: Vec<String>) -> Self {
+        Self {
+            paths,
+            root_cubes: root_cubes.into_iter().collect(),
+        }
+    }
+
+    /// The prefix of a declared join path that ends at `cube_name`, to be used
+    /// in place of a bare hint into that cube. `None` when no declared path
+    /// leads there, or when the view reaches the cube at its root as well.
+    pub fn path_to(&self, cube_name: &String) -> Option<&[String]> {
+        for path in self.paths.iter() {
+            if let Some(index) = path.iter().position(|part| part == cube_name) {
+                // A cube the view also includes at the root of its join tree is
+                // reachable on its own, so a bare hint into it must not be moved
+                // onto a longer path - that path serves the members included
+                // under it.
+                if index > 0 && self.root_cubes.contains(cube_name) {
+                    return None;
+                }
+                return Some(&path[0..=index]);
+            }
+        }
+        None
+    }
+}
+
 /// Symbol for a cube referenced as a table expression
 /// (`{CUBE.sql()}`); renders by evaluating the cube's `sql:`
 /// function or its raw `sql_table:` value.
@@ -82,7 +119,7 @@ pub struct CubeTableSymbol {
     member_sql: Option<Rc<SqlCall>>,
     alias: String,
     is_table_sql: bool,
-    join_map: Option<Vec<Vec<String>>>,
+    join_map: Option<ViewJoinMap>,
 }
 
 impl CubeTableSymbol {
@@ -92,7 +129,7 @@ impl CubeTableSymbol {
         member_sql: Option<Rc<SqlCall>>,
         alias: String,
         is_table_sql: bool,
-        join_map: Option<Vec<Vec<String>>>,
+        join_map: Option<ViewJoinMap>,
     ) -> Rc<Self> {
         let path = CubeNameSymbol::normalize_path(path, &cube_name);
         Rc::new(Self {
@@ -152,7 +189,7 @@ impl CubeTableSymbol {
         self.alias.clone()
     }
 
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         &self.join_map
     }
 }
@@ -203,13 +240,20 @@ impl CubeTableSymbolFactory {
         } else {
             PlanSqlTemplates::alias_name(&cube_name)
         };
+        let static_data = definition.static_data();
+        let join_map = static_data.join_map.as_ref().map(|paths| {
+            ViewJoinMap::new(
+                paths.clone(),
+                static_data.root_cubes.clone().unwrap_or_default(),
+            )
+        });
         Ok(CubeTableSymbol::new(
             cube_name,
             path,
             sql,
             alias,
             is_table_sql,
-            definition.static_data().join_map.clone(),
+            join_map,
         ))
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_symbol.rs
@@ -14,7 +14,7 @@ use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::GranularityHelper;
 use crate::planner::SqlInterval;
 use crate::planner::TimeDimensionSymbol;
-use crate::planner::{Compiler, SqlCall};
+use crate::planner::{Compiler, SqlCall, ViewJoinMap};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -239,7 +239,7 @@ impl DimensionSymbol {
         self.compiled_path.cube_name().clone()
     }
 
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         self.compiled_path.join_map()
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
@@ -9,7 +9,7 @@ use crate::cube_bridge::member_sql::MemberSql;
 use crate::planner::collectors::find_owned_by_cube_child;
 use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::SqlInterval;
-use crate::planner::{Compiler, SqlCall};
+use crate::planner::{Compiler, SqlCall, ViewJoinMap};
 use cubenativeutils::CubeError;
 use itertools::Itertools;
 use std::cmp::{Eq, PartialEq};
@@ -369,7 +369,7 @@ impl MeasureSymbol {
         self.compiled_path.cube_name().clone()
     }
 
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         self.compiled_path.join_map()
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
@@ -1,7 +1,7 @@
 use cubenativeutils::CubeError;
 use itertools::Itertools;
 
-use crate::planner::{Case, CubeRef, SqlCall};
+use crate::planner::{Case, CubeRef, SqlCall, ViewJoinMap};
 
 use super::common::CompiledMemberPath;
 use super::deps::{self, DepVisitor, DepVisitorMut, SymbolDeps};
@@ -123,7 +123,7 @@ impl MemberSymbol {
     }
 
     /// Join-path metadata proxied from the owning cube definition.
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         self.compiled_path().join_map()
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
@@ -13,7 +13,7 @@ pub mod transforms;
 
 pub use common::*;
 pub use cube_symbol::{
-    CubeNameSymbol, CubeNameSymbolFactory, CubeTableSymbol, CubeTableSymbolFactory,
+    CubeNameSymbol, CubeNameSymbolFactory, CubeTableSymbol, CubeTableSymbolFactory, ViewJoinMap,
 };
 pub use dimension_kinds::DimensionKind;
 pub use dimension_symbol::*;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/time_dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/time_dimension_symbol.rs
@@ -4,7 +4,7 @@ use super::MemberSymbol;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::state::State;
 use crate::planner::time_dimension::Granularity;
-use crate::planner::{GranularityHelper, QueryDateTime, QueryDateTimeHelper};
+use crate::planner::{GranularityHelper, QueryDateTime, QueryDateTimeHelper, ViewJoinMap};
 use chrono::Duration;
 use chrono_tz::Tz;
 use cubenativeutils::CubeError;
@@ -249,7 +249,7 @@ impl TimeDimensionSymbol {
         self.compiled_path.path()
     }
 
-    pub fn join_map(&self) -> &Option<Vec<Vec<String>>> {
+    pub fn join_map(&self) -> &Option<ViewJoinMap> {
         self.compiled_path.join_map()
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
@@ -21,6 +21,8 @@ pub struct MockCubeDefinition {
     is_calendar: Option<bool>,
     #[builder(default)]
     join_map: Option<Vec<Vec<String>>>,
+    #[builder(default)]
+    root_cubes: Option<Vec<String>>,
 
     #[builder(default, setter(strip_option(fallback = sql_table_opt)))]
     sql_table: Option<String>,
@@ -41,7 +43,8 @@ impl_static_data!(
     sql_alias,
     is_view,
     is_calendar,
-    join_map
+    join_map,
+    root_cubes
 );
 
 impl CubeDefinition for MockCubeDefinition {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
@@ -660,7 +660,7 @@ impl MockViewBuilder {
         // does differently is evaluate the join path as a reference instead of
         // splitting the raw string, so a fixture would only diverge with a join
         // path that is not a literal.
-        let join_map = self
+        let join_paths = self
             .view_cubes
             .iter()
             .map(|view_cube| {
@@ -670,13 +670,28 @@ impl MockViewBuilder {
                     .map(|part| part.to_string())
                     .collect::<Vec<_>>()
             })
+            .collect::<Vec<_>>();
+
+        let join_map = join_paths
+            .iter()
             .filter(|path| path.len() > 1)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // The other half of the same split: a single-segment join path names a
+        // cube the view reaches at the root of its join tree, and such a cube
+        // keeps a longer path of the same view off a bare hint into it.
+        let root_cubes = join_paths
+            .iter()
+            .filter(|path| path.len() == 1)
+            .map(|path| path[0].clone())
             .collect::<Vec<_>>();
 
         let view_def = MockCubeDefinition::builder()
             .name(self.view_name.clone())
             .is_view(Some(true))
             .join_map(Some(join_map))
+            .root_cubes(Some(root_cubes))
             .default_filters(self.default_filters)
             .build();
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_independent_join_roots.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_independent_join_roots.yaml
@@ -41,6 +41,12 @@ cubes:
       - name: yield_pct
         type: number
         sql: "{good_count} / NULLIF({total_count}, 0) * 100"
+      # Same shape as `yield_pct`, so its components also resolve to bare
+      # `boards` hints. The view includes it under the longer path instead, to
+      # hold that those hints do not pull it off that path.
+      - name: scrap_pct
+        type: number
+        sql: "({total_count} - {good_count}) / NULLIF({total_count}, 0) * 100"
     pre_aggregations:
       # Carries one dimension more than the query below asks for, which only the
       # additive matching path allows. A query taken for a multiplied one is
@@ -65,6 +71,7 @@ views:
       - join_path: locations.boards
         includes:
           - product
+          - scrap_pct
       - join_path: boards
         includes:
           - yield_pct

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_independent_join_roots.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_independent_join_roots.yaml
@@ -1,0 +1,71 @@
+# `locations` fans out over `boards` - two location rows per board - so a query
+# rooted at `locations` multiplies the `boards` measures. A view declares
+# `boards` both as a root of its own and as the tail of `locations.boards`, and
+# members of the independent root must not be planned through the longer path.
+cubes:
+  - name: locations
+    sql: "SELECT * FROM locations"
+    joins:
+      - name: boards
+        relationship: many_to_one
+        sql: "{locations}.board_id = {boards.board_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: pos
+        type: string
+        sql: pos
+    measures:
+      - name: count
+        type: count
+
+  - name: boards
+    sql: "SELECT * FROM boards"
+    dimensions:
+      - name: board_id
+        type: string
+        sql: board_id
+        primary_key: true
+      - name: product
+        type: string
+        sql: product
+    measures:
+      - name: good_count
+        type: sum
+        sql: good
+      - name: total_count
+        type: sum
+        sql: total
+      - name: yield_pct
+        type: number
+        sql: "{good_count} / NULLIF({total_count}, 0) * 100"
+    pre_aggregations:
+      # Carries one dimension more than the query below asks for, which only the
+      # additive matching path allows. A query taken for a multiplied one is
+      # matched on the strict path that wants the dimensions to be equal, and
+      # then this rollup is not usable.
+      - name: boards_rollup
+        type: rollup
+        measures:
+          - good_count
+          - total_count
+        dimensions:
+          - board_id
+          - product
+
+views:
+  - name: kpi
+    cubes:
+      - join_path: locations
+        includes:
+          - count
+          - pos
+      - join_path: locations.boards
+        includes:
+          - product
+      - join_path: boards
+        includes:
+          - yield_pct
+          - board_id

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/views.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/views.rs
@@ -264,3 +264,62 @@ async fn test_view_raw_and_granular_time_dimension_converted_once_each() {
         insta::assert_snapshot!(result);
     }
 }
+
+/// A view that declares a cube both as a root of its own and as the tail of a
+/// longer join path. A query over the members of the independent root alone
+/// must stay on that root: the longer path serves the members declared under
+/// it, and walking it here would fan the measures out over `locations` and put
+/// pre-aggregation matching on the strict, multiplied path.
+fn independent_roots_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/view_independent_join_roots.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_independent_root_query_does_not_walk_the_dotted_path() {
+    let ctx = independent_roots_context();
+
+    let query = indoc! {"
+        measures:
+          - kpi.yield_pct
+        dimensions:
+          - kpi.board_id
+        order:
+          - id: kpi.board_id
+    "};
+
+    let (sql, pre_aggregations) = ctx.build_sql_with_used_pre_aggregations(query).unwrap();
+
+    assert!(
+        !sql.contains("locations"),
+        "the query touches no member of locations, got: {sql}"
+    );
+    assert_eq!(
+        pre_aggregations.len(),
+        1,
+        "the rollup on boards covers the query, got: {sql}"
+    );
+    assert_eq!(pre_aggregations[0].name(), "boards_rollup");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_dotted_path_query_still_walks_it() {
+    let ctx = independent_roots_context();
+
+    let query = indoc! {"
+        measures:
+          - kpi.count
+        dimensions:
+          - kpi.product
+        order:
+          - id: kpi.product
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("locations"),
+        "the query counts locations rows, got: {sql}"
+    );
+    assert!(sql.contains("boards"), "got: {sql}");
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/views.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/views.rs
@@ -302,24 +302,36 @@ async fn test_view_independent_root_query_does_not_walk_the_dotted_path() {
     assert_eq!(pre_aggregations[0].name(), "boards_rollup");
 }
 
+/// The other side of the same rule. `scrap_pct` is declared under
+/// `locations.boards`, and its components resolve to bare `boards` hints -
+/// exactly the hints the rule above leaves alone. They must not pull the
+/// measure off the path it is declared on: it still fans out over `locations`,
+/// which is what forces the deduplicating keys subquery.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_view_dotted_path_query_still_walks_it() {
     let ctx = independent_roots_context();
 
     let query = indoc! {"
         measures:
-          - kpi.count
+          - kpi.scrap_pct
         dimensions:
-          - kpi.product
+          - kpi.board_id
         order:
-          - id: kpi.product
+          - id: kpi.board_id
     "};
 
-    let sql = ctx.build_sql(query).unwrap();
+    let (sql, pre_aggregations) = ctx.build_sql_with_used_pre_aggregations(query).unwrap();
 
     assert!(
         sql.contains("locations"),
-        "the query counts locations rows, got: {sql}"
+        "the measure is declared under locations.boards, got: {sql}"
     );
-    assert!(sql.contains("boards"), "got: {sql}");
+    assert!(
+        sql.contains(r#" AS "keys""#),
+        "the fan-out has to be deduplicated, got: {sql}"
+    );
+    assert!(
+        pre_aggregations.is_empty(),
+        "a multiplied query does not match the rollup on boards, got: {sql}"
+    );
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
@@ -169,3 +169,42 @@ async fn test_many_to_one_view_build_sql() {
         insta::assert_snapshot!(result);
     }
 }
+
+// --- independent join_path root tests ---
+
+fn independent_roots_ctx() -> TestContext {
+    TestContext::new(MockSchema::from_yaml_file(
+        "common/view_independent_join_roots.yaml",
+    ))
+    .unwrap()
+}
+
+#[test]
+fn test_join_hints_view_independent_root_measure() {
+    let ctx = independent_roots_ctx();
+    let measure = ctx.create_measure("kpi.yield_pct").unwrap();
+    let hints = collect_join_hints(&measure).unwrap();
+    assert_eq!(hints.len(), 1);
+    // `boards` is a root of the view on its own, so the `locations.boards` path
+    // the same view declares for its other member must not be imposed on it.
+    assert_eq!(hints.items(), &[s("boards")]);
+}
+
+#[test]
+fn test_join_hints_view_independent_root_dimension() {
+    let ctx = independent_roots_ctx();
+    let dim = ctx.create_dimension("kpi.board_id").unwrap();
+    let hints = collect_join_hints(&dim).unwrap();
+    assert_eq!(hints.len(), 1);
+    assert_eq!(hints.items(), &[s("boards")]);
+}
+
+#[test]
+fn test_join_hints_view_dotted_path_dimension() {
+    let ctx = independent_roots_ctx();
+    let dim = ctx.create_dimension("kpi.product").unwrap();
+    let hints = collect_join_hints(&dim).unwrap();
+    assert_eq!(hints.len(), 1);
+    // The member the view declares under `locations.boards` still walks it.
+    assert_eq!(hints.items(), &[v(&["locations", "boards"])]);
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/join_hints_collector.rs
@@ -208,3 +208,15 @@ fn test_join_hints_view_dotted_path_dimension() {
     // The member the view declares under `locations.boards` still walks it.
     assert_eq!(hints.items(), &[v(&["locations", "boards"])]);
 }
+
+#[test]
+fn test_join_hints_view_dotted_path_measure() {
+    let ctx = independent_roots_ctx();
+    let measure = ctx.create_measure("kpi.scrap_pct").unwrap();
+    let hints = collect_join_hints(&measure).unwrap();
+    // The measure is declared under `locations.boards`, and its components
+    // resolve to a bare `boards` hint - the hint the rule above leaves alone.
+    // The declared path has to come along all the same, or the member would be
+    // planned as if it sat on the view's `boards` root.
+    assert_eq!(hints.items(), &[v(&["locations", "boards"]), s("boards")]);
+}


### PR DESCRIPTION
Fixes #11680.

## Problem

A view can reach the same cube two ways: at the root of its join tree
(`join_path: boards`) and as the tail of a longer path declared for another
member (`join_path: locations.boards`). A query that touches only the members
of the independent root was planned as if it needed the fan-out join through
`locations`:

- its leaf measures resolved to the dotted form (`locations.boards.good_count`
  instead of `boards.good_count`);
- it counted as having multiplied measures, which puts pre-aggregation matching
  on the strict path that requires the dimensions to be equal;
- a rollup declared on `boards` alone therefore stopped matching, and the query
  fell back to scanning `SELECT DISTINCT ... FROM locations LEFT JOIN boards` -
  a cube it never references.

The same query straight against the cube, or through a view with independent
roots only, matched the rollup fine.

## Cause

A view records the join path of every cube it includes through more than one
segment, and a bare join hint into any cube on such a path is rewritten to the
prefix of that path. That is what makes a member proxied across cubes follow the
route the view declares rather than a shorter one the join graph would find on
its own - see `views-join-order-join-maps.test.ts`.

The rewrite has no way of telling which of the view's entries a hint came from,
so it also caught the cube the same view includes at its root: every bare
`boards` hint was moved onto `locations.boards`, `locations` became the root of
the join tree, and `boards` was marked multiplied.

## What changed

Views now also record the cubes they include at the root of their join tree -
the entries whose `join_path` is a single segment - and a bare hint into one of
those is left alone instead of being moved onto a longer path of the same view.
A hint that already sits at the head of a path is unaffected, so the route of a
member declared under a longer path does not change.

Both planners derive the rewrite from the same view metadata and both needed the
fix: with only the JS half, the leaf measures and the multiplied flag came out
right but Tesseract still built the `locations LEFT JOIN boards` keys subquery
and still refused the rollup.

## How it was verified

- New `view-independent-join-path-roots.test.ts` covers the shape end to end:
  leaf measure paths, the multiplied flag, and the rollup actually being used.
- New Tesseract tests cover the join hints collected for each of the view's
  members, and the SQL and pre-aggregation the query plans to.
- Both sides also cover the counterpart - a calculated measure declared under
  the longer path, whose components do yield bare hints, still walking that path
  and still fanning out.
- Every new test was confirmed to fail with the fix reverted.
- `cargo test -p cubesqlplanner`: 1378 passed.
- `cubejs-schema-compiler` unit suite: 955 passed, with only the pre-existing
  `error-reporter` ANSI-colour snapshot failures, which fail on `master` too.
- `cubejs-schema-compiler` Postgres integration suite against a real database
  with a locally built native planner: 51/51 suites, 577 tests.

## Risks

- The minimal schema in the issue - two independent roots and no dotted path -
  does not reproduce on current `master`; it resolves correctly and uses the
  rollup. The reporter's real model almost certainly also declares a path into
  the same cube, which is the shape fixed here. Worth confirming with them.
- A view that exposes the *same* cube measure twice, once at its root and once
  under a longer path, and is queried for both aliases at once now plans as two
  join trees. The outer projection identifies a measure by its leaf, so both
  aliases read the same group and the other one is computed and discarded. That
  is the planner's measure-identity model rather than something this change can
  settle locally - two aliases of one cube measure are one measure, so one of
  the two contradictory answers has to lose. Before this change the multiplied
  group won for both; now the root group does.
- `fallback_hints_for_measure` in `multi_fact_join_groups.rs` still derives a
  view's roots from the declared paths alone, so a hint-less member expression
  on a view with two unrelated roots still resolves to one of them instead of
  raising the "don't share a single root" error it has for that case. Left alone
  on purpose: it is a pre-existing gap in a different feature, and closing it
  turns queries that answer today into hard errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)