### PR TITLE
test(tesseract): pin the row set of a share whose denominator drops the query filter

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -856,9 +856,12 @@ cubes:
                       operator: notEquals
                       values: [pending]
 
-          # Denominator partitioned by members outside the query grain:
-          # `group_by` keeps nothing of the query's own dimensions and
-          # `filter.exclude` drops the query filter on `status`.
+          # Denominator whose partition is an intersection with the query
+          # grain, not an addition to it: `group_by` keeps only what the query
+          # already groups by, while `filter.exclude` drops the query filter on
+          # `status`. Naming `created_at` both bare and granularity-suffixed
+          # covers a reference form the intersection has to tolerate — a query
+          # time dimension matches the bare entry at any granularity.
           - name: amount_by_category_day_unfiltered
             type: sum
             sql: "{CUBE.total_amount}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -856,6 +856,27 @@ cubes:
                       operator: notEquals
                       values: [pending]
 
+          # Denominator partitioned by members outside the query grain:
+          # `group_by` keeps nothing of the query's own dimensions and
+          # `filter.exclude` drops the query filter on `status`.
+          - name: amount_by_category_day_unfiltered
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            group_by:
+                - orders.category
+                - orders.created_at
+                - orders.created_at.day
+            filter:
+                mode: relative
+                exclude:
+                    - orders.status
+
+          - name: amount_category_day_share_percent
+            type: number
+            multi_stage: true
+            sql: "100.0 * {CUBE.total_amount} / nullif({CUBE.amount_by_category_day_unfiltered}, 0)"
+
           # A rank whose ordering ignores the query filter on `status` and whose
           # partition drops it. Rank is deliberately left out of the keys side,
           # so the ranks span the whole universe and the rows do too.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -856,12 +856,6 @@ cubes:
                       operator: notEquals
                       values: [pending]
 
-          # Denominator whose partition is an intersection with the query
-          # grain, not an addition to it: `group_by` keeps only what the query
-          # already groups by, while `filter.exclude` drops the query filter on
-          # `status`. Naming `created_at` both bare and granularity-suffixed
-          # covers a reference form the intersection has to tolerate — a query
-          # time dimension matches the bare entry at any granularity.
           - name: amount_by_category_day_unfiltered
             type: sum
             sql: "{CUBE.total_amount}"
@@ -871,7 +865,6 @@ cubes:
                 - orders.created_at
                 - orders.created_at.day
             filter:
-                mode: relative
                 exclude:
                     - orders.status
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -567,3 +567,35 @@ async fn test_group_by_outside_query_grain_keeps_query_row_set() {
         insta::assert_snapshot!(result);
     }
 }
+
+// Same denominator, this time with a query grain the `group_by` partially
+// keeps: the time dimension survives the intersection while `status` does not,
+// so the widened key grid is non-empty and the share varies per partition.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_group_by_partially_kept_keeps_query_row_set() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_category_day_share_percent
+          - orders.total_amount
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: month
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.created_at
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -536,3 +536,34 @@ async fn test_rank_with_filter_exclude_ranks_over_whole_universe() {
         insta::assert_snapshot!(result);
     }
 }
+
+// Share-of-partition shape whose denominator partitions by members the query
+// does not group by at all: `group_by` intersects the query grain down to
+// nothing while `filter.exclude` drops the query filter on `status`. The
+// aggregation input widens both ways, so nothing of the query grain survives
+// into the measure side and the reported rows have to come from the keys side.
+// A denominator reported over the widened set surfaces as extra rows carrying
+// a NULL share.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_group_by_outside_query_grain_keeps_query_row_set() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_category_day_share_percent
+          - orders.total_amount
+        dimensions:
+          - orders.status
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
@@ -537,13 +537,6 @@ async fn test_rank_with_filter_exclude_ranks_over_whole_universe() {
     }
 }
 
-// Share-of-partition shape whose denominator partitions by members the query
-// does not group by at all: `group_by` intersects the query grain down to
-// nothing while `filter.exclude` drops the query filter on `status`. The
-// aggregation input widens both ways, so nothing of the query grain survives
-// into the measure side and the reported rows have to come from the keys side.
-// A denominator reported over the widened set surfaces as extra rows carrying
-// a NULL share.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_group_by_outside_query_grain_keeps_query_row_set() {
     let ctx = create_context();
@@ -568,9 +561,6 @@ async fn test_group_by_outside_query_grain_keeps_query_row_set() {
     }
 }
 
-// Same denominator, this time with a query grain the `group_by` partially
-// keeps: the time dimension survives the intersection while `status` does not,
-// so the widened key grid is non-empty and the share varies per partition.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_group_by_partially_kept_keeps_query_row_set() {
     let ctx = create_context();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__group_by_outside_query_grain_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__group_by_outside_query_grain_keeps_query_row_set.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+expression: result
+---
+orders__status | orders__amount_category_day_share_percent | orders__total_amount
+---------------+-------------------------------------------+---------------------
+completed      | 62.2222222222222222                       | 1400.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__group_by_partially_kept_keeps_query_row_set.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__filter_directive__group_by_partially_kept_keeps_query_row_set.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/filter_directive.rs
+expression: result
+---
+orders__status | orders__created_at_month | orders__amount_category_day_share_percent | orders__total_amount
+---------------+--------------------------+-------------------------------------------+---------------------
+completed      | 2024-01-01 00:00:00      | 60.0000000000000000                       | 300.00              
+completed      | 2024-02-01 00:00:00      | 66.6666666666666667                       | 500.00              
+completed      | 2024-03-01 00:00:00      | 60.0000000000000000                       | 600.00


### PR DESCRIPTION
## Problem

Reported: a multi-stage share measure whose denominator carries `group_by` naming
members outside the query grain, together with `filter: exclude` dropping the
query's own filter, returned extra rows with a NULL share — the values the query
filtered out came back alongside the real row.

## Cause

The denominator is a sum-of-sum aggregate, so it is eligible for the window path.
That path has one row set serving both the aggregation input and the reported
rows, so once `filter.exclude` widens the input, the widened rows are reported
too.

The planner already revokes the window path when a filter directive drops a
filter the query restricts the grid by, and that revocation is what saves this
shape — the reported query returns the correct single row on current master.
What was missing is a test: this shape differs from the covered ones in that
`group_by` intersects the query grain rather than extending it, so the measure
side can end up keeping none of the query's dimensions and the reported rows can
only come from the keys side.

## What changed

Tests only. No production code changes.

- `integration_multi_stage.yaml`: a denominator partitioned by `category` /
  `created_at` / `created_at.day` whose `filter.exclude` drops the query filter
  on `status`, plus a share measure consuming it.
- `filter_directive.rs`: two integration tests over that measure — one where the
  partition intersects the query grain down to nothing, one where the query's
  time dimension survives the intersection so the widened key grid is non-empty.

## How it was verified

- Both tests pass on master and fail when the window-path revocation is disabled,
  reproducing the report verbatim — the filtered-out statuses come back carrying
  NULL:

  ```
      1     1 │ orders__status | orders__amount_category_day_share_percent | orders__total_amount
      2     2 │ ---------------+-------------------------------------------+---------------------
            3 │+cancelled      | NULL                                      | NULL
            4 │+pending        | NULL                                      | NULL
      3     5 │ completed      | 62.2222222222222222                       | 1400.00
  ```

  and, in the partially-kept case, once per month:

  ```
      3     3 │ completed      | 2024-01-01 00:00:00 | 60.0000000000000000 | 300.00
            4 │+pending        | 2024-01-01 00:00:00 | NULL                | NULL
            5 │+cancelled      | 2024-01-01 00:00:00 | NULL                | NULL
  ```

- The reported model and query were also run end-to-end through the JS schema
  compiler against Postgres on both planners. Tesseract returns the single
  expected row. The legacy planner returns the same single row with the
  denominator still filtered (share = 1.0), because the `filter:` directive is
  Tesseract-only — a documented difference, not a regression.
- Full `cubesqlplanner` suite green with `--features integration-postgres`
  (1374 passed). CI covers these snapshots: `push.yml` runs
  `--features cubesqlplanner/integration-cubestore`, which implies
  `integration-postgres`.

## Risks

Low — the diff adds two tests and two measures to a shared test fixture. The new
measures are not exported by any view in that fixture, so no existing test
changes shape.

Known coverage gap, not addressed here: `tesseract/join_types_full` is defined
only by the Snowflake dialect, so the full-join assembly strategy has no test
coverage at all. Postgres rejects that join shape at every version ("FULL JOIN is
only supported with merge-joinable or hash-joinable join conditions"), so it
cannot be row-validated in the existing harness. It does not affect this shape:
the denominator CTE carries an explicit keys side, which selects the keys
strategy on every dialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
