### PR TITLE
fix(cross): Restore host Python interpreter in aarch64 images

### DIFF
--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
@@ -25,12 +25,15 @@ ARG PYTHON_VERSION
 ARG PYTHON_VERSION_SUFFIX
 ARG PYTHON_RELEASE
 
+# pyo3-build-config's build script runs on the host, where it honours PYO3_PYTHON over the
+# PYO3_CROSS_* config below, so python$PYTHON_RELEASE has to stay on PATH in the final image
+COPY --from=build-python /opt/build-python /opt/build-python
+RUN ln -s /opt/build-python/bin/python${PYTHON_RELEASE} /usr/local/bin/python${PYTHON_RELEASE};
+
 # --enable-optimizations is disabled, because it's not supported with CROSS
 # 3.9/3.10 ignore --with-build-python and instead search PATH for python$VERSION, so the build
 # interpreter has to be reachable both ways
-RUN --mount=type=bind,from=build-python,source=/opt/build-python,target=/opt/build-python \
-    export PATH="/opt/build-python/bin:${PATH}" \
-    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
+RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX}.tgz -O - | tar -xz \
     && cd Python-${PYTHON_VERSION}${PYTHON_VERSION_SUFFIX} \
     && touch config.site-aarch64 \
     && echo "ac_cv_buggy_getaddrinfo=no" >> config.site-aarch64 \


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

#11800 moved the aarch64 build interpreter into a `build-python` stage consumed through `RUN --mount=type=bind`, so it no longer exists once the image is built — but pyo3's build script runs on the host and honours the `PYO3_PYTHON=python$PYTHON_RELEASE` that `publish.yml` and `rust-cubesql.yml` set for every target, making every aarch64 native build fail with `failed to run the Python interpreter at python3.9: No such file or directory`. This copies the stage into the final image and symlinks it onto `PATH`, restoring what `ppa:deadsnakes` plus `apt-get install python$PYTHON_RELEASE` used to provide (and which 3.9/3.10's PATH-based build-interpreter lookup also needs). `CROSS_VERSION` intentionally stays at `08092026`: the aarch64 `-python-*` tags are unusable as published, so overwriting them lets the failed v1.7.36 release jobs be re-run unchanged instead of requiring a new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)