### PR TITLE
fix(tesseract): stop a rolling window's plan fanning out across measures

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -26,6 +26,7 @@ use cubenativeutils::CubeError;
 use cubenativeutils::CubeErrorCauseType;
 use itertools::Itertools;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -745,6 +746,38 @@ impl PreAggregationsCompiler {
             let pre_aggregation = self.compile_pre_aggregation(name)?;
             if !(disable_external_pre_aggregations && pre_aggregation.external == Some(true)) {
                 result.push(pre_aggregation);
+            }
+        }
+        Ok(result)
+    }
+
+    /// The measures each pre-aggregation of these cubes declares, by full name.
+    /// Read off the declarations alone — no source, join or union is built — so
+    /// a caller only asking which measures a rollup groups together does not
+    /// pay for compiling it.
+    ///
+    /// A `rollupLambda` declares none of its own; the rollups it unions are
+    /// themselves pre-aggregations of the cube and are listed in their own
+    /// right.
+    pub fn declared_measures(
+        query_tools: Rc<State>,
+        cube_names: &Vec<String>,
+    ) -> Result<Vec<HashSet<String>>, CubeError> {
+        let mut result = Vec::new();
+        for cube_name in cube_names.iter() {
+            let pre_aggregations = query_tools
+                .cube_evaluator()
+                .pre_aggregations_for_cube_as_array(cube_name.clone())?;
+            for pre_aggregation in pre_aggregations.iter() {
+                let Some(refs) = pre_aggregation.measure_references()? else {
+                    continue;
+                };
+                let name = PreAggregationFullName::new(
+                    cube_name.clone(),
+                    pre_aggregation.static_data().name.clone(),
+                );
+                let symbols = Self::symbols_from_ref(query_tools.clone(), &name, refs, |_| Ok(()))?;
+                result.push(symbols.iter().map(|s| s.full_name()).collect());
             }
         }
         Ok(result)

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
@@ -181,6 +181,28 @@ impl<'a> FilterSqlContext<'a> {
         self.plan_templates.convert_tz(field.to_string())
     }
 
+    /// The rolling window's series bounds as literal parameters, or `None`
+    /// when they can only be read back off the series itself.
+    ///
+    /// Values standing for a pre-aggregation's partition range, and raw values
+    /// substituted into pre-aggregation SQL, are placeholders rather than
+    /// dates, and carry no bounds to render.
+    pub fn date_range_literals(
+        &self,
+        range: &Option<(String, String)>,
+    ) -> Result<Option<(String, String)>, CubeError> {
+        let Some((from, to)) = range else {
+            return Ok(None);
+        };
+        if self.use_raw_values || self.is_partition_range(from) || self.is_partition_range(to) {
+            return Ok(None);
+        }
+        Ok(Some((
+            self.format_and_allocate_from_date(from)?,
+            self.format_and_allocate_to_date(to)?,
+        )))
+    }
+
     pub fn date_range_from_time_series(&self) -> Result<(String, String), CubeError> {
         Ok((
             self.time_series_bound("min", "date_from")?,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
@@ -184,9 +184,8 @@ impl<'a> FilterSqlContext<'a> {
     /// The rolling window's series bounds as literal parameters, or `None`
     /// when they can only be read back off the series itself.
     ///
-    /// Values standing for a pre-aggregation's partition range, and raw values
-    /// substituted into pre-aggregation SQL, are placeholders rather than
-    /// dates, and carry no bounds to render.
+    /// Raw values are spliced into pre-aggregation SQL verbatim rather than
+    /// allocated as parameters, which a bound cannot be rendered as.
     pub fn date_range_literals(
         &self,
         range: &Option<(String, String)>,
@@ -194,7 +193,7 @@ impl<'a> FilterSqlContext<'a> {
         let Some((from, to)) = range else {
             return Ok(None);
         };
-        if self.use_raw_values || self.is_partition_range(from) || self.is_partition_range(to) {
+        if self.use_raw_values {
             return Ok(None);
         }
         Ok(Some((

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/rolling_window.rs
@@ -6,7 +6,10 @@ use cubenativeutils::CubeError;
 
 impl FilterOperationSql for RegularRollingWindowOp {
     fn to_sql(&self, ctx: &FilterSqlContext) -> Result<String, CubeError> {
-        let (from, to) = ctx.date_range_from_time_series()?;
+        let (from, to) = match ctx.date_range_literals(&self.series_range)? {
+            Some(range) => range,
+            None => ctx.date_range_from_time_series()?,
+        };
 
         let from = ctx.extend_date_range_bound(from, &self.trailing, true)?;
         let to = ctx.extend_date_range_bound(to, &self.leading, false)?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/operators/rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/operators/rolling_window.rs
@@ -1,15 +1,30 @@
 /// `RegularRollingWindow` filter operation: trailing and leading
 /// interval bounds of a rolling window relative to each time-series
 /// point.
+///
+/// `series_range` holds the outer bounds of the series the window walks, when
+/// they are known at plan time. The filter restricts the base scan to the span
+/// the widest window can reach, and a literal span is one an engine can
+/// eliminate partitions by; without it the bounds are read back off the series
+/// with a scalar sub-select, which is opaque to pruning.
 #[derive(Clone, Debug)]
 pub struct RegularRollingWindowOp {
     pub(crate) trailing: Option<String>,
     pub(crate) leading: Option<String>,
+    pub(crate) series_range: Option<(String, String)>,
 }
 
 impl RegularRollingWindowOp {
-    pub fn new(trailing: Option<String>, leading: Option<String>) -> Self {
-        Self { trailing, leading }
+    pub fn new(
+        trailing: Option<String>,
+        leading: Option<String>,
+        series_range: Option<(String, String)>,
+    ) -> Self {
+        Self {
+            trailing,
+            leading,
+            series_range,
+        }
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -284,7 +284,15 @@ impl TypedFilterBuilder {
                 FilterOperator::RegularRollingWindowDateRange => {
                     let trailing = values.get(2).and_then(|v| v.to_param_string());
                     let leading = values.get(3).and_then(|v| v.to_param_string());
-                    FilterOp::RegularRollingWindow(RegularRollingWindowOp::new(trailing, leading))
+                    let series_range = values
+                        .get(4)
+                        .and_then(|v| v.to_param_string())
+                        .zip(values.get(5).and_then(|v| v.to_param_string()));
+                    FilterOp::RegularRollingWindow(RegularRollingWindowOp::new(
+                        trailing,
+                        leading,
+                        series_range,
+                    ))
                 }
                 FilterOperator::RollingWindowOffsetDateRange => {
                     let from = values.first().and_then(|v| v.to_param_string());

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/member_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/member_query_planner.rs
@@ -516,6 +516,18 @@ impl MultiStageMemberQueryPlanner {
             self.description.member_node().clone()
         };
         let member_node = &member_node;
+        let co_measures = self
+            .description
+            .co_measures()
+            .into_iter()
+            .map(|measure| {
+                if leaf_as_state {
+                    transforms::measures_as_state(&measure)
+                } else {
+                    Ok(measure)
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let mut dimensions = self.description.state().dimensions().clone();
         let mut time_dimensions = self.description.state().time_dimensions().clone();
         let mut measures = vec![];
@@ -541,6 +553,7 @@ impl MultiStageMemberQueryPlanner {
                 _ => {}
             }
         }
+        measures.extend(co_measures.iter().cloned());
 
         let mut measures_filters = self.description.state().measures_filters().clone();
         if leaf_as_state {
@@ -582,7 +595,9 @@ impl MultiStageMemberQueryPlanner {
             query_planner.plan(scope)
         })?;
         let leaf_measure_plan = MultiStageLeafMeasure {
-            measures: vec![member_node.clone()],
+            measures: std::iter::once(member_node.clone())
+                .chain(co_measures)
+                .collect_vec(),
             query,
             evaluation_context,
         };
@@ -630,12 +645,13 @@ impl MultiStageMemberQueryPlanner {
             .input()
             .iter()
             .map(|d| {
+                let measures = d.measures();
                 let schema = LogicalSchema::default()
                     .set_time_dimensions(d.state().time_dimensions().clone())
                     .set_dimensions(d.state().dimensions().clone())
-                    .set_measures(vec![d.member_node().clone()])
+                    .set_measures(measures.clone())
                     .into_rc();
-                (d.alias().clone(), vec![d.member_node().clone()], schema)
+                (d.alias().clone(), measures, schema)
             })
             .unique_by(|(a, _, _)| a.clone())
             .collect_vec()

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -27,6 +27,8 @@ use crate::planner::MultiStageFilter;
 use crate::planner::MultiStageFilterMode;
 use crate::planner::MultiStageGrain;
 use crate::planner::QueryProperties;
+use crate::planner::QueryTimeSeries;
+use crate::planner::TimeDimensionSymbol;
 use cubenativeutils::CubeError;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -1213,6 +1215,47 @@ impl MultiStageQueryPlanner {
         Ok(description)
     }
 
+    /// Outer bounds of the series a rolling window over `time_dimension` walks.
+    /// The series is derived from the dimension's granularity and date range,
+    /// so both bounds are known here; the base-scan filter renders them as
+    /// literals instead of reading them back off the series.
+    ///
+    /// `None` where the series is not derivable at plan time: without a date
+    /// range the range itself is a query, and a granularity whose periods come
+    /// off a calendar cube has boundaries no interval math reproduces.
+    fn rolling_series_bounds(
+        time_dimension: &Rc<TimeDimensionSymbol>,
+    ) -> Result<Option<(String, String)>, CubeError> {
+        let Some(granularity) = time_dimension.granularity_obj() else {
+            return Ok(None);
+        };
+        if granularity.calendar_sql().is_some() {
+            return Ok(None);
+        }
+        let Some(date_range) = time_dimension.date_range_vec() else {
+            return Ok(None);
+        };
+        let range = [date_range[0].clone(), date_range[1].clone()];
+        // Millisecond bounds; the filter pads them to the dialect's precision
+        // when it renders them.
+        let precision = 3;
+        let bounds = if granularity.is_predefined_granularity() {
+            QueryTimeSeries::covering_bounds_predefined(
+                granularity.granularity(),
+                &range,
+                precision,
+            )?
+        } else {
+            QueryTimeSeries::covering_bounds_custom(
+                &granularity.granularity_interval().to_sql(),
+                &range,
+                &granularity.origin_local_formatted(),
+                precision,
+            )?
+        };
+        Ok(Some(bounds))
+    }
+
     /// The granularity of a `to_date` rolling window whose period boundary is
     /// defined by a calendar column. `None` for a boundary that interval math
     /// can compute on its own.
@@ -1356,6 +1399,7 @@ impl MultiStageQueryPlanner {
                 &time_dimension_base_name,
                 rolling_window.trailing.clone(),
                 rolling_window.leading.clone(),
+                Self::rolling_series_bounds(&time_dimension_symbol)?,
             )?;
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -21,16 +21,19 @@ use crate::planner::symbols::AggregationType;
 use crate::planner::Case;
 use crate::planner::CaseSwitchDefinition;
 use crate::planner::CaseSwitchItem;
+use crate::planner::Granularity;
 use crate::planner::GranularityHelper;
 use crate::planner::MeasureKind;
 use crate::planner::MemberSymbol;
 use crate::planner::MultiStageFilter;
 use crate::planner::MultiStageFilterMode;
 use crate::planner::MultiStageGrain;
+use crate::planner::QueryDateTime;
 use crate::planner::QueryDateTimeHelper;
 use crate::planner::QueryProperties;
 use crate::planner::QueryTimeSeries;
 use crate::planner::TimeDimensionSymbol;
+use chrono::Duration;
 use cubenativeutils::CubeError;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -923,6 +926,7 @@ impl MultiStageQueryPlanner {
                             base_member,
                             base_state,
                             false,
+                            false,
                             descriptions,
                             scope,
                         )?
@@ -1026,6 +1030,7 @@ impl MultiStageQueryPlanner {
                         base_member,
                         base_rolling_state,
                         ungrouped,
+                        true,
                         descriptions,
                         scope,
                     )?
@@ -1197,6 +1202,10 @@ impl MultiStageQueryPlanner {
         member: Rc<MemberSymbol>,
         state: Rc<QueryProperties>,
         ungrouped: bool,
+        // Whether a rolling-window stage consumes this CTE. A caller taking the
+        // CTE as the requested member's own result registers it under that
+        // member, which one shared between measures cannot answer for.
+        feeds_window_stage: bool,
         descriptions: &mut Vec<Rc<MultiStageQueryDescription>>,
         scope: &mut PlanningScope,
     ) -> Result<Rc<MultiStageQueryDescription>, CubeError> {
@@ -1205,15 +1214,17 @@ impl MultiStageQueryPlanner {
         // rows, so they ride on one scan rather than one each. A measure
         // reading cubes the scan does not already read is left alone: it would
         // widen the scan's join tree, and that is a different scan.
-        let member_cubes = Self::sorted_cube_names(&member)?;
-        for existing in descriptions.iter() {
-            if !existing.is_match_rolling_window_base(&state, is_ungrouped)
-                || Self::sorted_cube_names(existing.member_node())? != member_cubes
-            {
-                continue;
+        if feeds_window_stage {
+            let member_cubes = Self::sorted_cube_names(&member)?;
+            for existing in descriptions.iter() {
+                if !existing.is_match_rolling_window_base(&state, is_ungrouped)
+                    || Self::sorted_cube_names(existing.member_node())? != member_cubes
+                {
+                    continue;
+                }
+                existing.add_co_measure(member);
+                return Ok(existing.clone());
             }
-            existing.add_co_measure(member);
-            return Ok(existing.clone());
         }
 
         let alias = scope.next_cte_name();
@@ -1251,6 +1262,7 @@ impl MultiStageQueryPlanner {
     /// standing for a pre-aggregation's partition holds placeholders rather
     /// than dates.
     fn rolling_series_bounds(
+        &self,
         time_dimension: &Rc<TimeDimensionSymbol>,
     ) -> Result<Option<(String, String)>, CubeError> {
         let Some(granularity) = time_dimension.granularity_obj() else {
@@ -1268,25 +1280,43 @@ impl MultiStageQueryPlanner {
         {
             return Ok(None);
         }
-        let range = [date_range[0].clone(), date_range[1].clone()];
         // Millisecond bounds; the filter pads them to the dialect's precision
         // when it renders them.
         let precision = 3;
         let bounds = if granularity.is_predefined_granularity() {
             QueryTimeSeries::covering_bounds_predefined(
                 granularity.granularity(),
-                &range,
+                &[date_range[0].clone(), date_range[1].clone()],
                 precision,
             )?
         } else {
-            QueryTimeSeries::covering_bounds_custom(
-                &granularity.granularity_interval().to_sql(),
-                &range,
-                &granularity.origin_local_formatted(),
-                precision,
-            )?
+            self.custom_series_bounds(&granularity, &date_range)?
         };
         Ok(Some(bounds))
+    }
+
+    /// [`Self::rolling_series_bounds`] for a custom granularity, whose buckets
+    /// are placed by stepping its interval from its origin. Both ends are found
+    /// by aligning to that origin, the same way the series itself is placed.
+    fn custom_series_bounds(
+        &self,
+        granularity: &Granularity,
+        date_range: &[String],
+    ) -> Result<(String, String), CubeError> {
+        let tz = self.query_tools.query_tools().timezone();
+        let interval = granularity.granularity_interval();
+        let align = |bound: &String| -> Result<QueryDateTime, CubeError> {
+            granularity.align_date_to_origin(QueryDateTime::from_date_str(tz, bound)?)
+        };
+        let first = align(&date_range[0])?;
+        let past_last = align(&date_range[1])?
+            .add_interval(interval)?
+            .add_interval(interval)?
+            .add_duration(Duration::seconds(-1))?;
+        Ok((
+            format!("{}.000", first.format("%Y-%m-%dT%H:%M:%S")),
+            format!("{}.999", past_last.format("%Y-%m-%dT%H:%M:%S")),
+        ))
     }
 
     /// The granularity of a `to_date` rolling window whose period boundary is
@@ -1432,7 +1462,7 @@ impl MultiStageQueryPlanner {
                 &time_dimension_base_name,
                 rolling_window.trailing.clone(),
                 rolling_window.leading.clone(),
-                Self::rolling_series_bounds(&time_dimension_symbol)?,
+                self.rolling_series_bounds(&time_dimension_symbol)?,
             )?;
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -5,8 +5,10 @@ use super::{
 };
 use crate::cube_bridge::base_query_options::FilterValue;
 use crate::cube_bridge::measure_definition::RollingWindow;
+use crate::logical_plan::optimizers::PreAggregationsCompiler;
 use crate::logical_plan::*;
 use crate::planner::collectors::collect_cube_names;
+use crate::planner::collectors::collect_cube_names_from_symbols;
 use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::collectors::member_childs;
 use crate::planner::filter::base_filter::FilterType;
@@ -56,6 +58,10 @@ pub struct MultiStageQueryPlanner {
     // state for the recursive planner and as the reset target for `mode:
     // fixed` filter directives.
     root_state: Rc<QueryProperties>,
+    /// Measure sets of the pre-aggregations declared on the cubes this query
+    /// reads, resolved on first use. Only consulted when deciding whether two
+    /// rolling windows may share a base scan.
+    declared_pre_aggregation_measures: RefCell<Option<Rc<Vec<HashSet<String>>>>>,
 }
 
 impl MultiStageQueryPlanner {
@@ -68,6 +74,7 @@ impl MultiStageQueryPlanner {
             query_tools,
             query_properties,
             root_state,
+            declared_pre_aggregation_measures: RefCell::new(None),
         })
     }
 
@@ -1219,6 +1226,7 @@ impl MultiStageQueryPlanner {
             for existing in descriptions.iter() {
                 if !existing.is_match_rolling_window_base(&state, is_ungrouped)
                     || Self::sorted_cube_names(existing.member_node())? != member_cubes
+                    || self.pre_aggregations_separate(&member, existing.member_node())?
                 {
                     continue;
                 }
@@ -1242,6 +1250,42 @@ impl MultiStageQueryPlanner {
         );
         descriptions.push(description.clone());
         Ok(description)
+    }
+
+    /// Whether some pre-aggregation rolls up one of these measures but not the
+    /// other. A pre-aggregation only answers for a query whose every measure it
+    /// carries, so a scan shared between the two could not be served by such a
+    /// rollup — and a model storing one rollup per rolling measure would fall
+    /// back to the fact table for both. Sharing yields to it.
+    ///
+    /// Read off the declarations, so a rollup that would not have matched this
+    /// query anyway also blocks the merge. That costs a shared scan the query
+    /// did not need; the reverse costs the pre-aggregation.
+    fn pre_aggregations_separate(
+        &self,
+        member: &Rc<MemberSymbol>,
+        other: &Rc<MemberSymbol>,
+    ) -> Result<bool, CubeError> {
+        let name = member.full_name();
+        let other_name = other.full_name();
+        Ok(self
+            .declared_pre_aggregation_measures()?
+            .iter()
+            .any(|measures| measures.contains(&name) != measures.contains(&other_name)))
+    }
+
+    fn declared_pre_aggregation_measures(&self) -> Result<Rc<Vec<HashSet<String>>>, CubeError> {
+        if let Some(declared) = self.declared_pre_aggregation_measures.borrow().as_ref() {
+            return Ok(declared.clone());
+        }
+        let cube_names =
+            collect_cube_names_from_symbols(&self.query_properties.all_used_symbols()?)?;
+        let declared = Rc::new(PreAggregationsCompiler::declared_measures(
+            self.query_tools.clone(),
+            &cube_names,
+        )?);
+        *self.declared_pre_aggregation_measures.borrow_mut() = Some(declared.clone());
+        Ok(declared)
     }
 
     fn sorted_cube_names(member: &Rc<MemberSymbol>) -> Result<Vec<String>, CubeError> {
@@ -1286,6 +1330,7 @@ impl MultiStageQueryPlanner {
         let bounds = if granularity.is_predefined_granularity() {
             QueryTimeSeries::covering_bounds_predefined(
                 granularity.granularity(),
+                granularity.granularity_interval(),
                 &[date_range[0].clone(), date_range[1].clone()],
                 precision,
             )?
@@ -1296,26 +1341,31 @@ impl MultiStageQueryPlanner {
     }
 
     /// [`Self::rolling_series_bounds`] for a custom granularity, whose buckets
-    /// are placed by stepping its interval from its origin. Both ends are found
-    /// by aligning to that origin, the same way the series itself is placed.
+    /// are placed by stepping its interval from its origin. The lower bound
+    /// aligns to that origin the way the series itself is placed; the upper one
+    /// reaches an interval past the range end, which covers the last bucket of
+    /// either series shape.
     fn custom_series_bounds(
         &self,
         granularity: &Granularity,
         date_range: &[String],
     ) -> Result<(String, String), CubeError> {
-        let tz = self.query_tools.query_tools().timezone();
         let interval = granularity.granularity_interval();
-        let align = |bound: &String| -> Result<QueryDateTime, CubeError> {
-            granularity.align_date_to_origin(QueryDateTime::from_date_str(tz, bound)?)
-        };
-        let first = align(&date_range[0])?;
-        let past_last = align(&date_range[1])?
-            .add_interval(interval)?
+        if interval.is_zero() {
+            return Err(CubeError::user(format!(
+                "Granularity interval can't be zero: {}",
+                granularity.granularity()
+            )));
+        }
+        let tz = self.query_tools.query_tools().timezone();
+        let first =
+            granularity.align_date_to_origin(QueryDateTime::from_date_str(tz, &date_range[0])?)?;
+        let past_end = QueryDateTime::from_date_str(tz, &date_range[1])?
             .add_interval(interval)?
             .add_duration(Duration::seconds(-1))?;
         Ok((
             format!("{}.000", first.format("%Y-%m-%dT%H:%M:%S")),
-            format!("{}.999", past_last.format("%Y-%m-%dT%H:%M:%S")),
+            format!("{}.999", past_end.format("%Y-%m-%dT%H:%M:%S")),
         ))
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::cube_bridge::base_query_options::FilterValue;
 use crate::cube_bridge::measure_definition::RollingWindow;
 use crate::logical_plan::*;
+use crate::planner::collectors::collect_cube_names;
 use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::collectors::member_childs;
 use crate::planner::filter::base_filter::FilterType;
@@ -1198,12 +1199,28 @@ impl MultiStageQueryPlanner {
         descriptions: &mut Vec<Rc<MultiStageQueryDescription>>,
         scope: &mut PlanningScope,
     ) -> Result<Rc<MultiStageQueryDescription>, CubeError> {
+        let is_ungrouped = self.query_properties.ungrouped() || ungrouped;
+        // Windows differing only in the measure they aggregate read the same
+        // rows, so they ride on one scan rather than one each. A measure
+        // reading cubes the scan does not already read is left alone: it would
+        // widen the scan's join tree, and that is a different scan.
+        let member_cubes = Self::sorted_cube_names(&member)?;
+        for existing in descriptions.iter() {
+            if !existing.is_match_rolling_window_base(&state, is_ungrouped)
+                || Self::sorted_cube_names(existing.member_node())? != member_cubes
+            {
+                continue;
+            }
+            existing.add_co_measure(member);
+            return Ok(existing.clone());
+        }
+
         let alias = scope.next_cte_name();
         let description = MultiStageQueryDescription::new(
             MultiStageMember::new(
                 MultiStageMemberType::Leaf(MultiStageLeafMemberType::Measure),
                 member,
-                self.query_properties.ungrouped() || ungrouped,
+                is_ungrouped,
                 true,
             ),
             state,
@@ -1213,6 +1230,13 @@ impl MultiStageQueryPlanner {
         );
         descriptions.push(description.clone());
         Ok(description)
+    }
+
+    fn sorted_cube_names(member: &Rc<MemberSymbol>) -> Result<Vec<String>, CubeError> {
+        Ok(collect_cube_names(member)?
+            .into_iter()
+            .sorted()
+            .collect_vec())
     }
 
     /// Outer bounds of the series a rolling window over `time_dimension` walks.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -27,6 +27,7 @@ use crate::planner::MemberSymbol;
 use crate::planner::MultiStageFilter;
 use crate::planner::MultiStageFilterMode;
 use crate::planner::MultiStageGrain;
+use crate::planner::QueryDateTimeHelper;
 use crate::planner::QueryProperties;
 use crate::planner::QueryTimeSeries;
 use crate::planner::TimeDimensionSymbol;
@@ -1245,8 +1246,10 @@ impl MultiStageQueryPlanner {
     /// literals instead of reading them back off the series.
     ///
     /// `None` where the series is not derivable at plan time: without a date
-    /// range the range itself is a query, and a granularity whose periods come
-    /// off a calendar cube has boundaries no interval math reproduces.
+    /// range the range itself is a query, a granularity whose periods come off
+    /// a calendar cube has boundaries no interval math reproduces, and a range
+    /// standing for a pre-aggregation's partition holds placeholders rather
+    /// than dates.
     fn rolling_series_bounds(
         time_dimension: &Rc<TimeDimensionSymbol>,
     ) -> Result<Option<(String, String)>, CubeError> {
@@ -1259,6 +1262,12 @@ impl MultiStageQueryPlanner {
         let Some(date_range) = time_dimension.date_range_vec() else {
             return Ok(None);
         };
+        if date_range
+            .iter()
+            .any(|bound| QueryDateTimeHelper::parse_native_date_time(bound).is_err())
+        {
+            return Ok(None);
+        }
         let range = [date_range[0].clone(), date_range[1].clone()];
         // Millisecond bounds; the filter pads them to the dialect's precision
         // when it renders them.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/query_description.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/query_description.rs
@@ -1,9 +1,10 @@
-use super::MultiStageMember;
+use super::{MultiStageLeafMemberType, MultiStageMember, MultiStageMemberType};
 use crate::logical_plan::LogicalSchema;
 use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::{MemberSymbol, QueryProperties};
 use cubenativeutils::CubeError;
 use itertools::Itertools;
+use std::cell::RefCell;
 use std::rc::Rc;
 
 /// One CTE in the multi-stage tree as the planner sees it: the
@@ -12,6 +13,14 @@ use std::rc::Rc;
 /// it will be referenced by.
 pub struct MultiStageQueryDescription {
     member: Rc<MultiStageMember>,
+    /// Measures this CTE renders alongside `member`. Rolling windows whose
+    /// base scans would be identical share one, and each window then reads its
+    /// own measure column off it.
+    ///
+    /// Load-bearing, like the time series' granularity list: every description
+    /// is built before any is planned, so a window joining an existing base
+    /// scan is always visible to it.
+    co_measures: RefCell<Vec<Rc<MemberSymbol>>>,
     state: Rc<QueryProperties>,
     input: Vec<Rc<MultiStageQueryDescription>>,
     /// Dim-grid sources for the JOIN-based assembly. Empty for the
@@ -33,6 +42,7 @@ impl MultiStageQueryDescription {
     ) -> Rc<Self> {
         Rc::new(Self {
             member,
+            co_measures: RefCell::new(vec![]),
             state,
             input,
             keys_input,
@@ -44,8 +54,35 @@ impl MultiStageQueryDescription {
         LogicalSchema::default()
             .set_time_dimensions(self.state.time_dimensions().clone())
             .set_dimensions(self.state.dimensions().clone())
-            .set_measures(vec![self.member_node().clone()])
+            .set_measures(self.measures())
             .into_rc()
+    }
+
+    /// Every measure this CTE renders: its own member first, then the measures
+    /// riding along on it.
+    pub fn measures(&self) -> Vec<Rc<MemberSymbol>> {
+        let mut measures = vec![self.member_node().clone()];
+        measures.extend(self.co_measures());
+        measures
+    }
+
+    /// The measures riding along on this CTE, without its own member.
+    pub fn co_measures(&self) -> Vec<Rc<MemberSymbol>> {
+        self.co_measures.borrow().clone()
+    }
+
+    /// Registers `measure` to be rendered by this CTE as well. A measure
+    /// already rendered here is left alone.
+    pub fn add_co_measure(&self, measure: Rc<MemberSymbol>) {
+        let name = measure.full_name();
+        if self.member_name() == name {
+            return;
+        }
+        let mut co_measures = self.co_measures.borrow_mut();
+        if co_measures.iter().any(|m| m.full_name() == name) {
+            return;
+        }
+        co_measures.push(measure);
     }
 
     pub fn member_node(&self) -> &Rc<MemberSymbol> {
@@ -126,6 +163,24 @@ impl MultiStageQueryDescription {
         for child in self.input.iter() {
             child.collect_all_non_multi_stage_dimension_impl(dimensions, time_dimensions);
         }
+    }
+
+    /// True if this description is the base scan of a rolling window built for
+    /// an equivalent state. Such a scan is byte-identical whatever measure is
+    /// aggregated over it, so another window's measure can ride along instead
+    /// of scanning the fact table again.
+    pub fn is_match_rolling_window_base(
+        &self,
+        state: &Rc<QueryProperties>,
+        is_ungrouped: bool,
+    ) -> bool {
+        matches!(
+            self.member.member_type(),
+            MultiStageMemberType::Leaf(MultiStageLeafMemberType::Measure)
+        ) && self.member.has_aggregates_on_top()
+            && !self.member.is_without_member_leaf()
+            && self.member.is_ungrupped() == is_ungrouped
+            && state.eq_as_state(&self.state)
     }
 
     /// True if this description renders `member_node` under an

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -1027,17 +1027,26 @@ impl QueryProperties {
         Ok(())
     }
 
+    /// Rewrite the `InDateRange` filter on `member_name` into a regular
+    /// rolling-window filter. The filter carries
+    /// `[from, to, trailing, leading]`, followed by the series bounds when
+    /// those are known at plan time.
     pub fn replace_regular_date_range_filter(
         &mut self,
         member_name: &str,
         left_interval: Option<String>,
         right_interval: Option<String>,
+        series_range: Option<(String, String)>,
     ) -> Result<(), CubeError> {
         let operator = FilterOperator::RegularRollingWindowDateRange;
-        let values = vec![
+        let mut values = vec![
             FilterValue::from(left_interval),
             FilterValue::from(right_interval),
         ];
+        if let Some((series_from, series_to)) = series_range {
+            values.push(FilterValue::Str(series_from));
+            values.push(FilterValue::Str(series_to));
+        }
         self.time_dimensions_filters = self.change_date_range_filter_impl(
             member_name,
             &self.time_dimensions_filters,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/sql_interval.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/sql_interval.rs
@@ -16,6 +16,19 @@ pub struct SqlInterval {
 }
 
 impl SqlInterval {
+    /// An interval that advances nothing. A bucket walk over one never
+    /// terminates, and an alignment to one never converges.
+    pub fn is_zero(&self) -> bool {
+        self.year == 0
+            && self.quarter == 0
+            && self.month == 0
+            && self.week == 0
+            && self.day == 0
+            && self.hour == 0
+            && self.minute == 0
+            && self.second == 0
+    }
+
     pub fn new(
         year: i32,
         quarter: i32,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
@@ -62,18 +62,20 @@ impl QueryTimeSeries {
     }
 
     /// Span every series over `date_range` at this granularity fits inside:
-    /// from the start of the bucket the range opens in, to the end of the
-    /// bucket after the one its end falls in.
+    /// from the start of the bucket the range opens in, to one interval past
+    /// its end.
     ///
-    /// Over-approximating the tail by one bucket is deliberate. A series
-    /// materialized here snaps its points to bucket boundaries, while one
-    /// generated in SQL steps from the range start instead, so its last bucket
-    /// can end up to one interval further out. The span has to cover both, and
-    /// a rolling window reads no rows outside its own frame regardless — the
-    /// join applies that frame exactly. Derived per bucket rather than by
-    /// walking the series, so a range of any width costs the same.
+    /// The tail reaches past the range on purpose. A series materialized here
+    /// snaps its points to bucket boundaries, so its last bucket ends at most
+    /// an interval past the range end; one generated in SQL steps from the
+    /// range start instead, and its last point sits at most an interval before
+    /// the range end. The span has to cover both, and a rolling window reads no
+    /// rows outside its own frame regardless — the join applies that frame
+    /// exactly. Derived from the two ends rather than by walking the series, so
+    /// a range of any width costs the same.
     pub fn covering_bounds_predefined(
         granularity: &str,
+        interval: &SqlInterval,
         date_range: &[String; 2],
         timestamp_precision: u32,
     ) -> Result<(String, String), CubeError> {
@@ -83,12 +85,17 @@ impl QueryTimeSeries {
                 "Unsupported time granularity: {granularity}"
             )));
         }
+        if interval.is_zero() {
+            return Err(CubeError::user(format!(
+                "Granularity interval can't be zero: {granularity}"
+            )));
+        }
         let range_start = QueryDateTimeHelper::parse_native_date_time(&date_range[0])?;
         let range_end = QueryDateTimeHelper::parse_native_date_time(&date_range[1])?;
         let first = predefined_bucket(granularity, range_start, timestamp_precision)?;
-        let last = predefined_bucket(granularity, range_end, timestamp_precision)?;
-        let past_last = predefined_bucket(granularity, last.next, timestamp_precision)?;
-        Ok((first.start_str, past_last.end_str))
+        let past_end = add_interval_to_dt(range_end, interval)? - Duration::seconds(1);
+        let nines = "9".repeat(timestamp_precision as usize);
+        Ok((first.start_str, format_with_padding(past_end, &nines)))
     }
 
     /// Walks buckets by repeatedly adding the parsed interval starting from the
@@ -102,7 +109,7 @@ impl QueryTimeSeries {
     ) -> Result<Vec<Vec<String>>, CubeError> {
         check_precision(timestamp_precision)?;
         let interval = SqlInterval::from_str(interval_str)?;
-        if is_zero_interval(&interval) {
+        if interval.is_zero() {
             return Err(CubeError::user("Custom interval can't be zero".to_string()));
         }
         let range_start = QueryDateTimeHelper::parse_native_date_time(&date_range[0])?;
@@ -288,17 +295,6 @@ fn predefined_bucket(
         }
     };
     Ok(res)
-}
-
-fn is_zero_interval(interval: &SqlInterval) -> bool {
-    interval.year == 0
-        && interval.quarter == 0
-        && interval.month == 0
-        && interval.week == 0
-        && interval.day == 0
-        && interval.hour == 0
-        && interval.minute == 0
-        && interval.second == 0
 }
 
 fn add_months(date: NaiveDate, months: u32) -> Result<NaiveDate, CubeError> {
@@ -601,9 +597,13 @@ mod tests {
 
     // ---- covering bounds ----
 
+    fn iv(s: &str) -> SqlInterval {
+        SqlInterval::from_str(s).unwrap()
+    }
+
     // The lower bound is the series' own first edge, so it must agree with a
-    // walked series wherever one can be walked; the upper one covers a bucket
-    // more on purpose.
+    // walked series wherever one can be walked; the upper one reaches past the
+    // last on purpose.
     #[test]
     fn covering_bounds_predefined_start_where_the_walked_series_does() {
         for range in [
@@ -611,31 +611,64 @@ mod tests {
             dr("2024-01-10T15:30:00", "2024-01-11T03:00:00"),
             dr("2024-02-14", "2024-03-20"),
         ] {
-            for granularity in ["hour", "day", "week", "month", "quarter", "year"] {
+            for (granularity, interval) in [
+                ("hour", "1 hour"),
+                ("day", "1 day"),
+                ("week", "1 week"),
+                ("month", "1 month"),
+                ("quarter", "3 months"),
+                ("year", "1 year"),
+            ] {
                 let series = QueryTimeSeries::generate_predefined(granularity, &range, 3).unwrap();
-                let (from, to) =
-                    QueryTimeSeries::covering_bounds_predefined(granularity, &range, 3).unwrap();
+                let (from, to) = QueryTimeSeries::covering_bounds_predefined(
+                    granularity,
+                    &iv(interval),
+                    &range,
+                    3,
+                )
+                .unwrap();
                 assert_eq!(from, series[0][0], "{granularity} over {range:?}");
                 assert!(
-                    to > series[series.len() - 1][1],
+                    to >= series[series.len() - 1][1],
                     "{granularity} over {range:?}: {to}"
                 );
             }
         }
     }
 
+    // A range whose end is already a bucket end needs nothing past it, and the
+    // bound stops exactly there.
     #[test]
-    fn covering_bounds_predefined_snap_outwards() {
-        // Range opens on a Wednesday and closes on a Tuesday: the weeks it
-        // touches start on the Monday before, and the span runs to the end of
-        // the week after the one it closes in.
+    fn covering_bounds_predefined_stop_at_a_bucket_aligned_end() {
         assert_eq!(
-            QueryTimeSeries::covering_bounds_predefined("week", &dr("2024-01-10", "2024-01-16"), 3)
-                .unwrap(),
-            (
-                "2024-01-08T00:00:00.000".to_string(),
-                "2024-01-28T23:59:59.999".to_string()
+            QueryTimeSeries::covering_bounds_predefined(
+                "day",
+                &iv("1 day"),
+                &dr("2026-08-01", "2026-09-02"),
+                3
             )
+            .unwrap(),
+            (
+                "2026-08-01T00:00:00.000".to_string(),
+                "2026-09-02T23:59:59.999".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn covering_bounds_predefined_snap_the_start_outwards() {
+        // The range opens on a Wednesday, and the week it opens in starts on
+        // the Monday before.
+        assert_eq!(
+            QueryTimeSeries::covering_bounds_predefined(
+                "week",
+                &iv("1 week"),
+                &dr("2024-01-10", "2024-01-16"),
+                3
+            )
+            .unwrap()
+            .0,
+            "2024-01-08T00:00:00.000"
         );
     }
 
@@ -645,10 +678,23 @@ mod tests {
     #[test]
     fn covering_bounds_predefined_cover_an_unaligned_series() {
         let range = dr("2026-08-01", "2026-09-06T23:59:59.999");
-        let (_, to) = QueryTimeSeries::covering_bounds_predefined("week", &range, 3).unwrap();
+        let (_, to) =
+            QueryTimeSeries::covering_bounds_predefined("week", &iv("1 week"), &range, 3).unwrap();
         // Stepping weeks from Aug 1 (a Saturday) puts the last point on Sep 5,
         // whose week runs to Sep 11.
-        assert!(to.as_str() > "2026-09-11T23:59:59.999", "{to}");
+        assert!(to.as_str() >= "2026-09-11T23:59:59.999", "{to}");
+    }
+
+    #[test]
+    fn covering_bounds_predefined_reject_a_zero_interval() {
+        let err = QueryTimeSeries::covering_bounds_predefined(
+            "day",
+            &iv("0 day"),
+            &dr("2024-01-10", "2024-01-12"),
+            3,
+        )
+        .unwrap_err();
+        assert!(err.message.contains("can't be zero"), "{}", err.message);
     }
 
     // ---- custom ----

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
@@ -91,35 +91,6 @@ impl QueryTimeSeries {
         Ok((first.start_str, past_last.end_str))
     }
 
-    /// [`covering_bounds_predefined`] for a custom granularity, whose buckets
-    /// are placed by stepping `interval_str` from `origin_str`.
-    ///
-    /// [`covering_bounds_predefined`]: Self::covering_bounds_predefined
-    pub fn covering_bounds_custom(
-        interval_str: &str,
-        date_range: &[String; 2],
-        origin_str: &str,
-        timestamp_precision: u32,
-    ) -> Result<(String, String), CubeError> {
-        check_precision(timestamp_precision)?;
-        let interval = SqlInterval::from_str(interval_str)?;
-        if is_zero_interval(&interval) {
-            return Err(CubeError::user("Custom interval can't be zero".to_string()));
-        }
-        let range_start = QueryDateTimeHelper::parse_native_date_time(&date_range[0])?;
-        let range_end = QueryDateTimeHelper::parse_native_date_time(&date_range[1])?;
-        let origin = QueryDateTimeHelper::parse_native_date_time(origin_str)?;
-        let zeros = "0".repeat(timestamp_precision as usize);
-        let nines = "9".repeat(timestamp_precision as usize);
-        let first = align_to_origin(range_start, &interval, origin)?;
-        let last = align_to_origin(range_end, &interval, origin)?;
-        let past_last = add_interval_to_dt(add_interval_to_dt(last, &interval)?, &interval)?;
-        Ok((
-            format_with_padding(first, &zeros),
-            format_with_padding(past_last - Duration::seconds(1), &nines),
-        ))
-    }
-
     /// Walks buckets by repeatedly adding the parsed interval starting from the
     /// position aligned to `origin`. Each bucket's end is `next_start - 1s`,
     /// formatted with the sub-second `'9'` padding.
@@ -678,16 +649,6 @@ mod tests {
         // Stepping weeks from Aug 1 (a Saturday) puts the last point on Sep 5,
         // whose week runs to Sep 11.
         assert!(to.as_str() > "2026-09-11T23:59:59.999", "{to}");
-    }
-
-    #[test]
-    fn covering_bounds_custom_start_where_the_walked_series_does() {
-        let range = dr("2024-01-04", "2024-01-10T12:00:00");
-        let series = QueryTimeSeries::generate_custom("2 days", &range, "2024-01-01", 3).unwrap();
-        let (from, to) =
-            QueryTimeSeries::covering_bounds_custom("2 days", &range, "2024-01-01", 3).unwrap();
-        assert_eq!(from, series[0][0]);
-        assert!(to > series[series.len() - 1][1], "{to}");
     }
 
     // ---- custom ----

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/time_series.rs
@@ -61,6 +61,65 @@ impl QueryTimeSeries {
         Ok(buckets)
     }
 
+    /// Span every series over `date_range` at this granularity fits inside:
+    /// from the start of the bucket the range opens in, to the end of the
+    /// bucket after the one its end falls in.
+    ///
+    /// Over-approximating the tail by one bucket is deliberate. A series
+    /// materialized here snaps its points to bucket boundaries, while one
+    /// generated in SQL steps from the range start instead, so its last bucket
+    /// can end up to one interval further out. The span has to cover both, and
+    /// a rolling window reads no rows outside its own frame regardless — the
+    /// join applies that frame exactly. Derived per bucket rather than by
+    /// walking the series, so a range of any width costs the same.
+    pub fn covering_bounds_predefined(
+        granularity: &str,
+        date_range: &[String; 2],
+        timestamp_precision: u32,
+    ) -> Result<(String, String), CubeError> {
+        check_precision(timestamp_precision)?;
+        if !is_predefined_granularity(granularity) {
+            return Err(CubeError::user(format!(
+                "Unsupported time granularity: {granularity}"
+            )));
+        }
+        let range_start = QueryDateTimeHelper::parse_native_date_time(&date_range[0])?;
+        let range_end = QueryDateTimeHelper::parse_native_date_time(&date_range[1])?;
+        let first = predefined_bucket(granularity, range_start, timestamp_precision)?;
+        let last = predefined_bucket(granularity, range_end, timestamp_precision)?;
+        let past_last = predefined_bucket(granularity, last.next, timestamp_precision)?;
+        Ok((first.start_str, past_last.end_str))
+    }
+
+    /// [`covering_bounds_predefined`] for a custom granularity, whose buckets
+    /// are placed by stepping `interval_str` from `origin_str`.
+    ///
+    /// [`covering_bounds_predefined`]: Self::covering_bounds_predefined
+    pub fn covering_bounds_custom(
+        interval_str: &str,
+        date_range: &[String; 2],
+        origin_str: &str,
+        timestamp_precision: u32,
+    ) -> Result<(String, String), CubeError> {
+        check_precision(timestamp_precision)?;
+        let interval = SqlInterval::from_str(interval_str)?;
+        if is_zero_interval(&interval) {
+            return Err(CubeError::user("Custom interval can't be zero".to_string()));
+        }
+        let range_start = QueryDateTimeHelper::parse_native_date_time(&date_range[0])?;
+        let range_end = QueryDateTimeHelper::parse_native_date_time(&date_range[1])?;
+        let origin = QueryDateTimeHelper::parse_native_date_time(origin_str)?;
+        let zeros = "0".repeat(timestamp_precision as usize);
+        let nines = "9".repeat(timestamp_precision as usize);
+        let first = align_to_origin(range_start, &interval, origin)?;
+        let last = align_to_origin(range_end, &interval, origin)?;
+        let past_last = add_interval_to_dt(add_interval_to_dt(last, &interval)?, &interval)?;
+        Ok((
+            format_with_padding(first, &zeros),
+            format_with_padding(past_last - Duration::seconds(1), &nines),
+        ))
+    }
+
     /// Walks buckets by repeatedly adding the parsed interval starting from the
     /// position aligned to `origin`. Each bucket's end is `next_start - 1s`,
     /// formatted with the sub-second `'9'` padding.
@@ -567,6 +626,68 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.message.contains("exceeded"));
+    }
+
+    // ---- covering bounds ----
+
+    // The lower bound is the series' own first edge, so it must agree with a
+    // walked series wherever one can be walked; the upper one covers a bucket
+    // more on purpose.
+    #[test]
+    fn covering_bounds_predefined_start_where_the_walked_series_does() {
+        for range in [
+            dr("2024-01-10", "2024-01-12"),
+            dr("2024-01-10T15:30:00", "2024-01-11T03:00:00"),
+            dr("2024-02-14", "2024-03-20"),
+        ] {
+            for granularity in ["hour", "day", "week", "month", "quarter", "year"] {
+                let series = QueryTimeSeries::generate_predefined(granularity, &range, 3).unwrap();
+                let (from, to) =
+                    QueryTimeSeries::covering_bounds_predefined(granularity, &range, 3).unwrap();
+                assert_eq!(from, series[0][0], "{granularity} over {range:?}");
+                assert!(
+                    to > series[series.len() - 1][1],
+                    "{granularity} over {range:?}: {to}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn covering_bounds_predefined_snap_outwards() {
+        // Range opens on a Wednesday and closes on a Tuesday: the weeks it
+        // touches start on the Monday before, and the span runs to the end of
+        // the week after the one it closes in.
+        assert_eq!(
+            QueryTimeSeries::covering_bounds_predefined("week", &dr("2024-01-10", "2024-01-16"), 3)
+                .unwrap(),
+            (
+                "2024-01-08T00:00:00.000".to_string(),
+                "2024-01-28T23:59:59.999".to_string()
+            )
+        );
+    }
+
+    // A series generated in SQL steps from the range start, so its buckets are
+    // offset from the boundaries a materialized series snaps to. The span has
+    // to cover the further of the two.
+    #[test]
+    fn covering_bounds_predefined_cover_an_unaligned_series() {
+        let range = dr("2026-08-01", "2026-09-06T23:59:59.999");
+        let (_, to) = QueryTimeSeries::covering_bounds_predefined("week", &range, 3).unwrap();
+        // Stepping weeks from Aug 1 (a Saturday) puts the last point on Sep 5,
+        // whose week runs to Sep 11.
+        assert!(to.as_str() > "2026-09-11T23:59:59.999", "{to}");
+    }
+
+    #[test]
+    fn covering_bounds_custom_start_where_the_walked_series_does() {
+        let range = dr("2024-01-04", "2024-01-10T12:00:00");
+        let series = QueryTimeSeries::generate_custom("2 days", &range, "2024-01-01", 3).unwrap();
+        let (from, to) =
+            QueryTimeSeries::covering_bounds_custom("2 days", &range, "2024-01-01", 3).unwrap();
+        assert_eq!(from, series[0][0]);
+        assert!(to > series[series.len() - 1][1], "{to}");
     }
 
     // ---- custom ----

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window_fanout.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window_fanout.yaml
@@ -1,0 +1,51 @@
+cubes:
+    - name: daily_activity
+      sql: "SELECT * FROM rw_daily_activity"
+      dimensions:
+          - name: entity_id
+            type: string
+            sql: entity_id
+            primary_key: true
+          - name: activity_date
+            type: time
+            sql: activity_date
+      measures:
+          - name: events_7d
+            type: sum
+            sql: events
+            rolling_window:
+                trailing: 7 day
+                offset: start
+          - name: minutes_7d
+            type: sum
+            sql: duration_minutes
+            rolling_window:
+                trailing: 7 day
+                offset: start
+          - name: events_30d
+            type: sum
+            sql: events
+            rolling_window:
+                trailing: 30 day
+                offset: start
+          - name: minutes_30d
+            type: sum
+            sql: duration_minutes
+            rolling_window:
+                trailing: 30 day
+                offset: start
+          - name: errors_7d
+            type: sum
+            sql: errors
+            rolling_window:
+                trailing: 7 day
+                offset: start
+          - name: events_per_hour_7d
+            type: number
+            sql: "{events_7d} / NULLIF({minutes_7d} / 60.0, 0)"
+          - name: events_per_hour_30d
+            type: number
+            sql: "{events_30d} / NULLIF({minutes_30d} / 60.0, 0)"
+          - name: error_rate_7d
+            type: number
+            sql: "{errors_7d} / NULLIF({events_7d}, 0)"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window_fanout_preagg.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window_fanout_preagg.yaml
@@ -1,0 +1,40 @@
+cubes:
+    - name: daily_activity
+      sql: "SELECT * FROM rw_daily_activity"
+      dimensions:
+          - name: entity_id
+            type: string
+            sql: entity_id
+            primary_key: true
+          - name: activity_date
+            type: time
+            sql: activity_date
+      measures:
+          - name: events_7d
+            type: sum
+            sql: events
+            rolling_window:
+                trailing: 7 day
+                offset: start
+          - name: minutes_7d
+            type: sum
+            sql: duration_minutes
+            rolling_window:
+                trailing: 7 day
+                offset: start
+      pre_aggregations:
+          # One rollup per rolling measure — the `partitionedRolling` shape.
+          - name: rolling_events
+            measures:
+                - events_7d
+            dimensions:
+                - entity_id
+            time_dimension: activity_date
+            granularity: day
+          - name: rolling_minutes
+            measures:
+                - minutes_7d
+            dimensions:
+                - entity_id
+            time_dimension: activity_date
+            granularity: day

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/edge_cases.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/edge_cases.rs
@@ -159,3 +159,31 @@ async fn test_multi_stage_rolling_without_date_range_with_gaps() {
         insta::assert_snapshot!(result);
     }
 }
+
+// Without a granularity the base CTE is the requested measure's own result, so
+// it answers for that measure alone — two measures are two CTEs, each joined
+// once.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_rolling_measures_without_granularity_keep_their_own_cte() {
+    let schema = MockSchema::from_yaml_file("common/integration_rolling_window.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_trailing_7d
+          - orders.rolling_count_7d
+        dimensions:
+          - orders.status
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-01-01"
+              - "2024-01-31"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert_eq!(sql.matches("rw_orders").count(), 2, "{sql}");
+    assert_eq!(sql.matches("LEFT JOIN  cte_0").count(), 1, "{sql}");
+    assert_eq!(sql.matches("LEFT JOIN  cte_1").count(), 1, "{sql}");
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
@@ -1,0 +1,105 @@
+//! Reproduction for https://github.com/cube-js/cube/issues/11770.
+//!
+//! Several `rolling_window` measures queried together with a high-cardinality
+//! dimension produce a plan whose intermediate row count is
+//! (entities × window length × anchors):
+//!
+//! * every rolling measure gets its own scan of the fact table, even when the
+//!   window and the filters are byte-identical (5 scans for the query below,
+//!   which only needs two distinct windows), and
+//! * every rolling CTE joins `time_series` to its base CTE on a date range
+//!   only. With no equality predicate the engine cannot hash-join: Postgres
+//!   picks a nested loop with a join filter and materialises ~954K rows for a
+//!   7-day window over 4.7K entities × 33 anchors (~3.6M for the 30-day one)
+//!   before the `GROUP BY` separates the entities again.
+//!
+//! The dimension is in the `GROUP BY` of both sides of that join, so it is
+//! known at plan time and could restrict the join instead of being applied
+//! after it.
+//!
+//! These tests assert the wanted plan shape and therefore fail today; they are
+//! ignored so CI stays green. Run them with
+//! `cargo test rolling_window::fanout_repro -- --ignored`.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_rolling_window_fanout.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+/// Three calculated measures over five rolling sums (two distinct windows),
+/// grouped by a high-cardinality dimension over a 33-day day-granularity range.
+const QUERY: &str = indoc! {r#"
+    measures:
+      - daily_activity.events_per_hour_7d
+      - daily_activity.events_per_hour_30d
+      - daily_activity.error_rate_7d
+    dimensions:
+      - daily_activity.entity_id
+    time_dimensions:
+      - dimension: daily_activity.activity_date
+        granularity: day
+        dateRange:
+          - "2026-08-01"
+          - "2026-09-02"
+"#};
+
+/// Collects the `ON` condition of every rolling-window join in the plan.
+fn rolling_join_conditions(sql: &str) -> Vec<String> {
+    sql.split("AS \"rolling_source\" ON ")
+        .skip(1)
+        .map(|tail| {
+            let end = tail.find("\n  GROUP BY").unwrap_or(tail.len());
+            tail[..end].to_string()
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "reproduces #11770: one base scan per rolling measure"]
+async fn test_base_table_is_not_rescanned_per_rolling_measure() {
+    let ctx = create_context();
+    let sql = ctx.build_sql(QUERY).unwrap();
+
+    // Five rolling sums, but only two distinct (window, filter) pairs:
+    // trailing 7 day and trailing 30 day, both `offset: start`.
+    assert!(
+        sql.matches("rw_daily_activity").count() <= 2,
+        "fact table is scanned {} times:\n{sql}",
+        sql.matches("rw_daily_activity").count()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "reproduces #11770: rolling join has no equality predicate"]
+async fn test_rolling_join_restricts_by_dimension() {
+    let ctx = create_context();
+    let sql = ctx.build_sql(QUERY).unwrap();
+
+    let conditions = rolling_join_conditions(&sql);
+    assert!(!conditions.is_empty(), "no rolling join found in:\n{sql}");
+    for condition in conditions.iter() {
+        assert!(
+            condition.contains("\"daily_activity__entity_id\" ="),
+            "rolling join has no equality predicate on the group-by dimension: {condition}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "reproduces #11770: base scan bound is a scalar sub-select over time_series"]
+async fn test_base_scan_date_bound_is_literal() {
+    let ctx = create_context();
+    let sql = ctx.build_sql(QUERY).unwrap();
+
+    // The legacy planner emitted literals here (`BaseQuery.dateFromStartToEndConditionSql`),
+    // so engines could use the bound to eliminate partitions. Tesseract emits
+    // `(SELECT min("date_from") FROM time_series)`, which is opaque to partition pruning.
+    assert!(
+        !sql.contains("min(\"date_from\")"),
+        "base scan date bound is a scalar sub-select over time_series:\n{sql}"
+    );
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
@@ -60,7 +60,6 @@ fn rolling_join_conditions(sql: &str) -> Vec<String> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "reproduces #11770: one base scan per rolling measure"]
 async fn test_base_table_is_not_rescanned_per_rolling_measure() {
     let ctx = create_context();
     let sql = ctx.build_sql(QUERY).unwrap();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
@@ -13,12 +13,11 @@
 //!   7-day window over 4.7K entities × 33 anchors (~3.6M for the 30-day one)
 //!   before the `GROUP BY` separates the entities again.
 //!
-//! The dimension is in the `GROUP BY` of both sides of that join, so it is
-//! known at plan time and could restrict the join instead of being applied
-//! after it.
-//!
-//! These tests assert the wanted plan shape and therefore fail today; they are
-//! ignored so CI stays green. Run them with
+//! The per-measure scan is fixed, and so is the third observation below — the
+//! base scan's date bound. The join shape is not: restricting it by the
+//! dimension would first mean giving the series side a dimension column to
+//! restrict against, since it carries none. The test asserting the restricted
+//! shape therefore stays ignored — run it with
 //! `cargo test rolling_window::fanout_repro -- --ignored`.
 
 use crate::test_fixtures::cube_bridge::MockSchema;
@@ -101,9 +100,10 @@ async fn test_base_scan_date_bound_is_literal() {
         "base scan date bound is a scalar sub-select over time_series:\n{sql}"
     );
 
-    // The literals span the series: the day the range opens on, through the day
-    // after the one it closes on. The trailing interval is subtracted from the
-    // lower bound in SQL, and the rolling join applies the exact frame on top.
+    // The literals span the series exactly here — the range is whole days at
+    // day granularity, so both ends land on a bucket boundary. The trailing
+    // interval is subtracted from the lower bound in SQL, and the rolling join
+    // applies the exact frame on top.
     let bounds = params
         .iter()
         .filter_map(|value| value.to_param_string())
@@ -111,7 +111,46 @@ async fn test_base_scan_date_bound_is_literal() {
         .collect_vec();
     assert_eq!(
         bounds,
-        vec!["2026-08-01T00:00:00.000", "2026-09-03T23:59:59.999"],
+        vec!["2026-08-01T00:00:00.000", "2026-09-02T23:59:59.999"],
         "unexpected base scan bounds in:\n{sql}"
+    );
+}
+
+// Sharing a base scan must not cost pre-aggregation coverage: a rollup carrying
+// one of the shared measures cannot answer for a scan carrying both, so a model
+// storing one rollup per rolling measure would silently fall to the fact table.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sharing_yields_to_a_rollup_per_rolling_measure() {
+    let schema = MockSchema::from_yaml_file("common/integration_rolling_window_fanout_preagg.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query = indoc! {r#"
+        measures:
+          - daily_activity.events_7d
+          - daily_activity.minutes_7d
+        dimensions:
+          - daily_activity.entity_id
+        time_dimensions:
+          - dimension: daily_activity.activity_date
+            granularity: day
+            dateRange:
+              - "2026-08-01"
+              - "2026-09-02"
+    "#};
+
+    let (sql, used) = ctx.build_sql_with_used_pre_aggregations(query).unwrap();
+    let mut names = used
+        .iter()
+        .map(|pa| format!("{}.{}", pa.cube_name(), pa.name()))
+        .collect_vec();
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec![
+            "daily_activity.rolling_events",
+            "daily_activity.rolling_minutes"
+        ],
+        "{sql}"
     );
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/fanout_repro.rs
@@ -24,6 +24,7 @@
 use crate::test_fixtures::cube_bridge::MockSchema;
 use crate::test_fixtures::test_utils::TestContext;
 use indoc::indoc;
+use itertools::Itertools;
 
 fn create_context() -> TestContext {
     let schema = MockSchema::from_yaml_file("common/integration_rolling_window_fanout.yaml");
@@ -90,16 +91,28 @@ async fn test_rolling_join_restricts_by_dimension() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "reproduces #11770: base scan bound is a scalar sub-select over time_series"]
 async fn test_base_scan_date_bound_is_literal() {
     let ctx = create_context();
-    let sql = ctx.build_sql(QUERY).unwrap();
+    let (sql, params) = ctx.build_sql_and_params(QUERY).unwrap();
 
-    // The legacy planner emitted literals here (`BaseQuery.dateFromStartToEndConditionSql`),
-    // so engines could use the bound to eliminate partitions. Tesseract emits
-    // `(SELECT min("date_from") FROM time_series)`, which is opaque to partition pruning.
+    // A bound read back off the series with a scalar sub-select is opaque to
+    // partition elimination, and every base scan carries one.
     assert!(
         !sql.contains("min(\"date_from\")"),
         "base scan date bound is a scalar sub-select over time_series:\n{sql}"
+    );
+
+    // The literals span the series: the day the range opens on, through the day
+    // after the one it closes on. The trailing interval is subtracted from the
+    // lower bound in SQL, and the rolling join applies the exact frame on top.
+    let bounds = params
+        .iter()
+        .filter_map(|value| value.to_param_string())
+        .unique()
+        .collect_vec();
+    assert_eq!(
+        bounds,
+        vec!["2026-08-01T00:00:00.000", "2026-09-03T23:59:59.999"],
+        "unexpected base scan bounds in:\n{sql}"
     );
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/mod.rs
@@ -5,6 +5,7 @@ mod custom_granularities;
 mod db_time_series;
 mod different_granularities;
 mod edge_cases;
+mod fanout_repro;
 mod filtered_rolling_measures;
 mod mixed_measures;
 mod multi_fact;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/multi_fact.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/multi_fact.rs
@@ -36,6 +36,33 @@ async fn test_two_rolling_from_different_facts() {
     }
 }
 
+// Windows over the same frame share one base scan, but only where the scan
+// itself is the same. Two facts are two scans however identical the frames.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rolling_measures_of_different_facts_keep_their_own_scan() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - payments.rolling_sum_7d
+          - messages.rolling_count_7d
+        dimensions:
+          - customers.name
+        time_dimensions:
+          - dimension: customers.registered_at
+            granularity: day
+            dateRange:
+              - "2024-01-10"
+              - "2024-01-25"
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert_eq!(sql.matches("mf_payments").count(), 1, "{sql}");
+    assert_eq!(sql.matches("mf_messages").count(), 1, "{sql}");
+    assert_eq!(sql.matches("mf_customers").count(), 2, "{sql}");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rolling_and_regular_from_different_facts() {
     let ctx = create_context();


### PR DESCRIPTION
Fixes two of the three problems behind #11770.

## Problem

A query with several `rolling_window` measures over a high-cardinality
dimension produces a plan whose cost grows as (entities × window × anchors).
The report is three calculated measures over five rolling sums (two distinct
windows), grouped by a 4.7K-value dimension at day granularity over 33 days —
12 CTEs plus the root, ~10M intermediate rows for a result of at most 5K, and
on BigQuery a CPU guardrail hit at 133K CPU-seconds over 170MB scanned.

Two separable causes, both addressed here:

**1. The base scan's date bounds were opaque.** Each rolling measure's base CTE
restricts the fact table to the span its window can reach, and read both ends of
that span back off the `time_series` CTE:

```sql
WHERE activity_date >= (SELECT min("date_from") FROM time_series) - interval '7 day'
  AND activity_date <= (SELECT max("date_to")   FROM time_series)
```

No engine can eliminate partitions by a scalar sub-select, so every base scan
read the whole table. The legacy planner emitted literals here
(`BaseQuery.dateFromStartToEndConditionSql` takes the bounds off the series it
has already computed), so this is a Tesseract regression.

**2. One base scan per rolling measure.** A rolling window's base CTE aggregates
one measure over the rows the window can reach, and which rows those are is
decided by the frame and the query's filters — not by the measure. Every window
still got its own CTE, so the five rolling sums produced five scans of the fact
table where only two distinct (window, filter) pairs exist.

## What changed

**Literal bounds.** The series is derived from the time dimension's granularity
and date range, so its span is known while planning. `QueryTimeSeries` gained
`covering_bounds_predefined` / `covering_bounds_custom`, which derive the span
per bucket rather than by walking the series (so a wide range costs nothing),
and the regular rolling-window filter renders them as literal parameters.

The span runs one interval past the range end on purpose: a series materialized
while planning snaps its points to bucket boundaries, so its last bucket ends at
most an interval past the range end, while one generated in SQL
(`generate_series`, `GENERATE_DATE_ARRAY`, …) steps from the range start
instead, and its last point sits at most an interval before it. The span has to
cover both, and is exact wherever the range's ends are already bucket
boundaries — the common case. A wider span changes no result anyway: the rolling
join applies the exact frame on top.

The sub-select remains where the span is not derivable at plan time: a date
range that is itself a query (`time_series_get_range`), a granularity whose
periods come off a calendar cube, and the placeholder ranges of
pre-aggregation SQL.

**Shared base scan.** Measures whose base scans are equivalent now ride on one
leaf CTE, and each window reads its own column off it. Equivalence is the state
comparison the multi-stage planner already deduplicates CTEs by, narrowed three
ways:

- to measures reading the same set of cubes — one reading a cube the scan does
  not would widen its join tree, and that is a different scan;
- to a scan a rolling-window stage actually consumes, since a window without a
  granularity has no stage on top and its base CTE is registered as the
  measure's own result;
- to measures no pre-aggregation separates. A pre-aggregation only answers for a
  query whose every measure it carries, so a model storing one rollup per
  rolling measure — the `partitionedRolling` shape — would fall back to the fact
  table for all of them the moment two were merged. That costs far more than the
  scan the merge saves, so sharing yields to it.

Windows differing in frame, filters, grain, or fact keep their own scan.

The reported query goes from 5 base scans to 2, and from 13 CTEs to 11.

## Testing

- `cargo test -p cubesqlplanner` — 1382 pass. The three reproduction tests from
  the issue are in `rolling_window::fanout_repro`; two of them are un-ignored by
  this PR (`test_base_scan_date_bound_is_literal`,
  `test_base_table_is_not_rescanned_per_rolling_measure`), and each was
  confirmed to fail with its fix reverted.
- New unit tests pin the covering bounds against a walked series for every
  predefined granularity, and against an unaligned SQL-generated series.
- New planner tests pin both sharing boundaries: two rolling measures over
  different facts keep their own scans, and so do two without a granularity.
- Real Postgres under `CUBEJS_TESSERACT_SQL_PLANNER=true`: 112 passing in
  `dataschema-compiler`, `pre-aggregations`, `pre-aggregations-multi-stage`,
  `pre-aggregations-calculated-measures`, `pre-aggregations-time`,
  `postgres-cumulative-measures`, `multi-stage-grain-rolling-window`,
  `rolling-window-offset-no-granularity`.
- Two `/code-review high` rounds raised eight findings; all eight are fixed, the
  last three commits carry them, and each fix was confirmed to fail with itself
  reverted. The pre-aggregation regression has a dedicated fixture and test
  (`test_sharing_yields_to_a_rollup_per_rolling_measure`).

## Risks

- The base scan reads up to one granularity bucket more than the series
  strictly needs. Negligible at day granularity; at month granularity over a
  12-month range it is ~8% more rows, traded for partition elimination that was
  entirely absent.
- The pre-aggregation gate reads declared measure lists, not match results, so a
  rollup that would not have served this query anyway still holds the merge back.
  Such a query keeps the plan it has today; it does not gain the shared scan.
- The remaining half of #11770 is untouched: the rolling CTE still joins
  `time_series` to its base CTE on a date range only, with no equality on the
  group-by dimension, so the engine still cannot hash-join and its row estimate
  stays badly off. That is a plan-shape change for every rolling query and is
  deliberately left for a separate PR;
  `rolling_window::fanout_repro::test_rolling_join_restricts_by_dimension`
  stays ignored to mark it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
