### PR TITLE
fix(cubesql): Cast `DATE +/- INTERVAL` explicitly in temporal comparisons

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -36,6 +36,8 @@ use crate::compile::{
 /// - binary operations between a literal string and an expression
 ///   of a different type to a string casted to that type
 /// - binary operations between a timestamp and a date to a timestamp and timestamp operation
+/// - comparisons of a timestamp with `DATE +/- INTERVAL` arithmetic to an explicit
+///   `TIMESTAMP` cast of that arithmetic
 /// - IN list expressions where expression being tested is `TIMESTAMP`
 ///   and values might be `DATE` to values casted to `TIMESTAMP`
 /// - BETWEEN expressions where expression being tested is `TIMESTAMP`
@@ -1342,6 +1344,8 @@ fn grouping_set_normalize(
 /// - binary operations between a literal string and an expression
 ///   of a different type to a string casted to that type
 /// - binary operations between a timestamp and a date to a timestamp and timestamp operation
+/// - comparisons of a timestamp with `DATE +/- INTERVAL` arithmetic to an explicit
+///   `TIMESTAMP` cast of that arithmetic
 #[inline(never)]
 fn binary_expr_normalize(
     optimizer: &PlanNormalize,
@@ -1378,6 +1382,37 @@ fn binary_expr_normalize(
             *left,
         ];
         return Ok(Box::new(Expr::ScalarUDF { fun, args }));
+    }
+
+    // DataFusion types `DATE +/- INTERVAL` as `TIMESTAMP` with no cast node. Strict dialects
+    // (BigQuery) type that arithmetic as `DATETIME` and reject comparing it to a `TIMESTAMP`,
+    // so the implicit cast is made explicit here. Unlike a BETWEEN bound it is not folded:
+    // the arithmetic may hold `now()`-like placeholders that only the rewrite rules resolve.
+    if matches!(
+        op,
+        Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq
+            | Operator::IsDistinctFrom
+            | Operator::IsNotDistinctFrom
+    ) {
+        let target_type = match (&left_type, &right_type) {
+            (DataType::Timestamp(_, _), DataType::Timestamp(_, _) | DataType::Date32) => {
+                Some(&left_type)
+            }
+            (DataType::Date32, DataType::Timestamp(_, _)) => Some(&right_type),
+            _ => None,
+        };
+        if let Some(target_type) = target_type {
+            let left =
+                normalize_temporal_operand(optimizer, left, &left_type, target_type, schema)?;
+            let right =
+                normalize_temporal_operand(optimizer, right, &right_type, target_type, schema)?;
+            return Ok(Box::new(Expr::BinaryExpr { left, op, right }));
+        }
     }
 
     // Check if the expression is `TIMESTAMP <op> DATE` or `DATE <op> TIMESTAMP`
@@ -1424,6 +1459,55 @@ fn binary_expr_normalize(
     // The literal can't be casted to the target type; keep the expression as is
     // instead of failing the whole plan normalization.
     Ok(Box::new(Expr::BinaryExpr { left, op, right }))
+}
+
+/// Normalizes one side of a temporal comparison to the `TIMESTAMP` type of the other side:
+/// `DATE +/- INTERVAL` arithmetic gets an explicit cast, a `DATE` side is casted and folded.
+fn normalize_temporal_operand(
+    optimizer: &PlanNormalize,
+    expr: Box<Expr>,
+    expr_type: &DataType,
+    target_type: &DataType,
+    schema: &DFSchema,
+) -> Result<Box<Expr>> {
+    if is_date_interval_arithmetic(&expr, schema)? {
+        return Ok(Box::new(Expr::Cast {
+            expr,
+            data_type: target_type.clone(),
+        }));
+    }
+    if matches!(expr_type, DataType::Date32) {
+        return evaluate_expr(optimizer, expr.cast_to(target_type, schema)?);
+    }
+    Ok(expr)
+}
+
+/// Checks if the expression is `DATE +/- INTERVAL` arithmetic, possibly offset by more
+/// intervals (`CURRENT_DATE - INTERVAL '1 month' + INTERVAL '1 day'`). DataFusion types
+/// such an expression as `TIMESTAMP` without an explicit cast.
+fn is_date_interval_arithmetic(expr: &Expr, schema: &DFSchema) -> Result<bool> {
+    let is_interval = |data_type: &DataType| matches!(data_type, DataType::Interval(_));
+    // Walk down the chain of interval offsets to the expression they apply to.
+    let mut expr = expr;
+    loop {
+        let Expr::BinaryExpr { left, op, right } = expr else {
+            return Ok(false);
+        };
+        if !matches!(op, Operator::Plus | Operator::Minus) {
+            return Ok(false);
+        }
+        let base = if is_interval(&right.get_type(schema)?) {
+            left
+        } else if *op == Operator::Plus && is_interval(&left.get_type(schema)?) {
+            right
+        } else {
+            return Ok(false);
+        };
+        if base.get_type(schema)? == DataType::Date32 {
+            return Ok(true);
+        }
+        expr = base;
+    }
 }
 
 /// Casts a string literal expression to the given type, evaluating it to a constant.
@@ -1776,6 +1860,55 @@ mod tests {
                     Some(expected_nanos),
                     None
                 )))
+            );
+        });
+
+        Ok(())
+    }
+
+    // `DATE - INTERVAL` is typed as TIMESTAMP by DataFusion without a cast; strict dialects
+    // produce a DATETIME there, so the implicit cast is made explicit when compared against
+    // a TIMESTAMP.
+    #[test]
+    fn test_binary_expr_timestamp_computed_date_bound() -> Result<()> {
+        run_async_test(async move {
+            let meta = get_test_tenant_ctx();
+            let cube_ctx = create_test_postgresql_cube_context(meta)
+                .await
+                .expect("Failed to create cube context");
+
+            let schema = Schema::new(vec![Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            )]);
+
+            let table_scan = LogicalPlanBuilder::scan_empty(Some("test_table"), &schema, None)
+                .expect("Failed to create table scan")
+                .build()
+                .expect("Failed to build plan");
+
+            // 2026-06-01 minus 28 days
+            let date = Expr::Literal(ScalarValue::Date32(Some(20605)));
+            let interval = Expr::Literal(ScalarValue::IntervalDayTime(Some(28i64 << 32)));
+            let plan = LogicalPlanBuilder::from(table_scan)
+                .filter(col("ts").gt_eq(date.clone() - interval.clone()))
+                .expect("Failed to add filter")
+                .build()
+                .expect("Failed to build plan");
+
+            let optimizer = PlanNormalize::new(&cube_ctx);
+            let optimized = optimizer.optimize(&plan, &OptimizerConfig::new()).unwrap();
+
+            let LogicalPlan::Filter(Filter { predicate, .. }) = &optimized else {
+                panic!("Expected Filter plan, got: {:?}", optimized);
+            };
+            assert_eq!(
+                *predicate,
+                col("test_table.ts").gt_eq(Expr::Cast {
+                    expr: Box::new(date - interval),
+                    data_type: DataType::Timestamp(TimeUnit::Nanosecond, None),
+                })
             );
         });
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/cast.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/cast.rs
@@ -1,7 +1,15 @@
-use crate::compile::rewrite::{
-    cast_expr, rewrite, rewriter::CubeRewrite, rules::wrapper::WrapperRules,
-    wrapper_pullup_replacer, wrapper_pushdown_replacer,
+use crate::{
+    compile::rewrite::{
+        cast_expr, rewrite,
+        rewriter::{CubeEGraph, CubeRewrite},
+        rules::wrapper::WrapperRules,
+        transforming_rewrite, wrapper_pullup_replacer, wrapper_pushdown_replacer,
+        wrapper_replacer_context, CastExprDataType,
+    },
+    var, var_iter,
 };
+use egg::Subst;
+use std::ops::ControlFlow;
 
 impl WrapperRules {
     pub fn cast_rules(&self, rules: &mut Vec<CubeRewrite>) {
@@ -11,11 +19,65 @@ impl WrapperRules {
                 wrapper_pushdown_replacer(cast_expr("?expr", "?data_type"), "?context"),
                 cast_expr(wrapper_pushdown_replacer("?expr", "?context"), "?data_type"),
             ),
-            rewrite(
+            transforming_rewrite(
                 "wrapper-pull-up-cast",
-                cast_expr(wrapper_pullup_replacer("?expr", "?context"), "?data_type"),
-                wrapper_pullup_replacer(cast_expr("?expr", "?data_type"), "?context"),
+                cast_expr(
+                    wrapper_pullup_replacer(
+                        "?expr",
+                        wrapper_replacer_context(
+                            "?alias_to_cube",
+                            "?push_to_cube",
+                            "?in_projection",
+                            "?cube_members",
+                            "?grouped_subqueries",
+                            "?ungrouped_scan",
+                            "?input_data_source",
+                        ),
+                    ),
+                    "?data_type",
+                ),
+                wrapper_pullup_replacer(
+                    cast_expr("?expr", "?data_type"),
+                    wrapper_replacer_context(
+                        "?alias_to_cube",
+                        "?push_to_cube",
+                        "?in_projection",
+                        "?cube_members",
+                        "?grouped_subqueries",
+                        "?ungrouped_scan",
+                        "?input_data_source",
+                    ),
+                ),
+                self.transform_cast_expr("?data_type", "?input_data_source"),
             ),
         ]);
+    }
+
+    fn transform_cast_expr(
+        &self,
+        data_type_var: &'static str,
+        input_data_source_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let data_type_var = var!(data_type_var);
+        let input_data_source_var = var!(input_data_source_var);
+        let meta = self.meta_context.clone();
+        move |egraph, subst| {
+            let Ok(data_source) = Self::get_data_source(egraph, subst, input_data_source_var)
+            else {
+                return false;
+            };
+
+            // Rendering a cast needs both the cast template and the template of its type
+            let sql_generator = match Self::template_sql_generator(&data_source, &meta) {
+                ControlFlow::Continue(sql_generator) => sql_generator,
+                ControlFlow::Break(verdict) => return verdict,
+            };
+            let templates = sql_generator.get_sql_templates();
+            if !templates.contains_template("expressions/cast") {
+                return false;
+            }
+            var_iter!(egraph[subst[data_type_var]], CastExprDataType)
+                .any(|data_type| templates.contains_sql_type(data_type))
+        }
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -44,10 +44,10 @@ use crate::{
     },
     config::ConfigObj,
     singular_eclass,
-    transport::{DataSource, MetaContext},
+    transport::{DataSource, MetaContext, SqlGenerator},
 };
 use egg::{Subst, Var};
-use std::{fmt::Display, sync::Arc};
+use std::{fmt::Display, ops::ControlFlow, sync::Arc};
 
 pub struct WrapperRules {
     meta_context: Arc<MetaContext>,
@@ -253,17 +253,29 @@ impl WrapperRules {
         }
     }
 
-    fn can_rewrite_template(data_source: &DataSource, meta: &MetaContext, template: &str) -> bool {
-        let sql_generator = match data_source {
+    /// The SQL generator whose templates a wrapper context renders with. `Break` carries the
+    /// verdict of a template check when there is none to consult: an unrestricted context may
+    /// render anything, while nothing renders for a data source `meta` does not know.
+    fn template_sql_generator<'meta>(
+        data_source: &DataSource,
+        meta: &'meta MetaContext,
+    ) -> ControlFlow<bool, &'meta Arc<dyn SqlGenerator + Send + Sync>> {
+        match data_source {
             DataSource::Specific(data_source) => {
-                let Some(sql_generator) = meta.data_source_to_sql_generator.get(*data_source)
-                else {
-                    return false;
-                };
-                sql_generator
+                match meta.data_source_to_sql_generator.get(*data_source) {
+                    Some(sql_generator) => ControlFlow::Continue(sql_generator),
+                    None => ControlFlow::Break(false),
+                }
             }
             // TODO is it correct?
-            DataSource::Unrestricted => return true,
+            DataSource::Unrestricted => ControlFlow::Break(true),
+        }
+    }
+
+    fn can_rewrite_template(data_source: &DataSource, meta: &MetaContext, template: &str) -> bool {
+        let sql_generator = match Self::template_sql_generator(data_source, meta) {
+            ControlFlow::Continue(sql_generator) => sql_generator,
+            ControlFlow::Break(verdict) => return verdict,
         };
 
         sql_generator

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -4670,3 +4670,243 @@ async fn test_wrapper_multi_data_source_view_cross_source_query_stays_plain() {
         );
     }
 }
+
+#[tokio::test]
+async fn test_wrapper_binary_expr_timestamp_computed_date_bound() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    // The window function forces the SQL push down of the `DATE - INTERVAL` bound.
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender AS step,
+            MEASURE(count) AS total_conversions,
+            ROW_NUMBER() OVER (ORDER BY customer_gender) AS step_order
+        FROM KibanaSampleDataEcommerce
+        WHERE KibanaSampleDataEcommerce.order_date >= CURRENT_DATE - INTERVAL '28 days'
+        GROUP BY customer_gender
+        ORDER BY customer_gender
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+    println!("Generated SQL: {sql}");
+
+    assert!(
+        sql.contains(
+            "${KibanaSampleDataEcommerce.order_date} >= CAST((CURRENT_DATE() - INTERVAL '28 DAY') AS TIMESTAMP)"
+        ),
+        "expected the DATE arithmetic explicitly casted to TIMESTAMP, got: {}",
+        sql
+    );
+}
+
+#[tokio::test]
+async fn test_wrapper_binary_expr_date_side_computed_date_bound() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    // A DATE tested side is casted up to the TIMESTAMP the bound is typed as.
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender AS step,
+            MEASURE(count) AS total_conversions,
+            ROW_NUMBER() OVER (ORDER BY customer_gender) AS step_order
+        FROM KibanaSampleDataEcommerce
+        WHERE CAST(KibanaSampleDataEcommerce.order_date AS DATE) >= CURRENT_DATE - INTERVAL '28 days'
+        GROUP BY customer_gender
+        ORDER BY customer_gender
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+    println!("Generated SQL: {sql}");
+
+    assert!(
+        sql.contains(
+            "CAST(CAST(${KibanaSampleDataEcommerce.order_date} AS DATE) AS TIMESTAMP) >= CAST((CURRENT_DATE() - INTERVAL '28 DAY') AS TIMESTAMP)"
+        ),
+        "expected both sides explicitly casted to TIMESTAMP, got: {}",
+        sql
+    );
+}
+
+#[tokio::test]
+async fn test_wrapper_binary_expr_computed_date_bound_bigquery_templates() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    // BigQuery-shaped templates: `CURRENT_DATE - INTERVAL 28 DAY` is a DATETIME there, and
+    // `CAST(... AS TIMESTAMP)` is a valid DATETIME to TIMESTAMP conversion.
+    let query_plan = convert_select_to_query_plan_customized(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender AS step,
+            MEASURE(count) AS total_conversions,
+            ROW_NUMBER() OVER (ORDER BY customer_gender) AS step_order
+        FROM KibanaSampleDataEcommerce
+        WHERE KibanaSampleDataEcommerce.order_date >= CURRENT_DATE - INTERVAL '28 days'
+        GROUP BY customer_gender
+        ORDER BY customer_gender
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+        vec![
+            (
+                "functions/CURRENTDATE".to_string(),
+                "CURRENT_DATE".to_string(),
+            ),
+            (
+                "expressions/binary".to_string(),
+                "{% if op == '%' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}".to_string(),
+            ),
+            (
+                "expressions/interval".to_string(),
+                "INTERVAL {{ interval }}".to_string(),
+            ),
+            (
+                "expressions/timestamp_literal".to_string(),
+                "TIMESTAMP('{{ value }}')".to_string(),
+            ),
+        ],
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+    println!("Generated SQL: {sql}");
+
+    assert!(
+        sql.contains(
+            "${KibanaSampleDataEcommerce.order_date} >= CAST((CURRENT_DATE - INTERVAL 28 DAY) AS TIMESTAMP)"
+        ),
+        "expected BigQuery DATE arithmetic explicitly casted to TIMESTAMP, got: {}",
+        sql
+    );
+}
+
+#[tokio::test]
+async fn test_binary_expr_computed_date_bound_cube_scan_filter() {
+    init_testing_logger();
+
+    // Without a shape that needs the SQL push down, the explicit cast over the constant
+    // `DATE - INTERVAL` bound still folds to a literal and becomes a CubeScan date filter.
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender,
+            MEASURE(count)
+        FROM KibanaSampleDataEcommerce
+        WHERE KibanaSampleDataEcommerce.order_date >= CURRENT_DATE - INTERVAL '28 days'
+        GROUP BY customer_gender
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert!(
+        logical_plan.try_expect_root_cube_scan().is_some(),
+        "expected a plain CubeScan, got: {:?}",
+        logical_plan
+    );
+    let filters = logical_plan.find_cube_scan().request.filters.unwrap();
+    assert_eq!(filters.len(), 1, "filters: {:?}", filters);
+    assert_eq!(
+        filters[0].member.as_deref(),
+        Some("KibanaSampleDataEcommerce.order_date")
+    );
+    assert_eq!(filters[0].operator.as_deref(), Some("afterOrOnDate"));
+    // Midnight 28 days before the plan-time (UTC) date. The test may straddle midnight, so
+    // the previous day is accepted too.
+    let values = filters[0].values.clone().unwrap();
+    let today = chrono::Utc::now().date_naive();
+    let expected = [today, today - chrono::Duration::days(1)]
+        .iter()
+        .map(|day| {
+            (*day - chrono::Duration::days(28))
+                .format("%Y-%m-%dT00:00:00.000Z")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        values.len() == 1 && expected.contains(&values[0]),
+        "expected one of {:?}, got: {:?}",
+        expected,
+        values
+    );
+}
+
+#[tokio::test]
+async fn test_wrapper_cast_without_template_folds_to_cube_scan_filter() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    // Without a cast template the explicit cast cannot be pushed down; the bound folds to a
+    // CubeScan date filter instead.
+    let query_plan = convert_select_to_query_plan_customized(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender AS step,
+            MEASURE(count) AS total_conversions,
+            ROW_NUMBER() OVER (ORDER BY customer_gender) AS step_order
+        FROM KibanaSampleDataEcommerce
+        WHERE KibanaSampleDataEcommerce.order_date >= CURRENT_DATE - INTERVAL '28 days'
+        GROUP BY customer_gender
+        ORDER BY customer_gender
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+        vec![("expressions/cast".to_string(), "".to_string())],
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    println!("Generated SQL: {sql}");
+    assert!(
+        !sql.contains("CAST("),
+        "no cast may reach the pushed down SQL without its template: {}",
+        sql
+    );
+    let filters = logical_plan.find_cube_scan().request.filters.unwrap();
+    assert_eq!(filters.len(), 1, "filters: {:?}", filters);
+    assert_eq!(
+        filters[0].member.as_deref(),
+        Some("KibanaSampleDataEcommerce.order_date")
+    );
+    assert_eq!(filters[0].operator.as_deref(), Some("afterOrOnDate"));
+}

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -1059,39 +1059,52 @@ impl SqlTemplates {
         self.render_template("types/nullable", context! { data_type => sql_type })
     }
 
-    pub fn sql_type(&self, data_type: DataType) -> Result<String, CubeError> {
-        let data_type = match data_type {
-            DataType::Decimal(precision, scale) => {
-                return self.render_template(
-                    "types/decimal",
-                    context! {
-                        precision => precision,
-                        scale => scale,
-                    },
-                )
-            }
+    /// The `types/*` template a data type renders with, `None` for a type without one.
+    fn sql_type_template(data_type: &DataType) -> Option<&'static str> {
+        Some(match data_type {
+            DataType::Decimal(_, _) => "types/decimal",
             // NULL is not a type in databases. In PostgreSQL, untyped NULL is TEXT
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Null => "string",
-            DataType::Boolean => "boolean",
-            DataType::Int8 | DataType::UInt8 => "tinyint",
-            DataType::Int16 | DataType::UInt16 => "smallint",
-            DataType::Int32 | DataType::UInt32 => "integer",
-            DataType::Int64 | DataType::UInt64 => "bigint",
-            DataType::Float16 | DataType::Float32 => "float",
-            DataType::Float64 => "double",
-            DataType::Timestamp(_, _) => "timestamp",
-            DataType::Date32 | DataType::Date64 => "date",
-            DataType::Time32(_) | DataType::Time64(_) => "time",
-            DataType::Duration(_) | DataType::Interval(_) => "interval",
-            DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => "binary",
-            dt => {
-                return Err(CubeError::unsupported(format!(
-                    "Can't generate SQL for type {:?}: not supported",
-                    dt
-                )))
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Null => "types/string",
+            DataType::Boolean => "types/boolean",
+            DataType::Int8 | DataType::UInt8 => "types/tinyint",
+            DataType::Int16 | DataType::UInt16 => "types/smallint",
+            DataType::Int32 | DataType::UInt32 => "types/integer",
+            DataType::Int64 | DataType::UInt64 => "types/bigint",
+            DataType::Float16 | DataType::Float32 => "types/float",
+            DataType::Float64 => "types/double",
+            DataType::Timestamp(_, _) => "types/timestamp",
+            DataType::Date32 | DataType::Date64 => "types/date",
+            DataType::Time32(_) | DataType::Time64(_) => "types/time",
+            DataType::Duration(_) | DataType::Interval(_) => "types/interval",
+            DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => {
+                "types/binary"
             }
+            _ => return None,
+        })
+    }
+
+    /// Whether `sql_type` can render the data type: a lookup, no template is rendered.
+    pub fn contains_sql_type(&self, data_type: &DataType) -> bool {
+        Self::sql_type_template(data_type)
+            .map(|template| self.contains_template(template))
+            .unwrap_or(false)
+    }
+
+    pub fn sql_type(&self, data_type: DataType) -> Result<String, CubeError> {
+        let Some(template) = Self::sql_type_template(&data_type) else {
+            return Err(CubeError::unsupported(format!(
+                "Can't generate SQL for type {:?}: not supported",
+                data_type
+            )));
         };
-        self.render_template(&format!("types/{}", data_type), context! {})
+        let ctx = match data_type {
+            DataType::Decimal(precision, scale) => context! {
+                precision => precision,
+                scale => scale,
+            },
+            _ => context! {},
+        };
+        self.render_template(template, ctx)
     }
 
     pub fn left_join(&self) -> Result<String, CubeError> {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR makes the implicit TIMESTAMP cast of `DATE +/- INTERVAL` arithmetic explicit in temporal comparisons, so SQL pushdown of filters like `time >= CURRENT_DATE - INTERVAL '28 days'` is valid on BigQuery. Related test is included.
