### PR TITLE
fix(server-core): build one orchestrator api per id, not one per concurrent caller

### DIFF
--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -131,17 +131,9 @@ export class CubejsServerCore {
   protected readonly orchestratorStorage: OrchestratorStorage = new OrchestratorStorage();
 
   /**
-   * Orchestrator apis that are being built right now, by id, so that concurrent
-   * callers of one id end up on a single api instead of one each.
-   *
-   * Building is asynchronous and the cache is only written at the end of it, so
-   * without this every caller of a cold id misses the cache together and caches
-   * an api of its own. Each of those writes replaces the entry, and a replaced
-   * entry is released -- which closes the Cube Store connection of the api the
-   * previous caller is about to run its query on, failing that query with
-   * `Cube Store connection is closed`. Concurrency of two is the everyday case
-   * rather than a rarity: one `/v1/load` with `total: true` fetches the api
-   * once for its data query and once for its count query.
+   * In-flight orchestrator api builds, by id. Concurrent callers of a cold id must
+   * share one build: `OrchestratorStorage` releases a replaced entry, so a second
+   * build closes the Cube Store connection of the api the first caller is using.
    */
   protected readonly buildingOrchestratorApis: Map<string, Promise<OrchestratorApi>> = new Map();
 
@@ -601,14 +593,14 @@ export class CubejsServerCore {
       return building;
     }
 
-    // Registered before the first `await` inside the build, so nothing can run
-    // between the miss above and this line and take the same branch.
+    // Registered before the first `await` in the build, so nothing can interleave
+    // between the miss above and this line.
     const pending = this.buildOrchestratorApi(orchestratorId, context)
       .finally(() => {
-        // A build that failed must not be left behind to fail every later
-        // request for this id, and the one that succeeded is in the cache by
-        // now, so both are dropped here. Guarded because a build started after
-        // this one finished owns the entry.
+        // Dropped once settled: a success is in the cache by now, and a failure must
+        // not become the cached answer for this id. Identity-checked because
+        // `resetInstanceState()` clears the map mid-build, after which the entry
+        // belongs to a later caller's build rather than to this one.
         if (this.buildingOrchestratorApis.get(orchestratorId) === pending) {
           this.buildingOrchestratorApis.delete(orchestratorId);
         }

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -574,6 +574,10 @@ export class CubejsServerCore {
     await this.orchestratorStorage.releaseConnections();
 
     this.orchestratorStorage.clear();
+    // A build still in flight would otherwise keep handing its pre-reset api --
+    // built from the pre-reset context and the env this is about to reload -- to
+    // every caller arriving until it settles.
+    this.buildingOrchestratorApis.clear();
     this.compilerCache.clear();
 
     this.reloadEnvVariables();

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -130,6 +130,21 @@ export class CubejsServerCore {
 
   protected readonly orchestratorStorage: OrchestratorStorage = new OrchestratorStorage();
 
+  /**
+   * Orchestrator apis that are being built right now, by id, so that concurrent
+   * callers of one id end up on a single api instead of one each.
+   *
+   * Building is asynchronous and the cache is only written at the end of it, so
+   * without this every caller of a cold id misses the cache together and caches
+   * an api of its own. Each of those writes replaces the entry, and a replaced
+   * entry is released -- which closes the Cube Store connection of the api the
+   * previous caller is about to run its query on, failing that query with
+   * `Cube Store connection is closed`. Concurrency of two is the everyday case
+   * rather than a rarity: one `/v1/load` with `total: true` fetches the api
+   * once for its data query and once for its count query.
+   */
+  protected readonly buildingOrchestratorApis: Map<string, Promise<OrchestratorApi>> = new Map();
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected repositoryFactory: ((context: RequestContext) => SchemaFileRepository) | (() => FileRepository);
 
@@ -576,6 +591,31 @@ export class CubejsServerCore {
       return this.orchestratorStorage.get(orchestratorId);
     }
 
+    const building = this.buildingOrchestratorApis.get(orchestratorId);
+
+    if (building) {
+      return building;
+    }
+
+    // Registered before the first `await` inside the build, so nothing can run
+    // between the miss above and this line and take the same branch.
+    const pending = this.buildOrchestratorApi(orchestratorId, context)
+      .finally(() => {
+        // A build that failed must not be left behind to fail every later
+        // request for this id, and the one that succeeded is in the cache by
+        // now, so both are dropped here. Guarded because a build started after
+        // this one finished owns the entry.
+        if (this.buildingOrchestratorApis.get(orchestratorId) === pending) {
+          this.buildingOrchestratorApis.delete(orchestratorId);
+        }
+      });
+
+    this.buildingOrchestratorApis.set(orchestratorId, pending);
+
+    return pending;
+  }
+
+  protected async buildOrchestratorApi(orchestratorId: string, context: RequestContext): Promise<OrchestratorApi> {
     /**
      * Hash table to store promises which will be resolved with the
      * datasource drivers. DriverFactoryByDataSource function is closure

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -11,8 +11,8 @@ function createServerCore(options: Record<string, unknown> = {}) {
   const core = new CubejsServerCore(<any>{
     apiSecret: 'secret',
     driverFactory: () => <any>({ type: 'postgres' }),
-    // One id for every caller: a burst of requests carrying the same security
-    // context, which is what the deployment that reported this was serving.
+    // One shared id for all callers: a burst of requests carrying the same
+    // security context, which is what the deployment that reported this served.
     contextToOrchestratorId: () => 'ORCHESTRATOR_ID',
     ...options,
   });

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -35,6 +35,16 @@ async function callConcurrently(core: CubejsServerCore, times: number) {
 // `disposeAfter` releases asynchronously, so let the microtasks drain first.
 const flushReleases = () => new Promise(resolve => { setImmediate(resolve); });
 
+async function waitFor(condition: () => boolean) {
+  for (let i = 0; i < 100 && !condition(); i++) {
+    await new Promise(resolve => { setImmediate(resolve); });
+  }
+
+  if (!condition()) {
+    throw new Error('Timed out waiting for the build to reach its gate');
+  }
+}
+
 describe('CubejsServerCore.getOrchestratorApi', () => {
   let release: jest.SpyInstance;
 
@@ -107,6 +117,54 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
     expect(attempts).toEqual(1);
     await expect(callConcurrently(core, 1)).resolves.toBeDefined();
     expect(attempts).toEqual(2);
+  });
+
+  // `resetInstanceState()` clears the memo mid-build, so the build it dropped
+  // settles to find the entry owned by a later caller's build. Deleting it there
+  // would send that build's callers back to building an api each. Reachable only
+  // when the dropped build fails: one that succeeds fills the cache on its way
+  // out, and callers read the cache before the memo.
+  test('a build that outlives a reset does not drop the build that replaced it', async () => {
+    const core = createServerCore();
+    const gates: Array<() => void> = [];
+    let builds = 0;
+
+    jest.spyOn(core as any, 'orchestratorOptions').mockImplementation(async () => {
+      const build = builds++;
+
+      // Only the two builds this test orchestrates are held: a third one is the
+      // defect, and letting it run to completion makes the assertions below
+      // report the duplicate rather than time out waiting on it.
+      if (build < 2) {
+        await new Promise<void>(resolve => { gates.push(resolve); });
+      }
+
+      if (build === 0) {
+        throw new Error('the deployment went away mid-build');
+      }
+
+      return {};
+    });
+
+    const acrossReset = callConcurrently(core, 1);
+    await waitFor(() => gates.length === 1);
+
+    await core.resetInstanceState();
+
+    const afterReset = callConcurrently(core, 1);
+    await waitFor(() => gates.length === 2);
+
+    gates[0]();
+    await expect(acrossReset).rejects.toThrow('the deployment went away mid-build');
+
+    // The replacement is still in flight and the cache is still empty, so this
+    // caller can only be answered by the memo entry the failure just ran past.
+    const later = callConcurrently(core, 1);
+    gates[1]();
+
+    expect((await later)[0]).toBe((await afterReset)[0]);
+    expect(builds).toEqual(2);
+    expect(release).not.toHaveBeenCalled();
   });
 
   test('the Cube Store driver of a live caller is not closed under it', async () => {

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -37,7 +37,7 @@ const flushReleases = () => new Promise(resolve => { setImmediate(resolve); });
 
 async function waitFor(condition: () => boolean) {
   for (let i = 0; i < 100 && !condition(); i++) {
-    await new Promise(resolve => { setImmediate(resolve); });
+    await flushReleases();
   }
 
   if (!condition()) {
@@ -132,11 +132,10 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
     expect(attempts).toEqual(2);
   });
 
-  // `resetInstanceState()` clears the memo mid-build, so the build it dropped
-  // settles to find the entry owned by a later caller's build. Deleting it there
-  // would send that build's callers back to building an api each. Reachable only
-  // when the dropped build fails: one that succeeds fills the cache on its way
-  // out, and callers read the cache before the memo.
+  // Reachable only when the build dropped by `resetInstanceState()` fails: one
+  // that succeeds fills the cache on its way out, and callers read the cache
+  // before the memo. Deleting the entry it finds would send the replacement
+  // build's callers back to building an api each.
   test('a build that outlives a reset does not drop the build that replaced it', async () => {
     const core = createServerCore();
     const gates: Array<() => void> = [];

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -1,10 +1,10 @@
+// A replaced `OrchestratorStorage` entry is released, and releasing an api closes
+// its Cube Store connection for good -- so building an api twice for one id
+// destroys the connection of whoever holds the api it replaces.
+
 import { CubejsServerCore } from '../../src';
 import { OrchestratorApi } from '../../src/core/OrchestratorApi';
 
-// A replaced `OrchestratorStorage` entry is released, and releasing an api
-// closes its Cube Store connection for good -- so building an api twice for one
-// id is not merely wasteful, it destroys the connection of whoever holds the
-// api it replaces.
 const cores: CubejsServerCore[] = [];
 
 function createServerCore(options: Record<string, unknown> = {}) {
@@ -83,6 +83,19 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
     const [dataQuery, countQuery] = await callConcurrently(createServerCore(), 2);
 
     expect(dataQuery).toBe(countQuery);
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  test('callers of different ids get an api each', async () => {
+    const core = createServerCore({
+      contextToOrchestratorId: (context: any) => context.requestId,
+    });
+
+    const apis = await callConcurrently(core, 3);
+
+    // The other cases all pin one id, so a memo keyed too loosely -- or not
+    // keyed at all -- would satisfy every one of them.
+    expect(new Set(apis).size).toEqual(3);
     expect(release).not.toHaveBeenCalled();
   });
 

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -1,20 +1,27 @@
 import { CubejsServerCore } from '../../src';
 import { OrchestratorApi } from '../../src/core/OrchestratorApi';
 
-/**
- * `getOrchestratorApi()` is asynchronous and only writes the cache at the end,
- * so concurrent callers for one id used to miss the cache together and each
- * cache an api of its own. Every one of those writes replaces the entry, and a
- * replaced entry is released -- which closes the Cube Store connection of the
- * api a caller is about to run its query on. It surfaced as
- * `ConnectionError: Cube Store connection is closed` on requests that had done
- * nothing wrong.
- *
- * Concurrency of two is the everyday case rather than a rarity: a single
- * `/v1/load` with `total: true` runs its data query and its count query through
- * `Promise.all`, each fetching the orchestrator api for itself
- * (`gateway.ts` -> `getSqlResponseInternal`).
- */
+// A replaced `OrchestratorStorage` entry is released, and releasing an api
+// closes its Cube Store connection for good -- so building an api twice for one
+// id is not merely wasteful, it destroys the connection of whoever holds the
+// api it replaces.
+const cores: CubejsServerCore[] = [];
+
+function createServerCore(options: Record<string, unknown> = {}) {
+  const core = new CubejsServerCore(<any>{
+    apiSecret: 'secret',
+    driverFactory: () => <any>({ type: 'postgres' }),
+    // One id for every caller: a burst of requests carrying the same security
+    // context, which is what the deployment that reported this was serving.
+    contextToOrchestratorId: () => 'ORCHESTRATOR_ID',
+    ...options,
+  });
+
+  cores.push(core);
+
+  return core;
+}
+
 async function callConcurrently(core: CubejsServerCore, times: number) {
   return Promise.all(
     Array.from({ length: times }, (_, i) => core.getOrchestratorApi({
@@ -25,68 +32,48 @@ async function callConcurrently(core: CubejsServerCore, times: number) {
   );
 }
 
-/**
- * `OrchestratorStorage` releases through lru-cache's `disposeAfter`, which runs
- * once the `set` that removed the entry has returned, and the release itself is
- * asynchronous -- so the connections close a few microtasks after the call that
- * cost them.
- */
+// `disposeAfter` releases asynchronously, so let the microtasks drain first.
 const flushReleases = () => new Promise(resolve => { setImmediate(resolve); });
-
-function createServerCore(options: Record<string, unknown> = {}) {
-  return new CubejsServerCore(<any>{
-    apiSecret: 'secret',
-    driverFactory: () => <any>({ type: 'postgres' }),
-    // One id for every caller: a burst of requests carrying the same security
-    // context, which is what the deployment that reported this was serving.
-    contextToOrchestratorId: () => 'ORCHESTRATOR_ID',
-    ...options,
-  });
-}
 
 describe('CubejsServerCore.getOrchestratorApi', () => {
   let release: jest.SpyInstance;
 
   beforeEach(() => {
-    // Releasing is what closes the Cube Store web socket, and that close is
-    // terminal, so counting these calls counts the connections destroyed.
+    // Releasing is what closes the Cube Store web socket, so counting these
+    // calls counts the connections destroyed.
     release = jest.spyOn(OrchestratorApi.prototype, 'release')
       .mockImplementation(async () => undefined);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // In `afterEach` rather than at the end of each test: `releaseConnections()`
+    // is what cancels the scheduled refresh timer the constructor starts, and a
+    // test that fails before its last line would otherwise leave it running.
+    await Promise.all(cores.splice(0).map(core => core.releaseConnections()));
+
     release.mockRestore();
   });
 
   test('concurrent callers of one id share a single orchestrator api', async () => {
-    const core = createServerCore();
-
-    const apis = await callConcurrently(core, 5);
+    const apis = await callConcurrently(createServerCore(), 5);
 
     expect(new Set(apis).size).toEqual(1);
-
-    await core.releaseConnections();
   });
 
   test('no orchestrator handed to a caller is released behind its back', async () => {
-    const core = createServerCore();
-
-    await callConcurrently(core, 5);
+    await callConcurrently(createServerCore(), 5);
 
     expect(release).not.toHaveBeenCalled();
-
-    await core.releaseConnections();
   });
 
+  // One `/v1/load` with `total: true` runs its data query and its count query
+  // through `Promise.all`, each fetching the api for itself, so a single request
+  // is enough to race with itself.
   test('the two queries of one total:true request get the same api', async () => {
-    const core = createServerCore();
-
-    const [dataQuery, countQuery] = await callConcurrently(core, 2);
+    const [dataQuery, countQuery] = await callConcurrently(createServerCore(), 2);
 
     expect(dataQuery).toBe(countQuery);
     expect(release).not.toHaveBeenCalled();
-
-    await core.releaseConnections();
   });
 
   test('a later caller reuses the cached api rather than building another', async () => {
@@ -97,8 +84,6 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
 
     expect(later.every(api => api === first)).toBe(true);
     expect(release).not.toHaveBeenCalled();
-
-    await core.releaseConnections();
   });
 
   test('a failed build is not left behind to fail every later request', async () => {
@@ -122,21 +107,16 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
     expect(attempts).toEqual(1);
     await expect(callConcurrently(core, 1)).resolves.toBeDefined();
     expect(attempts).toEqual(2);
-
-    await core.releaseConnections();
   });
 
   test('the Cube Store driver of a live caller is not closed under it', async () => {
-    // The step that turns a released api into the error the deployment saw:
-    // `release()` closes the external driver, and closing the Cube Store web
-    // socket is terminal, so the caller still holding that api fails its next
-    // query with `Cube Store connection is closed`.
+    // The step that turns a released api into the reported error: `release()`
+    // closes the external driver, and that close is terminal.
     release.mockRestore();
 
     const closed: number[] = [];
     let drivers = 0;
     const core = createServerCore({
-      externalDbType: 'cubestore',
       externalDriverFactory: () => {
         const id = drivers++;
 
@@ -150,12 +130,7 @@ describe('CubejsServerCore.getOrchestratorApi', () => {
     const apis = await callConcurrently(core, 3);
     await flushReleases();
 
-    // Every caller has to be left with a usable connection. Two of these three
-    // used to be released, each closing the connection of a caller that had
-    // just been handed it.
     expect(closed).toEqual([]);
     expect(new Set(apis).size).toEqual(1);
-
-    await core.releaseConnections();
   });
 });

--- a/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts
@@ -1,0 +1,161 @@
+import { CubejsServerCore } from '../../src';
+import { OrchestratorApi } from '../../src/core/OrchestratorApi';
+
+/**
+ * `getOrchestratorApi()` is asynchronous and only writes the cache at the end,
+ * so concurrent callers for one id used to miss the cache together and each
+ * cache an api of its own. Every one of those writes replaces the entry, and a
+ * replaced entry is released -- which closes the Cube Store connection of the
+ * api a caller is about to run its query on. It surfaced as
+ * `ConnectionError: Cube Store connection is closed` on requests that had done
+ * nothing wrong.
+ *
+ * Concurrency of two is the everyday case rather than a rarity: a single
+ * `/v1/load` with `total: true` runs its data query and its count query through
+ * `Promise.all`, each fetching the orchestrator api for itself
+ * (`gateway.ts` -> `getSqlResponseInternal`).
+ */
+async function callConcurrently(core: CubejsServerCore, times: number) {
+  return Promise.all(
+    Array.from({ length: times }, (_, i) => core.getOrchestratorApi({
+      requestId: `request-${i}`,
+      authInfo: null,
+      securityContext: null,
+    } as any))
+  );
+}
+
+/**
+ * `OrchestratorStorage` releases through lru-cache's `disposeAfter`, which runs
+ * once the `set` that removed the entry has returned, and the release itself is
+ * asynchronous -- so the connections close a few microtasks after the call that
+ * cost them.
+ */
+const flushReleases = () => new Promise(resolve => { setImmediate(resolve); });
+
+function createServerCore(options: Record<string, unknown> = {}) {
+  return new CubejsServerCore(<any>{
+    apiSecret: 'secret',
+    driverFactory: () => <any>({ type: 'postgres' }),
+    // One id for every caller: a burst of requests carrying the same security
+    // context, which is what the deployment that reported this was serving.
+    contextToOrchestratorId: () => 'ORCHESTRATOR_ID',
+    ...options,
+  });
+}
+
+describe('CubejsServerCore.getOrchestratorApi', () => {
+  let release: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Releasing is what closes the Cube Store web socket, and that close is
+    // terminal, so counting these calls counts the connections destroyed.
+    release = jest.spyOn(OrchestratorApi.prototype, 'release')
+      .mockImplementation(async () => undefined);
+  });
+
+  afterEach(() => {
+    release.mockRestore();
+  });
+
+  test('concurrent callers of one id share a single orchestrator api', async () => {
+    const core = createServerCore();
+
+    const apis = await callConcurrently(core, 5);
+
+    expect(new Set(apis).size).toEqual(1);
+
+    await core.releaseConnections();
+  });
+
+  test('no orchestrator handed to a caller is released behind its back', async () => {
+    const core = createServerCore();
+
+    await callConcurrently(core, 5);
+
+    expect(release).not.toHaveBeenCalled();
+
+    await core.releaseConnections();
+  });
+
+  test('the two queries of one total:true request get the same api', async () => {
+    const core = createServerCore();
+
+    const [dataQuery, countQuery] = await callConcurrently(core, 2);
+
+    expect(dataQuery).toBe(countQuery);
+    expect(release).not.toHaveBeenCalled();
+
+    await core.releaseConnections();
+  });
+
+  test('a later caller reuses the cached api rather than building another', async () => {
+    const core = createServerCore();
+
+    const [first] = await callConcurrently(core, 3);
+    const later = await callConcurrently(core, 3);
+
+    expect(later.every(api => api === first)).toBe(true);
+    expect(release).not.toHaveBeenCalled();
+
+    await core.releaseConnections();
+  });
+
+  test('a failed build is not left behind to fail every later request', async () => {
+    const core = createServerCore();
+    let attempts = 0;
+
+    jest.spyOn(core as any, 'orchestratorOptions').mockImplementation(async () => {
+      attempts += 1;
+
+      if (attempts === 1) {
+        throw new Error('orchestrator options are not available yet');
+      }
+
+      return {};
+    });
+
+    await expect(callConcurrently(core, 3)).rejects.toThrow('orchestrator options are not available yet');
+
+    // All three shared the one failing build, and the failure did not become
+    // the cached answer for this id.
+    expect(attempts).toEqual(1);
+    await expect(callConcurrently(core, 1)).resolves.toBeDefined();
+    expect(attempts).toEqual(2);
+
+    await core.releaseConnections();
+  });
+
+  test('the Cube Store driver of a live caller is not closed under it', async () => {
+    // The step that turns a released api into the error the deployment saw:
+    // `release()` closes the external driver, and closing the Cube Store web
+    // socket is terminal, so the caller still holding that api fails its next
+    // query with `Cube Store connection is closed`.
+    release.mockRestore();
+
+    const closed: number[] = [];
+    let drivers = 0;
+    const core = createServerCore({
+      externalDbType: 'cubestore',
+      externalDriverFactory: () => {
+        const id = drivers++;
+
+        return {
+          testConnection: async () => undefined,
+          release: async () => { closed.push(id); },
+        };
+      },
+    });
+
+    const apis = await callConcurrently(core, 3);
+    await flushReleases();
+
+    // Every caller has to be left with a usable connection. Two of these three
+    // used to be released, each closing the connection of a caller that had
+    // just been handed it.
+    expect(closed).toEqual([]);
+    expect(new Set(apis).size).toEqual(1);
+
+    await core.releaseConnections();
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[CORE-884](https://linear.app/cube-d3/issue/CORE-884/concurrent-getorchestratorapi-calls-build-duplicate-orchestrators-and) — a regression from [CORE-823](https://linear.app/cube-d3/issue/CORE-823/orchestratorstorage-lru-evicts-orchestrators-without-releasing-them) / #11661.

**Description of Changes Made**

`CubejsServerCore.getOrchestratorApi()` is asynchronous and writes the orchestrator cache only at the end of the build, so concurrent callers of a cold id all miss the cache together and each cache an api of their own. Since #11661 a replaced `OrchestratorStorage` entry is released (`disposeAfter`, reason `set`), and `WebSocketConnection.close()` is terminal — so every one of those writes closed the Cube Store web socket of the api the previous caller had just been handed, and that caller's next query failed with

```
ConnectionError: Cube Store connection is closed
    at WebSocketConnection.initWebSocket (.../cubestore-driver/src/WebSocketConnection.ts:120:13)
    at WebSocketConnection.sendMessage (.../WebSocketConnection.ts:433:31)
    at CubeStoreCacheDriver.get (.../CubeStoreCacheDriver.ts:68:18)
    at CubeQueryCache.cacheQueryResult (.../QueryCache.ts:1110:15)
```

Concurrency of two is the everyday case rather than a rarity: one `/v1/load` with `total: true` runs its data query and its count query through `Promise.all`, each fetching the api for itself (`gateway.ts` → `getSqlResponseInternal`), so a single request is enough to race with itself.

The build is now memoized by orchestrator id while it runs. The memo is registered before the first `await` inside the build, so nothing can interleave between the cache miss and it, and it is dropped once the build settles — a success is in the cache by then, and a failure must not become the cached answer for that id. `resetInstanceState()` clears the memo alongside the orchestrator storage.

**Evidence from the deployment that reported it**

v1.7.29, both API pods up for 4.5h with no restarts, so the id keeps going cold through LRU eviction (`OrchestratorStorage` max 100) on a multi-vhost deployment.

- Every failing request carries `total: true`.
- 22:39:00.148–.158 UTC: five REST requests, one security context (same `jti`/`vhost`/`iat`), **all five** failed and all at ~2.04s in — ten concurrent builds, one surviving api.
- 22:16:48.894 UTC: a single request, alone on the deployment for 35 seconds, failed the same way — its own two halves raced.

**Tests**

New `packages/cubejs-server-core/test/unit/getOrchestratorApi.test.ts`, 8 cases. Six of them fail against the parent commit; the one that matters most is the link from "an api was released" to "a Cube Store connection was closed":

```
✕ concurrent callers of one id share a single orchestrator api      Expected: 1  Received: 5
✕ no orchestrator handed to a caller is released behind its back    Expected 0 calls  Received 4
✕ the two queries of one total:true request get the same api
✕ a later caller reuses the cached api rather than building another
✕ a failed build is not left behind to fail every later request     Expected: 1  Received: 3
✕ the Cube Store driver of a live caller is not closed under it     Expected []  Received [0, 1]
```

Two more were added from review, each verified by mutation rather than assumed:

- `callers of different ids get an api each` — every other case pins `contextToOrchestratorId` to a constant, so a memo keyed too loosely would satisfy all of them. Keying the memo on a constant fails this one.
- `a build that outlives a reset does not drop the build that replaced it` — pins the identity check in the `finally`, which `resetInstanceState()` clearing the memo makes load-bearing. Reducing it to a plain `delete` fails this one in 77ms.

No e2e spec: the bug is a microtask-ordering race inside `server-core` with no user-drivable surface that reproduces it deterministically.

Suites run locally: `cubejs-server-core` unit (8/8 new; the 4 pre-existing failures in `RefreshScheduler`/`OptsHandler` are identical with this file removed entirely, so they are not from this change) and `cubejs-cubestore-driver` (22/22, so the terminal-close semantics from #11661 are untouched). The new file also exits clean under `jest --detectOpenHandles` without `--forceExit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gBgEB5wBDFxWrtBhk7G7X

[CORE-884]: https://cubedevinc.atlassian.net/browse/CORE-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-823]: https://cubedevinc.atlassian.net/browse/CORE-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ