### PR TITLE
docs: MCP dev-mode branch scoping, add-in column totals, dashboards, and agent controls

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -131,6 +131,7 @@ Make sure to use correct terms. On billing, pricing, and support pages, use **on
             - Spacer
             - Divider
             - Stack
+            - Grid
     - **Dashboard**
       - Scheduled refresh
     - **Semantic Model**

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -18,7 +18,7 @@ switcher's member, and pick a parent control's option** on the dashboard you're
 viewing — just ask in plain language (for example, _"filter to last 30 days"_
 or _"group by month"_). These changes affect only your own session and are
 never saved to the dashboard — see
-[Changing filters and time granularity](#changing-filters-and-time-granularity).
+[Changing filters and controls](#changing-filters-and-time-granularity).
 
 <Frame>
   <img
@@ -72,9 +72,9 @@ underlying SQL, the data, and the chart spec — along with the dashboard's
 **current filter and time-granularity state**. It uses this as context for
 answering and never edits the chart's definition. You can still ask it to change
 the dashboard's filters or time granularity — see
-[Changing filters and time granularity](#changing-filters-and-time-granularity).
+[Changing filters and controls](#changing-filters-and-time-granularity).
 
-## Changing filters and time granularity
+## Changing filters and controls {#changing-filters-and-time-granularity}
 
 Ask the agent, in plain language, to filter the dashboard, change a time
 granularity, switch a field, or set a parent control's option, and it applies
@@ -139,7 +139,7 @@ it never changes the **saved** dashboard.
 - Apply filters, change the time granularity, swap a field switcher's member,
   and pick a parent control's option on the dashboard you're viewing, for
   controls that exist on the dashboard (your session only — see
-  [Changing filters and time granularity](#changing-filters-and-time-granularity))
+  [Changing filters and controls](#changing-filters-and-time-granularity))
 - Explain how a metric or dimension is defined
 - Look up the values available for a dimension
 - Read the contents of [attachments](#attachments) you add to the chat

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -146,8 +146,8 @@ it never changes the **saved** dashboard.
 
 **It can't:**
 
-- Save its filter or time-granularity changes to the dashboard — they apply to
-  your session only and never change what other viewers see
+- Save its control changes to the dashboard — they apply to your session only
+  and never change what other viewers see
 - Edit the dashboard, or add/remove widgets
 - Create reports or workbooks
 - Change the data model

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dashboard Agent
-description: Ask questions about a dashboard and its charts — and change its filters and time granularity — using a conversational AI assistant docked alongside the dashboard.
+description: Ask questions about a dashboard and its charts — and change its filters, time granularity, and other controls — using a conversational AI assistant docked alongside the dashboard.
 ---
 
 The Dashboard Agent is a conversational assistant docked as a panel on a
@@ -13,10 +13,11 @@ shows. It can drill into a single chart, re-aggregate a metric, break a number
 down by a dimension, pull a longer time range than the chart displays, and
 summarize trends across the dashboard.
 
-It can also **apply filters and change the time granularity** on the dashboard
-you're viewing — just ask in plain language (for example, _"filter to last 30
-days"_ or _"group by month"_). These changes affect only your own session and
-are never saved to the dashboard — see
+It can also **apply filters, change the time granularity, swap a field
+switcher's member, and pick a parent control's option** on the dashboard you're
+viewing — just ask in plain language (for example, _"filter to last 30 days"_
+or _"group by month"_). These changes affect only your own session and are
+never saved to the dashboard — see
 [Changing filters and time granularity](#changing-filters-and-time-granularity).
 
 <Frame>
@@ -31,14 +32,14 @@ are never saved to the dashboard — see
 
   - **Dashboard Agent** (this page) — for viewers of a published or embedded
     dashboard: question-and-answer about what's on screen, plus changing your
-    own filters and time granularity.
+    own view of the controls.
   - **[Workbook Agent][ref-workbook-agent]** — full authoring inside a
     [workbook][ref-workbooks]: creating reports, building and editing
     dashboards, and running analysis.
 
-  The published Dashboard Agent can adjust **your own view** — filters and time
-  granularity, for your session only — but intentionally cannot author or change
-  the **saved** dashboard.
+  The published Dashboard Agent can adjust **your own view** — the controls in
+  front of you, for your session only — but intentionally cannot author or
+  change the **saved** dashboard.
 </Note>
 
 ## Opening the agent
@@ -75,26 +76,36 @@ the dashboard's filters or time granularity — see
 
 ## Changing filters and time granularity
 
-Ask the agent, in plain language, to filter the dashboard or change a time
-granularity, and it applies the change to the controls in front of you:
+Ask the agent, in plain language, to filter the dashboard, change a time
+granularity, switch a field, or set a parent control's option, and it applies
+the change to the controls in front of you:
 
 - _"Filter this dashboard to orders with status completed."_
 - _"Show only the Outerwear category."_
 - _"Filter to the last 30 days."_
 - _"Group by month."_
+- _"Switch that chart to show profit instead of revenue."_ (a [field
+  switcher][ref-field-switcher])
+- _"Set the region picker to EMEA."_ (a [parent control][ref-parent-control])
 - _"Reset the filters."_
 
 How it works and what to expect:
 
 - **Only controls that exist on the dashboard can be changed.** The agent can
-  change a filter or time granularity only when the dashboard has a matching
-  [filter or time-granularity control widget][ref-controls] for that dimension.
-  If there's no control for what you asked about, the agent tells you so instead
+  change a filter, time granularity, field switcher, or parent control only
+  when the dashboard has a matching [control widget][ref-controls] for it. If
+  there's no control for what you asked about, the agent tells you so instead
   of changing anything. A control whose [visibility][ref-control-visibility] is
   **Disabled** also can't be changed.
 - **Time granularity stays within the control's allowed granularities.** If a
   time-granularity control restricts which granularities viewers can pick, the
   agent only chooses from that set.
+- **A field switcher can only be set to one of its offered
+  members.** The agent picks from the same
+  [**Alternatives**][ref-field-switcher] a viewer could pick from by hand.
+- **A parent control can only be set to one of its defined options** — the
+  agent can't invent a new option, only choose among the ones the dashboard's
+  author configured.
 - **Changes apply to your session only.** They're applied the same way as
   changing a control by hand: reflected in the dashboard's URL — so you can
   share or bookmark the filtered view — but **not** saved to the dashboard. They
@@ -125,9 +136,9 @@ it never changes the **saved** dashboard.
 - Run **read-only queries** against the semantic model to go deeper — drill
   down, break a metric down by a dimension, or pull a longer time range than a
   chart shows
-- Apply filters and change the time granularity on the dashboard you're
-  viewing, for dimensions that have a matching
-  [control widget][ref-controls] (your session only — see
+- Apply filters, change the time granularity, swap a field switcher's member,
+  and pick a parent control's option on the dashboard you're viewing, for
+  controls that exist on the dashboard (your session only — see
   [Changing filters and time granularity](#changing-filters-and-time-granularity))
 - Explain how a metric or dimension is defined
 - Look up the values available for a dimension
@@ -145,16 +156,12 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
 
 ## Limitations
 
-- **Filter and time-granularity changes need a matching control.** The agent can
-  change a filter or time granularity only for dimensions that have a
-  corresponding [control widget][ref-controls] on the dashboard, and the change
-  applies to your session only — it is never saved to the dashboard. If you ask
-  it to change something with no control on the dashboard, it explains the
-  current state instead of applying a change.
-- **Field switchers aren't driven by the agent.** The agent can read and change
-  [filters and time granularities][ref-controls]; a
-  [field switcher][ref-field-switcher] is not among the controls it operates, so
-  ask it about the data instead and change the field yourself in the control.
+- **Control changes need a matching control widget.** The agent can change a
+  filter, time granularity, [field switcher][ref-field-switcher], or [parent
+  control][ref-parent-control] only when a corresponding control widget exists
+  on the dashboard, and the change applies to your session only — it is never
+  saved to the dashboard. If you ask it to change something with no control on
+  the dashboard, it explains the current state instead of applying a change.
 - **No authoring on published dashboards.** The published Dashboard Agent
   cannot create reports or build dashboards, edit the saved dashboard, or change
   the data model. Those live in the [Workbook Agent][ref-workbook-agent].
@@ -166,5 +173,6 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
 [ref-workbook-agent]: /docs/explore-analyze/workbooks/workbook-agent
 [ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
 [ref-field-switcher]: /docs/explore-analyze/dashboards/widgets/controls#field-switcher
+[ref-parent-control]: /docs/explore-analyze/dashboards/widgets/controls#parent
 [ref-control-visibility]: /docs/explore-analyze/dashboards/widgets/controls#visibility
 [ref-embedding]: /embedding/iframe/dashboards

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -368,7 +368,7 @@ Each control's picker offers only the members it can actually be resolved agains
 | [Field switcher](#field-switcher) set to **Dimension** | Dimensions. |
 | [Field switcher](#field-switcher) set to **Measure** | Measures, since the control replaces a measure. |
 
-The [Workbook Agent][ref-workbook-agent] can author filter, time granularity, and field switcher controls when it builds or edits a dashboard, and can set the same per-chart overrides you would from **Controls mapping** — exclude a chart from a filter, or remap any of the three onto a different member for one chart — so it can wire these controls across charts on different semantic views without you revisiting each chart manually.
+For filter, time granularity, and field switcher controls — the three that map onto a member — the [Workbook Agent][ref-workbook-agent] can set the same per-chart overrides you would from **Controls mapping**: exclude a chart from a filter, or remap any of the three onto a different member for one chart. That lets it wire these controls across charts on different semantic views without you revisiting each chart manually.
 
 [ref-embed-url-filters]: /embedding/iframe/dashboards#pre-set-dashboard-filters-via-url
 [ref-workbook-agent]: /docs/explore-analyze/workbooks/workbook-agent

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -368,9 +368,10 @@ Each control's picker offers only the members it can actually be resolved agains
 | [Field switcher](#field-switcher) set to **Dimension** | Dimensions. |
 | [Field switcher](#field-switcher) set to **Measure** | Measures, since the control replaces a measure. |
 
-Filter and time granularity mappings are also configurable by AI agents when they build or edit a dashboard, so an agent can wire those controls across charts that use different semantic views without you needing to revisit each chart manually. Field switchers are outside what agents author, so their mappings are yours to set.
+The [Workbook Agent][ref-workbook-agent] can author filter, time granularity, and field switcher controls when it builds or edits a dashboard, and can set the same per-chart overrides you would from **Controls mapping** — exclude a chart from a filter, or remap any of the three onto a different member for one chart — so it can wire these controls across charts on different semantic views without you revisiting each chart manually.
 
 [ref-embed-url-filters]: /embedding/iframe/dashboards#pre-set-dashboard-filters-via-url
+[ref-workbook-agent]: /docs/explore-analyze/workbooks/workbook-agent
 
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-charts]: /docs/explore-analyze/dashboards/widgets/charts

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/index.mdx
@@ -13,7 +13,7 @@ The dashboard builder supports the following widget types:
 - [Text](/docs/explore-analyze/dashboards/widgets/text) — Add titles, descriptions, and rich formatting in Markdown
 - [Controls](/docs/explore-analyze/dashboards/widgets/controls) — Let viewers filter the data, switch the time granularity, swap which field the charts are built on, or drive several controls at once
 - [AI summary](/docs/explore-analyze/dashboards/widgets/ai-summary) — Generate narrative summaries of dashboard data on demand
-- [Spacer, Divider & Stack](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace, section breaks, and grouping widgets
+- [Spacer, Divider, Stack & Grid](/docs/explore-analyze/dashboards/widgets/layout) — Non-data layout elements for whitespace, section breaks, and grouping widgets
 
 ## Adding widgets
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/layout.mdx
@@ -1,9 +1,9 @@
 ---
-title: Spacer, Divider & Stack
-description: Non-data layout elements — a spacer for whitespace, a divider line, and stack containers that group widgets — to help you structure a dashboard.
+title: Spacer, Divider, Stack & Grid
+description: Non-data layout elements — a spacer for whitespace, a divider line, and stack and grid containers that group widgets — to help you structure a dashboard.
 ---
 
-Spacers, dividers, and stacks are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace, visual structure, and grouping to a dashboard.
+Spacers, dividers, stacks, and grids are non-data **layout** widgets. They carry no data of their own; you place them on the canvas alongside charts, text, and controls to add whitespace, visual structure, and grouping to a dashboard.
 
 ## Spacer
 
@@ -28,9 +28,17 @@ Add a widget to a stack by dragging it in — from the canvas, the **Add Widgets
 
 Because a stack owns its children's layout, you work with the **container as a unit**: select, move, resize, or delete the stack itself and it carries its children with it. Individual widgets inside a stack are not separately selectable on the board — a marquee drawn over a stack selects the container, not its children. To rearrange children, drag one to a new position **within** the stack; to take one out, drag it onto the canvas or into another container.
 
+## Grid
+
+A **grid** is a container whose children each hold a fixed cell position and size, unlike a stack's evenly shared space. A grid is a window into the same uniform cell grid as the board that holds it, so a child keeps the exact footprint you give it — nothing is auto-compacted, swapped, resized, or moved to make room. Dragging, resizing, or dropping a widget onto a cell that's already occupied is rejected and the widget stays where it was.
+
+Click the grid's header to select it and drag its resize grip to change its size; resizing only crops or restores empty rows and columns (a grid can't shrink below 2×2 or cut into an occupied cell). Give the grid a title by clicking into the header once it's selected.
+
+A grid can be nested inside the root board or inside another grid, but not inside a stack.
+
 ## Adding a layout widget
 
-In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer**, **Divider**, **Horizontal Stack**, or **Vertical Stack**. The widget is added to the canvas, where you can drag it into place and resize it (a divider resizes horizontally only).
+In the [dashboard builder][ref-workbooks], open the **Add Widgets** menu in the toolbar and choose **Spacer**, **Divider**, **Horizontal Stack**, **Vertical Stack**, or **Grid**. The widget is added to the canvas, where you can drag it into place and resize it (a divider resizes horizontally only).
 
 ## Styling
 
@@ -39,6 +47,6 @@ The **spacer** and **divider** follow the dashboard's [widget styling settings](
 - The **divider** draws its line using the widget **border** width, style, and color.
 - A **spacer** picks up the same border and background settings while you are editing, so its bounds are easy to see.
 
-A **stack** draws no card of its own — it only groups and sizes its children, each of which keeps its own styling.
+A **stack** draws no card of its own — it only groups and sizes its children, each of which keeps its own styling. A **grid** draws a header band with its title, visible to viewers on the published dashboard too.
 
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
@@ -27,7 +27,8 @@ and dimension definitions), the Workbook Agent can:
 - **Create and save reports** in the workbook from a natural-language request
 - **Search existing reports** to find and reuse work already in the workbook
 - **Build and edit dashboards** — add and configure chart, KPI, filter,
-  time-grain, and text widgets
+  time-grain, field switcher, parent control, and text widgets, plus stack and
+  grid layout containers
 - **Publish dashboards**
 
 ## How charts get added to a dashboard

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -153,6 +153,32 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the exploration and survive **Refresh**.
 
+### Column totals
+
+The **Column totals** switch, below **Measure position** on the **Display** tab,
+appends a bold **Total** row at the bottom of the written range, with one value per
+measure column. It's disabled, with a tooltip explaining why, until the query has at
+least one measure.
+
+Each total is computed by a separate query rather than summed from the cells on the
+sheet, so it's correct for non-additive measures — an average totals to the average
+over the whole column, not an average of the visible rows, and the same for a
+count-distinct. With a dimension pivoted onto columns, each pivot column gets its own
+total the same way. [Calculations][ref-calculated-fields] based on window functions,
+such as running totals, are excluded — the same exclusion as Cube's own [row, column,
+and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
+
+Totals are computed over the query's full result, not just the rows visible on the
+sheet, so a row-limited query still totals the whole result. Measure filters are
+dropped from the totals query; dimension filters are kept. With measures on **Rows**
+and no row dimension, no totals row is written, since each "total" would just restate
+its own data row.
+
+Column totals are saved with the exploration and survive **Refresh**; with auto-run
+off, toggling the switch waits for **Run** like any other display change.
+
+{/* TODO: screenshot — a pivoted exploration with the Total row on the sheet */}
+
 When your exploration is ready, click **Save** to add it to your workspace. You
 can then [work with the exploration](#work-with-explorations) from the add-on.
 To discard an unsaved exploration instead, choose **Delete exploration** from
@@ -227,3 +253,4 @@ Saved explorations also appear in the Cube workspace. See
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-sql-api-enabled]: /reference/core-data-apis/sql-api#cube-cloud
 [ref-explorations]: /docs/explore-analyze/explore#saving-explorations
+[ref-calculated-fields]: /docs/explore-analyze/workbooks/calculated-fields

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -155,27 +155,29 @@ the exploration and survive **Refresh**.
 
 ### Column totals
 
-The **Column totals** switch, below **Measure position** on the **Display** tab,
-appends a bold **Total** row at the bottom of the written range, with one value per
-measure column. It's disabled, with a tooltip explaining why, until the query has at
-least one measure.
+The **Column totals** switch, below **Measure position** on the **Display**
+tab, appends a bold **Total** row at the bottom of the written range, with one
+value per measure column. It's disabled, with a tooltip explaining why, until
+the query has at least one measure.
 
-Each total is computed by a separate query rather than summed from the cells on the
-sheet, so it's correct for non-additive measures — an average totals to the average
-over the whole column, not an average of the visible rows, and the same for a
-count-distinct. With a dimension pivoted onto columns, each pivot column gets its own
-total the same way. [Calculations][ref-calculated-fields] based on window functions,
-such as running totals, are excluded — the same exclusion as Cube's own [row, column,
-and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
+Each total is computed by a separate query rather than summed from the cells
+on the sheet, so it's correct for non-additive measures — an average totals
+to the average over the whole column, not an average of the visible rows,
+and the same for a count-distinct. With a dimension pivoted onto columns,
+each pivot column gets its own total the same way.
+[Calculations][ref-calculated-fields] based on window functions, such as
+running totals, are excluded — the same exclusion as Cube's own [row,
+column, and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
 
-Totals are computed over the query's full result, not just the rows visible on the
-sheet, so a row-limited query still totals the whole result. Measure filters are
-dropped from the totals query; dimension filters are kept. With measures on **Rows**
-and no row dimension, no totals row is written, since each "total" would just restate
-its own data row.
+Totals are computed over the query's full result, not just the rows visible
+on the sheet, so a row-limited query still totals the whole result. Measure
+filters are dropped from the totals query; dimension filters are kept. With
+measures on **Rows** and no row dimension, no totals row is written, since
+each "total" would just restate its own data row.
 
-Column totals are saved with the exploration and survive **Refresh**; with auto-run
-off, toggling the switch waits for **Run** like any other display change.
+Column totals are saved with the exploration and survive **Refresh**; with
+auto-run off, toggling the switch waits for **Run** like any other display
+change.
 
 {/* TODO: screenshot — a pivoted exploration with the Total row on the sheet */}
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -206,6 +206,31 @@ that is outside the allow-list — or that you don't have permission to see — 
 with a **403 Forbidden** (`Deployment <id> is not available via MCP for this account`), so
 neither `listDeployments` nor the `chat` selection can reach an excluded deployment.
 
+## Target a dev-mode branch
+
+By default, an MCP session reads and queries the deployed data model. To exercise a
+[development mode][ref-dev-mode] branch — a data-model change plus its agent
+configuration (skills, rules, spaces) — before it's committed, connect with the dev
+`branchName` returned by `startDataModelEdit`:
+
+```text
+https://cubecloud.dev/mcp?branchName=dev-<user>-<hash>
+```
+
+A client that can't set a query parameter on the endpoint can send the same value as an
+`x-mcp-branch-name` header instead (checked first; `mcp-branch-name` is a second, lower-priority
+alias). Only an active dev branch is accepted — `main`, the deploy branch, or a branch
+with no dev worker running is rejected at connect time with a `400` error, never a silent
+fallback to the deployed model.
+
+Once connected this way, every branch-aware tool below defaults to that branch instead of
+the deployed model — you don't need to keep passing `branchName` on each call. Any tool
+can still override it per call: pass a different `branchName` to target another branch for
+just that one request, or pass `null` to force the deployed model for one call on an
+otherwise branch-scoped session. Every response echoes back the branch it actually ran on
+as `branchName` (`null` means the deployed model), so a client can always confirm what it
+queried.
+
 ## Available actions
 
 The MCP server exposes 23 tools, grouped below.
@@ -228,27 +253,36 @@ happens without an explicit approval.
 | Tool | Description |
 | --- | --- |
 | `listDeployments` | Lists the deployments and agents you can reach over MCP. |
-| `chat` | Asks a question of a Cube agent, optionally targeting a specific deployment and agent. |
+| `chat` | Asks a question of a Cube agent, optionally targeting a specific deployment and agent. Pass `branchName` to have the agent answer from a dev branch's model instead of the deployed one. |
 | `loadQueryResults` | Paginates through the results of a previous query. |
 
 See [Select a deployment and agent](#select-a-deployment-and-agent) for how these three
 work together.
 
+A chat conversation is pinned to whichever branch answered its first message — later
+messages in the same conversation stay on that branch, and `loadQueryResults` pages using
+it. Passing a different `branchName` while resuming an existing `chatId` fails rather than
+silently switching branches mid-conversation: omit `branchName` to keep talking on the
+conversation's branch, or omit `chatId` to start a new conversation on the one you want.
+
 ### Query and discovery
 
 | Tool | Description | Access |
 | --- | --- | --- |
-| `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
+| `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. Pass the dev `branchName` from `startDataModelEdit` to search that branch's model, including members that don't exist in production yet. | Read-only |
 | `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. Pass the dev `branchName` from `startDataModelEdit` to query that branch instead of the deployed model. | Read-only |
 
 Call `searchDataModel` before `runQuery` to find exact view and member names rather than
-guessing them.
+guessing them — pass the same `branchName` to both so the members you find are the ones the
+query will see.
 
-Omitting `branchName` queries the deployed model, exactly as before this parameter existed.
-Passing a `branchName` that isn't an active dev branch — for example the deploy branch's own
-name, or a feature branch with no dev worker running — fails with an error rather than
-silently answering from the deployed model, so a query aimed at the wrong branch never
-looks like a query that just returned no rows.
+Omitting `branchName` on a call uses the session's branch if you [connected with
+one](#target-a-dev-mode-branch), or the deployed model otherwise; passing `null` forces the
+deployed model for that one call regardless of the session. Passing a `branchName` that
+isn't an active dev branch — for example the deploy branch's own name, or a feature branch
+with no dev worker running — fails with an error rather than silently answering from the
+deployed model, so a query aimed at the wrong branch never looks like a query that just
+returned no rows.
 
 ### Dashboard authoring
 
@@ -285,8 +319,8 @@ default. Users without it never see them.
 
 | Tool | Description | Access |
 | --- | --- | --- |
-| `listDataModelFiles` | Lists the semantic model source files (raw YAML, JavaScript, or Python). | Read-only |
-| `readDataModelFile` | Reads one file's raw source. | Read-only |
+| `listDataModelFiles` | Lists the semantic model source files (raw YAML, JavaScript, or Python). Pass `branchName` to list a dev branch's files instead of the deploy branch's. | Read-only |
+| `readDataModelFile` | Reads one file's raw source. Pass `branchName` to read it from a dev branch instead of the deploy branch. | Read-only |
 | `startDataModelEdit` | Enters [development mode][ref-dev-mode], starts a dev worker, and returns the dev `branchName` that every write tool requires. | Write |
 | `writeDataModelFile` | Creates or overwrites a model source file on the dev branch (whole-file replacement). Recompiles the model and reports `valid` plus any `validationError`. | Destructive — prompts |
 | `deleteDataModelFile` | Deletes a model source file on the dev branch. | Destructive — prompts |
@@ -339,8 +373,8 @@ registered under the same semantic-model permission as the data model tools abov
 
 | Tool | Description | Access |
 | --- | --- | --- |
-| `getPreAggregationStatus` | Lists the data model's pre-aggregations with their definitions and, for each, how many partitions exist, how many were built, when the newest build landed, and the exact error if a build failed. | Read-only |
-| `buildPreAggregation` | Queues an on-demand build of one pre-aggregation and returns once it is accepted. The build runs asynchronously. | Write |
+| `getPreAggregationStatus` | Lists the data model's pre-aggregations with their definitions and, for each, how many partitions exist, how many were built, when the newest build landed, and the exact error if a build failed. Pass `branchName` to check a dev branch's pre-aggregations instead of the deployed model's. | Read-only |
+| `buildPreAggregation` | Queues an on-demand build of one pre-aggregation and returns once it is accepted. The build runs asynchronously. Pass `branchName` to build against a dev branch's definition. | Write |
 
 Together these close the loop on pre-aggregation work: a query alone cannot prove a rollup
 was used, and external pre-aggregations fail in configuration-specific ways — a missing

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -142,6 +142,32 @@ To change the order measures appear in within their group, drag them within
 the **Measures** pane on the **Pivot** tab. Position and order are saved with
 the exploration and survive **Refresh**.
 
+### Column totals
+
+The **Column totals** switch, below **Measure position** on the **Display** tab,
+appends a bold **Total** row at the bottom of the written range, with one value per
+measure column. It's disabled, with a tooltip explaining why, until the query has at
+least one measure.
+
+Each total is computed by a separate query rather than summed from the cells on the
+sheet, so it's correct for non-additive measures — an average totals to the average
+over the whole column, not an average of the visible rows, and the same for a
+count-distinct. With a dimension pivoted onto columns, each pivot column gets its own
+total the same way. [Calculations][ref-calculated-fields] based on window functions,
+such as running totals, are excluded — the same exclusion as Cube's own [row, column,
+and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
+
+Totals are computed over the query's full result, not just the rows visible on the
+sheet, so a row-limited query still totals the whole result. Measure filters are
+dropped from the totals query; dimension filters are kept. With measures on **Rows**
+and no row dimension, no totals row is written, since each "total" would just restate
+its own data row.
+
+Column totals are saved with the exploration and survive **Refresh**; with auto-run
+off, toggling the switch waits for **Run** like any other display change.
+
+{/* TODO: screenshot — a pivoted exploration with the Total row on the sheet */}
+
 When your exploration is ready, click **Save** to add it to your workspace. You
 can then [work with the exploration](#work-with-explorations) from the add-in.
 To discard an unsaved exploration instead, choose **Delete exploration** from
@@ -218,3 +244,4 @@ Saved explorations also appear in the Cube workspace. See
 [link-excel-addins]: https://support.microsoft.com/en-us/office/add-or-remove-add-ins-in-excel-0af570c4-5cf3-4fa9-9b88-403625a0b460
 [link-ms-appsource]: https://appsource.microsoft.com/en-us/product/office/WA200008486
 [ref-explorations]: /docs/explore-analyze/explore#saving-explorations
+[ref-calculated-fields]: /docs/explore-analyze/workbooks/calculated-fields

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -144,27 +144,29 @@ the exploration and survive **Refresh**.
 
 ### Column totals
 
-The **Column totals** switch, below **Measure position** on the **Display** tab,
-appends a bold **Total** row at the bottom of the written range, with one value per
-measure column. It's disabled, with a tooltip explaining why, until the query has at
-least one measure.
+The **Column totals** switch, below **Measure position** on the **Display**
+tab, appends a bold **Total** row at the bottom of the written range, with one
+value per measure column. It's disabled, with a tooltip explaining why, until
+the query has at least one measure.
 
-Each total is computed by a separate query rather than summed from the cells on the
-sheet, so it's correct for non-additive measures — an average totals to the average
-over the whole column, not an average of the visible rows, and the same for a
-count-distinct. With a dimension pivoted onto columns, each pivot column gets its own
-total the same way. [Calculations][ref-calculated-fields] based on window functions,
-such as running totals, are excluded — the same exclusion as Cube's own [row, column,
-and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
+Each total is computed by a separate query rather than summed from the cells
+on the sheet, so it's correct for non-additive measures — an average totals
+to the average over the whole column, not an average of the visible rows,
+and the same for a count-distinct. With a dimension pivoted onto columns,
+each pivot column gets its own total the same way.
+[Calculations][ref-calculated-fields] based on window functions, such as
+running totals, are excluded — the same exclusion as Cube's own [row,
+column, and pivot totals](/docs/explore-analyze/workbooks/querying-data#totals).
 
-Totals are computed over the query's full result, not just the rows visible on the
-sheet, so a row-limited query still totals the whole result. Measure filters are
-dropped from the totals query; dimension filters are kept. With measures on **Rows**
-and no row dimension, no totals row is written, since each "total" would just restate
-its own data row.
+Totals are computed over the query's full result, not just the rows visible
+on the sheet, so a row-limited query still totals the whole result. Measure
+filters are dropped from the totals query; dimension filters are kept. With
+measures on **Rows** and no row dimension, no totals row is written, since
+each "total" would just restate its own data row.
 
-Column totals are saved with the exploration and survive **Refresh**; with auto-run
-off, toggling the switch waits for **Run** like any other display change.
+Column totals are saved with the exploration and survive **Refresh**; with
+auto-run off, toggling the switch waits for **Run** like any other display
+change.
 
 {/* TODO: screenshot — a pivoted exploration with the Total row on the sheet */}
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -103,22 +103,27 @@ format. Reading the parameters works anywhere; it's the writing that is
 published-only. See [Controls → Sharing the current
 selection](/docs/explore-analyze/dashboards/widgets/controls#sharing-the-current-selection).
 
-## Allow chart export {#allow-csv-export}
+## Allow chart and dashboard export {#allow-csv-export}
 
 By default, embedded dashboards do not expose a download action on individual
-widgets. To let viewers download a chart widget as a **CSV**, **PNG**, or
-**PDF** file, add the `allowExport=true` query parameter to the embed URL:
+widgets or on the dashboard as a whole. To let viewers download a chart widget
+as a **CSV**, **PNG**, or **PDF** file, and download the **whole dashboard** as
+a **PNG** or **PDF**, add the `allowExport=true` query parameter to the embed
+URL:
 
 ```text
 https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&allowExport=true
 ```
 
 When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
-as PNG**, and **Download as PDF** actions. `allowExport` is the single switch
-for all three formats — there is no way to allow one format while blocking
-another. Only the exact literal string `true` opts in: `allowExport=1`,
-`allowExport=TRUE`, a bare `?allowExport`, and omitting the parameter (the
-default) all leave every download action hidden.
+as PNG**, and **Download as PDF** actions, and a dashboard-level ⋮ appears —
+docked in the header in creator mode, floating over the dashboard in the
+published-dashboard embed — with **Download as PNG** and **Download as PDF**
+for the whole dashboard. `allowExport` is the single switch for all of these —
+there is no way to allow one format, or only chart- or dashboard-level export,
+while blocking another. Only the exact literal string `true` opts in:
+`allowExport=1`, `allowExport=TRUE`, a bare `?allowExport`, and omitting the
+parameter (the default) all leave every download action hidden.
 
 The CSV is generated client-side from the data already loaded into the
 widget, so no additional query is issued. Inside an embed, `allowExport` —

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -117,13 +117,14 @@ https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?sessi
 
 When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
 as PNG**, and **Download as PDF** actions, and a dashboard-level ⋮ appears —
-docked in the header in [Creator Mode](/embedding/iframe/creator-mode), floating over the dashboard in the
-published-dashboard embed — with **Download as PNG** and **Download as PDF**
-for the whole dashboard. `allowExport` is the single switch for all of these —
-there is no way to allow one format while blocking another, or to allow
-chart-level export without dashboard-level export. Only the exact literal string `true` opts in:
-`allowExport=1`, `allowExport=TRUE`, a bare `?allowExport`, and omitting the
-parameter (the default) all leave every download action hidden.
+docked in the header in [Creator Mode](/embedding/iframe/creator-mode),
+floating over the dashboard in the published-dashboard embed — with **Download
+as PNG** and **Download as PDF** for the whole dashboard. `allowExport` is the
+single switch for all of these — there is no way to allow one format while
+blocking another, or to allow chart-level export without dashboard-level
+export. Only the exact literal string `true` opts in: `allowExport=1`,
+`allowExport=TRUE`, a bare `?allowExport`, and omitting the parameter (the
+default) all leave every download action hidden.
 
 The CSV is generated client-side from the data already loaded into the
 widget, so no additional query is issued. Inside an embed, `allowExport` —

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -117,11 +117,11 @@ https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?sessi
 
 When enabled, each chart widget's ⋮ menu shows **Download as CSV**, **Download
 as PNG**, and **Download as PDF** actions, and a dashboard-level ⋮ appears —
-docked in the header in creator mode, floating over the dashboard in the
+docked in the header in [Creator Mode](/embedding/iframe/creator-mode), floating over the dashboard in the
 published-dashboard embed — with **Download as PNG** and **Download as PDF**
 for the whole dashboard. `allowExport` is the single switch for all of these —
-there is no way to allow one format, or only chart- or dashboard-level export,
-while blocking another. Only the exact literal string `true` opts in:
+there is no way to allow one format while blocking another, or to allow
+chart-level export without dashboard-level export. Only the exact literal string `true` opts in:
 `allowExport=1`, `allowExport=TRUE`, a bare `?allowExport`, and omitting the
 parameter (the default) all leave every download action hidden.
 

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -211,10 +211,11 @@ the exported rows themselves.
 ```
 
 <Note>
-  A dashboard widget's download actions (CSV, PNG, PDF) only appear when the
-  embed URL includes `allowExport=true` (see [Dashboards → Allow chart
-  export](/embedding/iframe/dashboards#allow-csv-export)). The event fires when a
-  viewer uses one of them.
+  A dashboard's download actions — per-widget (CSV, PNG, PDF) and
+  whole-dashboard (PNG, PDF) — only appear when the embed URL includes
+  `allowExport=true` (see [Dashboards → Allow chart and dashboard
+  export](/embedding/iframe/dashboards#allow-csv-export)). The event fires
+  when a viewer uses one of them.
 </Note>
 
 #### `cube:event:drilldown` {#cube-event-drilldown}


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (n/a — docs only)
- [ ] Linter has been run for changed code (n/a — docs only)
- [ ] Tests for the changes have been added if not covered yet (n/a — docs only)

**Description of Changes Made**

Found while cross-checking recent Cube Cloud changes against docs-mintlify for undocumented customer-facing features:

- **Grid container widget** — a new dashboard layout container (children hold a fixed cell position/size, unlike a Stack's evenly-shared space) shipped alongside Spacer/Divider/Stack, but wasn't documented anywhere. Added a "Grid" section to `docs/explore-analyze/dashboards/widgets/layout.mdx` and updated the page title/description and the widgets index.
- **Whole-dashboard PNG/PDF export on embeds** — the same `allowExport=true` embed parameter that already enabled per-chart CSV/PNG/PDF downloads now also adds a dashboard-level export menu. Updated `embedding/iframe/dashboards.mdx`'s "Allow chart export" section (renamed to "Allow chart and dashboard export").
- **Dashboard Agent / Workbook Agent control support** — the published/embedded Dashboard Agent can now drive field switchers and parent controls (previously only filters/time granularity), and the Workbook Agent can now author parent controls and stack/grid containers. Updated `dashboard-agent.mdx` and `workbook-agent.mdx` accordingly — this also corrects an existing doc that said field switchers "aren't driven by the agent", which is no longer accurate.
- **MCP sessions can target a dev-mode branch** — connecting to the MCP endpoint with a branch name (or an `x-mcp-branch-name` header) scopes the whole session to that branch's un-deployed data model and agent configuration, and the per-call `branchName` argument used to exist only on `runQuery` — it's now also on `searchDataModel`, `chat`, and the pre-aggregation and data-model-read tools. Updated `docs/integrations/mcp-server.mdx` with a new "Target a dev-mode branch" section and corrected the tool tables/paragraphs that described `branchName` as a `runQuery`-only parameter.
- **Google Sheets / Excel add-in "Column totals"** — the Display tab's **Column totals** switch (a summary row totaling each measure column) wasn't documented. Added a "Column totals" section to both `docs/integrations/google-sheets.mdx` and `docs/integrations/microsoft-excel.mdx`.
- Addressed review feedback on the dashboard-agent and embedding pages: retitled a heading that undersold its own scope, fixed a sentence that didn't parse after an earlier edit, and fixed a product-term capitalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViDwvxeu4oSk7d7EDN4YV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViDwvxeu4oSk7d7EDN4YV7)_