### PR TITLE
fix(api-gateway): return 403 for RBAC member-level denials

### DIFF
--- a/docs-mintlify/docs/data-modeling/access-control/member-level-security.mdx
+++ b/docs-mintlify/docs/data-modeling/access-control/member-level-security.mdx
@@ -131,6 +131,11 @@ This configuration results in the following access:
 | `guest` | Only the `count_30d` measure |
 | All other users | No access to this view at all |
 
+Querying a member that a group has no access to is refused rather than silently
+ignored: the [REST][ref-rest-api] and [GraphQL][ref-graphql-api] APIs respond
+with `403 Forbidden`, naming the denied members the query asked for, and the
+[SQL API][ref-sql-api] returns an empty result.
+
 Access policies also respect member-level security restrictions configured via
 `public` parameters. For more details, see the [access policies
 reference][ref-dap-ref].
@@ -162,3 +167,6 @@ them entirely, see [data masking][ref-data-masking] in access policies.
 [ref-dynamic-data-modeling]: /docs/data-modeling/dynamic
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-data-masking]: /docs/data-modeling/data-access-policies#data-masking
+[ref-rest-api]: /reference/core-data-apis/rest-api
+[ref-graphql-api]: /reference/core-data-apis/graphql-api
+[ref-sql-api]: /reference/core-data-apis/sql-api

--- a/docs-mintlify/docs/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/docs/data-modeling/data-access-policies.mdx
@@ -111,8 +111,11 @@ every region granted by every matching policy:
 - **A member is masked** when no granting policy gives it unconditional full
   access through `member_level`, but some matching policy lists it under
   `member_masking`.
-- **Access is denied** (an empty result) only when a queried member is granted
-  by **no** matching policy at all.
+- **Access is denied** only when a queried member is granted by **no** matching
+  policy at all. The [REST API](/reference/core-data-apis/rest-api) and
+  [GraphQL API](/reference/core-data-apis/graphql-api) reject such a query with
+  `403 Forbidden`, naming the denied members it asked for; the
+  [SQL API](/reference/core-data-apis/sql-api) returns an empty result.
 
 #### Diagram and behavior
 

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1324,6 +1324,12 @@ class ApiGateway {
   /**
    * Convert incoming query parameter (JSON fetched from the HTTP) to
    * an array of query type and array of normalized queries.
+   *
+   * The last element lists the members an access policy refused member-level
+   * access to (empty when nothing was denied). Denied queries are still
+   * normalized — `applyRowLevelSecurity` neutralizes them with a `1 = 0`
+   * segment — so each API can decide whether that's an empty result (SQL API)
+   * or an error (data APIs, see `load`).
    */
   protected async getNormalizedQueries(
     inputQuery: Record<string, any> | Record<string, any>[],
@@ -1331,7 +1337,7 @@ class ApiGateway {
     persistent = false,
     memberExpressions: boolean = false,
     cacheMode?: CacheMode,
-  ): Promise<[QueryType, NormalizedQuery[], NormalizedQuery[]]> {
+  ): Promise<[QueryType, NormalizedQuery[], NormalizedQuery[], string[]]> {
     let query = this.parseQueryParam(inputQuery);
 
     let queryType: QueryType = QueryTypeEnum.REGULAR_QUERY;
@@ -1380,6 +1386,8 @@ class ApiGateway {
       };
     });
 
+    const deniedMembers = new Set<string>();
+
     let normalizedQueries: NormalizedQuery[] = await Promise.all(
       queryNormalizationResult.map(
         async ({ normalizedQuery, hasExpressionsInQuery }) => {
@@ -1392,11 +1400,16 @@ class ApiGateway {
           }
 
           // First apply cube/view level security policies
-          const { query: queryWithRlsFilters, denied } = await compilerApi.applyRowLevelSecurity(
+          const {
+            query: queryWithRlsFilters,
+            denied,
+            deniedMembers: queryDeniedMembers,
+          } = await compilerApi.applyRowLevelSecurity(
             normalizedQuery,
             evaluatedQuery,
             context
           );
+          (queryDeniedMembers || []).forEach((member: string) => deniedMembers.add(member));
           // Then apply user-supplied queryRewrite
           let rewrittenQuery = !denied ? await this.queryRewrite(
             queryWithRlsFilters,
@@ -1443,7 +1456,12 @@ class ApiGateway {
       }
     }
 
-    return [queryType, normalizedQueries, queryNormalizationResult.map((it) => remapToQueryAdapterFormat(it.normalizedQuery))];
+    return [
+      queryType,
+      normalizedQueries,
+      queryNormalizationResult.map((it) => remapToQueryAdapterFormat(it.normalizedQuery)),
+      Array.from(deniedMembers),
+    ];
   }
 
   protected async sql4sql({
@@ -2007,6 +2025,97 @@ class ApiGateway {
   }
 
   /**
+   * Collects the member names a request asked for, including the members
+   * referenced by its filters and the dimension behind a `dimension.granularity`
+   * path.
+   */
+  private requestedMemberNames(query: Query | Query[] | undefined): Set<string> {
+    const names = new Set<string>();
+
+    const addName = (member: unknown) => {
+      if (typeof member !== 'string') {
+        return;
+      }
+      names.add(member);
+      // `orders.created_at.month` references the `orders.created_at` dimension
+      const parts = member.split('.');
+      if (parts.length > 2) {
+        names.add(parts.slice(0, 2).join('.'));
+      }
+    };
+
+    const addFilters = (filters: any[] | undefined) => {
+      for (const filter of filters || []) {
+        if (filter?.and || filter?.or) {
+          addFilters(filter.and || filter.or);
+        } else {
+          addName(filter?.member || filter?.dimension);
+        }
+      }
+    };
+
+    const queries = (Array.isArray(query) ? query : [query]).filter(Boolean) as Query[];
+
+    for (const currentQuery of queries) {
+      (currentQuery.measures || []).forEach(addName);
+      (currentQuery.dimensions || []).forEach(addName);
+      (currentQuery.segments || []).forEach(addName);
+      (currentQuery.timeDimensions || []).forEach((td: any) => addName(td?.dimension));
+      addFilters(currentQuery.filters);
+    }
+
+    return names;
+  }
+
+  /**
+   * Fails the request when an access policy denied member-level access to any
+   * of the queried members.
+   *
+   * Such a query is not a server fault and must not be answered with the data
+   * it asks for, so it's reported as `403 Forbidden` rather than surfacing later
+   * as an internal error while the (deliberately empty) result is transformed.
+   *
+   * The message names the denied members the request itself asked for — the
+   * caller supplied those names, and a member that doesn't exist already fails
+   * differently (`400`, "not found for path"), so withholding them would hide
+   * nothing while making a denial hard to act on. Policies are evaluated over
+   * the members the generated SQL touches, though, which pulls in members the
+   * caller never named (a cube's primary key, for one); those are logged only.
+   *
+   * Dev mode is left alone: it doesn't enforce security checks, so a request
+   * without a token — the playground's normal state — carries no security
+   * context, resolves to no groups, and is therefore denied by every policy.
+   * Failing those would break the playground for any model using access
+   * policies, so the denial is only logged there.
+   */
+  protected assertMemberAccess(deniedMembers: string[], query: Query | Query[] | undefined, context: RequestContext) {
+    if (!deniedMembers.length) {
+      return;
+    }
+
+    this.log({
+      type: 'Access Policy Denied',
+      query,
+      deniedMembers,
+    }, context);
+
+    if (getEnv('devMode')) {
+      return;
+    }
+
+    const requested = this.requestedMemberNames(query);
+    const reportableMembers = deniedMembers.filter(member => requested.has(member)).sort();
+
+    throw new CubejsHandlerError(
+      403,
+      'Forbidden',
+      reportableMembers.length
+        ? `Access to the following members is denied by an access policy: ${reportableMembers.join(', ')}`
+        : 'Access to some of the requested members is denied by an access policy'
+    );
+  }
+
+  /**
    * Data queries APIs (`/load`, `/subscribe`) entry point. Used by
    * `CubejsApi#load` and `CubejsApi#subscribe` methods to fetch the
    * data.
@@ -2038,8 +2147,10 @@ class ApiGateway {
         query
       }, context);
 
-      const [queryType, normalizedQueries] =
+      const [queryType, normalizedQueries, , deniedMembers] =
         await this.getNormalizedQueries(query, context, false, false, cacheMode);
+
+      this.assertMemberAccess(deniedMembers, query, context);
 
       if (
         queryType !== QueryTypeEnum.REGULAR_QUERY &&

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -13,6 +13,7 @@ import {
   preAggregationsResultFactory,
   preAggregationPartitionsResultFactory,
   compilerApi,
+  compilerApiWithAccessDenied,
   RefreshSchedulerMock,
   DataSourceStorageMock,
   AdapterApiMock
@@ -49,11 +50,12 @@ const API_SECRET = 'secret';
 async function createApiGateway(
   adapterApi: any = new AdapterApiMock(),
   dataSourceStorage: any = new DataSourceStorageMock(),
-  options: Partial<ApiGatewayOptions> = {}
+  options: Partial<ApiGatewayOptions> = {},
+  compilerApiMock: any = compilerApi
 ) {
   process.env.NODE_ENV = 'production';
 
-  const apiGateway = new ApiGateway(API_SECRET, compilerApi, async () => adapterApi, logger, {
+  const apiGateway = new ApiGateway(API_SECRET, compilerApiMock, async () => adapterApi, logger, {
     standalone: true,
     dataSourceStorage,
     basePath: '/cubejs-api',
@@ -151,6 +153,84 @@ describe('API Gateway', () => {
 
     expect(res.body && res.body.error).toStrictEqual(
       'Query should contain either measures, dimensions or timeDimensions with granularities in order to be valid'
+    );
+  });
+
+  test('access policy denial responds with 403 naming the requested members', async () => {
+    const { app } = await createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {},
+      compilerApiWithAccessDenied(['Foo.bar'])
+    );
+
+    const res = await request(app)
+      .get('/cubejs-api/v1/load?query={"measures":["Foo.bar"]}')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(403);
+
+    expect(res.body && res.body.error).toStrictEqual(
+      'Access to the following members is denied by an access policy: Foo.bar'
+    );
+  });
+
+  test('access policy denial names a member requested through a filter', async () => {
+    const { app } = await createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {},
+      compilerApiWithAccessDenied(['Foo.id'])
+    );
+
+    const res = await request(app)
+      .get(
+        '/cubejs-api/v1/load?query={"measures":["Foo.bar"],"filters":[{"member":"Foo.id","operator":"equals","values":["1"]}]}'
+      )
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(403);
+
+    expect(res.body && res.body.error).toStrictEqual(
+      'Access to the following members is denied by an access policy: Foo.id'
+    );
+  });
+
+  test('access policy denial keeps members the request never asked for out of the response', async () => {
+    const { app } = await createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {},
+      // Denied because SQL generation pulls the primary key in, not because the caller asked for it
+      compilerApiWithAccessDenied(['Foo.id'])
+    );
+
+    const res = await request(app)
+      .get('/cubejs-api/v1/load?query={"measures":["Foo.bar"]}')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(403);
+
+    expect(res.body && res.body.error).toStrictEqual(
+      'Access to some of the requested members is denied by an access policy'
+    );
+    expect(JSON.stringify(res.body)).not.toContain('Foo.id');
+  });
+
+  test('access policy denial responds with 403 on POST /load too', async () => {
+    const { app } = await createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {},
+      compilerApiWithAccessDenied(['Foo.bar'])
+    );
+
+    const res = await request(app)
+      .post('/cubejs-api/v1/load')
+      .set('Content-type', 'application/json')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .send({ query: { measures: ['Foo.bar'] } })
+      .expect(403);
+
+    expect(res.body && res.body.error).toStrictEqual(
+      'Access to the following members is denied by an access policy: Foo.bar'
     );
   });
 

--- a/packages/cubejs-api-gateway/test/mocks.ts
+++ b/packages/cubejs-api-gateway/test/mocks.ts
@@ -268,6 +268,20 @@ export const compilerApi = jest.fn().mockImplementation(async () => ({
   },
 }));
 
+/**
+ * Compiler API whose access policies deny member-level access to `deniedMembers`,
+ * mirroring what `CompilerApi.applyRowLevelSecurity` returns for an RBAC denial:
+ * the query is neutralized with a `1 = 0` segment and the denied members are
+ * reported back to the gateway.
+ */
+export const compilerApiWithAccessDenied = (deniedMembers: string[]) => jest.fn().mockImplementation(async () => ({
+  ...(await compilerApi()),
+
+  async applyRowLevelSecurity(query: any) {
+    return { query, denied: true, deniedMembers };
+  },
+}));
+
 export class RefreshSchedulerMock {
   public async preAggregationPartitions() {
     return preAggregationPartitionsResultFactory();

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -53,6 +53,20 @@ export interface CompilerApiOptions {
   allowNodeRequire?: boolean;
 }
 
+/**
+ * Outcome of evaluating access policies against a query.
+ *
+ * `denied` means member-level access was refused: at least one queried member
+ * is granted by no applicable policy. `deniedMembers` lists those members so
+ * the denial can be logged server-side — it must not be echoed back to the
+ * caller, who isn't allowed to know the members exist.
+ */
+export interface RowLevelSecurityResult {
+  query: NormalizedQuery;
+  denied: boolean;
+  deniedMembers: string[];
+}
+
 export interface GetSqlOptions {
   includeDebugInfo?: boolean;
   exportAnnotatedSql?: boolean;
@@ -489,12 +503,12 @@ export class CompilerApi {
     query: NormalizedQuery,
     evaluatedQuery: NormalizedQuery,
     context: Context
-  ): Promise<{ query: NormalizedQuery; denied: boolean }> {
+  ): Promise<RowLevelSecurityResult> {
     const compilers = await this.getCompilers({ requestId: context.requestId });
     const { cubeEvaluator } = compilers;
 
     if (!cubeEvaluator.isRbacEnabled()) {
-      return { query, denied: false };
+      return { query, denied: false, deniedMembers: [] };
     }
 
     // Get the SQL to extract member names from the query
@@ -682,17 +696,28 @@ export class CompilerApi {
         // SQL renders CASE WHEN {rowFilter} THEN {value} ELSE {mask} END.
         const memberRowConstraints: any[] = [];
         const seenRowConstraints = new Set<string>();
-        let cubeAccessDenied = false;
+
+        // Members no policy grants at all. Collected up front (rather than
+        // bailing on the first one) so callers can report every denied member
+        // of the cube instead of a single arbitrary one.
+        const deniedMembers = cubeMembersInQuery.filter(
+          (memberName) => !userPolicies.some((policy: any) => policyGrantsMember(policy, memberName))
+        );
+
+        if (deniedMembers.length > 0) {
+          query.segments = query.segments || [];
+          query.segments.push({
+            expression: () => '1 = 0',
+            cubeName: cube.name,
+            name: 'rlsAccessDenied',
+          } as unknown as MemberExpression);
+          return { query, denied: true, deniedMembers };
+        }
 
         for (const memberName of cubeMembersInQuery) {
           const grantingPolicies = userPolicies.filter(
             (policy: any) => policyGrantsMember(policy, memberName)
           );
-
-          if (grantingPolicies.length === 0) {
-            cubeAccessDenied = true;
-            break;
-          }
 
           const hasUnconditionalFullAccess = grantingPolicies.some((policy: any) => {
             const inFullAccess = !policy.memberLevel ||
@@ -746,16 +771,6 @@ export class CompilerApi {
           }
         }
 
-        if (cubeAccessDenied) {
-          query.segments = query.segments || [];
-          query.segments.push({
-            expression: () => '1 = 0',
-            cubeName: cube.name,
-            name: 'rlsAccessDenied',
-          } as unknown as MemberExpression);
-          return { query, denied: true };
-        }
-
         if (memberRowConstraints.length > 0) {
           rlsConstraints.push(
             memberRowConstraints.length === 1
@@ -795,7 +810,7 @@ export class CompilerApi {
         filter: memberMaskFiltersMap[member],
       }));
     }
-    return { query, denied: false };
+    return { query, denied: false, deniedMembers: [] };
   }
 
   protected filterMemberName(filter: any): string | undefined {

--- a/packages/cubejs-server-core/test/unit/CompilerApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/CompilerApi.test.ts
@@ -106,4 +106,136 @@ describe('CompilerApi', () => {
       expect(() => compilers.cubeEvaluator).toThrow(/disposed CompilerApi instance/);
     });
   });
+
+  describe('applyRowLevelSecurity', () => {
+    let compilerApi: CompilerApi;
+
+    // `analyst` may read `count` and `status`; `secret` and `other_secret` are
+    // granted by no policy, so querying them is a member-level denial. `id` is
+    // granted too: policies are checked against the members the generated SQL
+    // references, which includes the cube's primary key.
+    const rbacRepository: SchemaFileRepository = {
+      localPath: () => '/mock/path',
+      dataSchemaFiles: () => Promise.resolve([
+        {
+          fileName: 'orders.js',
+          content: `
+            cube('orders', {
+              sql: 'SELECT * FROM orders',
+              measures: {
+                count: {
+                  type: 'count'
+                }
+              },
+              dimensions: {
+                id: {
+                  sql: 'id',
+                  type: 'number',
+                  primaryKey: true
+                },
+                status: {
+                  sql: 'status',
+                  type: 'string'
+                },
+                secret: {
+                  sql: 'secret',
+                  type: 'string'
+                },
+                other_secret: {
+                  sql: 'other_secret',
+                  type: 'string'
+                }
+              },
+              accessPolicy: [
+                {
+                  group: 'analyst',
+                  memberLevel: {
+                    includes: ['count', 'status', 'id']
+                  }
+                }
+              ]
+            });
+          `
+        }
+      ])
+    };
+
+    const analystContext = {
+      requestId: 'test-request',
+      securityContext: { groups: ['analyst'] },
+    };
+
+    beforeEach(() => {
+      compilerApi = new CompilerApi(
+        rbacRepository,
+        async () => 'postgres',
+        {
+          logger: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+          contextToGroups: (context: any) => context.securityContext?.groups || [],
+        }
+      );
+    });
+
+    afterEach(() => {
+      if (compilerApi) {
+        compilerApi.dispose();
+      }
+    });
+
+    test('allows a query that every member is granted for', async () => {
+      const query: any = {
+        measures: ['orders.count'],
+        dimensions: ['orders.status'],
+        timezone: 'UTC',
+        filters: [],
+      };
+
+      const result = await compilerApi.applyRowLevelSecurity(query, query, analystContext);
+
+      expect(result.denied).toBe(false);
+      expect(result.deniedMembers).toEqual([]);
+    });
+
+    test('denies a query and reports every member no policy grants', async () => {
+      const query: any = {
+        measures: ['orders.count'],
+        dimensions: ['orders.secret', 'orders.other_secret'],
+        timezone: 'UTC',
+        filters: [],
+      };
+
+      const result = await compilerApi.applyRowLevelSecurity(query, query, analystContext);
+
+      expect(result.denied).toBe(true);
+      // Both denied members are reported, not just the first one encountered
+      expect(result.deniedMembers).toEqual(
+        expect.arrayContaining(['orders.secret', 'orders.other_secret'])
+      );
+      // Granted members are not reported as denied
+      expect(result.deniedMembers).not.toContain('orders.count');
+      // The query is neutralized so an API that keeps serving it returns no rows
+      expect(result.query.segments).toContainEqual(
+        expect.objectContaining({ name: 'rlsAccessDenied', cubeName: 'orders' })
+      );
+    });
+
+    test('denies every member when no policy matches the user at all', async () => {
+      const query: any = {
+        measures: ['orders.count'],
+        dimensions: ['orders.status'],
+        timezone: 'UTC',
+        filters: [],
+      };
+
+      const result = await compilerApi.applyRowLevelSecurity(query, query, {
+        requestId: 'test-request',
+        securityContext: { groups: ['nobody'] },
+      });
+
+      expect(result.denied).toBe(true);
+      expect(result.deniedMembers).toEqual(
+        expect.arrayContaining(['orders.count', 'orders.status'])
+      );
+    });
+  });
 });

--- a/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
@@ -10,6 +10,11 @@ import {
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
 } from './smoke-tests';
 
+// Member-level denials are refused up front by the API gateway, so the response
+// carries a policy error naming the denied members instead of the
+// post-execution "hidden member" error.
+const ACCESS_DENIED_ERROR = 'denied by an access policy';
+
 describe('GraphQL Schema Caching and RBAC', () => {
   jest.setTimeout(60 * 5 * 1000);
   let birdbox: BirdBox;
@@ -84,7 +89,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
       }
     }`);
     expect(restrictedResult.errors).toBeDefined();
-    expect(restrictedResult.errors[0].message).toContain('You requested hidden member');
+    expect(restrictedResult.errors[0].message).toContain(ACCESS_DENIED_ERROR);
   });
 
   test('tenant-b can query tier but not internalCode', async () => {
@@ -103,7 +108,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
       }
     }`);
     expect(restrictedResult.errors).toBeDefined();
-    expect(restrictedResult.errors[0].message).toContain('You requested hidden member');
+    expect(restrictedResult.errors[0].message).toContain(ACCESS_DENIED_ERROR);
   });
 
   test('default group cannot query any fields - complete denial returns errors', async () => {
@@ -113,7 +118,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
       }
     }`);
     expect(result1.errors).toBeDefined();
-    expect(result1.errors[0].message).toContain('You requested hidden member');
+    expect(result1.errors[0].message).toContain(ACCESS_DENIED_ERROR);
 
     const result2 = await graphqlRequest('default', `{
       cube(where: { orders: {} }) {
@@ -121,7 +126,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
       }
     }`);
     expect(result2.errors).toBeDefined();
-    expect(result2.errors[0].message).toContain('You requested hidden member');
+    expect(result2.errors[0].message).toContain(ACCESS_DENIED_ERROR);
 
     const result3 = await graphqlRequest('default', `{
       cube(where: { orders: {} }) {
@@ -129,6 +134,6 @@ describe('GraphQL Schema Caching and RBAC', () => {
       }
     }`);
     expect(result3.errors).toBeDefined();
-    expect(result3.errors[0].message).toContain('You requested hidden member');
+    expect(result3.errors[0].message).toContain(ACCESS_DENIED_ERROR);
   });
 });

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -51,6 +51,11 @@ async function createPostgresClient(user: string, password: string) {
   return conn;
 }
 
+// Member-level denials are refused up front by the API gateway (HTTP 403), so the
+// response carries a policy error naming the denied members instead of the
+// post-execution "hidden member" error.
+const ACCESS_DENIED_ERROR = 'denied by an access policy';
+
 describe('Cube RBAC Engine', () => {
   jest.setTimeout(60 * 5 * 1000);
   let db: StartedTestContainer;
@@ -1422,12 +1427,18 @@ describe('Cube RBAC Engine', () => {
         },
       };
       let error = '';
+      let status: number | undefined;
       try {
         await client.load(query, {});
       } catch (e: any) {
         error = e.toString();
+        status = e.status;
       }
-      expect(error).toContain('You requested hidden member');
+      // A policy denial is an authorization failure, not a server fault
+      expect(status).toBe(403);
+      expect(error).toContain(ACCESS_DENIED_ERROR);
+      // The denied member the caller asked for is named, so the denial is actionable
+      expect(error).toContain('line_items.price_dim');
 
       query = {
         measures: ['line_items_view_no_policy.count'],
@@ -1443,14 +1454,18 @@ describe('Cube RBAC Engine', () => {
 
     test('orders_view and cube with default policy', async () => {
       let error = '';
+      let status: number | undefined;
       try {
         await defaultClient.load({
           measures: ['orders.count'],
         });
       } catch (e: any) {
         error = e.toString();
+        status = e.status;
       }
-      expect(error).toContain('You requested hidden member');
+      expect(status).toBe(403);
+      expect(error).toContain(ACCESS_DENIED_ERROR);
+      expect(error).toContain('orders.count');
 
       error = '';
       try {
@@ -1464,7 +1479,7 @@ describe('Cube RBAC Engine', () => {
       } catch (e: any) {
         error = e.toString();
       }
-      expect(error).toContain('You requested hidden member');
+      expect(error).toContain(ACCESS_DENIED_ERROR);
 
       const result = await defaultClient.load({
         measures: ['orders_open.count'],


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #11769

**Description of Changes Made**

A query that an access policy denies member-level access to was still executed. It came back with no rows and then failed while the result was transformed, with ``You requested hidden member: 'orders_view.status'. Please make it visible using `public: true`...``, surfaced to the caller as **HTTP 500**.

Two problems from the issue: an authorization failure is reported as a server fault, and the guidance tells the operator to set `public: true`, which would weaken the very policy that did the denying.

`CompilerApi.applyRowLevelSecurity` already detects the denial **before** execution — it neutralizes the query with a `1 = 0` segment — so the information needed to answer correctly was there all along, just not propagated. This PR follows the issue's preferred fix (evaluate member access in JS before execution and throw a typed error):

- `applyRowLevelSecurity` now returns `deniedMembers` alongside `denied`, collecting every member no policy grants rather than bailing on the first one.
- `ApiGateway.getNormalizedQueries` propagates those members to its callers.
- `ApiGateway.load` — the data-API entry point shared by REST, GraphQL and subscriptions — rejects a denied query with `403 Forbidden` and a message naming the denied members: `Access to the following members is denied by an access policy: orders_view.status`.

On the third point in the issue (the restricted member name being disclosed): the response names the denied members that **the request itself asked for**. The caller supplied those names, and a member that doesn't exist already fails differently — `400`, ``"'foo' not found for path 'orders.foo'"`` — so existence is disclosed by the status code either way. Withholding the names would hide nothing while making a denial on a many-membered query hard to act on. Policies are evaluated over the members the generated SQL touches, which pulls in members the caller never named (a cube's primary key, for one); those are filtered out of the message and logged server-side (`Access Policy Denied`) instead.

Deliberately unchanged:

- **SQL API** keeps its empty-result semantics for denials (`sqlApiLoad`/`stream` ignore the new flag), so the existing two-dimensional policy-overlap behavior is untouched.
- **Members hidden by `public: false` outside of RBAC** keep the existing message — there the `public: true` advice is the correct guidance, so the Rust-side check in `query_result_transform.rs` is left alone.

**Dev mode is deliberately left as it was.** It doesn't enforce security checks (`enforceSecurityChecks` is false outside `NODE_ENV=production`), so a request without a token — the playground's normal state — carries no security context, resolves to no groups, and is therefore denied by *every* policy. Returning 403 there would break the playground for any model using access policies, so the denial is only logged in dev mode.

That does leave a related wart untouched: in dev mode the neutralized query is served as `[{"products.count": "0"}]`, because the `1 = 0` segment turns a policy denial into a row that reads as a legitimate answer. It's out of scope here, but happy to follow up separately if you'd like it addressed.

**Tests**

- `packages/cubejs-server-core/test/unit/CompilerApi.test.ts` — new `applyRowLevelSecurity` unit tests: an allowed query is not denied, a denied query reports *every* ungranted member (not just the first) and is neutralized with the `rlsAccessDenied` segment, and a user matched by no policy at all is denied.
- `packages/cubejs-api-gateway/test/index.test.ts` — `/load` (GET and POST) returns 403 naming the denied member, a member denied via a filter is named too, and a member the request never asked for is kept out of the response body.
- `packages/cubejs-testing/test/smoke-rbac.test.ts` and `smoke-rbac-graphql.test.ts` — updated to the new error, plus assertions that the response status is `403` and that the denied member is named. The dev-mode tests are unchanged.

Ran locally, all green: `cubejs-server-core` 92/92, `cubejs-api-gateway` 239/239, `smoke-rbac-graphql` 4/4, and `smoke-rbac` 91/94 against a birdbox built from this branch. The 3 remaining `smoke-rbac` failures are all `[Python config]` blocks failing to boot on a fallback build of the native extension ("Unable to load Python configuration because you are using the fallback build of native extension"), unrelated to this change. eslint clean on all changed files.

**Docs**

- `docs/data-modeling/data-access-policies.mdx` — the "Access is denied (an empty result)" bullet now states the actual per-API behavior.
- `docs/data-modeling/access-control/member-level-security.mdx` — short note on what a caller gets when querying a member their group has no access to.
