### PR TITLE
feat: Support named ESM exports across all drivers

### DIFF
--- a/packages/cubejs-athena-driver/package.json
+++ b/packages/cubejs-athena-driver/package.json
@@ -27,6 +27,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@aws-sdk/client-athena": "^3.22.0",

--- a/packages/cubejs-bigquery-driver/package.json
+++ b/packages/cubejs-bigquery-driver/package.json
@@ -27,6 +27,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@cubejs-backend/base-driver": "1.7.36",

--- a/packages/cubejs-clickhouse-driver/package.json
+++ b/packages/cubejs-clickhouse-driver/package.json
@@ -17,6 +17,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-crate-driver/package.json
+++ b/packages/cubejs-crate-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -17,6 +17,15 @@
     "dist/codegen/*"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-dremio-driver/driver/DremioDriver.js
+++ b/packages/cubejs-dremio-driver/driver/DremioDriver.js
@@ -276,4 +276,5 @@ class DremioDriver extends BaseDriver {
 }
 
 module.exports = DremioDriver;
+module.exports.DremioDriver = DremioDriver;
 module.exports.applyParams = applyParams;

--- a/packages/cubejs-druid-driver/src/index.ts
+++ b/packages/cubejs-druid-driver/src/index.ts
@@ -1,3 +1,4 @@
 import { DruidDriver } from './DruidDriver';
 
 export default DruidDriver;
+export { DruidDriver };

--- a/packages/cubejs-duckdb-driver/package.json
+++ b/packages/cubejs-duckdb-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-firebolt-driver/package.json
+++ b/packages/cubejs-firebolt-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-hive-driver/src/HiveDriver.js
+++ b/packages/cubejs-hive-driver/src/HiveDriver.js
@@ -222,3 +222,4 @@ class HiveDriver extends BaseDriver {
 }
 
 module.exports = HiveDriver;
+module.exports.HiveDriver = HiveDriver;

--- a/packages/cubejs-jdbc-driver/package.json
+++ b/packages/cubejs-jdbc-driver/package.json
@@ -12,6 +12,15 @@
     "node": ">=20.0.0"
   },
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-ksql-driver/package.json
+++ b/packages/cubejs-ksql-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-materialize-driver/package.json
+++ b/packages/cubejs-materialize-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-mssql-driver/package.json
+++ b/packages/cubejs-mssql-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-mysql-aurora-serverless-driver/driver/AuroraServerlessMySqlDriver.js
+++ b/packages/cubejs-mysql-aurora-serverless-driver/driver/AuroraServerlessMySqlDriver.js
@@ -197,3 +197,4 @@ class AuroraServerlessMySqlDriver extends BaseDriver {
 }
 
 module.exports = AuroraServerlessMySqlDriver;
+module.exports.AuroraServerlessMySqlDriver = AuroraServerlessMySqlDriver;

--- a/packages/cubejs-mysql-driver/package.json
+++ b/packages/cubejs-mysql-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-oracle-driver/driver/OracleDriver.js
+++ b/packages/cubejs-oracle-driver/driver/OracleDriver.js
@@ -278,3 +278,4 @@ class OracleDriver extends BaseDriver {
 }
 
 module.exports = OracleDriver;
+module.exports.OracleDriver = OracleDriver;

--- a/packages/cubejs-pinot-driver/package.json
+++ b/packages/cubejs-pinot-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-questdb-driver/package.json
+++ b/packages/cubejs-questdb-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-redshift-driver/package.json
+++ b/packages/cubejs-redshift-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-snowflake-driver/package.json
+++ b/packages/cubejs-snowflake-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-sqlite-driver/driver/SqliteDriver.js
+++ b/packages/cubejs-sqlite-driver/driver/SqliteDriver.js
@@ -118,3 +118,4 @@ class SqliteDriver extends BaseDriver {
 }
 
 module.exports = SqliteDriver;
+module.exports.SqliteDriver = SqliteDriver;

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -16,6 +16,15 @@
     "index.js"
   ],
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npm run tsc",

--- a/packages/cubejs-vertica-driver/src/VerticaDriver.js
+++ b/packages/cubejs-vertica-driver/src/VerticaDriver.js
@@ -111,3 +111,4 @@ class VerticaDriver extends BaseDriver {
 }
 
 module.exports = VerticaDriver;
+module.exports.VerticaDriver = VerticaDriver;


### PR DESCRIPTION
`import { PostgresDriver } from '@cubejs-backend/postgres-driver'` threw `does not provide an export named 'PostgresDriver'`. Node discovers a CJS module's named exports with cjs-module-lexer, a static source scan, and the hand-written root `index.js` shim hides them behind a runtime loop:

    const toExport = PostgresDriver;
    for (const [key, module] of Object.entries(fromExports)) {
      toExport[key] = module;
    }
    module.exports = toExport;

so ESM saw only a synthetic `default`. 27 of the 28 drivers in DriverDependencies were affected, in three shapes:

| Shape | Packages | Change |
| --- | --- | --- |
| Root `index.js` shim (TS) | 20 | `exports` map routing `import` at the tsc output | | `main` at dist, no named re-export | 1 (druid) | `export { DruidDriver };` | | Plain JS, bare `module.exports = Class` | 6 | `module.exports.XDriver = XDriver;` | | Already correct | 1 (databricks-jdbc) | none |

The tsc-emitted `dist/src/index.js` is already lexer-friendly, so the 20 shim drivers need no wrapper file — only a conditional `exports` map, matching the shape cubejs-client-core already uses. The plain-JS one-liner is the idiom DremioDriver.js already used for `applyParams`.

CommonJS still resolves to the same `index.js`, and both conditions load one underlying module instance, so `require(pkg) === (await import(pkg)).XDriver` continues to hold.

Note: on the 20 shim drivers `import X from '@cubejs-backend/x-driver'` now yields the module namespace rather than the driver class, because Node always sets a CJS module's ESM `default` to `module.exports` and ignores `__esModule`. This is not treated as a breaking change: the ESM surface of these packages was not usable before — no export could be imported by name, and the class only arrived as `default` as a side effect of the shim assigning it to `module.exports`, never as a designed entry point. Nothing in the repo or the docs imports a driver that way; every documented sample uses `require`, which is unaffected. Named imports are now the one consistent path across all 28 drivers.

Extension-less deep imports (`.../dist/src/PostgresDriver`) also stop resolving now that subpaths are explicit; `./dist/*` keeps the extension-ful form working, and nothing in the repo, docs, or examples deep-imports a driver.

Verified by probing every driver in its own subprocess, deriving the expected class name from CommonJS and asserting ESM exposes the same object: 27 of 28 packages fail before this change, all 28 pass after.