### PR TITLE
refactor(cubejs-cli): remove all create templates except docker

### DIFF
--- a/packages/cubejs-cli/src/command/create.ts
+++ b/packages/cubejs-cli/src/command/create.ts
@@ -22,8 +22,7 @@ const logStage = (stage) => {
 };
 
 const create = async (projectName, options) => {
-  options.template = options.template || 'docker';
-  const createAppOptions = { projectName, dbType: options.dbType, template: options.template };
+  const createAppOptions = { projectName, dbType: options.dbType, template: 'docker' };
 
   event({
     event: 'Create App',
@@ -39,13 +38,7 @@ const create = async (projectName, options) => {
     );
   }
 
-  if (!templates[options.template]) {
-    await displayError(
-      `Unknown template ${chalk.red(options.template)}`,
-      createAppOptions
-    );
-  }
-  const templateConfig = templates[options.template];
+  const templateConfig = templates.docker;
 
   await fs.ensureDir(projectName);
   process.chdir(projectName);
@@ -58,12 +51,12 @@ const create = async (projectName, options) => {
     version: '0.0.1',
     private: true,
     scripts: templateConfig.scripts,
-    template: options.template,
+    template: 'docker',
     templateVersion: cliManifest.version,
   });
 
   logStage('Installing server dependencies');
-  await npmInstall(['@cubejs-backend/server'], options.template === 'docker');
+  await npmInstall(['@cubejs-backend/server'], true);
 
   if (!options.dbType) {
     const Drivers = requireFromPackage<any>('@cubejs-backend/server-core/dist/src/core/DriverDependencies.js');
@@ -85,7 +78,7 @@ const create = async (projectName, options) => {
     await displayError(`Unsupported db type: ${chalk.green(options.dbType)}`, createAppOptions);
   }
 
-  await npmInstall([driverPackageName], options.template === 'docker');
+  await npmInstall([driverPackageName], true);
 
   if (driverPackageName === '@cubejs-backend/jdbc-driver') {
     logStage('Installing JDBC dependencies');
@@ -137,7 +130,6 @@ const create = async (projectName, options) => {
   const env = {
     dbType: options.dbType,
     apiSecret: crypto.randomBytes(64).toString('hex'),
-    projectName,
     dockerVersion: `v${dockerVersion.version}`,
     driverEnvVariables: driverClass.driverEnvVariables && driverClass.driverEnvVariables()
   };
@@ -146,16 +138,6 @@ const create = async (projectName, options) => {
     await fs.ensureDir(path.dirname(fileName));
     await fs.writeFile(fileName, templateConfig.files[fileName](env));
   }));
-
-  if (templateConfig.dependencies) {
-    logStage('Installing template dependencies');
-    await npmInstall(templateConfig.dependencies);
-  }
-
-  if (templateConfig.devDependencies) {
-    logStage('Installing template dev dependencies');
-    await npmInstall(templateConfig.devDependencies);
-  }
 
   await event({
     event: 'Create App Success',
@@ -180,10 +162,6 @@ export function configureCreateCommand(program: CommanderStatic) {
       '-d, --db-type <db-type>',
       'Preconfigure for selected database.\n\t\t\t     ' +
       'Options: postgres, mysql, mongobi, athena, redshift, bigquery, mssql, clickhouse, snowflake, presto, questdb, materialize, firebolt'
-    )
-    .option(
-      '-t, --template <template>',
-      'App template. Options: docker (default), express, serverless, serverless-google.'
     )
     .description('Create new Cube app')
     .action(

--- a/packages/cubejs-cli/src/command/create.ts
+++ b/packages/cubejs-cli/src/command/create.ts
@@ -10,7 +10,7 @@ import {
   displayError,
   executeCommand, findMaxVersion,
   loadCliManifest,
-  npmInstall,
+  npmInstallDev,
   writePackageJson,
   event,
 } from '../utils';
@@ -55,8 +55,10 @@ const create = async (projectName, options) => {
     templateVersion: cliManifest.version,
   });
 
+  // The official Docker image bundles the Cube packages and docker-compose masks
+  // node_modules/@cubejs-backend/, so these are only installed for local tooling.
   logStage('Installing server dependencies');
-  await npmInstall(['@cubejs-backend/server'], true);
+  await npmInstallDev(['@cubejs-backend/server']);
 
   if (!options.dbType) {
     const Drivers = requireFromPackage<any>('@cubejs-backend/server-core/dist/src/core/DriverDependencies.js');
@@ -78,7 +80,7 @@ const create = async (projectName, options) => {
     await displayError(`Unsupported db type: ${chalk.green(options.dbType)}`, createAppOptions);
   }
 
-  await npmInstall([driverPackageName], true);
+  await npmInstallDev([driverPackageName]);
 
   if (driverPackageName === '@cubejs-backend/jdbc-driver') {
     logStage('Installing JDBC dependencies');

--- a/packages/cubejs-cli/src/templates.ts
+++ b/packages/cubejs-cli/src/templates.ts
@@ -1,7 +1,6 @@
 export type TemplateFileContext = {
   dbType: string,
   apiSecret: string,
-  projectName: string,
   dockerVersion: string,
   driverEnvVariables?: string[],
 };
@@ -9,30 +8,7 @@ export type TemplateFileContext = {
 export type Template = {
   scripts: Record<string, string>,
   files: Record<string, (ctx: TemplateFileContext) => string>,
-  dependencies?: string[],
-  devDependencies?: string[],
 };
-
-/**
- * @deprecated
- */
-const indexJs = `const CubejsServer = require('@cubejs-backend/server');
-
-const server = new CubejsServer();
-
-server.listen().then(({ version, port }) => {
-  console.log(\`🚀 Cube server (\${version}) is listening on \${port}\`);
-}).catch(e => {
-  console.error('Fatal error during server start: ');
-  console.error(e.stack || e);
-});
-`;
-
-/**
- * @deprecated
- */
-const handlerJs = `module.exports = require('@cubejs-backend/serverless');
-`;
 
 // Shared environment variables, across all DB types
 const sharedDotEnvVars = env => `CUBEJS_DEV_MODE=true
@@ -79,199 +55,6 @@ const gitIgnore = `.env
 node_modules
 .cubestore
 upstream
-`;
-
-/**
- * @deprecated
- */
-const serverlessYml = env => `service: ${env.projectName}
-
-provider:
-  name: aws
-  runtime: nodejs12.x
-  iamRoleStatements:
-    - Effect: "Allow"
-      Action:
-        - "sns:*"
-# Athena permissions
-#        - "athena:*"
-#        - "s3:*"
-#        - "glue:*"
-      Resource: '*'
-# When you uncomment vpc please make sure lambda has access to internet: https://medium.com/@philippholly/aws-lambda-enable-outgoing-internet-access-within-vpc-8dd250e11e12
-#  vpc:
-#    securityGroupIds:
-#     - sg-12345678901234567 # Your DB and Redis security groups here
-#    subnetIds:
-#     - subnet-12345678901234567 # Put here subnet with access to your DB, Redis and internet. For internet access 0.0.0.0/0 should be routed through NAT only for this subnet!
-  environment:
-    CUBEJS_DB_HOST: <YOUR_DB_HOST_HERE>
-    CUBEJS_DB_NAME: <YOUR_DB_NAME_HERE>
-    CUBEJS_DB_USER: <YOUR_DB_USER_HERE>
-    CUBEJS_DB_PASS: <YOUR_DB_PASS_HERE>
-    CUBEJS_DB_PORT: <YOUR_DB_PORT_HERE>
-    CUBEJS_REDIS_URL: <YOUR_REDIS_URL_HERE>
-    CUBEJS_DB_TYPE: ${env.dbType}
-    CUBEJS_API_SECRET: ${env.apiSecret}
-    CUBEJS_APP: "\${self:service.name}-\${self:provider.stage}"
-    NODE_ENV: production
-    AWS_ACCOUNT_ID:
-      Fn::Join:
-        - ""
-        - - Ref: "AWS::AccountId"
-
-functions:
-  cubejs:
-    handler: index.api
-    timeout: 30
-    events:
-      - http:
-          path: /
-          method: GET
-      - http:
-          path: /{proxy+}
-          method: ANY
-          cors:
-            origin: '*'
-            headers:
-              - Content-Type
-              - Authorization
-              - X-Request-Id
-              - X-Amz-Date
-              - X-Amz-Security-Token
-              - X-Api-Key
-  cubejsProcess:
-    handler: index.process
-    timeout: 630
-    events:
-      - sns: "\${self:service.name}-\${self:provider.stage}-process"
-
-plugins:
-  - serverless-express
-`;
-
-/**
- * @deprecated
- */
-const serverlessGoogleYml = env => `service: ${env.projectName} # NOTE: Don't put the word "google" in here
-
-provider:
-  name: google
-  stage: dev
-  runtime: nodejs12
-  region: us-central1
-  project: <YOUR_GOOGLE_PROJECT_ID_HERE>
-  # The GCF credentials can be a little tricky to set up. Luckily we've documented this for you here:
-  # https://serverless.com/framework/docs/providers/google/guide/credentials/
-  #
-  # the path to the credentials file needs to be absolute
-  credentials: </path/to/service/account/keyfile.json>
-  environment:
-    CUBEJS_DB_TYPE: ${env.dbType}
-    CUBEJS_DB_HOST: <YOUR_DB_HOST_HERE>
-    CUBEJS_DB_NAME: <YOUR_DB_NAME_HERE>
-    CUBEJS_DB_USER: <YOUR_DB_USER_HERE>
-    CUBEJS_DB_PASS: <YOUR_DB_PASS_HERE>
-    CUBEJS_DB_PORT: <YOUR_DB_PORT_HERE>
-    CUBEJS_DB_BQ_PROJECT_ID: "\${self:provider.project}"
-    CUBEJS_REDIS_URL: <YOUR_REDIS_URL_HERE>
-    CUBEJS_API_SECRET: ${env.apiSecret}
-    CUBEJS_APP: "\${self:service.name}-\${self:provider.stage}"
-    CUBEJS_SERVERLESS_PLATFORM: "\${self:provider.name}"
-
-plugins:
-  - serverless-google-cloudfunctions
-  - serverless-express
-
-# needs more granular excluding in production as only the serverless provider npm
-# package should be excluded (and not the whole node_modules directory)
-package:
-  exclude:
-    - node_modules/**
-    - .gitignore
-    - .git/**
-
-functions:
-  cubejs:
-    handler: api
-    events:
-      - http: ANY
-  cubejsProcess:
-    handler: process
-    events:
-      - event:
-          eventType: providers/cloud.pubsub/eventTypes/topic.publish
-          resource: "projects/\${self:provider.project}/topics/\${self:service.name}-\${self:provider.stage}-process"
-`;
-
-const ordersJs = `cube(\`orders\`, {
-  sql: \`
-  SELECT 1 AS id, 100 AS amount, 'new' status
-  UNION ALL
-  SELECT 2 AS id, 200 AS amount, 'new' status
-  UNION ALL
-  SELECT 3 AS id, 300 AS amount, 'processed' status
-  UNION ALL
-  SELECT 4 AS id, 500 AS amount, 'processed' status
-  UNION ALL
-  SELECT 5 AS id, 600 AS amount, 'shipped' status
-  \`,
-
-  pre_aggregations: {
-    // Pre-aggregation definitions go here.
-    // Learn more in the documentation: https://cube.dev/docs/caching/pre-aggregations/getting-started
-  },
-
-  measures: {
-    count: {
-      type: \`count\`
-    },
-
-    total_amount: {
-      sql: \`amount\`,
-      type: \`sum\`
-    }
-  },
-
-  dimensions: {
-    status: {
-      sql: \`status\`,
-      type: \`string\`
-    }
-  }
-});
-`;
-
-const exampleViewJs = `// In Cube, views are used to expose slices of your data graph and act as data marts.
-// You can control which measures and dimensions are exposed to BIs or data apps,
-// as well as the direction of joins between the exposed cubes.
-// You can learn more about views in documentation here - https://cube.dev/docs/schema/reference/view
-
-// The following example shows a view defined on top of orders and customers cubes.
-// Both orders and customers cubes are exposed using the "includes" parameter to
-// control which measures and dimensions are exposed.
-// Prefixes can also be applied when exposing measures or dimensions.
-// In this case, the customers' city dimension is prefixed with the cube name,
-// resulting in "customers_city" when querying the view.
-
-// view(\`example_view\`, {
-//   cubes: [
-//     {
-//       join_path: orders,
-//       includes: [
-//         'status',
-//         'created_date',
-//       ],
-//     },
-//     {
-//       join_path: orders.customers,
-//       prefix: true,
-//       includes: [
-//         'city',
-//       ],
-//     },
-//   ]
-// });
 `;
 
 const ordersYml = `cubes:
@@ -360,19 +143,6 @@ services:
 `;
 
 const templates: Record<string, Template> = {
-  'docker-js': {
-    scripts: {
-      dev: 'cubejs-server',
-    },
-    files: {
-      'cube.js': () => cubeJs,
-      'docker-compose.yml': dockerCompose,
-      '.env': dotEnv,
-      '.gitignore': () => gitIgnore,
-      'model/cubes/orders.js': () => ordersJs,
-      'model/views/example_view.js': () => exampleViewJs,
-    }
-  },
   docker: {
     scripts: {
       dev: 'cubejs-server',
@@ -385,44 +155,6 @@ const templates: Record<string, Template> = {
       'model/cubes/orders.yml': () => ordersYml,
       'model/views/example_view.yml': () => exampleViewYml,
     }
-  },
-  express: {
-    scripts: {
-      dev: 'node index.js',
-    },
-    files: {
-      'index.js': () => indexJs,
-      '.env': dotEnv,
-      '.gitignore': () => gitIgnore,
-      'model/cubes/orders.js': () => ordersJs
-    }
-  },
-  serverless: {
-    scripts: {
-      dev: 'cubejs-dev-server',
-    },
-    files: {
-      'index.js': () => handlerJs,
-      'serverless.yml': serverlessYml,
-      '.env': dotEnv,
-      '.gitignore': () => gitIgnore,
-      'model/cubes/orders.js': () => ordersJs
-    },
-    dependencies: ['@cubejs-backend/serverless', '@cubejs-backend/serverless-aws']
-  },
-  'serverless-google': {
-    scripts: {
-      dev: 'cubejs-dev-server',
-    },
-    files: {
-      'index.js': () => handlerJs,
-      'serverless.yml': serverlessGoogleYml,
-      '.env': dotEnv,
-      '.gitignore': () => gitIgnore,
-      'schema/Orders.js': () => ordersJs
-    },
-    dependencies: ['@cubejs-backend/serverless', '@cubejs-backend/serverless-google'],
-    devDependencies: ['serverless-google-cloudfunctions']
   }
 };
 

--- a/packages/cubejs-cli/src/utils.ts
+++ b/packages/cubejs-cli/src/utils.ts
@@ -25,8 +25,8 @@ export const writePackageJson = async (json: any) => fs.writeJson('package.json'
   EOL: os.EOL
 });
 
-export const npmInstall = (dependencies: string[], isDev?: boolean) => executeCommand(
-  'npm', ['install', isDev ? '--save-dev' : '--save'].concat(dependencies)
+export const npmInstallDev = (dependencies: string[]) => executeCommand(
+  'npm', ['install', '--save-dev'].concat(dependencies)
 );
 
 export const displayWarning = (message: string) => {

--- a/packages/cubejs-cli/test/templates.test.ts
+++ b/packages/cubejs-cli/test/templates.test.ts
@@ -1,6 +1,6 @@
 import templates from '../src/templates';
 
-const dotEnv = templates.express.files['.env'];
+const dotEnv = templates.docker.files['.env'];
 
 const secret = 123;
 
@@ -8,7 +8,6 @@ const generateTestEnv = (apiSecret, dbType) => ({
   apiSecret,
   dbType,
   dockerVersion: 'latest',
-  projectName: 'test',
 });
 
 test('dotEnv should return default env vars for mysql DB type', () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

`cubejs create` supported five app templates; everything except `docker` was dead weight — `express` was built on the `@deprecated` `indexJs` entry point, `serverless`/`serverless-google` installed `@cubejs-backend/serverless*` which was removed from the product in v0.35.0 (so the generated project could not even install), and `docker-js` was undocumented and referenced nowhere. This PR removes those four templates along with their now-unused file generators and the `Template.dependencies`/`devDependencies` and `TemplateFileContext.projectName` fields, so `cubejs create` always scaffolds the Docker project with a YAML data model and the `-t, --template` option is gone.

Verified with `tsc`, the package's jest suite (4/4 green, the `.env` test repointed at `templates.docker`), oxlint, and a live `cubejs create tmp-app -d postgres` run that emitted exactly `cube.js`, `docker-compose.yml`, `.env`, `.gitignore`, `model/cubes/orders.yml`, and `model/views/example_view.yml`. No docs change was needed: the only page documenting `-t` lives in the deprecated legacy `/docs` site, and `docs-mintlify` has no CLI reference page mentioning templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)