### PR TITLE
chore(playground): Restore Form.Item single child in the connection wizard

### DIFF
--- a/packages/cubejs-playground/src/pages/ConnectionWizard/components/DatabaseForm.tsx
+++ b/packages/cubejs-playground/src/pages/ConnectionWizard/components/DatabaseForm.tsx
@@ -3,6 +3,27 @@ import { useEffect } from 'react';
 
 import Base64Upload from './Base64Upload';
 
+function DatabaseFormControl({ param }) {
+  if (!param.title) {
+    return (
+      <Input.TextArea
+        data-testid={param.env}
+        rows={1}
+        style={{
+          overflow: 'hidden',
+          resize: 'none',
+        }}
+      />
+    );
+  }
+
+  if (param.env === 'CUBEJS_DB_PASS') {
+    return <Input.Password data-testid={param.env} />;
+  }
+
+  return <Input data-testid={param.env} />;
+}
+
 export default function DatabaseForm({
   db,
   deployment,
@@ -56,22 +77,7 @@ export default function DatabaseForm({
           label={param.title || param.env}
           name={param.env}
         >
-          {param.title && param.env === 'CUBEJS_DB_PASS' && (
-            <Input.Password data-testid={param.env} />
-          )}
-          {param.title && param.env !== 'CUBEJS_DB_PASS' && (
-            <Input data-testid={param.env} />
-          )}
-          {!param.title && (
-            <Input.TextArea
-              data-testid={param.env}
-              rows={1}
-              style={{
-                overflow: 'hidden',
-                resize: 'none',
-              }}
-            />
-          )}
+          <DatabaseFormControl param={param} />
         </Form.Item>
       )))}
 

--- a/packages/cubejs-playground/src/pages/ConnectionWizard/components/DatabaseForm.tsx
+++ b/packages/cubejs-playground/src/pages/ConnectionWizard/components/DatabaseForm.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 
 import Base64Upload from './Base64Upload';
 
-function DatabaseFormControl({ param }) {
+function databaseFormControl(param) {
   if (!param.title) {
     return (
       <Input.TextArea
@@ -77,7 +77,7 @@ export default function DatabaseForm({
           label={param.title || param.env}
           name={param.env}
         >
-          <DatabaseFormControl param={param} />
+          {databaseFormControl(param)}
         </Form.Item>
       )))}
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

The oxlint migration (#11790) unrolled the nested ternary that picks the input control into three sibling `&&` expressions inside `<Form.Item name={param.env}>`, and antd 4.16 only injects `value`/`onChange` when `isValidElement(children)` holds — with an array it warns and renders the children untouched, leaving every connection wizard input unbound from the form. That has kept two Cypress birdbox tests red on master since that commit: `copies values of the localhost tip box` (the tip box's `form.setFieldsValue({ CUBEJS_DB_HOST })` never reached the input) and `PostgreSQL connection flow -- connects to the DB` (typed credentials never landed in form state, so submit posted empty values and the error alert never cleared). This moves the control selection into a `DatabaseFormControl` helper so `Form.Item` gets a single child again, with identical logic and no nested ternary. Existing Cypress coverage already exercises both paths, so no new tests were needed; I could not run the linter or Cypress locally because this worktree has no installed `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)