### PR TITLE
chore(testing-shared): Retry docker image pulls in testcontainers runners

### DIFF
--- a/packages/cubejs-testing-shared/src/db-container-runners/clickhouse.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/clickhouse.ts
@@ -1,6 +1,7 @@
 import { GenericContainer } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class ClickhouseDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -16,6 +17,6 @@ export class ClickhouseDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/crate.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/crate.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 const DEFAULT_VERSION = '6.3.5';
 
@@ -18,6 +19,6 @@ export class CrateDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/cubestore.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/cubestore.ts
@@ -1,6 +1,7 @@
 import { GenericContainer } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class CubeStoreDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -15,6 +16,6 @@ export class CubeStoreDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/index.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/index.ts
@@ -12,3 +12,4 @@ export * from './trino';
 export * from './oracle';
 export * from './kafka';
 export * from './ksql';
+export * from './start-with-retry';

--- a/packages/cubejs-testing-shared/src/db-container-runners/kafka.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/kafka.ts
@@ -1,5 +1,6 @@
 import { KafkaContainer } from '@testcontainers/kafka';
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class KafkaDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -26,6 +27,6 @@ export class KafkaDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/ksql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/ksql.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
 import { pausePromise } from '@cubejs-backend/shared';
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class KsqlDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -27,7 +28,7 @@ export class KsqlDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 
   public static async loadData(db: StartedTestContainer) {

--- a/packages/cubejs-testing-shared/src/db-container-runners/materialize.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/materialize.ts
@@ -1,6 +1,7 @@
 import { GenericContainer } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class MaterializeDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -16,6 +17,6 @@ export class MaterializeDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/mssql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/mssql.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class MssqlDbRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -22,6 +23,6 @@ export class MssqlDbRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/mysql.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class MysqlDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -45,6 +46,6 @@ export class MysqlDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/oracle.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class OracleDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -18,6 +19,6 @@ export class OracleDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/postgres.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/postgres.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import { execSync } from 'child_process';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class PostgresDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -29,7 +30,7 @@ export class PostgresDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 
   public static async loadEcom(db: StartedTestContainer) {

--- a/packages/cubejs-testing-shared/src/db-container-runners/prestodb.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/prestodb.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class PrestoDbRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -16,6 +17,6 @@ export class PrestoDbRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/questdb.ts
@@ -1,6 +1,7 @@
 import { GenericContainer } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class QuestDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -15,6 +16,6 @@ export class QuestDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/start-with-retry.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/start-with-retry.ts
@@ -6,10 +6,14 @@ export interface StartContainerRetryOptions {
   delay?: number;
 }
 
-// Subclass instead of a cast to any: an upstream rename of `imageName` fails the build.
-class ImageNameReader extends GenericContainer {
-  public static of(container: GenericContainer): ImageName {
-    return (container as ImageNameReader).imageName;
+// Subclass instead of a cast to any: an upstream rename of these fields fails the build.
+class ContainerInternals extends GenericContainer {
+  public static imageNameOf(container: GenericContainer): ImageName {
+    return (container as ContainerInternals).imageName;
+  }
+
+  public static platformOf(container: GenericContainer): string | undefined {
+    return (container as ContainerInternals).createOpts.platform;
   }
 }
 
@@ -37,7 +41,11 @@ function isPermanent(error: unknown): boolean {
 
 // Pulling here rather than in start() keeps the retry on the pull: a container that
 // fails its wait strategy is a real failure and restarting it only burns the timeout.
-export async function pullImageWithRetry(imageName: ImageName, options: StartContainerRetryOptions = {}) {
+async function pullImageWithRetry(
+  imageName: ImageName,
+  platform: string | undefined,
+  options: StartContainerRetryOptions,
+) {
   const attempts = options.attempts
     ?? parseInt(process.env.TEST_CONTAINER_PULL_ATTEMPTS || '3', 10);
   const delay = options.delay
@@ -47,7 +55,7 @@ export async function pullImageWithRetry(imageName: ImageName, options: StartCon
 
   for (let attempt = 1; ; attempt++) {
     try {
-      await client.image.pull(imageName, { force: false, platform: undefined });
+      await client.image.pull(imageName, { force: false, platform });
       return;
     } catch (error) {
       if (attempt >= attempts || isPermanent(error)) {
@@ -69,7 +77,11 @@ export async function startContainerWithRetry<C extends GenericContainer>(
   container: C,
   options: StartContainerRetryOptions = {},
 ): Promise<Awaited<ReturnType<C['start']>>> {
-  await pullImageWithRetry(ImageNameReader.of(container), options);
+  await pullImageWithRetry(
+    ContainerInternals.imageNameOf(container),
+    ContainerInternals.platformOf(container),
+    options,
+  );
 
   return container.start() as Promise<Awaited<ReturnType<C['start']>>>;
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/start-with-retry.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/start-with-retry.ts
@@ -1,0 +1,75 @@
+import { GenericContainer, ImageName, getContainerRuntimeClient } from 'testcontainers';
+import { pausePromise } from '@cubejs-backend/shared';
+
+export interface StartContainerRetryOptions {
+  attempts?: number;
+  delay?: number;
+}
+
+// Subclass instead of a cast to any: an upstream rename of `imageName` fails the build.
+class ImageNameReader extends GenericContainer {
+  public static of(container: GenericContainer): ImageName {
+    return (container as ImageNameReader).imageName;
+  }
+}
+
+const PERMANENT_FAILURES = [
+  /manifest unknown/i,
+  /manifest for .+ not found/i,
+  /repository .+ not found/i,
+  /pull access denied/i,
+  /authentication required/i,
+  /invalid reference format/i,
+];
+
+function isPermanent(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const httpCode = message.match(/\(HTTP code (\d{3})\)/);
+
+  if (httpCode) {
+    const status = parseInt(httpCode[1], 10);
+
+    return status >= 400 && status < 500 && status !== 429;
+  }
+
+  return PERMANENT_FAILURES.some(pattern => pattern.test(message));
+}
+
+// Pulling here rather than in start() keeps the retry on the pull: a container that
+// fails its wait strategy is a real failure and restarting it only burns the timeout.
+export async function pullImageWithRetry(imageName: ImageName, options: StartContainerRetryOptions = {}) {
+  const attempts = options.attempts
+    ?? parseInt(process.env.TEST_CONTAINER_PULL_ATTEMPTS || '3', 10);
+  const delay = options.delay
+    ?? parseInt(process.env.TEST_CONTAINER_PULL_RETRY_DELAY || '5000', 10);
+
+  const client = await getContainerRuntimeClient();
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await client.image.pull(imageName, { force: false, platform: undefined });
+      return;
+    } catch (error) {
+      if (attempt >= attempts || isPermanent(error)) {
+        throw error;
+      }
+
+      const backoff = delay * (2 ** (attempt - 1));
+      console.warn(
+        `[testcontainers] pull ${imageName.string} attempt ${attempt}/${attempts} failed, retrying in ${backoff}ms:`,
+        error instanceof Error ? error.message : error,
+      );
+
+      await pausePromise(backoff);
+    }
+  }
+}
+
+export async function startContainerWithRetry<C extends GenericContainer>(
+  container: C,
+  options: StartContainerRetryOptions = {},
+): Promise<Awaited<ReturnType<C['start']>>> {
+  await pullImageWithRetry(ImageNameReader.of(container), options);
+
+  return container.start() as Promise<Awaited<ReturnType<C['start']>>>;
+}

--- a/packages/cubejs-testing-shared/src/db-container-runners/trino.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/trino.ts
@@ -1,6 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class TrinoDBRunner extends DbRunnerAbstract {
   public static startContainer(options: DBRunnerContainerOptions) {
@@ -16,6 +17,6 @@ export class TrinoDBRunner extends DbRunnerAbstract {
       container.withBindMounts(binds);
     }
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing-shared/src/db-container-runners/vertica.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/vertica.ts
@@ -1,5 +1,6 @@
 import { GenericContainer, Wait } from 'testcontainers';
 import { DbRunnerAbstract } from './db-runner.abstract';
+import { startContainerWithRetry } from './start-with-retry';
 
 export class VerticaDBRunner extends DbRunnerAbstract {
   public static startContainer() {
@@ -13,6 +14,6 @@ export class VerticaDBRunner extends DbRunnerAbstract {
         Wait.forLogMessage('Vertica is now running')
       );
 
-    return container.start();
+    return startContainerWithRetry(container);
   }
 }

--- a/packages/cubejs-testing/test/abstract-test-case.ts
+++ b/packages/cubejs-testing/test/abstract-test-case.ts
@@ -138,7 +138,7 @@ export function createBirdBoxTestCase(
 
     // eslint-disable-next-line consistent-return
     afterAll(async () => {
-      await wsTransport.close();
+      await stopIfStarted('wsTransport', wsTransport && (() => wsTransport.close()));
       await stopIfStarted('birdbox', birdbox);
     });
 

--- a/packages/cubejs-testing/test/abstract-test-case.ts
+++ b/packages/cubejs-testing/test/abstract-test-case.ts
@@ -4,6 +4,7 @@ import { jest, expect, beforeAll, afterAll } from '@jest/globals';
 import cubejs, { Query, CubeApi } from '@cubejs-client/core';
 import WebSocketTransport from '@cubejs-client/ws-transport';
 import { BirdBox } from '../src';
+import { stopIfStarted } from './smoke-tests';
 
 type QueryTestOptions = {
   name: string;
@@ -138,7 +139,7 @@ export function createBirdBoxTestCase(
     // eslint-disable-next-line consistent-return
     afterAll(async () => {
       await wsTransport.close();
-      await birdbox.stop();
+      await stopIfStarted('birdbox', birdbox);
     });
 
     it('Failing query rewrite', async () => {

--- a/packages/cubejs-testing/test/driver-test-case.ts
+++ b/packages/cubejs-testing/test/driver-test-case.ts
@@ -3,6 +3,7 @@ import { jest, expect, beforeAll, afterAll } from '@jest/globals';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import cubejs, { Query, CubeApi } from '@cubejs-client/core';
 import { BirdBox } from '../src';
+import { stopIfStarted } from './smoke-tests';
 
 // eslint-disable-next-line import/prefer-default-export
 export function createBirdBoxTestCase(name: string, entrypoint: () => Promise<BirdBox>) {
@@ -30,7 +31,7 @@ export function createBirdBoxTestCase(name: string, entrypoint: () => Promise<Bi
 
     // eslint-disable-next-line consistent-return
     afterAll(async () => {
-      await birdbox.stop();
+      await stopIfStarted('birdbox', birdbox);
     });
 
     it('Orders.totalAmount', async () => {

--- a/packages/cubejs-testing/test/driver-test-suite.ts
+++ b/packages/cubejs-testing/test/driver-test-suite.ts
@@ -7,6 +7,7 @@ import WebSocketTransport from '@cubejs-client/ws-transport';
 import { uniq } from 'ramda';
 import { BirdBox, Env, getBirdbox } from '../src';
 import { DriverTest } from './driverTests/driverTest';
+import { stopIfStarted } from './smoke-tests';
 
 type SupportedDriverType =
   'postgres' |
@@ -61,8 +62,8 @@ export function executeTestSuite({ type, tests, config = {} }: TestSuite) {
       });
     });
     afterAll(async () => {
-      await transport.close();
-      await box.stop();
+      await stopIfStarted('transport', transport && (() => transport.close()));
+      await stopIfStarted('birdbox', box);
     });
 
     for (const t of tests) {

--- a/packages/cubejs-testing/test/pre-aggregations-test-case.ts
+++ b/packages/cubejs-testing/test/pre-aggregations-test-case.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import WebSocketTransport from '@cubejs-client/ws-transport';
 
 import { BirdBox } from '../src';
+import { stopIfStarted } from './smoke-tests';
 
 type QueryTestOptions = {
   name: string;
@@ -216,7 +217,7 @@ export function createBirdBoxTestCase(name: string, entrypoint: () => Promise<Bi
     afterAll(async () => {
       await wsTransport.close();
 
-      await birdbox.stop();
+      await stopIfStarted('birdbox', birdbox);
     });
 
     it('Pre-aggregations API', async () => {

--- a/packages/cubejs-testing/test/pre-aggregations-test-case.ts
+++ b/packages/cubejs-testing/test/pre-aggregations-test-case.ts
@@ -215,7 +215,7 @@ export function createBirdBoxTestCase(name: string, entrypoint: () => Promise<Bi
 
     // eslint-disable-next-line consistent-return
     afterAll(async () => {
-      await wsTransport.close();
+      await stopIfStarted('wsTransport', wsTransport && (() => wsTransport.close()));
 
       await stopIfStarted('birdbox', birdbox);
     });

--- a/packages/cubejs-testing/test/rest-test-suite.ts
+++ b/packages/cubejs-testing/test/rest-test-suite.ts
@@ -4,6 +4,7 @@ import { BaseDriver } from '@cubejs-backend/base-driver';
 import { afterAll, beforeAll, expect, jest } from '@jest/globals';
 import WebSocketTransport from '@cubejs-client/ws-transport';
 import { BirdBox, Env, getBirdbox } from '../src';
+import { stopIfStarted } from './smoke-tests';
 
 type SupportedDriverType =
   'postgres' |
@@ -87,9 +88,9 @@ export function executeTestSuite({ type, config = {}, driver }: TestSuite) {
         //     overridedConfig.CUBEJS_PRE_AGGREGATIONS_SCHEMA
         //   } cascade;`
         // );
-        await driver.release();
-        await transport.close();
-        await box.stop();
+        await stopIfStarted('driver', () => driver.release());
+        await stopIfStarted('transport', transport && (() => transport.close()));
+        await stopIfStarted('birdbox', box);
       });
 
       test('/cubejs-system/v1/pre-aggregations/jobs', async () => {

--- a/packages/cubejs-testing/test/smoke-crate.test.ts
+++ b/packages/cubejs-testing/test/smoke-crate.test.ts
@@ -10,6 +10,7 @@ import {
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
   testQueryMeasure,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('crate', () => {
@@ -42,8 +43,8 @@ describe('crate', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure', () => testQueryMeasure(client));

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -80,7 +80,7 @@ describe('SQL API', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await connection.end();
+    await stopIfStarted('connection', connection && (() => connection.end()));
     await stopIfStarted('birdbox', birdbox);
     await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('SQL API', () => {
@@ -80,8 +81,8 @@ describe('SQL API', () => {
 
   afterAll(async () => {
     await connection.end();
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   describe('Cube SQL over HTTP', () => {

--- a/packages/cubejs-testing/test/smoke-duckdb.test.ts
+++ b/packages/cubejs-testing/test/smoke-duckdb.test.ts
@@ -8,6 +8,7 @@ import {
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
   testQueryMeasure,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('duckdb', () => {
@@ -33,7 +34,7 @@ describe('duckdb', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure', () => testQueryMeasure(client));

--- a/packages/cubejs-testing/test/smoke-graceful-shutdown.test.ts
+++ b/packages/cubejs-testing/test/smoke-graceful-shutdown.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('graceful shutdown', () => {
@@ -78,7 +79,7 @@ describe('graceful shutdown', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await db.stop();
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   const clientless = async (signal: 'SIGTERM' | 'SIGINT') => {

--- a/packages/cubejs-testing/test/smoke-lambda.test.ts
+++ b/packages/cubejs-testing/test/smoke-lambda.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 const CubeStoreDriver = require('@cubejs-backend/cubestore-driver');
@@ -79,8 +80,8 @@ describe('lambda', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
     await dbKafka.stop();
     await dbKsql.stop();
     await network.stop();

--- a/packages/cubejs-testing/test/smoke-lambda.test.ts
+++ b/packages/cubejs-testing/test/smoke-lambda.test.ts
@@ -82,10 +82,10 @@ describe('lambda', () => {
   afterAll(async () => {
     await stopIfStarted('birdbox', birdbox);
     await stopIfStarted('db', db);
-    await dbKafka.stop();
-    await dbKsql.stop();
-    await network.stop();
-    await cubestore.release();
+    await stopIfStarted('dbKafka', dbKafka);
+    await stopIfStarted('dbKsql', dbKsql);
+    await stopIfStarted('network', network);
+    await stopIfStarted('cubestore', cubestore && (() => cubestore.release()));
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('Query lambda with ksql ', async () => {

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('links through views', () => {
@@ -41,8 +42,8 @@ describe('links through views', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('meta exposes link synthetic dimensions on view with explicit includes', async () => {

--- a/packages/cubejs-testing/test/smoke-materialize.test.ts
+++ b/packages/cubejs-testing/test/smoke-materialize.test.ts
@@ -11,6 +11,7 @@ import {
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
   testQueryMeasure,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('materialize', () => {
@@ -45,8 +46,8 @@ describe('materialize', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure', () => testQueryMeasure(client));

--- a/packages/cubejs-testing/test/smoke-mssql.test.ts
+++ b/packages/cubejs-testing/test/smoke-mssql.test.ts
@@ -9,6 +9,7 @@ import {
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
   testQueryMeasure,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('mssql', () => {
@@ -40,7 +41,7 @@ describe('mssql', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure', () => testQueryMeasure(client));

--- a/packages/cubejs-testing/test/smoke-multi-fact.test.ts
+++ b/packages/cubejs-testing/test/smoke-multi-fact.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 // AOV end to end: the numerator (sales dollars, day/item/location grain) and
@@ -54,7 +55,7 @@ describe('multi-fact derived measure', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   // Numeric measures come back as strings or numbers depending on the type and

--- a/packages/cubejs-testing/test/smoke-multidb.test.ts
+++ b/packages/cubejs-testing/test/smoke-multidb.test.ts
@@ -91,7 +91,7 @@ describe('multidb', () => {
   afterAll(async () => {
     await stopIfStarted('birdbox', birdbox);
     await stopIfStarted('db', db);
-    await db2.stop();
+    await stopIfStarted('db2', db2);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query', async () => {

--- a/packages/cubejs-testing/test/smoke-multidb.test.ts
+++ b/packages/cubejs-testing/test/smoke-multidb.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 // TODO: Random port?
@@ -88,8 +89,8 @@ describe('multidb', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
     await db2.stop();
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 

--- a/packages/cubejs-testing/test/smoke-postgres.test.ts
+++ b/packages/cubejs-testing/test/smoke-postgres.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('postgres pa', () => {
@@ -43,8 +44,8 @@ describe('postgres pa', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('basic pa', async () => {

--- a/packages/cubejs-testing/test/smoke-questdb.test.ts
+++ b/packages/cubejs-testing/test/smoke-questdb.test.ts
@@ -10,6 +10,7 @@ import {
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
   testQueryMeasure,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('questdb', () => {
@@ -43,8 +44,8 @@ describe('questdb', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure', () => testQueryMeasure(client));

--- a/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('GraphQL Schema Caching and RBAC', () => {
@@ -31,7 +32,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   async function graphqlRequest(group: string, query: string): Promise<any> {

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 const PG_PORT = 5656;
@@ -83,8 +84,8 @@ describe('Cube RBAC Engine', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   describe('RBAC via SQL API', () => {
@@ -1513,8 +1514,8 @@ describe('Cube RBAC Engine [Tesseract]', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   describe('Shorthand and mask tests via SQL API [Tesseract]', () => {
@@ -1756,8 +1757,8 @@ describe('Cube RBAC Engine [dev mode]', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('line_items hidden created_at', async () => {
@@ -1812,8 +1813,8 @@ describe('Cube RBAC Engine [Python config]', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   describe('RBAC via SQL API [python config]', () => {
@@ -1879,8 +1880,8 @@ describe('Cube RBAC Engine [Python config][dev mode]', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('products with no matching policy', async () => {

--- a/packages/cubejs-testing/test/smoke-shared-calc-group.test.ts
+++ b/packages/cubejs-testing/test/smoke-shared-calc-group.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 // End-to-end pre-aggregation coverage for rolling-window metrics exposed
@@ -50,8 +51,8 @@ describe('shared calc group pre-aggregations in Cube Store', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   const REPRO_FILTERS: Query['filters'] = [

--- a/packages/cubejs-testing/test/smoke-snowflake.test.ts
+++ b/packages/cubejs-testing/test/smoke-snowflake.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 const CubeStoreDriver = require('@cubejs-backend/cubestore-driver');
@@ -42,7 +43,7 @@ describe('snowflake', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('int column data type', async () => {

--- a/packages/cubejs-testing/test/smoke-tests.ts
+++ b/packages/cubejs-testing/test/smoke-tests.ts
@@ -28,3 +28,15 @@ export async function testQueryMeasure(client: CubeApi) {
   });
   expect(response.rawData()).toMatchSnapshot('query');
 }
+
+interface Stoppable {
+  stop(): Promise<unknown>;
+}
+
+export async function stopIfStarted(name: string, resource: Stoppable | undefined) {
+  if (resource) {
+    await resource.stop();
+  } else {
+    console.warn(`[smoke] ${name} was never started, nothing to stop`);
+  }
+}

--- a/packages/cubejs-testing/test/smoke-tests.ts
+++ b/packages/cubejs-testing/test/smoke-tests.ts
@@ -34,9 +34,14 @@ interface Stoppable {
 }
 
 export async function stopIfStarted(name: string, resource: Stoppable | undefined) {
-  if (resource) {
-    await resource.stop();
-  } else {
+  if (!resource) {
     console.warn(`[smoke] ${name} was never started, nothing to stop`);
+    return;
+  }
+
+  try {
+    await resource.stop();
+  } catch (e) {
+    console.warn(`[smoke] failed to stop ${name}:`, e);
   }
 }

--- a/packages/cubejs-testing/test/smoke-tests.ts
+++ b/packages/cubejs-testing/test/smoke-tests.ts
@@ -33,14 +33,16 @@ interface Stoppable {
   stop(): Promise<unknown>;
 }
 
-export async function stopIfStarted(name: string, resource: Stoppable | undefined) {
+type Teardown = Stoppable | (() => Promise<unknown>);
+
+export async function stopIfStarted(name: string, resource: Teardown | undefined) {
   if (!resource) {
     console.warn(`[smoke] ${name} was never started, nothing to stop`);
     return;
   }
 
   try {
-    await resource.stop();
+    await (typeof resource === 'function' ? resource() : resource.stop());
   } catch (e) {
     console.warn(`[smoke] failed to stop ${name}:`, e);
   }

--- a/packages/cubejs-testing/test/smoke-trino.test.ts
+++ b/packages/cubejs-testing/test/smoke-trino.test.ts
@@ -2,21 +2,24 @@ import cubejs, { CubeApi } from '@cubejs-client/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { afterAll, beforeAll, expect, jest } from '@jest/globals';
 import { TrinoDBRunner } from '@cubejs-backend/testing-shared';
+import { StartedTestContainer } from 'testcontainers';
 import { BirdBox, getBirdbox } from '../src';
 import {
   DEFAULT_API_TOKEN,
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('trino', () => {
   jest.setTimeout(60 * 5 * 1000);
+  let db: StartedTestContainer;
   let birdbox: BirdBox;
   let client: CubeApi;
 
   beforeAll(async () => {
-    const db = await TrinoDBRunner.startContainer({});
+    db = await TrinoDBRunner.startContainer({});
     birdbox = await getBirdbox(
       'trino',
       {
@@ -39,7 +42,8 @@ describe('trino', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('query measure grouped by time dimension with timezone', async () => {

--- a/packages/cubejs-testing/test/smoke-vertica.test.ts
+++ b/packages/cubejs-testing/test/smoke-vertica.test.ts
@@ -5,7 +5,7 @@ import { VerticaDBRunner } from '@cubejs-backend/testing-shared';
 import cubejs, { CubeApi, Query } from '@cubejs-client/core';
 import { afterAll, beforeAll, expect, jest } from '@jest/globals';
 import { BirdBox, getBirdbox } from '../src';
-import { DEFAULT_CONFIG } from './smoke-tests';
+import { DEFAULT_CONFIG, stopIfStarted } from './smoke-tests';
 
 describe('vertica pa', () => {
   jest.setTimeout(60 * 5 * 1000);
@@ -38,8 +38,8 @@ describe('vertica pa', () => {
   });
 
   afterAll(async () => {
-    await birdbox.stop();
-    await db.stop();
+    await stopIfStarted('birdbox', birdbox);
+    await stopIfStarted('db', db);
   });
 
   test('basic pa', async () => {

--- a/packages/cubejs-testing/test/smoke-view-groups.test.ts
+++ b/packages/cubejs-testing/test/smoke-view-groups.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONFIG,
   JEST_AFTER_ALL_DEFAULT_TIMEOUT,
   JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  stopIfStarted,
 } from './smoke-tests';
 
 describe('view groups', () => {
@@ -31,7 +32,7 @@ describe('view groups', () => {
   }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
 
   afterAll(async () => {
-    await birdbox.stop();
+    await stopIfStarted('birdbox', birdbox);
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
   test('meta response includes viewGroups', async () => {


### PR DESCRIPTION
Docker Hub answers manifest requests with 500s often enough to fail a whole smoke suite in `beforeAll` (`(HTTP code 500) server error - Head ".../trinodb/trino/manifests/403"`), and testcontainers has no pull retry of its own — `PullPolicy` only decides *whether* to pull. The DB runners now pull the image explicitly via `getContainerRuntimeClient()` before `start()`, retrying registry 5xx/429 three times with a 5s→10s backoff (overridable per call and via `TEST_CONTAINER_PULL_ATTEMPTS` / `TEST_CONTAINER_PULL_RETRY_DELAY`), while 4xx and wait-strategy failures still fail immediately. The same job also reported `TypeError: Cannot read properties of undefined (reading 'stop')`, which is `afterAll` masking the real `beforeAll` error, so smoke tests now stop via `stopIfStarted`, which logs instead of throwing; `smoke-trino` additionally never stopped its Trino container at all. The pull path was verified against a real Docker daemon (happy pull + start, immediate failure on a bad tag, three backed-off attempts on a 500); the smoke suites themselves were not run locally, so CI is the check here.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

🤖 Generated with [Claude Code](https://claude.com/claude-code)