### PR TITLE
feat(cube-cli): upload dbt manifests for sync

### DIFF
--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -425,6 +425,9 @@ right after `dbt run` or `dbt build`. As soon as your warehouse tables are rebui
 your pipeline can upload the `target/manifest.json` that command produced and tell Cube
 to regenerate the matching cubes.
 
+The dbt settings card shows the exact REST endpoint for your deployment if your
+pipeline calls the API directly.
+
 <Frame>
   <img
     src="https://ucarecdn.com/2c278503-75cc-474b-920e-877ac5f530d7/2a32f0e7-light.png"

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -12,10 +12,14 @@ Available on [Premium and above plans](https://cube.dev/pricing).
 
 If your team already models data in [dbt](https://www.getdbt.com/), you can import
 those models into Cube as cubes instead of redefining them by hand. **dbt pull**
-connects to your dbt project's Git repository, parses the project, converts each dbt
-model into a cube — including dimensions, measures, descriptions, and joins — and
-commits the generated files to a branch where you review them before they reach
-production.
+converts each dbt model into a cube — including dimensions, measures, descriptions,
+and joins — and commits the generated files to a branch where you review them before
+they reach production.
+
+Cube can either clone and parse your dbt project's Git repository, or accept the
+`target/manifest.json` your own CI job produced. Uploading the manifest converts the
+exact artifact your pipeline validated and doesn't require Cube to have a credential
+for the dbt repository.
 
 Pulls can run manually, from your CI/CD pipeline, automatically on every push to your
 dbt repository, or from [Analytics Chat](#trigger-from-analytics-chat) — so your
@@ -32,23 +36,24 @@ available via [dbt push](#push-cubes-to-dbt), currently in preview.
 
 ## How it works
 
-When a pull runs — whether triggered manually, from CI, or by a repository push —
-Cube spins up a short-lived, isolated sandbox and:
+Every pull converts a dbt manifest into cube definitions and commits the generated
+files to a review branch. How the manifest reaches Cube depends on the source:
 
-1. **Clones your dbt repository** (a shallow clone of the branch you selected).
-2. **Installs your project's dependencies** (`dbt deps`).
-3. **Parses the project** (`dbt parse`) to produce dbt's `manifest.json` — the
-   structured description of every model, column, test, and constraint.
-4. **Converts each dbt model into a cube definition** (one `.yml` file per model).
-5. **Commits the generated files** to a branch for review, then tears the sandbox
-   down.
+- **Git (default):** Cube creates a short-lived, isolated sandbox, clones the selected
+  branch, installs dependencies with `dbt deps`, and runs `dbt parse`. It converts the
+  resulting `target/manifest.json`, commits the cubes, and tears the sandbox down.
+- **Uploaded manifest:** Your pipeline runs `dbt parse`, `dbt compile`, `dbt run`, or
+  `dbt build`, then uploads the resulting `target/manifest.json` with the Cube CLI.
+  Cube validates and converts that artifact directly. It doesn't create a sandbox,
+  clone a repository, or run dbt, so this path usually takes seconds rather than
+  minutes.
 
-**By default, no connection to your data warehouse is made during a pull.** Cube uses
-`dbt parse`, not `dbt run` or `dbt compile`, so it reads your project's structure
-without ever querying your warehouse. dbt pull generates cube definitions; it assumes
-the underlying tables were already built by your own production `dbt run`. The one
-exception is [Infer column types from dbt catalog](#infer-column-types-from-dbt-catalog),
-an opt-in option that reads real column types from your warehouse.
+**Cube doesn't build your dbt models during either kind of pull.** A Git-based pull
+uses `dbt parse`, which doesn't query the warehouse. A manifest pull doesn't run dbt
+at all, although the pipeline command that produced the manifest might. The generated
+cubes assume the underlying tables were already built by your production dbt job. The
+one Cube-side exception is [Infer column types from dbt catalog](#infer-column-types-from-dbt-catalog),
+an opt-in option for Git-based pulls that reads real column types from the warehouse.
 
 ## Prerequisites
 
@@ -56,11 +61,10 @@ an opt-in option that reads real column types from your warehouse.
   **Amazon Redshift**, **PostgreSQL**, **Google BigQuery**, **Databricks**,
   **Amazon Athena**, and **ClickHouse**. If your deployment uses any other database
   type, the pull dialog will tell you it's unsupported.
-- **A Git repository** containing your dbt project, reachable over **HTTPS** or
-  **SSH**. GitHub, GitLab, Bitbucket, Azure DevOps, and self-hosted Git servers all
-  work.
-- **Read access to that repository** — either a personal access token (PAT) for
-  HTTPS, or the ability to register a read-only deploy key for SSH.
+- **A source for dbt metadata:** either a Git repository Cube can reach over HTTPS or
+  SSH, with a PAT or read-only deploy key; or a CI job that can produce and upload
+  `target/manifest.json` with the [Cube CLI](/reference/cli#dbt-sync). GitHub, GitLab,
+  Bitbucket, Azure DevOps, and self-hosted Git servers all work for the Git source.
 - For the generated cubes to return data, the dbt models must already be **built into
   your warehouse** by your normal production `dbt run`. dbt pull generates cube
   definitions that point at each model's relation; it does not create the underlying
@@ -71,6 +75,14 @@ an opt-in option that reads real column types from your warehouse.
 ## Connect your dbt repository
 
 The dbt connection is configured on your deployment's **default data source**.
+
+<Info>
+
+Skip this section if your CI pipeline uploads `manifest.json`. A manifest pull doesn't
+need a dbt Git integration or repository credential. When an integration is configured,
+its conversion settings still shape the generated cubes.
+
+</Info>
 
 <Steps>
 
@@ -157,10 +169,12 @@ the second is the common override
 
 <Warning>
 If your project overrides `generate_schema_name` and keys it on the environment —
-the widespread `{% if target.name == 'prod' %}` pattern — you **must** set **dbt
-target** to that production target name. Otherwise the macro takes its fallback
-branch and every model collapses onto the **dbt target schema** value, so every
-generated cube points at one schema.
+the widespread `{% if target.name == 'prod' %}` pattern — a Git-based pull **must**
+set **dbt target** to that production target name. Otherwise the macro takes its
+fallback branch and every model collapses onto the **dbt target schema** value, so
+every generated cube points at one schema. For a manifest upload, the target and
+resolved schemas are already baked into the artifact by your pipeline; Cube doesn't
+re-resolve them.
 </Warning>
 
 To see what a pull actually resolved, open any generated `.yml` and read its
@@ -171,15 +185,16 @@ declared-vs-resolved breakdown in the sync logs for a given pull.)
 
 ## Configure pull settings
 
-Pull options are saved on the integration itself, so every pull — manual or
-automated — uses the same configuration:
+Pull options are saved on the integration itself. Options that shape conversion apply
+to Git and uploaded-manifest pulls. A manifest pull without an integration uses the
+defaults below. Options that require Cube to run dbt apply only to the Git source.
 
 | Option | Default | Description |
 | --- | --- | --- |
 | **Output path** | `/model/cubes/dbt` | Directory in the repository where the generated cube files are written. This folder is replaced on each pull. |
 | **Name prefix** | `dbt_` | Prefix added to each generated cube's name. |
 | **Title prefix** | `(dbt) ` | Prefix added to each generated cube's display title. |
-| **Model selector** | _(empty)_ | Optional dbt selector using `dbt ls --select` syntax to limit which models are pulled, e.g. `tag:cube` or `marts.*`. Leave empty to pull all models. |
+| **Model selector** | _(empty)_ | **Git source only.** Optional dbt selector using `dbt ls --select` syntax to limit which models are pulled, e.g. `tag:cube` or `marts.*`. Leave empty to pull all models. |
 | **Only pull marts** | Off | When enabled, only pulls models whose path starts with the **Marts folder** value (e.g. `marts`). |
 | **Auto-detect primary keys from column names** | On | Falls back to a column-name guess when dbt declares no key. See [Primary key detection](#primary-key-detection). |
 | **Primary key column suffixes** | `_id` | Comma-separated suffixes treated as key columns, e.g. `_sk, _key`. The default `_id` also matches a column named `id`. Only shown when **Auto-detect primary keys from column names** is on. |
@@ -188,7 +203,7 @@ automated — uses the same configuration:
 | **Include descriptions** | On | Carries dbt model and column descriptions into cubes and dimensions. |
 | **Generate joins** | On | Infers joins between cubes from dbt `relationships` tests and foreign-key constraints. |
 | **Also generate reverse joins** | Off | Adds a `one_to_many` join back to the referencing cube, so a query can start from either side. Only shown when **Generate joins** is on. |
-| **Infer column types from dbt catalog** | Off | Reads real warehouse column types from dbt's `catalog.json` instead of guessing from column names. See [below](#infer-column-types-from-dbt-catalog). |
+| **Infer column types from dbt catalog** | Off | **Git source only.** Reads real warehouse column types from dbt's `catalog.json` instead of guessing from column names. See [below](#infer-column-types-from-dbt-catalog). |
 
 ### Primary key detection
 
@@ -240,8 +255,9 @@ models:
       # …every other column of the model needs a data_type too
 ```
 
-Your warehouse doesn't have to enforce primary keys for this to work — most don't. The
-pull only runs `dbt parse`, and reads the declaration out of `manifest.json`.
+Your warehouse doesn't have to enforce primary keys for this to work — most don't. A
+Git-based pull reads the declaration from the manifest produced by `dbt parse`; a
+manifest pull reads it from the artifact you upload.
 
 If your project doesn't use contracts, tier 2 is the way to declare a single-column key:
 add `unique` and `not_null` tests to it.
@@ -274,6 +290,10 @@ when none is declared — from a column-name heuristic (`*_id` → `number`, `cr
 `time`, …). Enable this option and the pull additionally runs `dbt docs generate` to
 produce dbt's `catalog.json`, which carries the **actual warehouse column types**.
 
+This option is only available for the Git source. An uploaded-manifest pull never runs
+dbt and accepts only `manifest.json`, so it uses declared data types from that artifact
+and the column-name fallback.
+
 Type precedence becomes: **declared `data_type` → catalog type → column-name heuristic**.
 An explicit `data_type` in your dbt YAML still wins; the catalog only fills the gaps.
 
@@ -287,6 +307,9 @@ An explicit `data_type` in your dbt YAML still wins; the catalog only fills the 
   declared and name-based types exactly as it would with the option off.
 
 ## Pass environment variables to dbt
+
+This section applies only to Git-based pulls. A manifest pull runs no dbt process in
+Cube; provide any variables to the pipeline command that creates the manifest.
 
 Some dbt projects read environment variables while the sandbox runs — most
 commonly a token used to install a **private dbt package**. For example, a
@@ -346,6 +369,9 @@ and the settings card flags it.
 
 ## Run a pull manually
 
+Manual pulls from the Cube UI use the Git source. To upload a manifest, use the
+[Cube CLI](#trigger-from-your-cicd-pipeline).
+
 <Steps>
 
 <Step title="Enter development mode">
@@ -387,16 +413,17 @@ through your normal workflow.
 
 ## Keep Cube in sync automatically
 
-Automated syncs run the same pipeline as a manual pull, but instead of committing to
-your working branch they **create a fresh review branch** — so a person can approve
-the update before it reaches the live data model.
+Automated syncs **create a fresh review branch** instead of committing to your working
+branch, so a person can approve the update before it reaches the live data model. CI
+can upload a manifest or ask Cube to clone a Git ref; repository webhooks use the Git
+source.
 
 ### Trigger from your CI/CD pipeline
 
 Cube exposes a REST endpoint you can call at the end of your dbt deployment pipeline,
-right after `dbt run`. As soon as your warehouse tables are rebuilt, your pipeline
-tells Cube to regenerate the matching cubes. The exact endpoint URL for your
-deployment is shown in the dbt settings card, ready to drop into a CI step.
+right after `dbt run` or `dbt build`. As soon as your warehouse tables are rebuilt,
+your pipeline can upload the `target/manifest.json` that command produced and tell Cube
+to regenerate the matching cubes.
 
 <Frame>
   <img
@@ -405,18 +432,30 @@ deployment is shown in the dbt settings card, ready to drop into a CI step.
   />
 </Frame>
 
-The [Cube CLI](/reference/cli#dbt-sync) wraps the same endpoint and can **wait** for
-the sync to finish, which is what turns it into a test gate: sync the ref under
-review, compile it, and fail the job before anything reaches production.
+The [Cube CLI](/reference/cli#dbt-sync) parses and uploads the manifest, then can
+**wait** for the sync to finish:
+
+```bash
+cube dbt sync DEPLOYMENT_ID --manifest target/manifest.json --wait
+```
+
+This is the preferred CI path: Cube converts the exact manifest the job validated,
+even if the remote branch moves before the sync starts. Cube needs no access to the
+dbt repository, and skips sandbox creation, cloning, dependency installation, and
+`dbt parse`. Use `--manifest -` to read the JSON from standard input. `--wait` exits
+non-zero if the sync fails.
+
+If Cube already has repository access and your job doesn't have a manifest, run a
+Git-based sync instead:
 
 ```bash
 cube dbt sync DEPLOYMENT_ID --ref "$GITHUB_HEAD_REF" --wait
 ```
 
-`--wait` exits non-zero if the sync fails, and `--ref` syncs the branch being
-reviewed rather than the one saved on the integration. See [dbt sync as a CI test
-gate](/reference/cli#dbt-sync-as-a-ci-test-gate) for the full pipeline, including
-the compile and query steps.
+`--ref` syncs the branch being reviewed rather than the one saved on the integration.
+It can't be combined with `--manifest`. See [dbt sync as a CI test
+gate](/reference/cli#dbt-sync-as-a-ci-test-gate) for a complete manifest-based pipeline,
+including the compile and query steps.
 
 ### Trigger on every push
 
@@ -682,8 +721,9 @@ Each push creates exactly two new files:
   [primary keys](#primary-key-detection) and joins.
 - **Pull is one-directional** — dbt pull never writes back to your dbt repository.
   Promoting cubes into dbt is the [dbt push](#push-cubes-to-dbt) direction (in preview).
-- **No warehouse connection** — a pull doesn't trigger a `dbt run`; it assumes your
-  tables are already built. The only exception is the opt-in
+- **No model build** — a pull doesn't trigger a `dbt run`; it assumes your tables are
+  already built. An uploaded-manifest pull never connects to the warehouse. The only
+  Cube-side warehouse connection is the Git source's opt-in
   [Infer column types from dbt catalog](#infer-column-types-from-dbt-catalog) option
   (in preview), which runs `dbt docs generate` on Snowflake, Amazon Redshift,
   PostgreSQL, and ClickHouse.

--- a/docs-mintlify/recipes/data-modeling/dbt.mdx
+++ b/docs-mintlify/recipes/data-modeling/dbt.mdx
@@ -6,8 +6,8 @@ description: Layer Cube cubes and views on dbt-built warehouse models, aligning 
 <Info>
 
 This recipe covers dynamic data models built with the Python `cube_dbt` package. To
-generate static cube files with Cube's dbt pull—including uploading your CI
-job's exact manifest with `cube dbt sync --manifest`—see the [dbt
+generate static cube files with Cube's dbt pull — including uploading your CI
+job's exact manifest with `cube dbt sync --manifest` — see the [dbt
 integration](/docs/integrations/dbt#trigger-from-your-cicd-pipeline).
 
 </Info>

--- a/docs-mintlify/recipes/data-modeling/dbt.mdx
+++ b/docs-mintlify/recipes/data-modeling/dbt.mdx
@@ -3,6 +3,15 @@ title: Using Cube with dbt
 description: Layer Cube cubes and views on dbt-built warehouse models, aligning documentation patterns with dimensions, measures, joins, and downstream APIs.
 ---
 
+<Info>
+
+This recipe covers dynamic data models built with the Python `cube_dbt` package. To
+generate static cube files with Cube's dbt pull—including uploading your CI
+job's exact manifest with `cube dbt sync --manifest`—see the [dbt
+integration](/docs/integrations/dbt#trigger-from-your-cicd-pipeline).
+
+</Info>
+
 [dbt][link-dbt-docs] is a popular data integration tool used by many Cube
 users to transform the data in the data warehouse before bringing it to the
 semantic layer.

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -177,7 +177,7 @@ Run `cube <command> --help` for the full options of any command.
 | `regions` | List available deployment regions |
 | `github` (`gh`) | GitHub integration: `status`, `installations`, `repos`, `branches`, `connect` |
 | `data-model` | Data model files and Git workflow: `list`, `get`, `put`, `delete`, `rename`, `file-hashes`, `branches`, `create-branch`, `delete-branch`, `enable-branch`/`disable-branch`, `dev-mode`, `commit`, `pull`, `merge`, `merge-to-default` |
-| `dbt` | dbt sync: `sync` (`--ref`, `--wait`), `status`, `result`, `logs`, `history` (`--status`, `--trigger`), `cancel` |
+| `dbt` | dbt sync: `sync` (`--ref` or `--manifest`, `--wait`), `status`, `result`, `logs`, `history` (`--status`, `--trigger`), `cancel` |
 | `environments` | Deployment environments and environment tokens |
 | `variables` | Deployment environment variables |
 | `folders`, `workbooks`, `reports`, `workspace` | Workspace content management |
@@ -333,13 +333,34 @@ cube data-model disable-branch DEPLOYMENT_ID my-branch
 
 ## dbt sync
 
-Pull a dbt project's models in as cubes. The repository, credential and
-warehouse settings come from the deployment's dbt integration, so a sync needs
-only the deployment:
+Pull a dbt project's models in as cubes. By default, Cube clones the repository
+configured on the deployment's dbt integration and runs dbt to produce a
+manifest, so a Git-based sync needs only the deployment:
 
 ```bash
 cube dbt sync DEPLOYMENT_ID --wait
 ```
+
+In CI, upload the manifest the dbt job already produced instead:
+
+```bash
+dbt parse
+cube dbt sync DEPLOYMENT_ID --manifest target/manifest.json --wait
+```
+
+`--manifest` parses the file as JSON and uploads it with the sync request. Cube
+converts that exact artifact without cloning the dbt repository, using a repository
+credential, provisioning a sandbox, or running dbt. This makes the sync faster and
+also works when the deployment has no dbt Git integration. Any dbt command that
+parses the project can produce `target/manifest.json`, including `dbt parse`, `dbt
+compile`, `dbt run`, and `dbt build`. Use `--manifest -` to read it from standard
+input.
+
+The server validates that the upload is a supported dbt manifest, rather than another
+dbt artifact such as `catalog.json` or `run_results.json`. Saved conversion settings
+are still applied when the deployment has them; otherwise their defaults are used.
+Settings that require Cube to execute dbt, such as the model selector and catalog type
+inference, apply only to Git-based syncs.
 
 Each sync creates a **new branch** for the generated cubes and prints its name.
 `--wait` polls until the sync finishes, reporting each stage, then prints the
@@ -352,9 +373,8 @@ cube dbt result DEPLOYMENT_ID SYNC_JOB_ID
 cube dbt cancel DEPLOYMENT_ID SYNC_JOB_ID
 ```
 
-`--ref` syncs a specific branch or tag of the dbt repository instead of the one
-saved on the integration — which is what makes a pull-request gate meaningful,
-since otherwise every run would compile the tracked branch:
+For a Git-based sync, `--ref` syncs a specific branch or tag of the dbt repository
+instead of the one saved on the integration:
 
 ```bash
 cube dbt sync DEPLOYMENT_ID --ref feature/orders-model --wait
@@ -362,17 +382,18 @@ cube dbt sync DEPLOYMENT_ID --ref feature/orders-model --wait
 
 <Note>
 
-`--ref` takes a branch or tag, not a commit SHA. Syncs are not free — each one
-provisions a sandbox and parses the project — so prefer one per push over one per
-commit.
+`--ref` takes a branch or tag, not a commit SHA, and can't be combined with
+`--manifest`: the uploaded manifest already identifies the exact dbt state to convert.
+Git-based syncs provision a sandbox and parse the project, so prefer one per push over
+one per commit. Manifest syncs skip those phases.
 
 </Note>
 
 ### Sync history and logs
 
-`history` lists a deployment's recent syncs — how each one was triggered, how it
-ended, and how long it took — and `logs` prints one sync's phase timeline,
-including the text a failed phase produced:
+`history` lists a deployment's recent syncs — how each one was triggered, whether its
+source was `git` or `manifest`, how it ended, and how long it took — and `logs` prints
+one sync's phase timeline, including the text a failed phase produced:
 
 ```bash
 cube dbt history DEPLOYMENT_ID
@@ -390,7 +411,9 @@ to and how long that phase took.
 Both need only `SchemaRead`. Durations are the server's own single-clock figure, so
 they never disagree with the run they describe. `--json` carries the rest of each
 record — the dbt ref that was synced, the phase that failed, per-phase timings and
-manifest counts.
+manifest counts. When the manifest provides them, `stats.dbtVersion` and
+`stats.manifestGeneratedAt` identify the dbt version and when the artifact itself was
+generated.
 
 `logs` is what turns a red CI step into something self-explaining: a failed
 `--wait` reports the reason, and the timeline says which phase produced it.
@@ -416,8 +439,9 @@ reason it prints says the sync was cancelled.
 
 ### dbt sync as a CI test gate
 
-Sync the branch under review, compile it, query it, and fail the job if any step
-breaks — without touching production:
+Parse the dbt project under review, upload that exact manifest, compile the generated
+Cube model, query it, and fail the job if any step breaks — without touching
+production or granting Cube access to the dbt repository:
 
 ```yaml
 # Dev mode is per credential, so two runs of this gate on one deployment would
@@ -433,10 +457,15 @@ env:
   DEPLOYMENT_ID: ${{ vars.CUBE_DEPLOYMENT_ID }}
 
 steps:
-  - name: Sync the dbt branch under review
+  # If an earlier step already ran dbt compile, run, or build, reuse the
+  # target/manifest.json it produced and omit this step.
+  - name: Parse the dbt project under review
+    run: dbt parse
+
+  - name: Upload the dbt manifest
     shell: bash
     run: |
-      cube dbt sync "$DEPLOYMENT_ID" --ref "$GITHUB_HEAD_REF" --wait --json > sync.json
+      cube dbt sync "$DEPLOYMENT_ID" --manifest target/manifest.json --wait --json > sync.json
       BRANCH=$(jq -er '.branchName | select(length > 0)' sync.json)
       echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
 
@@ -477,9 +506,11 @@ steps:
 ```
 
 With `--wait --json`, the sync returns the generated branch and terminal result in one
-document. The query must use the deployment's `deploymentUrl`, and the loop must retry
-[`Continue wait`][ref-rest-api-continue-wait] responses until data arrives. Replace
-`dbt_fct_orders.count` with a measure generated by the sync.
+document. Uploading the artifact produced in the preceding dbt step ensures Cube
+converts the same project state the job validated, even if the remote branch moves
+while the job is running. The query must use the deployment's `deploymentUrl`, and the
+loop must retry [`Continue wait`][ref-rest-api-continue-wait] responses until data
+arrives. Replace `dbt_fct_orders.count` with a measure generated by the sync.
 
 <Warning>
 
@@ -502,9 +533,7 @@ successful `jq` process.
 New dbt inputs such as `dbt sync --ref` reject an empty value, as do required branch
 arguments such as `data-model dev-mode` and `delete-branch`. Existing optional flags keep
 their previous behavior: `deployments build-status --branch ''` is still accepted for a
-one-shot status request, but is rejected with the new `--wait` gate. Note that
-`$GITHUB_HEAD_REF` is only set on `pull_request` events; on any other trigger `--ref`
-gets an empty string, which is why the run stops there.
+one-shot status request, but is rejected with the new `--wait` gate.
 
 Other existing optional `--branch` flags may accept an empty value for compatibility;
 omit them when you want the documented default.

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -354,8 +354,8 @@ credential, provisioning a sandbox, or running dbt. This makes the sync faster a
 also works when the deployment has no dbt Git integration. Any dbt command that
 parses the project can produce `target/manifest.json`, including `dbt parse`, `dbt
 compile`, `dbt run`, and `dbt build`. Use `--manifest -` to read it from standard
-input. The complete serialized request must be no larger than 50 MiB; the CLI checks
-this before uploading and directs larger projects to the Git-based sync path.
+input. Manifest upload requests must be no larger than 50 MiB; use the Git-based sync
+path for larger projects.
 After starting the sync, the CLI reads its history row to confirm the tenant honored
 the `manifest` source instead of silently falling back to Git, so `--manifest` requires
 both `SchemaUpdate` and `SchemaRead` access.

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -354,7 +354,11 @@ credential, provisioning a sandbox, or running dbt. This makes the sync faster a
 also works when the deployment has no dbt Git integration. Any dbt command that
 parses the project can produce `target/manifest.json`, including `dbt parse`, `dbt
 compile`, `dbt run`, and `dbt build`. Use `--manifest -` to read it from standard
-input.
+input. The complete serialized request must be no larger than 50 MiB; the CLI checks
+this before uploading and directs larger projects to the Git-based sync path.
+After starting the sync, the CLI reads its history row to confirm the tenant honored
+the `manifest` source instead of silently falling back to Git, so `--manifest` requires
+both `SchemaUpdate` and `SchemaRead` access.
 
 The server validates that the upload is a supported dbt manifest, rather than another
 dbt artifact such as `catalog.json` or `run_results.json`. Saved conversion settings

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -1,6 +1,7 @@
+use std::io::Read;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use clap::Subcommand;
 use owo_colors::OwoColorize;
 use serde_json::Value;
@@ -9,7 +10,7 @@ use crate::client::{Client, Query};
 use crate::wait::{self, Progress, Wait};
 use crate::{output, util, Ctx};
 
-/// Run a deployment's dbt sync: pull the dbt project, convert its models into
+/// Run a deployment's dbt sync: convert a dbt project or uploaded manifest into
 /// cubes, and commit them to a fresh branch.
 #[derive(clap::Args)]
 pub struct Args {
@@ -28,6 +29,10 @@ enum Cmd {
         /// only, so CI can test the ref under review.
         #[arg(long, value_parser = util::nonempty_ref)]
         r#ref: Option<String>,
+        /// Read and upload a dbt manifest from this path (`-` for stdin), instead
+        /// of cloning the dbt repository and running dbt
+        #[arg(long, value_name = "PATH", conflicts_with = "ref")]
+        manifest: Option<String>,
         /// Name for the Cube branch the generated cubes land on (defaults to a
         /// generated `dbt-sync/…` name)
         #[arg(long, value_parser = util::nonempty)]
@@ -106,6 +111,53 @@ enum Cmd {
 
 fn base(deployment: i64) -> String {
     format!("/api/v1/deployments/{deployment}/dbt-sync")
+}
+
+/// Read the manifest locally so the API receives the JSON object it declares, rather
+/// than a string containing JSON. Only the shape required by the wire contract is
+/// checked here; the server owns dbt artifact and schema-version validation, keeping
+/// one acceptance rule for every caller.
+fn read_manifest(path: &str) -> Result<Value> {
+    let (raw, source) = if path == "-" {
+        let mut raw = String::new();
+        std::io::stdin()
+            .read_to_string(&mut raw)
+            .context("failed to read dbt manifest from stdin")?;
+        (raw, "stdin".to_string())
+    } else {
+        (
+            std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read dbt manifest from {path}"))?,
+            path.to_string(),
+        )
+    };
+
+    parse_manifest(&raw, &source)
+}
+
+fn parse_manifest(raw: &str, source: &str) -> Result<Value> {
+    let manifest: Value = serde_json::from_str(raw)
+        .with_context(|| format!("dbt manifest from {source} is not valid JSON"))?;
+    if !manifest.is_object() {
+        bail!("dbt manifest from {source} must be a JSON object");
+    }
+
+    Ok(manifest)
+}
+
+/// Build the start payload in one place so the source discriminator can never be sent
+/// without the manifest it describes (or vice versa). Omitting a manifest deliberately
+/// omits `source` too, preserving the server's backwards-compatible git default.
+fn start_body(branch: &Option<String>, r#ref: &Option<String>, manifest: Option<Value>) -> Value {
+    let mut body = serde_json::Map::new();
+    util::set(&mut body, "branchName", branch);
+    util::set(&mut body, "ref", r#ref);
+    if let Some(manifest) = manifest {
+        body.insert("source".to_string(), Value::String("manifest".to_string()));
+        body.insert("manifest".to_string(), manifest);
+    }
+
+    util::body(body)
 }
 
 /// The status values that end a sync. Everything else — including a value this
@@ -324,10 +376,11 @@ fn human_duration_ms(raw: &str) -> String {
 /// The columns of `history`, paired with the row `history_row` builds — the two are
 /// positional, so they are declared next to each other and a test holds them the same
 /// width.
-const HISTORY_COLUMNS: [&str; 6] = [
+const HISTORY_COLUMNS: [&str; 7] = [
     "SYNC JOB ID",
     "STATUS",
     "TRIGGER",
+    "SOURCE",
     "STARTED",
     "DURATION",
     "BRANCH",
@@ -339,7 +392,7 @@ const ID_COLUMN: usize = 0;
 
 /// One run as a table row, under the names the list endpoint publishes.
 ///
-/// The columns are the six a run is identified and judged by; the rest of the record —
+/// The columns are the seven a run is identified and judged by; the rest of the record —
 /// `gitRef`, `failedPhase`, `lastStage`, per-phase timings, manifest counts — is in
 /// `--json`, which is where a table would stop being one.
 fn history_row(run: &Value) -> Vec<String> {
@@ -356,6 +409,7 @@ fn history_row(run: &Value) -> Vec<String> {
         // it shows what the row says.
         cell("status"),
         cell("trigger"),
+        cell("source"),
         cell("startedAt"),
         // `durationMs` ONLY — never `completedAt` minus `startedAt`. Those two stamps
         // are written by different processes, so their difference can disagree with the
@@ -542,15 +596,15 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
         Cmd::Sync {
             deployment,
             r#ref,
+            manifest,
             branch,
             wait,
             timeout,
             poll,
         } => {
-            let mut body = serde_json::Map::new();
-            util::set(&mut body, "branchName", &branch);
-            util::set(&mut body, "ref", &r#ref);
-            let started = api.post(&base(deployment), Some(&util::body(body))).await?;
+            let manifest = manifest.as_deref().map(read_manifest).transpose()?;
+            let body = start_body(&branch, &r#ref, manifest);
+            let started = api.post(&base(deployment), Some(&body)).await?;
 
             let sync_job_id = output::field(&started, "syncJobId");
             let branch_name = output::field(&started, "branchName");
@@ -848,6 +902,7 @@ mod tests {
     fn a_run_renders_the_record_the_list_endpoint_publishes() {
         let run = json!({
             "syncJobId": "abc", "deploymentId": 42, "status": "COMPLETED", "trigger": "api",
+            "source": "manifest",
             "branchName": "dbt-sync/main-1", "gitRef": "feature/orders",
             "startedAt": "2026-08-24T10:00:00Z", "completedAt": "2026-08-24T10:15:12Z",
             "durationMs": 912_345, "stats": { "cubeCount": 12 }
@@ -858,6 +913,7 @@ mod tests {
                 "abc",
                 "COMPLETED",
                 "api",
+                "manifest",
                 "2026-08-24T10:00:00Z",
                 "15m 12s",
                 "dbt-sync/main-1"
@@ -881,6 +937,50 @@ mod tests {
         assert_eq!(
             cell(&history_row(&json!({"status": " FAILED\n"})), "STATUS"),
             "FAILED"
+        );
+    }
+
+    #[test]
+    fn a_manifest_start_payload_selects_the_manifest_source() {
+        let manifest = json!({
+            "metadata": { "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json" },
+            "nodes": {}
+        });
+        assert_eq!(
+            start_body(&Some("review".to_string()), &None, Some(manifest.clone())),
+            json!({
+                "branchName": "review",
+                "source": "manifest",
+                "manifest": manifest
+            })
+        );
+
+        // The existing call remains byte-for-byte the old shape. The server defaults an
+        // omitted source to git, which keeps this CLI compatible with older tenants.
+        assert_eq!(
+            start_body(&None, &Some("main".to_string()), None),
+            json!({ "ref": "main" })
+        );
+    }
+
+    #[test]
+    fn a_manifest_must_be_a_json_object() {
+        let manifest = parse_manifest(r#"{"metadata":{},"nodes":{}}"#, "manifest.json")
+            .expect("an object is a valid request value");
+        assert!(manifest.is_object());
+
+        let array = parse_manifest("[]", "manifest.json").unwrap_err();
+        assert_eq!(
+            array.to_string(),
+            "dbt manifest from manifest.json must be a JSON object"
+        );
+
+        let malformed = parse_manifest("{", "manifest.json").unwrap_err();
+        assert!(
+            malformed
+                .to_string()
+                .starts_with("dbt manifest from manifest.json is not valid JSON"),
+            "{malformed:#}"
         );
     }
 

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{Read, Write};
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context as _, Result};
@@ -163,14 +163,31 @@ fn start_body(branch: &Option<String>, r#ref: &Option<String>, manifest: Option<
     util::body(body)
 }
 
-/// Cube's public edge and console server both accept JSON request bodies up to 50 MiB.
-/// Measure the complete serialized request, not the source file: parsing removes dbt's
-/// formatting, while the source and optional branch fields add their own bytes.
+/// Kept in step with the `50mb` JSON parsers in cubejs-enterprise's console-server
+/// `app.ts` and cloud-router `jsonBodyParsers.ts`. Measure the serialized request,
+/// because parsing removes dbt's formatting while the other request fields add bytes.
 const MANIFEST_UPLOAD_LIMIT_BYTES: usize = 50 * 1024 * 1024;
+const MANIFEST_SOURCE_TIMEOUT: Duration = Duration::from_secs(30);
+const MANIFEST_SOURCE_POLL: Duration = Duration::from_secs(1);
+
+#[derive(Default)]
+struct ByteCounter(usize);
+
+impl Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 fn ensure_manifest_upload_fits(body: &Value) -> Result<()> {
-    let bytes = serde_json::to_vec(body)?.len();
-    ensure_manifest_upload_size(bytes)
+    let mut counter = ByteCounter::default();
+    serde_json::to_writer(&mut counter, body)?;
+    ensure_manifest_upload_size(counter.0)
 }
 
 fn ensure_manifest_upload_size(bytes: usize) -> Result<()> {
@@ -186,48 +203,58 @@ fn ensure_manifest_upload_size(bytes: usize) -> Result<()> {
 }
 
 /// A pre-manifest server accepts the unknown fields, then silently starts a Git sync.
-/// Start/status do not carry a source; history is recorded before start returns, so its
-/// discriminator is the confirmation required before reporting success.
-fn ensure_manifest_source(history: &Value, sync_job_id: &str) -> Result<()> {
+/// Start/status do not carry a source, so require the history row's discriminator before
+/// reporting success; a briefly absent row remains a wait state rather than a verdict.
+fn manifest_source_progress(history: &Value, sync_job_id: &str) -> Result<Progress<()>> {
     let runs = output::items(history);
     let Some(run) = runs
         .iter()
         .find(|run| output::field(run, "syncJobId") == sync_job_id)
     else {
-        bail!(
-            "dbt sync {sync_job_id} started, but its manifest source could not be verified \
-             because the run is absent from sync history; the CLI will not treat it as a \
-             manifest sync"
-        );
+        return Ok(Progress::Waiting(
+            "sync history not available yet".to_string(),
+        ));
     };
 
     let source = output::field(run, "source");
     if source == "manifest" {
-        return Ok(());
+        return Ok(Progress::Done(()));
     }
 
     let report = if util::is_blank(&source) {
-        "did not report a source".to_string()
+        "did not report a source at all".to_string()
     } else {
-        format!("reported source `{source}`")
+        format!("reported source `{source}` instead of `manifest`")
     };
     bail!(
         "this Cube tenant did not confirm dbt manifest upload support: dbt sync \
-         {sync_job_id} {report} \
-         instead of `manifest`; update the tenant before retrying with `--manifest`"
+         {sync_job_id} {report}; update the tenant before retrying with `--manifest`"
     )
 }
 
 async fn verify_manifest_source(api: &Client, deployment: i64, sync_job_id: &str) -> Result<()> {
     let query = vec![("first".to_string(), "100".to_string())];
-    let history = api.get(&base(deployment), &query).await.with_context(|| {
-        format!(
-            "dbt sync {sync_job_id} started, but its manifest source could not be \
-                 verified from sync history"
+    wait::poll(
+        Wait::new(
+            "dbt manifest source",
+            MANIFEST_SOURCE_TIMEOUT,
+            MANIFEST_SOURCE_POLL,
         )
-    })?;
-
-    ensure_manifest_source(&history, sync_job_id)
+        .advising_nothing(),
+        || async {
+            let history = api.get(&base(deployment), &query).await?;
+            manifest_source_progress(&history, sync_job_id)
+        },
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "dbt sync {sync_job_id} was started, but the CLI could not confirm it used the \
+             uploaded manifest. Cancel the in-flight sync with `cube dbt cancel \
+             {deployment} {}`. Source verification requires `SchemaRead` access",
+            util::shell_quote(sync_job_id)
+        )
+    })
 }
 
 /// The status values that end a sync. Everything else — including a value this
@@ -679,12 +706,11 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
                 ensure_manifest_upload_fits(&body)?;
             }
             let started = api.post(&base(deployment), Some(&body)).await?;
+            let sync_job_id = output::field(&started, "syncJobId");
             if manifest_requested {
-                let sync_job_id = output::field(&started, "syncJobId");
                 verify_manifest_source(&api, deployment, &sync_job_id).await?;
             }
 
-            let sync_job_id = output::field(&started, "syncJobId");
             let branch_name = output::field(&started, "branchName");
             // Every message below says which branch, and a payload that named none would
             // otherwise leave a hole mid-sentence. The raw value stays for the two things
@@ -1043,23 +1069,27 @@ mod tests {
 
     #[test]
     fn a_manifest_start_must_be_confirmed_by_the_server() {
-        assert!(ensure_manifest_source(
-            &json!({ "items": [{
-                "syncJobId": "sync-1",
-                "source": "manifest"
-            }]}),
-            "sync-1"
-        )
-        .is_ok());
+        assert!(matches!(
+            manifest_source_progress(
+                &json!({ "items": [{
+                    "syncJobId": "sync-1",
+                    "source": "manifest"
+                }]}),
+                "sync-1"
+            )
+            .unwrap(),
+            Progress::Done(())
+        ));
 
-        let git = ensure_manifest_source(
+        let git = manifest_source_progress(
             &json!({ "items": [{
                 "syncJobId": "sync-2",
                 "source": "git"
             }]}),
             "sync-2",
         )
-        .unwrap_err();
+        .err()
+        .expect("a Git fallback must fail immediately");
         assert_eq!(
             git.to_string(),
             "this Cube tenant did not confirm dbt manifest upload support: dbt sync sync-2 \
@@ -1068,16 +1098,22 @@ mod tests {
         );
 
         let missing =
-            ensure_manifest_source(&json!({ "items": [{ "syncJobId": "sync-3" }] }), "sync-3")
-                .unwrap_err();
-        assert!(missing.to_string().contains("did not report a source"));
+            manifest_source_progress(&json!({ "items": [{ "syncJobId": "sync-3" }] }), "sync-3")
+                .err()
+                .expect("a row without a source must fail immediately");
+        assert_eq!(
+            missing.to_string(),
+            "this Cube tenant did not confirm dbt manifest upload support: dbt sync sync-3 \
+             did not report a source at all; update the tenant before retrying with \
+             `--manifest`"
+        );
 
-        let absent = ensure_manifest_source(
+        let absent = manifest_source_progress(
             &json!({ "items": [{ "syncJobId": "another-sync", "source": "manifest" }] }),
             "sync-4",
         )
-        .unwrap_err();
-        assert!(absent.to_string().contains("absent from sync history"));
+        .expect("an absent row is not a settled failure");
+        assert!(matches!(absent, Progress::Waiting(_)));
     }
 
     #[test]

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -165,14 +165,14 @@ fn start_body(branch: &Option<String>, r#ref: &Option<String>, manifest: Option<
 
 /// A pre-manifest server accepts the unknown fields, then silently starts a Git sync.
 /// Start/status do not carry a source, so require the synchronously recorded history
-/// row's discriminator before reporting success.
+/// row's discriminator before reporting success. History is ordered newest-first.
 fn ensure_manifest_source(history: &Value, sync_job_id: &str) -> Result<()> {
     let runs = output::items(history);
     let Some(run) = runs
         .iter()
         .find(|run| output::field(run, "syncJobId") == sync_job_id)
     else {
-        bail!("dbt sync {sync_job_id} is absent from sync history");
+        bail!("dbt sync {sync_job_id} was not found among the 100 most recent syncs");
     };
 
     let source = output::field(run, "source");
@@ -1062,7 +1062,7 @@ mod tests {
         .expect_err("an absent row must fail safely");
         assert_eq!(
             absent.to_string(),
-            "dbt sync sync-4 is absent from sync history"
+            "dbt sync sync-4 was not found among the 100 most recent syncs"
         );
     }
 

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -654,6 +654,12 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             let started = api.post(&base(deployment), Some(&body)).await?;
             let sync_job_id = output::field(&started, "syncJobId");
             if manifest_requested {
+                if util::is_blank(&sync_job_id) {
+                    bail!(
+                        "Cube started the dbt manifest sync but did not return a sync job id, \
+                         so its source could not be verified"
+                    );
+                }
                 verify_manifest_source(&api, deployment, &sync_job_id).await?;
             }
 

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::Read;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context as _, Result};
@@ -163,62 +163,21 @@ fn start_body(branch: &Option<String>, r#ref: &Option<String>, manifest: Option<
     util::body(body)
 }
 
-/// Kept in step with the `50mb` JSON parsers in cubejs-enterprise's console-server
-/// `app.ts` and cloud-router `jsonBodyParsers.ts`. Measure the serialized request,
-/// because parsing removes dbt's formatting while the other request fields add bytes.
-const MANIFEST_UPLOAD_LIMIT_BYTES: usize = 50 * 1024 * 1024;
-const MANIFEST_SOURCE_TIMEOUT: Duration = Duration::from_secs(30);
-const MANIFEST_SOURCE_POLL: Duration = Duration::from_secs(1);
-
-#[derive(Default)]
-struct ByteCounter(usize);
-
-impl Write for ByteCounter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0 += buf.len();
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-fn ensure_manifest_upload_fits(body: &Value) -> Result<()> {
-    let mut counter = ByteCounter::default();
-    serde_json::to_writer(&mut counter, body)?;
-    ensure_manifest_upload_size(counter.0)
-}
-
-fn ensure_manifest_upload_size(bytes: usize) -> Result<()> {
-    if bytes > MANIFEST_UPLOAD_LIMIT_BYTES {
-        bail!(
-            "dbt manifest upload is {:.1} MiB after JSON serialization, exceeding Cube's \
-             50 MiB request limit; omit `--manifest` and use a Git-based dbt sync instead",
-            bytes as f64 / (1024.0 * 1024.0)
-        );
-    }
-
-    Ok(())
-}
-
 /// A pre-manifest server accepts the unknown fields, then silently starts a Git sync.
-/// Start/status do not carry a source, so require the history row's discriminator before
-/// reporting success; a briefly absent row remains a wait state rather than a verdict.
-fn manifest_source_progress(history: &Value, sync_job_id: &str) -> Result<Progress<()>> {
+/// Start/status do not carry a source, so require the synchronously recorded history
+/// row's discriminator before reporting success.
+fn ensure_manifest_source(history: &Value, sync_job_id: &str) -> Result<()> {
     let runs = output::items(history);
     let Some(run) = runs
         .iter()
         .find(|run| output::field(run, "syncJobId") == sync_job_id)
     else {
-        return Ok(Progress::Waiting(
-            "sync history not available yet".to_string(),
-        ));
+        bail!("dbt sync {sync_job_id} is absent from sync history");
     };
 
     let source = output::field(run, "source");
     if source == "manifest" {
-        return Ok(Progress::Done(()));
+        return Ok(());
     }
 
     let report = if util::is_blank(&source) {
@@ -234,27 +193,17 @@ fn manifest_source_progress(history: &Value, sync_job_id: &str) -> Result<Progre
 
 async fn verify_manifest_source(api: &Client, deployment: i64, sync_job_id: &str) -> Result<()> {
     let query = vec![("first".to_string(), "100".to_string())];
-    wait::poll(
-        Wait::new(
-            "dbt manifest source",
-            MANIFEST_SOURCE_TIMEOUT,
-            MANIFEST_SOURCE_POLL,
-        )
-        .advising_nothing(),
-        || async {
-            let history = api.get(&base(deployment), &query).await?;
-            manifest_source_progress(&history, sync_job_id)
-        },
-    )
-    .await
-    .with_context(|| {
-        format!(
-            "dbt sync {sync_job_id} was started, but the CLI could not confirm it used the \
-             uploaded manifest. Cancel the in-flight sync with `cube dbt cancel \
-             {deployment} {}`. Source verification requires `SchemaRead` access",
-            util::shell_quote(sync_job_id)
-        )
-    })
+    api.get(&base(deployment), &query)
+        .await
+        .and_then(|history| ensure_manifest_source(&history, sync_job_id))
+        .with_context(|| {
+            format!(
+                "dbt sync {sync_job_id} was started, but the CLI could not confirm it used the \
+                 uploaded manifest. Cancel the in-flight sync with `cube dbt cancel \
+                 {deployment} {}`. Source verification requires `SchemaRead` access",
+                util::shell_quote(sync_job_id)
+            )
+        })
 }
 
 /// The status values that end a sync. Everything else — including a value this
@@ -702,9 +651,6 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             let manifest_requested = manifest.is_some();
             let manifest = manifest.as_deref().map(read_manifest).transpose()?;
             let body = start_body(&branch, &r#ref, manifest);
-            if manifest_requested {
-                ensure_manifest_upload_fits(&body)?;
-            }
             let started = api.post(&base(deployment), Some(&body)).await?;
             let sync_job_id = output::field(&started, "syncJobId");
             if manifest_requested {
@@ -1069,27 +1015,23 @@ mod tests {
 
     #[test]
     fn a_manifest_start_must_be_confirmed_by_the_server() {
-        assert!(matches!(
-            manifest_source_progress(
-                &json!({ "items": [{
-                    "syncJobId": "sync-1",
-                    "source": "manifest"
-                }]}),
-                "sync-1"
-            )
-            .unwrap(),
-            Progress::Done(())
-        ));
+        assert!(ensure_manifest_source(
+            &json!({ "items": [{
+                "syncJobId": "sync-1",
+                "source": "manifest"
+            }]}),
+            "sync-1"
+        )
+        .is_ok());
 
-        let git = manifest_source_progress(
+        let git = ensure_manifest_source(
             &json!({ "items": [{
                 "syncJobId": "sync-2",
                 "source": "git"
             }]}),
             "sync-2",
         )
-        .err()
-        .expect("a Git fallback must fail immediately");
+        .expect_err("a Git fallback must fail immediately");
         assert_eq!(
             git.to_string(),
             "this Cube tenant did not confirm dbt manifest upload support: dbt sync sync-2 \
@@ -1098,9 +1040,8 @@ mod tests {
         );
 
         let missing =
-            manifest_source_progress(&json!({ "items": [{ "syncJobId": "sync-3" }] }), "sync-3")
-                .err()
-                .expect("a row without a source must fail immediately");
+            ensure_manifest_source(&json!({ "items": [{ "syncJobId": "sync-3" }] }), "sync-3")
+                .expect_err("a row without a source must fail immediately");
         assert_eq!(
             missing.to_string(),
             "this Cube tenant did not confirm dbt manifest upload support: dbt sync sync-3 \
@@ -1108,25 +1049,15 @@ mod tests {
              `--manifest`"
         );
 
-        let absent = manifest_source_progress(
+        let absent = ensure_manifest_source(
             &json!({ "items": [{ "syncJobId": "another-sync", "source": "manifest" }] }),
             "sync-4",
         )
-        .expect("an absent row is not a settled failure");
-        assert!(matches!(absent, Progress::Waiting(_)));
-    }
-
-    #[test]
-    fn a_manifest_upload_stays_inside_the_request_limit() {
-        assert!(ensure_manifest_upload_fits(&json!({
-            "source": "manifest",
-            "manifest": { "nodes": {} }
-        }))
-        .is_ok());
-        assert!(ensure_manifest_upload_size(MANIFEST_UPLOAD_LIMIT_BYTES).is_ok());
-
-        let too_large = ensure_manifest_upload_size(MANIFEST_UPLOAD_LIMIT_BYTES + 1).unwrap_err();
-        assert!(too_large.to_string().contains("50 MiB request limit"));
+        .expect_err("an absent row must fail safely");
+        assert_eq!(
+            absent.to_string(),
+            "dbt sync sync-4 is absent from sync history"
+        );
     }
 
     #[test]

--- a/rust/cube-cli/src/commands/dbt.rs
+++ b/rust/cube-cli/src/commands/dbt.rs
@@ -31,7 +31,12 @@ enum Cmd {
         r#ref: Option<String>,
         /// Read and upload a dbt manifest from this path (`-` for stdin), instead
         /// of cloning the dbt repository and running dbt
-        #[arg(long, value_name = "PATH", conflicts_with = "ref")]
+        #[arg(
+            long,
+            value_name = "PATH",
+            value_parser = util::nonempty_path,
+            conflicts_with = "ref"
+        )]
         manifest: Option<String>,
         /// Name for the Cube branch the generated cubes land on (defaults to a
         /// generated `dbt-sync/…` name)
@@ -113,10 +118,8 @@ fn base(deployment: i64) -> String {
     format!("/api/v1/deployments/{deployment}/dbt-sync")
 }
 
-/// Read the manifest locally so the API receives the JSON object it declares, rather
-/// than a string containing JSON. Only the shape required by the wire contract is
-/// checked here; the server owns dbt artifact and schema-version validation, keeping
-/// one acceptance rule for every caller.
+/// Read locally so the API receives a JSON object rather than a string containing JSON.
+/// The server owns dbt artifact and schema-version validation.
 fn read_manifest(path: &str) -> Result<Value> {
     let (raw, source) = if path == "-" {
         let mut raw = String::new();
@@ -158,6 +161,73 @@ fn start_body(branch: &Option<String>, r#ref: &Option<String>, manifest: Option<
     }
 
     util::body(body)
+}
+
+/// Cube's public edge and console server both accept JSON request bodies up to 50 MiB.
+/// Measure the complete serialized request, not the source file: parsing removes dbt's
+/// formatting, while the source and optional branch fields add their own bytes.
+const MANIFEST_UPLOAD_LIMIT_BYTES: usize = 50 * 1024 * 1024;
+
+fn ensure_manifest_upload_fits(body: &Value) -> Result<()> {
+    let bytes = serde_json::to_vec(body)?.len();
+    ensure_manifest_upload_size(bytes)
+}
+
+fn ensure_manifest_upload_size(bytes: usize) -> Result<()> {
+    if bytes > MANIFEST_UPLOAD_LIMIT_BYTES {
+        bail!(
+            "dbt manifest upload is {:.1} MiB after JSON serialization, exceeding Cube's \
+             50 MiB request limit; omit `--manifest` and use a Git-based dbt sync instead",
+            bytes as f64 / (1024.0 * 1024.0)
+        );
+    }
+
+    Ok(())
+}
+
+/// A pre-manifest server accepts the unknown fields, then silently starts a Git sync.
+/// Start/status do not carry a source; history is recorded before start returns, so its
+/// discriminator is the confirmation required before reporting success.
+fn ensure_manifest_source(history: &Value, sync_job_id: &str) -> Result<()> {
+    let runs = output::items(history);
+    let Some(run) = runs
+        .iter()
+        .find(|run| output::field(run, "syncJobId") == sync_job_id)
+    else {
+        bail!(
+            "dbt sync {sync_job_id} started, but its manifest source could not be verified \
+             because the run is absent from sync history; the CLI will not treat it as a \
+             manifest sync"
+        );
+    };
+
+    let source = output::field(run, "source");
+    if source == "manifest" {
+        return Ok(());
+    }
+
+    let report = if util::is_blank(&source) {
+        "did not report a source".to_string()
+    } else {
+        format!("reported source `{source}`")
+    };
+    bail!(
+        "this Cube tenant did not confirm dbt manifest upload support: dbt sync \
+         {sync_job_id} {report} \
+         instead of `manifest`; update the tenant before retrying with `--manifest`"
+    )
+}
+
+async fn verify_manifest_source(api: &Client, deployment: i64, sync_job_id: &str) -> Result<()> {
+    let query = vec![("first".to_string(), "100".to_string())];
+    let history = api.get(&base(deployment), &query).await.with_context(|| {
+        format!(
+            "dbt sync {sync_job_id} started, but its manifest source could not be \
+                 verified from sync history"
+        )
+    })?;
+
+    ensure_manifest_source(&history, sync_job_id)
 }
 
 /// The status values that end a sync. Everything else — including a value this
@@ -602,9 +672,17 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             timeout,
             poll,
         } => {
+            let manifest_requested = manifest.is_some();
             let manifest = manifest.as_deref().map(read_manifest).transpose()?;
             let body = start_body(&branch, &r#ref, manifest);
+            if manifest_requested {
+                ensure_manifest_upload_fits(&body)?;
+            }
             let started = api.post(&base(deployment), Some(&body)).await?;
+            if manifest_requested {
+                let sync_job_id = output::field(&started, "syncJobId");
+                verify_manifest_source(&api, deployment, &sync_job_id).await?;
+            }
 
             let sync_job_id = output::field(&started, "syncJobId");
             let branch_name = output::field(&started, "branchName");
@@ -961,6 +1039,82 @@ mod tests {
             start_body(&None, &Some("main".to_string()), None),
             json!({ "ref": "main" })
         );
+    }
+
+    #[test]
+    fn a_manifest_start_must_be_confirmed_by_the_server() {
+        assert!(ensure_manifest_source(
+            &json!({ "items": [{
+                "syncJobId": "sync-1",
+                "source": "manifest"
+            }]}),
+            "sync-1"
+        )
+        .is_ok());
+
+        let git = ensure_manifest_source(
+            &json!({ "items": [{
+                "syncJobId": "sync-2",
+                "source": "git"
+            }]}),
+            "sync-2",
+        )
+        .unwrap_err();
+        assert_eq!(
+            git.to_string(),
+            "this Cube tenant did not confirm dbt manifest upload support: dbt sync sync-2 \
+             reported source `git` instead of `manifest`; update the tenant before retrying \
+             with `--manifest`"
+        );
+
+        let missing =
+            ensure_manifest_source(&json!({ "items": [{ "syncJobId": "sync-3" }] }), "sync-3")
+                .unwrap_err();
+        assert!(missing.to_string().contains("did not report a source"));
+
+        let absent = ensure_manifest_source(
+            &json!({ "items": [{ "syncJobId": "another-sync", "source": "manifest" }] }),
+            "sync-4",
+        )
+        .unwrap_err();
+        assert!(absent.to_string().contains("absent from sync history"));
+    }
+
+    #[test]
+    fn a_manifest_upload_stays_inside_the_request_limit() {
+        assert!(ensure_manifest_upload_fits(&json!({
+            "source": "manifest",
+            "manifest": { "nodes": {} }
+        }))
+        .is_ok());
+        assert!(ensure_manifest_upload_size(MANIFEST_UPLOAD_LIMIT_BYTES).is_ok());
+
+        let too_large = ensure_manifest_upload_size(MANIFEST_UPLOAD_LIMIT_BYTES + 1).unwrap_err();
+        assert!(too_large.to_string().contains("50 MiB request limit"));
+    }
+
+    #[test]
+    fn manifest_input_rejects_empty_paths_and_ref_combinations() {
+        use clap::Parser as _;
+
+        let empty = crate::Cli::try_parse_from(["cube", "dbt", "sync", "1", "--manifest", ""])
+            .err()
+            .expect("an empty manifest path should be rejected");
+        assert!(empty.to_string().contains("an empty value"));
+
+        let conflict = crate::Cli::try_parse_from([
+            "cube",
+            "dbt",
+            "sync",
+            "1",
+            "--manifest",
+            "-",
+            "--ref",
+            "main",
+        ])
+        .err()
+        .expect("manifest and ref should conflict");
+        assert!(conflict.to_string().contains("cannot be used with"));
     }
 
     #[test]

--- a/rust/cube-cli/src/util.rs
+++ b/rust/cube-cli/src/util.rs
@@ -178,6 +178,18 @@ pub fn nonempty_ref(s: &str) -> Result<String, String> {
     Ok(s.to_string())
 }
 
+/// Reject a supplied-but-empty file path while preserving meaningful whitespace in
+/// names that really contain it. `-` remains valid for commands that use it as stdin.
+pub fn nonempty_path(s: &str) -> Result<String, String> {
+    if s.trim().is_empty() {
+        return Err(format!(
+            "{EMPTY_VALUE_REFUSED} names no file to read — pass a path or `-` for stdin"
+        ));
+    }
+
+    Ok(s.to_string())
+}
+
 /// `nonempty` with a message specific to a LIST FILTER — `dbt history --status`, and
 /// anything that follows it — where an empty value is neither a filter nor nothing at
 /// all: `push` sends `status=`, and every runs / no runs / a complaint are three answers
@@ -554,6 +566,10 @@ mod tests {
         assert!(nonempty_ref("main").is_ok());
         assert!(nonempty_ref("").is_err());
         assert!(nonempty_ref("\t").is_err());
+        assert_eq!(nonempty_path("manifest.json").unwrap(), "manifest.json");
+        assert_eq!(nonempty_path("-").unwrap(), "-");
+        assert!(nonempty_path("").is_err());
+        assert!(nonempty_path("  ").is_err());
         assert_eq!(nonempty_filter("FAILED").unwrap(), "FAILED");
         assert!(nonempty_filter("").is_err());
         assert!(nonempty_filter("  ").is_err());


### PR DESCRIPTION
## Summary

- add `cube dbt sync --manifest <PATH>` with stdin support and local JSON-object validation
- send the uploaded artifact through the manifest sync source added by cubedevinc/cubejs-enterprise#14863; keep the existing Git request shape unchanged
- reject `--manifest` together with `--ref`, and show each run source in `dbt history`
- document the credential-free manifest workflow and update the existing CI-gate example
- distinguish the Python `cube_dbt` recipe from Cube CLI dbt pull

## Verification

- `cargo +1.90.0 fmt --all --check`
- `cargo +1.90.0 clippy --all-targets -- -D warnings`
- `cargo +1.90.0 test --locked` (91 passed)
- CLI help and `--manifest`/`--ref` conflict smoke test
- `git diff --check`
- docs internal-link scan: no failures in changed files (the repository-wide scanner reports 47 pre-existing unrelated links)