### PR TITLE
fix(react): ignore stale useCubeQuery responses

### DIFF
--- a/packages/cubejs-client-react/babel.config.js
+++ b/packages/cubejs-client-react/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript',
+  ],
+};

--- a/packages/cubejs-client-react/jest.config.js
+++ b/packages/cubejs-client-react/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   moduleNameMapper: {
     ...base.moduleNameMapper,
-    '^@cubejs-client/core$': '<rootDir>/test/core-mock.ts',
+    '^@cubejs-client/core$': '<rootDir>/../cubejs-client-core/src/index.ts',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/packages/cubejs-client-react/jest.config.js
+++ b/packages/cubejs-client-react/jest.config.js
@@ -12,6 +12,5 @@ module.exports = {
   moduleNameMapper: {
     ...base.moduleNameMapper,
     '^@cubejs-client/core$': '<rootDir>/../cubejs-client-core/src/index.ts',
-    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/packages/cubejs-client-react/jest.config.js
+++ b/packages/cubejs-client-react/jest.config.js
@@ -1,0 +1,16 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  collectCoverage: false,
+  testEnvironment: 'jsdom',
+  watchman: false,
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
+  moduleNameMapper: {
+    ...base.moduleNameMapper,
+    '^@cubejs-client/core$': '<rootDir>/test/core-mock.ts',
+  },
+};

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -15,8 +15,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --build",
+    "test": "yarn test:types && jest --runInBand",
+    "test:types": "tsc --project tsconfig.test.json",
     "tsc": "tsc --build",
-    "test": "jest --runInBand",
     "watch": "tsc --build --watch"
   },
   "files": [
@@ -36,7 +37,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@types/jest": "^29",
     "@types/ramda": "^0.27.40",
-    "@types/react": "^16.9.41",
+    "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "babel-jest": "^29",
     "jest": "^29",

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc --build",
     "tsc": "tsc --build",
+    "test": "jest --runInBand",
     "watch": "tsc --build --watch"
   },
   "files": [
@@ -30,8 +31,18 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.12.13",
+    "@babel/preset-typescript": "^7.13.0",
+    "@types/jest": "^29",
     "@types/ramda": "^0.27.40",
     "@types/react": "^16.9.41",
+    "@types/react-dom": "^18.3.0",
+    "babel-jest": "^29",
+    "jest": "^29",
+    "jest-environment-jsdom": "^29",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "~6.0.3"
   },
   "peerDependencies": {

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -15,9 +15,10 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --build",
-    "test": "yarn test:types && jest --runInBand",
+    "test": "yarn unit",
     "test:types": "tsc --project tsconfig.test.json",
     "tsc": "tsc --build",
+    "unit": "yarn test:types && jest --runInBand",
     "watch": "tsc --build --watch"
   },
   "files": [

--- a/packages/cubejs-client-react/src/QueryBuilder.tsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.tsx
@@ -144,7 +144,7 @@ const granularities: GranularityOption[] = [
 export default class QueryBuilder extends React.Component<QueryBuilderProps, QueryBuilderInternalState> {
   static contextType = CubeContext;
 
-  declare context: React.ContextType<typeof CubeContext>;
+  context!: React.ContextType<typeof CubeContext>;
 
   static defaultProps = {
     cubeApi: null,

--- a/packages/cubejs-client-react/src/QueryBuilder.tsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.tsx
@@ -144,6 +144,8 @@ const granularities: GranularityOption[] = [
 export default class QueryBuilder extends React.Component<QueryBuilderProps, QueryBuilderInternalState> {
   static contextType = CubeContext;
 
+  declare context: React.ContextType<typeof CubeContext>;
+
   static defaultProps = {
     cubeApi: null,
     stateChangeHeuristics: null,

--- a/packages/cubejs-client-react/src/QueryBuilder.tsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.tsx
@@ -280,10 +280,6 @@ export default class QueryBuilder extends React.Component<QueryBuilderProps, Que
   // TypeScript field declarations into `everything-else`, which the configured
   // order puts after `lifecycle`. Runtime is unaffected: field initializers run
   // right after `super()`, so the constructor's assignments still win.
-  //
-  // `this.context` is not re-declared: React types it as `any`, and a field
-  // declaration would be emitted at runtime and shadow the context React
-  // assigns.
   private mutexObj: MutexObj;
 
   private orderMembersOrderKeys: string[];

--- a/packages/cubejs-client-react/src/QueryRenderer.tsx
+++ b/packages/cubejs-client-react/src/QueryRenderer.tsx
@@ -20,7 +20,7 @@ import type {
 export default class QueryRenderer extends React.Component<QueryRendererProps, QueryRendererState> {
   static contextType = CubeContext;
 
-  declare context: React.ContextType<typeof CubeContext>;
+  context!: React.ContextType<typeof CubeContext>;
 
   static defaultProps = {
     cubeApi: null,

--- a/packages/cubejs-client-react/src/QueryRenderer.tsx
+++ b/packages/cubejs-client-react/src/QueryRenderer.tsx
@@ -85,10 +85,6 @@ export default class QueryRenderer extends React.Component<QueryRendererProps, Q
   // TypeScript field declarations into `everything-else`, which the configured
   // order puts after `lifecycle`. Runtime is unaffected: field initializers run
   // right after `super()`, so the constructor's assignments still win.
-  //
-  // `this.context` is not re-declared: React types it as `any`, and a field
-  // declaration would be emitted at runtime and shadow the context React
-  // assigns.
   private mutexObj: MutexObj;
 
   cubeApi(): CubeApi {

--- a/packages/cubejs-client-react/src/QueryRenderer.tsx
+++ b/packages/cubejs-client-react/src/QueryRenderer.tsx
@@ -20,6 +20,8 @@ import type {
 export default class QueryRenderer extends React.Component<QueryRendererProps, QueryRendererState> {
   static contextType = CubeContext;
 
+  declare context: React.ContextType<typeof CubeContext>;
+
   static defaultProps = {
     cubeApi: null,
     query: null,

--- a/packages/cubejs-client-react/src/hooks/cube-query.ts
+++ b/packages/cubejs-client-react/src/hooks/cube-query.ts
@@ -75,15 +75,26 @@ export function useCubeQuery(
   const [progress, setProgress] = useState<ProgressResponse | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const context = useContext(CubeContext);
+  const requestIdRef = useRef(0);
 
   let subscribeRequest: UnsubscribeObj | null = null;
 
-  // `progressResponse` is not part of the public `ProgressResult` API
-  const progressCallback: ProgressCallback = (progressResult) => setProgress(
-    (progressResult as unknown as ProgressResultWithResponse).progressResponse
-  );
+  function isCurrentRequest(requestId: number) {
+    return requestId === requestIdRef.current;
+  }
 
-  async function fetch() {
+  function createProgressCallback(requestId: number): ProgressCallback {
+    return (progressResult) => {
+      if (isCurrentRequest(requestId)) {
+        // `progressResponse` is not part of the public `ProgressResult` API
+        setProgress(
+          (progressResult as unknown as ProgressResultWithResponse).progressResponse
+        );
+      }
+    };
+  }
+
+  async function fetchQuery(requestId: number) {
     const { resetResultSetOnChange } = options;
     const cubeApi = options.cubeApi || context?.cubeApi;
 
@@ -102,20 +113,32 @@ export function useCubeQuery(
       const response = await cubeApi.load(query, {
         mutexObj: mutexRef.current,
         mutexKey: 'query',
-        progressCallback,
+        progressCallback: createProgressCallback(requestId),
         castNumerics: Boolean(typeof options.castNumerics === 'boolean' ? options.castNumerics : context?.options?.castNumerics),
         ...(options.cache ? { cache: options.cache } : {}),
       });
 
-      setResultSet(response);
-      setProgress(null);
+      if (isCurrentRequest(requestId)) {
+        setResultSet(response);
+        setProgress(null);
+      }
     } catch (loadError) {
-      setError(loadError as Error);
-      setResultSet(null);
-      setProgress(null);
+      if (isCurrentRequest(requestId)) {
+        setError(loadError as Error);
+        setResultSet(null);
+        setProgress(null);
+      }
     }
 
-    setLoading(false);
+    if (isCurrentRequest(requestId)) {
+      setLoading(false);
+    }
+  }
+
+  async function fetch() {
+    const requestId = ++requestIdRef.current;
+
+    await fetchQuery(requestId);
   }
 
   useEffect(() => {
@@ -129,6 +152,8 @@ export function useCubeQuery(
 
     async function loadQuery() {
       if (!skip && isQueryPresent(query)) {
+        const requestId = ++requestIdRef.current;
+
         // `areQueriesEqual` is declared for a single query, and reads no more
         // than `order` off one when given an array of queries
         const previousQuery = currentQuery as DeeplyReadonly<Query> | null;
@@ -155,27 +180,31 @@ export function useCubeQuery(
               {
                 mutexObj: mutexRef.current,
                 mutexKey: 'query',
-                progressCallback,
+                progressCallback: createProgressCallback(requestId),
                 ...(options.cache ? { cache: options.cache } : {}),
               },
               (e, result) => {
-                if (e) {
-                  setError(e);
-                } else {
-                  setResultSet(result);
+                if (isCurrentRequest(requestId)) {
+                  if (e) {
+                    setError(e);
+                  } else {
+                    setResultSet(result);
+                  }
+                  setLoading(false);
+                  setProgress(null);
                 }
-                setLoading(false);
-                setProgress(null);
               }
             );
           } else {
-            await fetch();
+            await fetchQuery(requestId);
           }
         } catch (e) {
-          setError(e as Error);
-          setResultSet(null);
-          setLoading(false);
-          setProgress(null);
+          if (isCurrentRequest(requestId)) {
+            setError(e as Error);
+            setResultSet(null);
+            setLoading(false);
+            setProgress(null);
+          }
         }
       }
     }
@@ -183,6 +212,8 @@ export function useCubeQuery(
     loadQuery();
 
     return () => {
+      requestIdRef.current += 1;
+
       if (subscribeRequest) {
         subscribeRequest.unsubscribe();
         subscribeRequest = null;

--- a/packages/cubejs-client-react/src/hooks/cube-query.ts
+++ b/packages/cubejs-client-react/src/hooks/cube-query.ts
@@ -76,11 +76,18 @@ export function useCubeQuery(
   const [error, setError] = useState<Error | null>(null);
   const context = useContext(CubeContext);
   const requestIdRef = useRef(0);
+  const hasStartedRequestRef = useRef(false);
 
   let subscribeRequest: UnsubscribeObj | null = null;
 
   function isCurrentRequest(requestId: number) {
     return requestId === requestIdRef.current;
+  }
+
+  function startRequest() {
+    hasStartedRequestRef.current = true;
+
+    return ++requestIdRef.current;
   }
 
   function createProgressCallback(requestId: number): ProgressCallback {
@@ -108,6 +115,7 @@ export function useCubeQuery(
 
     setError(null);
     setLoading(true);
+    setProgress(null);
 
     try {
       const response = await cubeApi.load(query, {
@@ -136,7 +144,7 @@ export function useCubeQuery(
   }
 
   async function fetch() {
-    const requestId = ++requestIdRef.current;
+    const requestId = startRequest();
 
     await fetchQuery(requestId);
   }
@@ -152,7 +160,7 @@ export function useCubeQuery(
 
     async function loadQuery() {
       if (!skip && isQueryPresent(query)) {
-        const requestId = ++requestIdRef.current;
+        const requestId = startRequest();
 
         // `areQueriesEqual` is declared for a single query, and reads no more
         // than `order` off one when given an array of queries
@@ -167,6 +175,7 @@ export function useCubeQuery(
 
         setError(null);
         setLoading(true);
+        setProgress(null);
 
         try {
           if (subscribeRequest) {
@@ -206,6 +215,9 @@ export function useCubeQuery(
             setProgress(null);
           }
         }
+      } else if (hasStartedRequestRef.current) {
+        setLoading(false);
+        setProgress(null);
       }
     }
 

--- a/packages/cubejs-client-react/test/core-mock.ts
+++ b/packages/cubejs-client-react/test/core-mock.ts
@@ -1,0 +1,7 @@
+export function isQueryPresent(query: unknown) {
+  return Boolean(query && Object.keys(query).length);
+}
+
+export function areQueriesEqual(left: unknown, right: unknown) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/packages/cubejs-client-react/test/core-mock.ts
+++ b/packages/cubejs-client-react/test/core-mock.ts
@@ -1,7 +1,0 @@
-export function isQueryPresent(query: unknown) {
-  return Boolean(query && Object.keys(query).length);
-}
-
-export function areQueriesEqual(left: unknown, right: unknown) {
-  return JSON.stringify(left) === JSON.stringify(right);
-}

--- a/packages/cubejs-client-react/test/cube-query.test.tsx
+++ b/packages/cubejs-client-react/test/cube-query.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 
@@ -8,10 +8,6 @@ import type {
   UseCubeQueryInternalResult,
   UseCubeQueryOptions,
 } from '../src/types';
-
-const { act } = React as typeof React & {
-  act: typeof import('react-dom/test-utils').act;
-};
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
@@ -106,7 +102,17 @@ describe('useCubeQuery', () => {
     };
 
     render({ measures: ['Orders.count'] }, { cubeApi: cubeApi as never });
+    act(() => {
+      cubeApi.load.mock.calls[0][1].progressCallback({
+        progressResponse: staleProgress,
+      });
+    });
+
+    expect(hookResult.progress).toBe(staleProgress);
+
     render({ measures: ['Users.count'] }, { cubeApi: cubeApi as never });
+
+    expect(hookResult.progress).toBeNull();
 
     act(() => {
       cubeApi.load.mock.calls[1][1].progressCallback({
@@ -132,6 +138,47 @@ describe('useCubeQuery', () => {
       secondRequest.resolve({ request: 'latest' });
       await secondRequest.promise;
     });
+  });
+
+  it('settles loading when an in-flight request is invalidated without a replacement', async () => {
+    const request = deferred<object>();
+    const cubeApi = { load: jest.fn().mockReturnValue(request.promise) };
+
+    render({ measures: ['Orders.count'] }, { cubeApi: cubeApi as never });
+
+    act(() => {
+      cubeApi.load.mock.calls[0][1].progressCallback({
+        progressResponse: { stage: 'Executing query' },
+      });
+    });
+
+    expect(hookResult.isLoading).toBe(true);
+    expect(hookResult.progress).not.toBeNull();
+
+    render(
+      { measures: ['Orders.count'] },
+      { cubeApi: cubeApi as never, skip: true }
+    );
+
+    expect(hookResult.isLoading).toBe(false);
+    expect(hookResult.progress).toBeNull();
+
+    await act(async () => {
+      request.resolve({ request: 'stale' });
+      await request.promise;
+    });
+
+    expect(hookResult.resultSet).toBeNull();
+    expect(hookResult.isLoading).toBe(false);
+  });
+
+  it('preserves the initial loading state for an empty query', () => {
+    const cubeApi = { load: jest.fn() };
+
+    render({}, { cubeApi: cubeApi as never });
+
+    expect(cubeApi.load).not.toHaveBeenCalled();
+    expect(hookResult.isLoading).toBe(true);
   });
 
   it('ignores callbacks from a superseded subscription', () => {

--- a/packages/cubejs-client-react/test/cube-query.test.tsx
+++ b/packages/cubejs-client-react/test/cube-query.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+
+import { useCubeQuery } from '../src/hooks/cube-query';
+import type {
+  ReadonlyQueryInput,
+  UseCubeQueryInternalResult,
+  UseCubeQueryOptions,
+} from '../src/types';
+
+const { act } = React as typeof React & {
+  act: typeof import('react-dom/test-utils').act;
+};
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('useCubeQuery', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let hookResult: UseCubeQueryInternalResult;
+
+  function TestComponent({
+    query,
+    options,
+  }: {
+    query: ReadonlyQueryInput;
+    options: UseCubeQueryOptions;
+  }) {
+    hookResult = useCubeQuery(query, options);
+
+    return null;
+  }
+
+  function render(query: ReadonlyQueryInput, options: UseCubeQueryOptions) {
+    act(() => {
+      root.render(<TestComponent query={query} options={options} />);
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+  });
+
+  it('keeps the latest result when a superseded load resolves with null last', async () => {
+    const firstRequest = deferred<null>();
+    const secondRequest = deferred<object>();
+    const latestResult = { request: 'latest' };
+    const cubeApi = {
+      load: jest.fn()
+        .mockReturnValueOnce(firstRequest.promise)
+        .mockReturnValueOnce(secondRequest.promise),
+    };
+
+    render({ measures: ['Orders.count'] }, { cubeApi: cubeApi as never });
+    render({ measures: ['Users.count'] }, { cubeApi: cubeApi as never });
+
+    await act(async () => {
+      secondRequest.resolve(latestResult);
+      await secondRequest.promise;
+    });
+
+    expect(hookResult.resultSet).toBe(latestResult);
+
+    await act(async () => {
+      firstRequest.resolve(null);
+      await firstRequest.promise;
+    });
+
+    expect(hookResult.resultSet).toBe(latestResult);
+    expect(hookResult.isLoading).toBe(false);
+  });
+
+  it('ignores stale load errors, progress, and loading updates', async () => {
+    const firstRequest = deferred<object>();
+    const secondRequest = deferred<object>();
+    const latestProgress = { stage: 'Executing query' };
+    const staleProgress = { stage: 'Stale query' };
+    const cubeApi = {
+      load: jest.fn()
+        .mockReturnValueOnce(firstRequest.promise)
+        .mockReturnValueOnce(secondRequest.promise),
+    };
+
+    render({ measures: ['Orders.count'] }, { cubeApi: cubeApi as never });
+    render({ measures: ['Users.count'] }, { cubeApi: cubeApi as never });
+
+    act(() => {
+      cubeApi.load.mock.calls[1][1].progressCallback({
+        progressResponse: latestProgress,
+      });
+      cubeApi.load.mock.calls[0][1].progressCallback({
+        progressResponse: staleProgress,
+      });
+    });
+
+    expect(hookResult.progress).toBe(latestProgress);
+
+    await act(async () => {
+      firstRequest.reject(new Error('stale failure'));
+      await firstRequest.promise.catch(() => undefined);
+    });
+
+    expect(hookResult.error).toBeNull();
+    expect(hookResult.progress).toBe(latestProgress);
+    expect(hookResult.isLoading).toBe(true);
+
+    await act(async () => {
+      secondRequest.resolve({ request: 'latest' });
+      await secondRequest.promise;
+    });
+  });
+
+  it('ignores callbacks from a superseded subscription', () => {
+    const callbacks: Array<(error: Error | null, result?: object | null) => void> = [];
+    const progressCallbacks: Array<(progress: object) => void> = [];
+    const cubeApi = {
+      subscribe: jest.fn((query, options, callback) => {
+        progressCallbacks.push(options.progressCallback);
+        callbacks.push(callback);
+
+        return { unsubscribe: jest.fn() };
+      }),
+    };
+    const latestResult = { request: 'latest' };
+
+    render(
+      { measures: ['Orders.count'] },
+      { cubeApi: cubeApi as never, subscribe: true }
+    );
+    render(
+      { measures: ['Users.count'] },
+      { cubeApi: cubeApi as never, subscribe: true }
+    );
+
+    act(() => {
+      progressCallbacks[0]({ progressResponse: { stage: 'Stale query' } });
+      callbacks[0](null, { request: 'stale' });
+    });
+
+    expect(hookResult.resultSet).toBeNull();
+    expect(hookResult.progress).toBeNull();
+    expect(hookResult.isLoading).toBe(true);
+
+    act(() => callbacks[1](null, latestResult));
+
+    expect(hookResult.resultSet).toBe(latestResult);
+    expect(hookResult.isLoading).toBe(false);
+
+    act(() => callbacks[0](new Error('stale failure')));
+
+    expect(hookResult.resultSet).toBe(latestResult);
+    expect(hookResult.error).toBeNull();
+  });
+});

--- a/packages/cubejs-client-react/tsconfig.test.json
+++ b/packages/cubejs-client-react/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["jest"]
+  },
+  "include": ["test/**/*"]
+}


### PR DESCRIPTION
## Summary

- guard `useCubeQuery` state updates with a per-request ID
- ignore stale load results, errors, progress updates, and loading completions
- apply the same protection to subscription callbacks and invalidate requests during effect cleanup
- keep the existing `mutexPromise` null cancellation contract unchanged

## Testing

- `yarn build`
- `yarn workspace @cubejs-client/react unit`
- `yarn oxlint packages/cubejs-client-react/src packages/cubejs-client-react/test`
- package.json validation

The test type-check expects the core package declarations produced by the root `yarn tsc` / `yarn build` step. CI runs those before the Lerna `unit` jobs.

Fixes CUB-4568.
