### PR TITLE
docs: document CUBEJS_API_SECRETS

### DIFF
--- a/docs-mintlify/embedding/authentication/jwt.mdx
+++ b/docs-mintlify/embedding/authentication/jwt.mdx
@@ -21,7 +21,7 @@ The diagram below shows how it works during the request processing in Cube:
 
 Relevant configuration options: [`check_auth`][ref-config-check-auth] and [`jwt`][ref-config-jwt].
 
-Relevant environment variables: [`CUBEJS_API_SECRET`](/reference/configuration/environment-variables#cubejs_api_secret), [`CUBEJS_JWT_KEY`](/reference/configuration/environment-variables#cubejs_jwt_key), [`CUBEJS_JWK_URL`](/reference/configuration/environment-variables#cubejs_jwk_url),
+Relevant environment variables: [`CUBEJS_API_SECRET`](/reference/configuration/environment-variables#cubejs_api_secret), [`CUBEJS_API_SECRETS`](/reference/configuration/environment-variables#cubejs_api_secrets), [`CUBEJS_JWT_KEY`](/reference/configuration/environment-variables#cubejs_jwt_key), [`CUBEJS_JWK_URL`](/reference/configuration/environment-variables#cubejs_jwk_url),
 [`CUBEJS_JWT_AUDIENCE`](/reference/configuration/environment-variables#cubejs_jwt_audience), [`CUBEJS_JWT_ISSUER`](/reference/configuration/environment-variables#cubejs_jwt_issuer), [`CUBEJS_JWT_SUBJECT`](/reference/configuration/environment-variables#cubejs_jwt_subject), [`CUBEJS_JWT_CLAIMS_NAMESPACE`](/reference/configuration/environment-variables#cubejs_jwt_claims_namespace).
 
 ## Custom authentication

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -24,6 +24,33 @@ The secret key used to sign and verify JWTs. Generated on project scaffold with
 See also the [`check_auth` configuration
 option](/reference/configuration/config#check_auth).
 
+## `CUBEJS_API_SECRETS`
+
+A comma-separated list of secret keys accepted when verifying JWTs. Use it to
+rotate [`CUBEJS_API_SECRET`](#cubejs_api_secret) without a window in which valid
+tokens are rejected: list the outgoing and incoming secrets together until every
+client has re-signed, then drop the outgoing one.
+
+| Possible Values                   | Default in Development | Default in Production |
+| --------------------------------- | ---------------------- | --------------------- |
+| A comma-separated list of strings | N/A                    | N/A                   |
+
+```dotenv
+CUBEJS_API_SECRETS=outgoing-secret,incoming-secret
+```
+
+A token is accepted if any secret in the list verifies its signature. Whitespace
+around entries is trimmed, empty entries are dropped, and duplicates are removed.
+
+When set to a non-empty value, this variable takes precedence over
+`CUBEJS_API_SECRET` and only the listed secrets are accepted. Set it to an empty
+value to fall back to `CUBEJS_API_SECRET`.
+
+This variable affects verification only; tokens are still signed with whichever
+single secret the issuer holds. It has no effect when
+[`CUBEJS_JWK_URL`](#cubejs_jwk_url) is set, because signing keys are then
+resolved from the JWKS endpoint by key ID.
+
 ## `CUBEJS_APP`
 
 An application ID used to uniquely identify the Cube deployment. Can be


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`CUBEJS_API_SECRETS` shipped in **v1.6.54** (#10985, merged 3 Jun 2026) but the accompanying docs went into the deprecated `docs/` tree, so the variable has never appeared on docs.cube.dev. A customer rotating their API secret searches the live docs, finds only `CUBEJS_API_SECRET`, and concludes that zero-downtime rotation is unsupported.

This adds the reference entry next to `CUBEJS_API_SECRET`, and lists it among the relevant environment variables on the JWT authentication page so it is discoverable from the auth flow.

Docs-only change; no package code is touched, so the first three checklist items do not apply.

### Documented behavior

Taken from the implementation rather than the PR description:

- Any secret in the list verifies a token — `createDefaultCheckAuth`, `packages/cubejs-api-gateway/src/gateway.ts`
- Non-empty list takes precedence over the singular; empty falls back — `apiSecrets`, `packages/cubejs-backend-shared/src/env.ts`
- Entries are trimmed, empties dropped, duplicates removed — same accessor
- Verification only; signing is unchanged
- No effect when `CUBEJS_JWK_URL` is set, since keys resolve from JWKS by `kid`

### Verified

Behavior was checked against a live v1.7.33 deployment before writing: two secrets in the list both accepted simultaneously, a secret outside the list rejected, and narrowing the list revoked the dropped secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)