### PR TITLE
refactor(tesseract): render member references as symbols

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
@@ -55,7 +55,7 @@ impl LogicalSchema {
         for (i, m) in self.time_dimensions.iter().enumerate() {
             if m.full_name() == name {
                 result.push(i + self.dimensions.len());
-            } else if let Ok(time_dimension) = m.as_time_dimension() {
+            } else if let Some(time_dimension) = m.time_dimension_behind_references() {
                 if time_dimension.base_symbol().full_name() == name {
                     result.push(i + self.dimensions.len());
                 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
@@ -230,6 +230,46 @@ mod tests {
         Ok(())
     }
 
+    /// A time dimension a select reads from a source is held in the schema as a
+    /// reference. ORDER BY names the base dimension, without the granularity
+    /// suffix, so the position lookup has to find it through that reference —
+    /// otherwise the sort key is silently dropped.
+    #[test]
+    fn test_find_member_positions_for_a_referenced_time_dimension() -> Result<(), CubeError> {
+        use crate::physical_plan::symbols::column_ref_symbol::column_reference;
+        use crate::physical_plan::QualifiedColumnName;
+
+        let schema = MockSchema::from_yaml_file("common/visitors.yaml");
+        let ctx = TestContext::new(schema)?;
+
+        let time_dim_base = ctx.create_dimension("visitors.created_at")?;
+        let time_dim = MemberSymbol::new_time_dimension(TimeDimensionSymbol::new(
+            time_dim_base,
+            Some("day".to_string()),
+            None,
+            None,
+        ));
+        let reference = column_reference(
+            &time_dim,
+            QualifiedColumnName::new(Some("src".to_string()), "created_at_day".to_string()),
+        );
+
+        let logical_schema = LogicalSchema::default().set_time_dimensions(vec![reference.clone()]);
+
+        assert_eq!(
+            logical_schema.find_member_positions("visitors.created_at"),
+            vec![0],
+            "the base name must find the referenced time dimension"
+        );
+        assert_eq!(
+            logical_schema.find_member_positions(&time_dim.full_name()),
+            vec![0],
+            "so must the granular name the reference carries"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_get_member_at_position_out_of_bounds() -> Result<(), CubeError> {
         let schema = MockSchema::from_yaml_file("common/visitors.yaml");

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/transforms/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/transforms/mod.rs
@@ -8,7 +8,9 @@
 //! container of symbols belongs here.
 
 mod render_modifier;
+mod substitute_symbols;
 mod tz_converted_at_source;
 
 pub use render_modifier::*;
+pub use substitute_symbols::*;
 pub use tz_converted_at_source::*;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/transforms/substitute_symbols.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/transforms/substitute_symbols.rs
@@ -1,0 +1,40 @@
+use super::super::LogicalSchema;
+use crate::planner::filter::Filter;
+use crate::planner::symbols::transforms;
+use crate::planner::MemberSymbol;
+use cubenativeutils::CubeError;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Copy of the schema with every member named in `substitutions`
+/// replaced by the symbol mapped to it. Every schema member is
+/// rewritten, so a substituted member is replaced both where it is
+/// exposed on its own and where it appears inside another member's
+/// expression tree.
+pub fn substitute_symbols_in_schema(
+    schema: &LogicalSchema,
+    substitutions: &HashMap<String, Rc<MemberSymbol>>,
+) -> Result<Rc<LogicalSchema>, CubeError> {
+    let substitute = |members: &Vec<Rc<MemberSymbol>>| {
+        members
+            .iter()
+            .map(|m| transforms::substitute_by_name(m, substitutions))
+            .collect::<Result<Vec<_>, _>>()
+    };
+    let mut new = schema.clone();
+    new.time_dimensions = substitute(&new.time_dimensions)?;
+    new.dimensions = substitute(&new.dimensions)?;
+    new.measures = substitute(&new.measures)?;
+    Ok(Rc::new(new))
+}
+
+/// Copy of the filter with every member named in `substitutions`
+/// replaced by the symbol mapped to it.
+pub fn substitute_symbols_in_filter(
+    filter: Option<Filter>,
+    substitutions: &HashMap<String, Rc<MemberSymbol>>,
+) -> Result<Option<Filter>, CubeError> {
+    transforms::map_filter_symbols(filter, &|symbol| {
+        transforms::substitute_filter_member_by_name(symbol, substitutions)
+    })
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/mod.rs
@@ -29,7 +29,7 @@ pub use join::{Join, JoinCondition, JoinItem, RegularRollingWindowJoinCondition}
 pub use optimizers::collapse_trivial_subqueries;
 pub use order::OrderBy;
 pub use query_plan::QueryPlan;
-pub use references_builder::ReferencesBuilder;
+pub use references_builder::{ReferenceSubstitutions, ReferencesBuilder};
 pub use schema::{QualifiedColumnName, Schema, SchemaColumn};
 pub use select::{AliasedExpr, Select};
 pub use sql_visitor::SqlEvaluatorVisitor;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/references_builder.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/references_builder.rs
@@ -1,11 +1,18 @@
-use crate::physical_plan::sql_nodes::RenderReferences;
+use crate::physical_plan::symbols::column_ref_symbol::column_reference;
 use crate::physical_plan::{
     CalcGroupsJoin, From, FromSource, Join, QualifiedColumnName, SingleAliasedSource, SingleSource,
 };
 use crate::planner::filter::{Filter, FilterItem};
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
+use std::collections::HashMap;
 use std::rc::Rc;
+
+/// What one select replaces its members with: `full_name` of a member
+/// the select reads from one of its sources → the reference symbol that
+/// reads it. Applied to the select's whole symbol environment at once,
+/// so a member named here is read wherever the select mentions it.
+pub type ReferenceSubstitutions = HashMap<String, Rc<MemberSymbol>>;
 
 pub struct ReferencesBuilder {
     source: Rc<From>,
@@ -44,35 +51,75 @@ impl ReferencesBuilder {
         Ok(())
     }
 
-    pub fn resolve_references_for_member(
+    /// Records how `member` is read from this select's sources: the
+    /// member itself when a source produces it, otherwise the
+    /// dependencies of its expression that a source produces.
+    ///
+    /// The first entry for a name wins, so a caller that pins a member
+    /// itself (a value fixed by the query, an axis column of a join)
+    /// records it before the walk reaches it.
+    pub fn collect_substitutions_for_member(
         &self,
         member: Rc<MemberSymbol>,
         strict_source: &Option<String>,
-        references: &mut RenderReferences,
+        substitutions: &mut ReferenceSubstitutions,
     ) -> Result<(), CubeError> {
+        // A reference already names the column it reads. Resolving it
+        // again would look its origin up in this select's sources and
+        // point it somewhere else.
+        if matches!(member.as_ref(), MemberSymbol::ColumnRef(_)) {
+            return Ok(());
+        }
         let member_name = member.full_name();
-        if references.contains_key(&member_name) {
+        if substitutions.contains_key(&member_name) {
             return Ok(());
         }
-        if let Some(reference) = self.find_reference_for_member(&member, strict_source) {
-            references.insert(member_name.clone(), reference);
+        if let Some(column) = self.find_reference_for_member(&member, strict_source) {
+            substitutions.insert(member_name, column_reference(&member, column));
             return Ok(());
         }
 
-        let dependencies = member.get_dependencies();
-        if !dependencies.is_empty() {
-            for dep in dependencies.iter() {
-                self.resolve_references_for_member(dep.clone(), strict_source, references)?
+        for dep in member.get_dependencies().iter() {
+            self.collect_substitutions_for_member(dep.clone(), strict_source, substitutions)?;
+        }
+        Ok(())
+    }
+
+    pub fn collect_substitutions_for_filter(
+        &self,
+        filter: &Option<Filter>,
+        substitutions: &mut ReferenceSubstitutions,
+    ) -> Result<(), CubeError> {
+        if let Some(filter) = filter {
+            for itm in filter.items.iter() {
+                self.collect_substitutions_for_filter_item(itm, substitutions)?;
             }
-        } else {
-            /*             if !self.has_source_for_leaf_memeber(&member, strict_source) {
-                return Err(CubeError::internal(format!(
-                    "Planning error: member {} has no source",
-                    member_name
-                )));
-            } */
         }
+        Ok(())
+    }
 
+    fn collect_substitutions_for_filter_item(
+        &self,
+        item: &FilterItem,
+        substitutions: &mut ReferenceSubstitutions,
+    ) -> Result<(), CubeError> {
+        match item {
+            FilterItem::Item(item) => self.collect_substitutions_for_member(
+                item.member_evaluator().clone(),
+                &None,
+                substitutions,
+            )?,
+            FilterItem::Group(group) => {
+                for itm in group.items.iter() {
+                    self.collect_substitutions_for_filter_item(itm, substitutions)?
+                }
+            }
+            FilterItem::Segment(segment) => self.collect_substitutions_for_member(
+                segment.member_evaluator().clone(),
+                &None,
+                substitutions,
+            )?,
+        }
         Ok(())
     }
 
@@ -104,19 +151,6 @@ impl ReferencesBuilder {
         Ok(())
     }
 
-    pub fn resolve_references_for_filter(
-        &self,
-        filter: &Option<Filter>,
-        references: &mut RenderReferences,
-    ) -> Result<(), CubeError> {
-        if let Some(filter) = filter {
-            for itm in filter.items.iter() {
-                self.resolve_references_for_filter_item(itm, references)?;
-            }
-        }
-        Ok(())
-    }
-
     fn validate_filter_item(&self, item: &FilterItem) -> Result<(), CubeError> {
         match item {
             FilterItem::Item(item) => {
@@ -130,31 +164,6 @@ impl ReferencesBuilder {
             FilterItem::Segment(segment) => {
                 self.validate_member(segment.member_evaluator().clone(), &None)?
             }
-        }
-        Ok(())
-    }
-
-    fn resolve_references_for_filter_item(
-        &self,
-        item: &FilterItem,
-        references: &mut RenderReferences,
-    ) -> Result<(), CubeError> {
-        match item {
-            FilterItem::Item(item) => self.resolve_references_for_member(
-                item.member_evaluator().clone(),
-                &None,
-                references,
-            )?,
-            FilterItem::Group(group) => {
-                for itm in group.items.iter() {
-                    self.resolve_references_for_filter_item(itm, references)?
-                }
-            }
-            FilterItem::Segment(segment) => self.resolve_references_for_member(
-                segment.member_evaluator().clone(),
-                &None,
-                references,
-            )?,
         }
         Ok(())
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
@@ -19,6 +19,11 @@ use std::rc::Rc;
 /// the query needs (time shifts, render references, pre-aggregation
 /// refs, cube aliases) and assembles them into a layered `SqlNode`
 /// via `default_node_processor`.
+///
+/// `render_references` covers what a select cannot express through its
+/// symbols: the SQL of a join condition, which is built while the FROM
+/// is still being assembled and so cannot be rewritten along with the
+/// select's members.
 #[derive(Clone, Default)]
 pub struct SqlNodesFactory {
     time_shifts: TimeShiftState,
@@ -27,7 +32,6 @@ pub struct SqlNodesFactory {
     render_references: RenderReferences,
     pre_aggregation_dimensions_references: RenderReferences,
     pre_aggregation_measures_references: RenderReferences,
-    ungrouped_measure_references: RenderReferences,
     cube_name_references: HashMap<String, String>,
     use_local_tz_in_date_range: bool,
     original_sql_pre_aggregations: HashMap<String, String>,
@@ -85,18 +89,6 @@ impl SqlNodesFactory {
         self.render_references.insert(name, value);
     }
 
-    pub fn render_references(&self) -> &RenderReferences {
-        &self.render_references
-    }
-
-    pub fn clear_render_references(&mut self) {
-        self.render_references = RenderReferences::default();
-    }
-
-    pub fn render_references_mut(&mut self) -> &mut RenderReferences {
-        &mut self.render_references
-    }
-
     pub fn add_pre_aggregation_dimension_reference<T: Into<RenderReferencesType>>(
         &mut self,
         name: String,
@@ -116,14 +108,6 @@ impl SqlNodesFactory {
         value: T,
     ) {
         self.pre_aggregation_measures_references.insert(name, value);
-    }
-
-    pub fn add_ungrouped_measure_reference<T: Into<RenderReferencesType>>(
-        &mut self,
-        name: String,
-        value: T,
-    ) {
-        self.ungrouped_measure_references.insert(name, value);
     }
 
     pub fn set_cube_name_references(&mut self, value: HashMap<String, String>) {
@@ -147,9 +131,8 @@ impl SqlNodesFactory {
     /// time-shift wraps), a time-dimension chain, and a measure
     /// chain (case → measure filter → render-modifier dispatch over
     /// the final-measure / rolling-merge / ungrouped chains → mask →
-    /// multi-stage window and rank wraps). The whole tree is then
-    /// wrapped in a top-level `RenderReferencesSqlNode` for
-    /// query-wide reference substitution.
+    /// multi-stage window and rank wraps). A reference symbol is
+    /// dispatched by `RootSqlNode` itself and never enters any of them.
     pub fn default_node_processor(&self, query_tools: &QueryTools) -> Rc<dyn SqlNode> {
         // Build an "unmasked" copy of the tree (masking disabled, but still
         // dispatching by member kind) only when the query has masked members. It
@@ -189,7 +172,6 @@ impl SqlNodesFactory {
         let measure_filter_processor = MeasureFilterSqlNode::new(parenthesize_processor.clone());
         let measure_processor = CaseSqlNode::new(measure_filter_processor.clone());
 
-        let measure_processor = self.add_ungrouped_measure_reference_if_needed(measure_processor);
         let measure_processor = self.final_measure_node_processor(measure_processor);
         // Wrap the entire measure chain with MaskedSqlNode so masked measures
         // are intercepted before aggregation/ungrouped wrapping.
@@ -225,7 +207,14 @@ impl SqlNodesFactory {
             measure_processor.clone(),
             default_processor,
         );
-        RenderReferencesSqlNode::new(root_node, self.render_references.clone())
+        if self.render_references.is_empty() {
+            root_node
+        } else {
+            // Only the SQL of a join condition needs this: it is rendered
+            // outside any select's symbol environment, so the member it names
+            // is resolved here instead of being substituted beforehand.
+            RenderReferencesSqlNode::new(root_node, self.render_references.clone())
+        }
     }
 
     /// When an ungrouped query reads from a pre-aggregation, a measure must
@@ -239,17 +228,6 @@ impl SqlNodesFactory {
             RenderReferencesSqlNode::new(node, self.pre_aggregation_measures_references.clone())
         } else {
             node
-        }
-    }
-
-    fn add_ungrouped_measure_reference_if_needed(
-        &self,
-        default: Rc<dyn SqlNode>,
-    ) -> Rc<dyn SqlNode> {
-        if !self.ungrouped_measure_references.is_empty() {
-            RenderReferencesSqlNode::new(default, self.ungrouped_measure_references.clone())
-        } else {
-            default
         }
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/final_pre_aggregation_measure.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/final_pre_aggregation_measure.rs
@@ -76,7 +76,6 @@ impl SqlNode for FinalPreAggregationMeasureSqlNode {
                         RenderReferencesType::LiteralValue(value) => {
                             templates.quote_string(value)?
                         }
-                        RenderReferencesType::RawReferenceValue(value) => value.clone(),
                     }
                 } else {
                     self.input.to_sql(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/render_references.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/render_references.rs
@@ -9,17 +9,13 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-#[derive(Clone)]
-pub struct RawReferenceValue(pub String);
-
 /// Replacement form for a member that is rendered as a reference
-/// instead of being evaluated: a qualified column, a quoted string
-/// literal, or a raw SQL fragment.
+/// instead of being evaluated: a qualified column or a quoted string
+/// literal.
 #[derive(Clone)]
 pub enum RenderReferencesType {
     QualifiedColumnName(QualifiedColumnName),
     LiteralValue(String),
-    RawReferenceValue(String),
 }
 
 impl From<QualifiedColumnName> for RenderReferencesType {
@@ -31,12 +27,6 @@ impl From<QualifiedColumnName> for RenderReferencesType {
 impl From<String> for RenderReferencesType {
     fn from(value: String) -> Self {
         Self::LiteralValue(value)
-    }
-}
-
-impl From<RawReferenceValue> for RenderReferencesType {
-    fn from(value: RawReferenceValue) -> Self {
-        Self::RawReferenceValue(value.0)
     }
 }
 
@@ -107,7 +97,6 @@ impl SqlNode for RenderReferencesSqlNode {
                     ))
                 }
                 RenderReferencesType::LiteralValue(value) => templates.quote_string(value),
-                RenderReferencesType::RawReferenceValue(value) => Ok(value.clone()),
             }
         } else {
             self.input.to_sql(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/render_references.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/render_references.rs
@@ -81,6 +81,18 @@ impl SqlNode for RenderReferencesSqlNode {
         node_processor: Rc<dyn SqlNode>,
         templates: &PlanSqlTemplates,
     ) -> Result<String, CubeError> {
+        // A reference already names what it reads, and it carries the name of
+        // the member it stands for — looking that name up here would render it
+        // from this map instead of from itself.
+        if matches!(node.as_ref(), MemberSymbol::ColumnRef(_)) {
+            return self.input.to_sql(
+                visitor,
+                node,
+                query_tools.clone(),
+                node_processor.clone(),
+                templates,
+            );
+        }
         let full_name = node.full_name();
         if let Some(reference) = self.references.get(&full_name) {
             match reference {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/root_processor.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/root_processor.rs
@@ -1,4 +1,4 @@
-use super::SqlNode;
+use super::{EvaluateSqlNode, SqlNode};
 use crate::physical_plan::SqlEvaluatorVisitor;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_templates::PlanSqlTemplates;
@@ -9,11 +9,18 @@ use std::rc::Rc;
 
 /// Dispatches rendering to a kind-specific sub-chain based on the
 /// member's variant: dimension / time dimension / measure / other.
+///
+/// A `ColumnRef` is the exception: it renders itself and nothing may
+/// wrap it, so it goes straight to the bare evaluate node rather than
+/// through any configured chain. This is the outermost dispatch of the
+/// chain, so that rule holds for every position a reference can appear
+/// in, including the dependencies of another member's SQL.
 pub struct RootSqlNode {
     dimension_processor: Rc<dyn SqlNode>,
     time_dimesions_processor: Rc<dyn SqlNode>,
     measure_processor: Rc<dyn SqlNode>,
     default_processor: Rc<dyn SqlNode>,
+    reference_processor: Rc<dyn SqlNode>,
 }
 
 impl RootSqlNode {
@@ -28,6 +35,7 @@ impl RootSqlNode {
             time_dimesions_processor,
             measure_processor,
             default_processor,
+            reference_processor: EvaluateSqlNode::new(),
         })
     }
 
@@ -75,7 +83,14 @@ impl SqlNode for RootSqlNode {
                 node_processor.clone(),
                 templates,
             )?,
-            _ => self.default_processor.to_sql(
+            MemberSymbol::ColumnRef(_) => self.reference_processor.to_sql(
+                visitor,
+                node,
+                query_tools.clone(),
+                node_processor.clone(),
+                templates,
+            )?,
+            MemberSymbol::MemberExpression(_) => self.default_processor.to_sql(
                 visitor,
                 node,
                 query_tools.clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/root_processor.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/root_processor.rs
@@ -12,9 +12,10 @@ use std::rc::Rc;
 ///
 /// A `ColumnRef` is the exception: it renders itself and nothing may
 /// wrap it, so it goes straight to the bare evaluate node rather than
-/// through any configured chain. This is the outermost dispatch of the
-/// chain, so that rule holds for every position a reference can appear
-/// in, including the dependencies of another member's SQL.
+/// through any configured chain. Every dispatch above this one passes a
+/// reference straight through, so the rule holds for every position a
+/// reference can appear in, including the dependencies of another
+/// member's SQL.
 pub struct RootSqlNode {
     dimension_processor: Rc<dyn SqlNode>,
     time_dimesions_processor: Rc<dyn SqlNode>,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/column_ref_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/column_ref_symbol.rs
@@ -1,0 +1,40 @@
+use super::{MemberSqlContext, ToSql};
+use crate::physical_plan::QualifiedColumnName;
+use crate::planner::symbols::{ColumnRefSymbol, ReferenceValue};
+use crate::planner::MemberSymbol;
+use cubenativeutils::CubeError;
+use std::rc::Rc;
+
+impl From<QualifiedColumnName> for ReferenceValue {
+    fn from(value: QualifiedColumnName) -> Self {
+        Self::Column {
+            source: value.source().clone(),
+            name: value.name().clone(),
+        }
+    }
+}
+
+/// A symbol that reads `origin` from `column` instead of computing it.
+pub fn column_reference(
+    origin: &Rc<MemberSymbol>,
+    column: QualifiedColumnName,
+) -> Rc<MemberSymbol> {
+    MemberSymbol::new_column_ref(ColumnRefSymbol::new(origin.clone(), column.into()))
+}
+
+/// A symbol that renders `origin` as a value the query pinned for it.
+pub fn literal_reference(origin: &Rc<MemberSymbol>, value: String) -> Rc<MemberSymbol> {
+    MemberSymbol::new_column_ref(ColumnRefSymbol::new(
+        origin.clone(),
+        ReferenceValue::Literal(value),
+    ))
+}
+
+impl ToSql for ColumnRefSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self.value() {
+            ReferenceValue::Column { source, name } => ctx.templates.column_reference(source, name),
+            ReferenceValue::Literal(value) => ctx.templates.quote_string(value),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/member_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/member_symbol.rs
@@ -9,6 +9,7 @@ impl ToSql for MemberSymbol {
             Self::TimeDimension(t) => t.to_sql(ctx),
             Self::Measure(m) => m.to_sql(ctx),
             Self::MemberExpression(e) => e.to_sql(ctx),
+            Self::ColumnRef(r) => r.to_sql(ctx),
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/mod.rs
@@ -1,3 +1,4 @@
+pub mod column_ref_symbol;
 pub mod dimension_kinds;
 pub mod dimension_symbol;
 pub mod measure_kinds;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/builder.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/builder.rs
@@ -244,10 +244,15 @@ impl PhysicalPlanBuilder {
         Ok(())
     }
 
+    /// Builds the ORDER BY of a select. An item present in the schema is
+    /// sorted by the schema's own symbol, which the select already
+    /// substituted; an item absent from it carries its own symbol and so
+    /// needs the same substitution applied here.
     pub(crate) fn make_order_by(
         &self,
         logical_schema: &LogicalSchema,
         order_by: &Vec<OrderByItem>,
+        substitutions: &ReferenceSubstitutions,
     ) -> Result<Vec<OrderBy>, CubeError> {
         let mut result = Vec::new();
         for o in order_by.iter() {
@@ -257,8 +262,10 @@ impl PhysicalPlanBuilder {
             // correct processing of order by dimension that is not included in the
             // selection list will be implemented
             if positions.is_empty() && o.member_symbol().is_measure() {
+                let symbol =
+                    symbol_transforms::substitute_by_name(&o.member_symbol(), substitutions)?;
                 result.push(OrderBy::new(
-                    Expr::Member(MemberExpression::new(o.member_symbol())),
+                    Expr::Member(MemberExpression::new(symbol)),
                     0,
                     o.desc(),
                 ));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/builder.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/builder.rs
@@ -4,6 +4,8 @@ use crate::logical_plan::*;
 use crate::physical_plan::join::JoinType;
 use crate::physical_plan::schema::QualifiedColumnName;
 use crate::physical_plan::sql_nodes::SqlNodesFactory;
+use crate::physical_plan::symbols::column_ref_symbol::column_reference;
+use crate::physical_plan::ReferenceSubstitutions;
 use crate::physical_plan::ReferencesBuilder;
 use crate::physical_plan::VisitorContext;
 use crate::physical_plan::*;
@@ -11,6 +13,7 @@ use crate::physical_plan_builder::context::MultiStageDimensionContext;
 use crate::planner::query_properties::OrderByItem;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::symbols::transforms as symbol_transforms;
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
 use itertools::Itertools;
@@ -171,23 +174,27 @@ impl PhysicalPlanBuilder {
 
                 if let Ok(dimension) = dim.as_dimension() {
                     if dimension.is_calc_group() {
+                        // Rendered through the enclosing select's context, which
+                        // is where a value pinned for the group resolves.
                         return Ok(vec![(sub_query_ref, Expr::new_member(dim.clone()))]);
                     }
                 }
 
-                let mut context_factory = context.make_sql_nodes_factory()?;
-                references_builder.resolve_references_for_member(
+                let mut substitutions = ReferenceSubstitutions::new();
+                references_builder.collect_substitutions_for_member(
                     dim.clone(),
                     &None,
-                    context_factory.render_references_mut(),
+                    &mut substitutions,
                 )?;
+                let dim = symbol_transforms::substitute_by_name(dim, &substitutions)?;
 
+                let context_factory = context.make_sql_nodes_factory()?;
                 let visitor_context =
                     VisitorContext::new(self.query_tools.clone(), &context_factory, None);
 
                 Ok(vec![(
                     sub_query_ref,
-                    Expr::new_member_with_context(dim.clone(), Rc::new(visitor_context)),
+                    Expr::new_member_with_context(dim, Rc::new(visitor_context)),
                 )])
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -201,27 +208,38 @@ impl PhysicalPlanBuilder {
         Ok(())
     }
 
-    pub(super) fn resolve_subquery_dimensions_references(
+    /// A subquery dimension is read from the joined subquery under the
+    /// alias of the measure that computes it, so the substitution maps
+    /// one member's name to another member's column.
+    ///
+    /// The same binding is also recorded as a render reference: a join
+    /// condition naming such a dimension is built while the FROM is
+    /// still being assembled, before there is a select symbol
+    /// environment to rewrite, so it resolves the dimension while
+    /// rendering instead.
+    pub(super) fn collect_subquery_dimensions_substitutions(
         &self,
         dimension_subqueries: &Vec<Rc<DimensionSubQuery>>,
         references_builder: &ReferencesBuilder,
+        substitutions: &mut ReferenceSubstitutions,
         context_factory: &mut SqlNodesFactory,
     ) -> Result<(), CubeError> {
         for dimension_subquery in dimension_subqueries.iter() {
-            if let Some(dim_ref) = references_builder.find_reference_for_member(
+            let Some(dim_ref) = references_builder.find_reference_for_member(
                 &dimension_subquery.measure_for_subquery_dimension,
                 &None,
-            ) {
-                context_factory.add_render_reference(
-                    dimension_subquery.subquery_dimension.full_name(),
-                    dim_ref,
-                );
-            } else {
+            ) else {
                 return Err(CubeError::internal(format!(
                     "Can't find source for subquery dimension {}",
                     dimension_subquery.subquery_dimension.full_name()
                 )));
-            }
+            };
+            substitutions.insert(
+                dimension_subquery.subquery_dimension.full_name(),
+                column_reference(&dimension_subquery.subquery_dimension, dim_ref.clone()),
+            );
+            context_factory
+                .add_render_reference(dimension_subquery.subquery_dimension.full_name(), dim_ref);
         }
         Ok(())
     }
@@ -263,27 +281,35 @@ impl PhysicalPlanBuilder {
         Ok(result)
     }
 
-    pub(super) fn process_query_dimension(
+    /// Records how a projected dimension is read from the select's
+    /// sources. A dimension that a full join produced on both sides is
+    /// projected as a `COALESCE` over its columns, so it is read from no
+    /// single one of them and stays computed.
+    pub(super) fn collect_query_dimension_substitution(
         &self,
         dimension: &Rc<MemberSymbol>,
         references_builder: &ReferencesBuilder,
+        from: &Rc<From>,
+        substitutions: &mut ReferenceSubstitutions,
+    ) -> Result<(), CubeError> {
+        if self.dimension_coalesce_refs(dimension, from).is_some() {
+            return Ok(());
+        }
+        references_builder.collect_substitutions_for_member(dimension.clone(), &None, substitutions)
+    }
+
+    pub(super) fn project_query_dimension(
+        &self,
+        dimension: &Rc<MemberSymbol>,
         select_builder: &mut SelectBuilder,
-        context_factory: &mut SqlNodesFactory,
         context: &PushDownBuilderContext,
     ) -> Result<(), CubeError> {
         if let Some(coalesce_ref) = self.dimension_coalesce_refs(dimension, select_builder.from()) {
             select_builder.add_projection_coalesce_member(dimension, coalesce_ref, None)?;
+        } else if context.measure_subquery {
+            select_builder.add_projection_member_without_schema(dimension, None);
         } else {
-            references_builder.resolve_references_for_member(
-                dimension.clone(),
-                &None,
-                context_factory.render_references_mut(),
-            )?;
-            if context.measure_subquery {
-                select_builder.add_projection_member_without_schema(dimension, None);
-            } else {
-                select_builder.add_projection_member(dimension, None);
-            }
+            select_builder.add_projection_member(dimension, None);
         }
         Ok(())
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
@@ -1,13 +1,14 @@
 use super::super::{LogicalNodeProcessor, ProcessableNode, PushDownBuilderContext};
 use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::{AggregateMultipliedSubquery, AggregateMultipliedSubquerySource};
-use crate::physical_plan::ReferencesBuilder;
+use crate::physical_plan::symbols::column_ref_symbol::column_reference;
 use crate::physical_plan::VisitorContext;
 use crate::physical_plan::{
-    Expr, From, JoinBuilder, JoinCondition, MemberExpression, QualifiedColumnName, Select,
-    SelectBuilder,
+    Expr, From, JoinBuilder, JoinCondition, MemberExpression, QualifiedColumnName,
+    ReferenceSubstitutions, ReferencesBuilder, Select, SelectBuilder,
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
+use crate::planner::symbols::transforms;
 use crate::planner::MeasureRenderModifier;
 use crate::planner::{AggregateWrap, MemberSymbol};
 use cubenativeutils::CubeError;
@@ -95,6 +96,10 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
             .cube()
             .default_alias_with_prefix(&Some(format!("{}_key", pk_cube.cube().default_alias())));
 
+        // Set when the measures come from a joined subquery: they are then read
+        // from it rather than computed here.
+        let mut measure_source: Option<Rc<Select>> = None;
+
         match &aggregate_multiplied_subquery.source {
             AggregateMultipliedSubquerySource::Cube(cube) => {
                 // Bind a dedicated VisitorContext to the join's right-hand side
@@ -166,15 +171,7 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
                         Ok(vec![(keys_query_ref, measure_subquery_ref)])
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                for meas in aggregate_multiplied_subquery.schema.measures.iter() {
-                    context_factory.add_ungrouped_measure_reference(
-                        meas.full_name(),
-                        QualifiedColumnName::new(
-                            Some(pk_cube_alias.clone()),
-                            subquery.schema().resolve_member_alias(meas),
-                        ),
-                    );
-                }
+                measure_source = Some(subquery.clone());
 
                 join_builder.left_join_subselect(
                     subquery,
@@ -186,12 +183,12 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
 
         let from = From::new_from_join(join_builder.build());
         let references_builder = ReferencesBuilder::new(from.clone());
-        let mut select_builder = SelectBuilder::new(from.clone());
-        let mut group_by = Vec::new();
 
-        self.builder.resolve_subquery_dimensions_references(
+        let mut substitutions = ReferenceSubstitutions::new();
+        self.builder.collect_subquery_dimensions_substitutions(
             &aggregate_multiplied_subquery.dimension_subqueries,
             &references_builder,
+            &mut substitutions,
             &mut context_factory,
         )?;
 
@@ -207,27 +204,52 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
         };
 
         for member in schema.all_dimensions() {
-            references_builder.resolve_references_for_member(
+            references_builder.collect_substitutions_for_member(
                 member.clone(),
                 &None,
-                context_factory.render_references_mut(),
+                &mut substitutions,
             )?;
+        }
+        let measures_for_query = self.builder.measures_for_query(&schema.measures, &context);
+        for (measure, exists) in measures_for_query.iter() {
+            if !exists {
+                continue;
+            }
+            if let Some(subquery) = &measure_source {
+                // The joined subquery aggregated the deduplicated rows, so the
+                // measure re-aggregates its column instead of its own value.
+                let input = column_reference(
+                    measure,
+                    QualifiedColumnName::new(
+                        Some(pk_cube_alias.clone()),
+                        subquery.schema().resolve_member_alias(measure),
+                    ),
+                );
+                let measure_symbol = measure.as_measure()?;
+                let over_input = transforms::measure_over_reference(&measure_symbol, input);
+                substitutions.insert(measure.full_name(), MemberSymbol::new_measure(over_input));
+            } else {
+                references_builder.collect_substitutions_for_member(
+                    measure.clone(),
+                    &None,
+                    &mut substitutions,
+                )?;
+            }
+        }
+
+        let schema = logical_transforms::substitute_symbols_in_schema(&schema, &substitutions)?;
+
+        let mut select_builder = SelectBuilder::new(from.clone());
+        let mut group_by = Vec::new();
+
+        for member in schema.all_dimensions() {
             let alias = references_builder.resolve_alias_for_member(&member, &None);
             group_by.push(Expr::Member(MemberExpression::new(member.clone())));
             select_builder.add_projection_member(&member, alias);
         }
-        for (measure, exists) in self.builder.measures_for_query(&schema.measures, &context) {
-            if exists {
-                if matches!(
-                    &aggregate_multiplied_subquery.source,
-                    AggregateMultipliedSubquerySource::Cube(_)
-                ) {
-                    references_builder.resolve_references_for_member(
-                        measure.clone(),
-                        &None,
-                        context_factory.render_references_mut(),
-                    )?;
-                }
+        for (measure, exists) in measures_for_query.iter() {
+            if *exists {
+                let measure = transforms::substitute_by_name(measure, &substitutions)?;
                 select_builder.add_projection_member(&measure, None);
             } else {
                 select_builder.add_null_projection(&measure, None);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
@@ -216,6 +216,12 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
                 continue;
             }
             if let Some(subquery) = &measure_source {
+                // Only a measure reads its input through an aggregation. A
+                // member expression the SQL API built reaches this list too and
+                // renders its own SQL, as it did before.
+                let Ok(measure_symbol) = measure.as_measure() else {
+                    continue;
+                };
                 // The joined subquery aggregated the deduplicated rows, so the
                 // measure re-aggregates its column instead of its own value.
                 let input = column_reference(
@@ -225,7 +231,6 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
                         subquery.schema().resolve_member_alias(measure),
                     ),
                 );
-                let measure_symbol = measure.as_measure()?;
                 let over_input = transforms::measure_over_reference(&measure_symbol, input);
                 substitutions.insert(measure.full_name(), MemberSymbol::new_measure(over_input));
             } else {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
@@ -102,15 +102,12 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
 
         match &aggregate_multiplied_subquery.source {
             AggregateMultipliedSubquerySource::Cube(cube) => {
-                // Bind a dedicated VisitorContext to the join's right-hand side
-                // so that primary-key dimensions render against `pk_cube_alias`
-                // (the source cube join). Without it, the outer factory's
-                // render_references — populated later for the SELECT — map
-                // these dimensions to the inner `keys` subquery alias, and
-                // both sides of the ON clause collapse to `keys.<pk> = keys.<pk>`.
-                // Clone the parent factory rather than rebuilding from context so
-                // that any state already added above (currently none, but this
-                // makes the lineage explicit for future maintenance) is preserved.
+                // This condition is rendered through a context of its own,
+                // built while the FROM is still being assembled, so it never
+                // receives the cube aliases the select derives from its
+                // finished FROM. Naming the alias the cube is joined under is
+                // what keeps the primary key off the cube's default alias,
+                // which nothing in this select is joined as.
                 let mut join_context_factory = context_factory.clone();
                 join_context_factory
                     .add_cube_name_reference(cube.cube().name().clone(), pk_cube_alias.clone());

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/full_join_aggregate_strategy.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/full_key_aggregate/full_join_aggregate_strategy.rs
@@ -2,11 +2,12 @@ use super::FullKeyAggregateStrategy;
 use crate::logical_plan::{FullKeyAggregate, LogicalJoin};
 use crate::physical_plan::sql_nodes::SqlNodesFactory;
 use crate::physical_plan::{
-    Expr, From, FromSource, JoinBuilder, JoinCondition, QualifiedColumnName, ReferencesBuilder,
-    Select, SelectBuilder, SingleAliasedSource,
+    Expr, From, FromSource, JoinBuilder, JoinCondition, QualifiedColumnName,
+    ReferenceSubstitutions, ReferencesBuilder, Select, SelectBuilder, SingleAliasedSource,
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use crate::physical_plan_builder::PushDownBuilderContext;
+use crate::planner::symbols::transforms;
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
 use itertools::Itertools;
@@ -67,25 +68,34 @@ impl<'a> FullJoinFullKeyAggregateStrategy<'a> {
         context: &PushDownBuilderContext,
     ) -> Result<Rc<Select>, CubeError> {
         let query_tools = self.builder.query_tools();
-        let mut context_factory = SqlNodesFactory::new();
+        let context_factory = SqlNodesFactory::new();
         let references_builder = ReferencesBuilder::new(from.clone());
-        let mut select_builder = SelectBuilder::new(from);
+
+        let mut substitutions = ReferenceSubstitutions::new();
         for dimension in dimensions.iter() {
-            self.builder.process_query_dimension(
+            self.builder.collect_query_dimension_substitution(
                 dimension,
                 &references_builder,
-                &mut select_builder,
-                &mut context_factory,
-                &context,
+                &from,
+                &mut substitutions,
+            )?;
+        }
+        for measure in measures {
+            references_builder.collect_substitutions_for_member(
+                measure.clone(),
+                &None,
+                &mut substitutions,
             )?;
         }
 
+        let mut select_builder = SelectBuilder::new(from);
+        for dimension in dimensions.iter() {
+            let dimension = transforms::substitute_by_name(dimension, &substitutions)?;
+            self.builder
+                .project_query_dimension(&dimension, &mut select_builder, &context)?;
+        }
         for measure in measures {
-            references_builder.resolve_references_for_member(
-                measure.clone(),
-                &None,
-                context_factory.render_references_mut(),
-            )?;
+            let measure = transforms::substitute_by_name(measure, &substitutions)?;
             select_builder.add_projection_member(&measure, None);
         }
         let res = Rc::new(select_builder.build(query_tools.clone(), context_factory));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/keys_sub_query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/keys_sub_query.rs
@@ -1,10 +1,14 @@
 use super::super::{LogicalNodeProcessor, ProcessableNode, PushDownBuilderContext};
+use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::{all_symbols, KeysSubQuery};
+use crate::physical_plan::symbols::column_ref_symbol::literal_reference;
 use crate::physical_plan::{
-    CalcGroupItem, CalcGroupsJoin, From, ReferencesBuilder, Select, SelectBuilder,
+    CalcGroupItem, CalcGroupsJoin, From, ReferenceSubstitutions, ReferencesBuilder, Select,
+    SelectBuilder,
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use crate::planner::collectors::collect_calc_group_dims_from_nodes;
+use crate::planner::symbols::transforms;
 use crate::planner::symbols::transforms::get_filtered_values;
 use cubenativeutils::CubeError;
 use itertools::Itertools as _;
@@ -51,10 +55,20 @@ impl<'a> LogicalNodeProcessor<'a, KeysSubQuery> for KeysSubQueryProcessor<'a> {
                 values,
             }
         });
+        // A value pinned by the query is not read from the source, so it is
+        // recorded before the walk below can map the dimension to a column.
+        let mut substitutions = ReferenceSubstitutions::new();
         for item in calc_groups_items
             .clone()
             .filter(|itm| itm.values.len() == 1)
         {
+            substitutions.insert(
+                item.symbol.full_name(),
+                literal_reference(&item.symbol, item.values[0].clone()),
+            );
+            // A join condition can name a calc-group dimension too, and it is
+            // built before there is a select symbol environment to rewrite, so
+            // it resolves the value while rendering.
             context_factory.add_render_reference(item.symbol.full_name(), item.values[0].clone());
         }
         let calc_groups_to_join = calc_groups_items
@@ -68,46 +82,65 @@ impl<'a> LogicalNodeProcessor<'a, KeysSubQuery> for KeysSubQueryProcessor<'a> {
         };
 
         let references_builder = ReferencesBuilder::new(source.clone());
-        let mut select_builder = SelectBuilder::new(source);
-        self.builder.resolve_subquery_dimensions_references(
+        self.builder.collect_subquery_dimensions_substitutions(
             &keys_subquery.source().dimension_subqueries(),
             &references_builder,
+            &mut substitutions,
             &mut context_factory,
         )?;
         for member in keys_subquery.schema().all_dimensions() {
-            let alias = member.alias();
-            references_builder.resolve_references_for_member(
+            references_builder.collect_substitutions_for_member(
                 member.clone(),
                 &None,
-                context_factory.render_references_mut(),
+                &mut substitutions,
             )?;
-            select_builder.add_projection_member(member, Some(alias));
         }
-
-        if !context.dimensions_query {
-            for member in keys_subquery.primary_keys_dimensions().iter() {
-                // A primary key that is also a query dimension is already
-                // projected above. Projecting it again would put two columns
-                // under one alias, making every reference to it from the
-                // enclosing re-join ambiguous. Symbols are matched the way
-                // `Schema::find_column_for_member` matches them, so that the
-                // re-join resolves to the surviving column.
-                let resolved = member.clone().resolve_reference_chain();
-                if keys_subquery
-                    .schema()
-                    .all_dimensions()
-                    .any(|dim| dim.clone().resolve_reference_chain() == resolved)
-                {
-                    continue;
-                }
-                let alias = member.alias();
-                references_builder.resolve_references_for_member(
+        let primary_keys_dimensions = if context.dimensions_query {
+            vec![]
+        } else {
+            // A primary key that is also a query dimension is already projected
+            // above. Projecting it again would put two columns under one alias,
+            // making every reference to it from the enclosing re-join ambiguous.
+            // Symbols are matched the way `Schema::find_column_for_member`
+            // matches them, so that the re-join resolves to the surviving
+            // column.
+            let members = keys_subquery
+                .primary_keys_dimensions()
+                .iter()
+                .filter(|member| {
+                    let resolved = (*member).clone().resolve_reference_chain();
+                    !keys_subquery
+                        .schema()
+                        .all_dimensions()
+                        .any(|dim| dim.clone().resolve_reference_chain() == resolved)
+                })
+                .cloned()
+                .collect_vec();
+            for member in members.iter() {
+                references_builder.collect_substitutions_for_member(
                     member.clone(),
                     &None,
-                    context_factory.render_references_mut(),
+                    &mut substitutions,
                 )?;
-                select_builder.add_projection_member(member, Some(alias));
             }
+            members
+        };
+
+        let schema = logical_transforms::substitute_symbols_in_schema(
+            &keys_subquery.schema(),
+            &substitutions,
+        )?;
+        let filter = logical_transforms::substitute_symbols_in_filter(filter, &substitutions)?;
+
+        let mut select_builder = SelectBuilder::new(source);
+        for member in schema.all_dimensions() {
+            let alias = member.alias();
+            select_builder.add_projection_member(member, Some(alias));
+        }
+        for member in primary_keys_dimensions.iter() {
+            let member = transforms::substitute_by_name(member, &substitutions)?;
+            let alias = member.alias();
+            select_builder.add_projection_member(&member, Some(alias));
         }
 
         select_builder.set_distinct();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/measure_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/measure_subquery.rs
@@ -1,7 +1,7 @@
 use super::super::{LogicalNodeProcessor, ProcessableNode, PushDownBuilderContext};
+use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::MeasureSubquery;
-use crate::physical_plan::ReferencesBuilder;
-use crate::physical_plan::{Select, SelectBuilder};
+use crate::physical_plan::{ReferenceSubstitutions, ReferencesBuilder, Select, SelectBuilder};
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use crate::planner::symbols::transforms;
 use crate::planner::MeasureRenderModifier;
@@ -30,19 +30,26 @@ impl<'a> LogicalNodeProcessor<'a, MeasureSubquery> for MeasureSubqueryProcessor<
 
         let mut context_factory = context.make_sql_nodes_factory()?;
         let references_builder = ReferencesBuilder::new(from.clone());
-        let mut select_builder = SelectBuilder::new(from);
 
-        self.builder.resolve_subquery_dimensions_references(
+        let mut substitutions = ReferenceSubstitutions::new();
+        self.builder.collect_subquery_dimensions_substitutions(
             &measure_subquery.source.dimension_subqueries(),
             &references_builder,
+            &mut substitutions,
             &mut context_factory,
         )?;
-        for dim in measure_subquery.schema.dimensions.iter() {
+        let schema = logical_transforms::substitute_symbols_in_schema(
+            &measure_subquery.schema,
+            &substitutions,
+        )?;
+
+        let mut select_builder = SelectBuilder::new(from);
+        for dim in schema.dimensions.iter() {
             select_builder.add_projection_member(dim, None);
         }
         // The subquery emits raw row-level measure values; the enclosing
         // aggregate select applies the actual aggregation.
-        for meas in measure_subquery.schema.measures.iter() {
+        for meas in schema.measures.iter() {
             let meas =
                 transforms::measures_render_modifier(meas, &MeasureRenderModifier::RawValue)?;
             select_builder.add_projection_member(&meas, None);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_dimension_calculation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_dimension_calculation.rs
@@ -1,8 +1,10 @@
 use super::super::context::PushDownBuilderContext;
 use super::super::{LogicalNodeProcessor, ProcessableNode};
+use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::MultiStageDimensionCalculation;
-use crate::physical_plan::ReferencesBuilder;
-use crate::physical_plan::{Expr, MemberExpression, QueryPlan, SelectBuilder};
+use crate::physical_plan::{
+    Expr, MemberExpression, QueryPlan, ReferenceSubstitutions, ReferencesBuilder, SelectBuilder,
+};
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use cubenativeutils::CubeError;
 use std::rc::Rc;
@@ -25,35 +27,37 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageDimensionCalculation>
         context: &PushDownBuilderContext,
     ) -> Result<Self::PhysycalNode, CubeError> {
         let query_tools = self.builder.query_tools();
-        let mut context_factory = context.make_sql_nodes_factory()?;
+        let context_factory = context.make_sql_nodes_factory()?;
         let from = self
             .builder
             .process_node(measure_calculation.source().as_ref(), context)?;
         let references_builder = ReferencesBuilder::new(from.clone());
 
-        let mut select_builder = SelectBuilder::new(from.clone());
-
-        for member in measure_calculation.schema().all_dimensions() {
-            references_builder.resolve_references_for_member(
+        let mut substitutions = ReferenceSubstitutions::new();
+        for member in measure_calculation.schema().all_members() {
+            references_builder.collect_substitutions_for_member(
                 member.clone(),
                 &None,
-                context_factory.render_references_mut(),
+                &mut substitutions,
             )?;
+        }
+        let schema = logical_transforms::substitute_symbols_in_schema(
+            measure_calculation.schema(),
+            &substitutions,
+        )?;
+
+        let mut select_builder = SelectBuilder::new(from.clone());
+
+        for member in schema.all_dimensions() {
             select_builder.add_projection_member(&member, None);
         }
 
-        for measure in measure_calculation.schema().measures.iter() {
-            references_builder.resolve_references_for_member(
-                measure.clone(),
-                &None,
-                context_factory.render_references_mut(),
-            )?;
+        for measure in schema.measures.iter() {
             let alias = references_builder.resolve_alias_for_member(&measure, &None);
             select_builder.add_projection_member(&measure, alias);
         }
 
-        let group_by = measure_calculation
-            .schema()
+        let group_by = schema
             .all_dimensions()
             .map(|symbol| -> Result<_, CubeError> {
                 Ok(Expr::Member(MemberExpression::new(symbol.clone())))

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_get_date_range.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_get_date_range.rs
@@ -1,9 +1,9 @@
 use super::super::context::PushDownBuilderContext;
 use super::super::{LogicalNodeProcessor, ProcessableNode};
 use crate::logical_plan::MultiStageGetDateRange;
-use crate::physical_plan::ReferencesBuilder;
-use crate::physical_plan::{QueryPlan, SelectBuilder};
+use crate::physical_plan::{QueryPlan, ReferenceSubstitutions, ReferencesBuilder, SelectBuilder};
 use crate::physical_plan_builder::PhysicalPlanBuilder;
+use crate::planner::symbols::transforms;
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -29,7 +29,18 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageGetDateRange> for MultiStageGetDateR
         let references_builder = ReferencesBuilder::new(from.clone());
         let mut select_builder = SelectBuilder::new(from);
         let mut context_factory = context.make_sql_nodes_factory()?;
-        let args = vec![get_date_range.time_dimension.clone()];
+
+        let mut substitutions = ReferenceSubstitutions::new();
+        self.builder.collect_subquery_dimensions_substitutions(
+            &get_date_range.source.dimension_subqueries(),
+            &references_builder,
+            &mut substitutions,
+            &mut context_factory,
+        )?;
+        let args = vec![transforms::substitute_by_name(
+            &get_date_range.time_dimension,
+            &substitutions,
+        )?];
         select_builder.add_projection_function_expression(
             "MAX",
             args.clone(),
@@ -42,11 +53,6 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageGetDateRange> for MultiStageGetDateR
             "min_date".to_string(),
         );
 
-        self.builder.resolve_subquery_dimensions_references(
-            &get_date_range.source.dimension_subqueries(),
-            &references_builder,
-            &mut context_factory,
-        )?;
         let select = Rc::new(select_builder.build(query_tools.clone(), context_factory));
         Ok(QueryPlan::Select(select))
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
@@ -2,12 +2,13 @@ use super::super::context::PushDownBuilderContext;
 use super::super::{LogicalNodeProcessor, ProcessableNode};
 use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::{MultiStageCalculationWindowFunction, MultiStageMeasureCalculation};
-use crate::physical_plan::ReferencesBuilder;
-use crate::physical_plan::{Expr, MemberExpression, QueryPlan, SelectBuilder};
+use crate::physical_plan::{
+    Expr, MemberExpression, QueryPlan, ReferenceSubstitutions, ReferencesBuilder, SelectBuilder,
+};
 use crate::physical_plan_builder::PhysicalPlanBuilder;
+use crate::planner::symbols::transforms;
 use crate::planner::MeasureRenderModifier;
 use cubenativeutils::CubeError;
-use itertools::Itertools;
 use std::rc::Rc;
 
 pub struct MultiStageMeasureCalculationProcessor<'a> {
@@ -28,33 +29,29 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
         context: &PushDownBuilderContext,
     ) -> Result<Self::PhysycalNode, CubeError> {
         let query_tools = self.builder.query_tools();
-        let mut context_factory = context.make_sql_nodes_factory()?;
+        let context_factory = context.make_sql_nodes_factory()?;
         let from = self
             .builder
             .process_node(measure_calculation.source().as_ref(), context)?;
         let references_builder = ReferencesBuilder::new(from.clone());
 
-        let mut select_builder = SelectBuilder::new(from.clone());
-        let all_dimensions = measure_calculation
-            .schema()
-            .all_dimensions()
-            .cloned()
-            .collect_vec();
-
-        for member in measure_calculation.schema().all_dimensions() {
-            references_builder.resolve_references_for_member(
+        let mut substitutions = ReferenceSubstitutions::new();
+        for member in measure_calculation.schema().all_members() {
+            references_builder.collect_substitutions_for_member(
                 member.clone(),
                 &None,
-                context_factory.render_references_mut(),
+                &mut substitutions,
             )?;
-            select_builder.add_projection_member(&member, None);
         }
 
+        // The partition of a window function is rendered by the measure that
+        // carries it, so its dimensions are substituted into the form itself.
+        let mut partition_by = Vec::new();
         for dim in measure_calculation.partition_by().iter() {
-            references_builder.resolve_references_for_member(
+            references_builder.collect_substitutions_for_member(
                 dim.clone(),
                 &None,
-                context_factory.render_references_mut(),
+                &mut substitutions,
             )?;
             if references_builder
                 .find_reference_for_member(&dim, &None)
@@ -65,16 +62,17 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
                     dim.full_name()
                 )));
             }
+            partition_by.push(transforms::substitute_by_name(dim, &substitutions)?);
         }
         let measure_modifier = match measure_calculation.window_function_to_use() {
             MultiStageCalculationWindowFunction::Rank => {
                 Some(MeasureRenderModifier::MultiStageRank {
-                    partition: measure_calculation.partition_by().clone(),
+                    partition: partition_by,
                 })
             }
             MultiStageCalculationWindowFunction::Window => {
                 Some(MeasureRenderModifier::MultiStageWindow {
-                    partition: measure_calculation.partition_by().clone(),
+                    partition: partition_by,
                 })
             }
             MultiStageCalculationWindowFunction::None => None,
@@ -87,20 +85,24 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
         } else {
             measure_calculation.schema().clone()
         };
+        // Substitution comes last: a member the source already produced is read
+        // from it instead of being computed, whatever form was stamped on it.
+        let schema = logical_transforms::substitute_symbols_in_schema(&schema, &substitutions)?;
+
+        let mut select_builder = SelectBuilder::new(from.clone());
+
+        for member in schema.all_dimensions() {
+            select_builder.add_projection_member(&member, None);
+        }
 
         for measure in schema.measures.iter() {
-            references_builder.resolve_references_for_member(
-                measure.clone(),
-                &None,
-                context_factory.render_references_mut(),
-            )?;
             let alias = references_builder.resolve_alias_for_member(&measure, &None);
             select_builder.add_projection_member(measure, alias);
         }
 
         if !measure_calculation.is_ungrouped() {
-            let group_by = all_dimensions
-                .iter()
+            let group_by = schema
+                .all_dimensions()
                 .map(|dim| -> Result<_, CubeError> {
                     Ok(Expr::Member(MemberExpression::new(dim.clone())))
                 })

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
@@ -108,10 +108,11 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             select_builder.set_group_by(group_by);
-            select_builder.set_order_by(
-                self.builder
-                    .make_order_by(&schema, measure_calculation.order_by())?,
-            );
+            select_builder.set_order_by(self.builder.make_order_by(
+                &schema,
+                measure_calculation.order_by(),
+                &substitutions,
+            )?);
         }
 
         let select = Rc::new(select_builder.build(query_tools.clone(), context_factory));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_rolling_window.rs
@@ -139,12 +139,16 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageRollingWindow>
         // rolling source produced for it, so it reads its input from that
         // source instead of computing it.
         for measure in schema.measures.iter() {
+            // Only a measure reads its input through an aggregation; anything
+            // else in this list renders its own SQL, as it did before.
+            let Ok(measure_symbol) = measure.as_measure() else {
+                continue;
+            };
             let name_in_base_query = measure_input_schema.resolve_member_alias(measure);
             let input = column_reference(
                 measure,
                 QualifiedColumnName::new(Some(measure_input_alias.clone()), name_in_base_query),
             );
-            let measure_symbol = measure.as_measure()?;
             let over_input = transforms::measure_over_reference(&measure_symbol, input);
             substitutions.insert(measure.full_name(), MemberSymbol::new_measure(over_input));
         }
@@ -177,10 +181,11 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageRollingWindow>
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             select_builder.set_group_by(group_by);
-            select_builder.set_order_by(
-                self.builder
-                    .make_order_by(&schema, &rolling_window.order_by)?,
-            );
+            select_builder.set_order_by(self.builder.make_order_by(
+                &schema,
+                &rolling_window.order_by,
+                &substitutions,
+            )?);
         }
 
         let select = Rc::new(select_builder.build(query_tools.clone(), context_factory));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_rolling_window.rs
@@ -1,14 +1,15 @@
 use super::super::context::PushDownBuilderContext;
 use super::super::{LogicalNodeProcessor, ProcessableNode};
-use crate::logical_plan::transforms;
+use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::{MultiStageRollingWindow, MultiStageRollingWindowType};
-use crate::physical_plan::ReferencesBuilder;
+use crate::physical_plan::symbols::column_ref_symbol::column_reference;
 use crate::physical_plan::{
     Expr, From, JoinBuilder, JoinCondition, MemberExpression, QualifiedColumnName, QueryPlan,
-    SelectBuilder,
+    ReferenceSubstitutions, ReferencesBuilder, SelectBuilder,
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
-use crate::planner::MeasureRenderModifier;
+use crate::planner::symbols::transforms;
+use crate::planner::{MeasureRenderModifier, MemberSymbol};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -83,44 +84,74 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageRollingWindow>
             on,
         );
 
-        let mut context_factory = context.make_sql_nodes_factory()?;
+        let context_factory = context.make_sql_nodes_factory()?;
         let from = From::new_from_join(join_builder.build());
         let references_builder = ReferencesBuilder::new(from.clone());
-        let mut select_builder = SelectBuilder::new(from.clone());
 
-        //We insert render reference for main time dimension (with some granularity as in time series to avoid unnecessary date_tranc)
-        context_factory.add_render_reference(
+        let mut substitutions = ReferenceSubstitutions::new();
+        let date_from = || QualifiedColumnName::new(Some(root_alias.clone()), format!("date_from"));
+        //The main time dimension is read from the time series axis at the granularity the series was built with, so it needs no date_trunc of its own
+        substitutions.insert(
             time_dimension.full_name(),
-            QualifiedColumnName::new(Some(root_alias.clone()), format!("date_from")),
+            column_reference(&time_dimension, date_from()),
         );
 
-        //We also insert render reference for the base dimension of the time dimension (i.e. without `_granularity` prefix to let other time dimensions make date_tranc)
-        context_factory.add_render_reference(
-            time_dimension
-                .as_time_dimension()?
-                .base_symbol()
-                .full_name(),
-            QualifiedColumnName::new(Some(root_alias.clone()), format!("date_from")),
+        //The base dimension of that time dimension is read from the same axis, so a time dimension at another granularity truncates the axis column
+        let base_time_dimension = time_dimension.as_time_dimension()?.base_symbol().clone();
+        substitutions.insert(
+            base_time_dimension.full_name(),
+            column_reference(&base_time_dimension, date_from()),
         );
 
         // Time dimensions are read from the rolling source input, where they
         // are already timezone-converted and truncated, so they must render
         // without the conversion.
-        let schema = transforms::mark_tz_converted_at_source_in_schema(&rolling_window.schema)?;
+        let schema =
+            logical_transforms::mark_tz_converted_at_source_in_schema(&rolling_window.schema)?;
         // An ungrouped rolling select emits row-level values: count-like
         // measures render a not-null indicator over the input column;
         // otherwise the select merges the window's partial values.
         let schema = if rolling_window.is_ungrouped {
-            transforms::measures_render_modifier_in_schema(
+            logical_transforms::measures_render_modifier_in_schema(
                 &schema,
                 &MeasureRenderModifier::UngroupedFinal,
             )?
         } else {
-            transforms::measures_render_modifier_in_schema(
+            logical_transforms::measures_render_modifier_in_schema(
                 &schema,
                 &MeasureRenderModifier::RollingMerge,
             )?
         };
+
+        for dim in schema.dimensions.iter() {
+            if dim.clone().resolve_reference_chain()
+                != time_dimension.clone().resolve_reference_chain()
+            {
+                references_builder.collect_substitutions_for_member(
+                    dim.clone(),
+                    &Some(measure_input_alias.clone()),
+                    &mut substitutions,
+                )?;
+            }
+        }
+
+        // A measure of a rolling select aggregates the row-level values the
+        // rolling source produced for it, so it reads its input from that
+        // source instead of computing it.
+        for measure in schema.measures.iter() {
+            let name_in_base_query = measure_input_schema.resolve_member_alias(measure);
+            let input = column_reference(
+                measure,
+                QualifiedColumnName::new(Some(measure_input_alias.clone()), name_in_base_query),
+            );
+            let measure_symbol = measure.as_measure()?;
+            let over_input = transforms::measure_over_reference(&measure_symbol, input);
+            substitutions.insert(measure.full_name(), MemberSymbol::new_measure(over_input));
+        }
+
+        let schema = logical_transforms::substitute_symbols_in_schema(&schema, &substitutions)?;
+
+        let mut select_builder = SelectBuilder::new(from.clone());
 
         for dim in schema.time_dimensions.iter() {
             let alias = references_builder
@@ -129,27 +160,12 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageRollingWindow>
         }
 
         for dim in schema.dimensions.iter() {
-            if dim.clone().resolve_reference_chain()
-                != time_dimension.clone().resolve_reference_chain()
-            {
-                references_builder.resolve_references_for_member(
-                    dim.clone(),
-                    &Some(measure_input_alias.clone()),
-                    context_factory.render_references_mut(),
-                )?;
-            }
             let alias = references_builder
                 .resolve_alias_for_member(&dim, &Some(measure_input_alias.clone()));
             select_builder.add_projection_member(dim, alias);
         }
 
         for measure in schema.measures.iter() {
-            let name_in_base_query = measure_input_schema.resolve_member_alias(measure);
-            context_factory.add_ungrouped_measure_reference(
-                measure.full_name(),
-                QualifiedColumnName::new(Some(measure_input_alias.clone()), name_in_base_query),
-            );
-
             select_builder.add_projection_member(&measure, None);
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -292,26 +292,30 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         } else {
             logical_plan.modifers().order_by.clone()
         };
-        // Items present in the schema are sorted by their stamped and
-        // substituted schema symbol; only a measure absent from the projection
-        // carries its own symbol into the ORDER BY and needs both here.
-        let order_by = order_by
-            .iter()
-            .map(|o| -> Result<_, CubeError> {
-                if !schema.find_member_positions(&o.name()).is_empty() {
-                    return Ok(o.clone());
-                }
-                let symbol = match &measure_modifier {
-                    Some(modifier) => {
-                        transforms::measures_render_modifier(&o.member_symbol(), modifier)?
+        // Items present in the schema are sorted by their stamped schema
+        // symbol; only a measure absent from the projection carries its own
+        // symbol into the ORDER BY and needs the form stamped here.
+        let order_by = if let Some(modifier) = &measure_modifier {
+            order_by
+                .iter()
+                .map(|o| -> Result<_, CubeError> {
+                    if !schema.find_member_positions(&o.name()).is_empty() {
+                        return Ok(o.clone());
                     }
-                    None => o.member_symbol(),
-                };
-                let symbol = transforms::substitute_by_name(&symbol, &substitutions)?;
-                Ok(OrderByItem::new(symbol, o.desc()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        select_builder.set_order_by(self.builder.make_order_by(&schema, &order_by)?);
+                    Ok(OrderByItem::new(
+                        transforms::measures_render_modifier(&o.member_symbol(), modifier)?,
+                        o.desc(),
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            order_by
+        };
+        select_builder.set_order_by(self.builder.make_order_by(
+            &schema,
+            &order_by,
+            &substitutions,
+        )?);
 
         let res = Rc::new(select_builder.build(query_tools.clone(), context_factory));
         Ok(res)

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -1,9 +1,10 @@
 use super::super::{LogicalNodeProcessor, ProcessableNode, PushDownBuilderContext};
 use crate::logical_plan::transforms as logical_transforms;
 use crate::logical_plan::{all_symbols, Query, QuerySource};
+use crate::physical_plan::symbols::column_ref_symbol::literal_reference;
 use crate::physical_plan::{
-    CalcGroupItem, CalcGroupsJoin, Expr, From, MemberExpression, ReferencesBuilder, Select,
-    SelectBuilder,
+    CalcGroupItem, CalcGroupsJoin, Expr, From, MemberExpression, ReferenceSubstitutions,
+    ReferencesBuilder, Select, SelectBuilder,
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use crate::planner::collectors::collect_calc_group_dims_from_nodes;
@@ -85,7 +86,10 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
             ),
             QuerySource::FullKeyAggregate(_) => None,
         };
-        let mut calc_group_value_references: Vec<(String, String)> = Vec::new();
+        // Values pinned by the query rather than read from a source. Kept apart
+        // because a select over a pre-aggregation reads every other member from
+        // the rollup columns, but still renders these as literals.
+        let mut calc_group_literals = ReferenceSubstitutions::new();
         let from = if let Some(stored_dims) = calc_group_stored_dims {
             let all_symbols = all_symbols(&logical_plan.schema(), &logical_plan.filter());
             let calc_group_dims = collect_calc_group_dims_from_nodes(all_symbols.iter())?
@@ -104,9 +108,15 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
                 .clone()
                 .filter(|itm| itm.values.len() == 1)
             {
+                calc_group_literals.insert(
+                    item.symbol.full_name(),
+                    literal_reference(&item.symbol, item.values[0].clone()),
+                );
+                // A join condition can name a calc-group dimension too, and it
+                // is built before there is a select symbol environment to
+                // rewrite, so it resolves the value while rendering.
                 context_factory
                     .add_render_reference(item.symbol.full_name(), item.values[0].clone());
-                calc_group_value_references.push((item.symbol.full_name(), item.values[0].clone()));
             }
             let calc_groups_to_join = calc_groups_items
                 .filter(|itm| itm.values.len() > 1)
@@ -122,13 +132,15 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         };
 
         let mut schema = logical_plan.schema().clone();
+        let references_builder = ReferencesBuilder::new(from.clone());
+        let mut substitutions = calc_group_literals.clone();
 
         match logical_plan.source() {
             QuerySource::LogicalJoin(join) => {
-                let references_builder = ReferencesBuilder::new(from.clone());
-                self.builder.resolve_subquery_dimensions_references(
+                self.builder.collect_subquery_dimensions_substitutions(
                     &join.dimension_subqueries(),
                     &references_builder,
+                    &mut substitutions,
                     &mut context_factory,
                 )?;
             }
@@ -181,10 +193,6 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
 
         let is_pre_aggregation = matches!(logical_plan.source(), QuerySource::PreAggregation(_));
 
-        let references_builder = ReferencesBuilder::new(from.clone());
-
-        let mut select_builder = SelectBuilder::new(from);
-
         if !logical_plan.modifers().ungrouped {
             context_factory.set_group_by_members(
                 schema
@@ -195,31 +203,60 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         }
 
         for dimension in schema.all_dimensions() {
-            self.builder.process_query_dimension(
+            self.builder.collect_query_dimension_substitution(
                 dimension,
                 &references_builder,
-                &mut select_builder,
-                &mut context_factory,
-                &context,
+                &from,
+                &mut substitutions,
             )?;
         }
 
-        for (measure, exists) in self.builder.measures_for_query(&schema.measures, &context) {
-            if exists {
-                references_builder.resolve_references_for_member(
+        let measures_for_query = self.builder.measures_for_query(&schema.measures, &context);
+        for (measure, exists) in measures_for_query.iter() {
+            if *exists {
+                references_builder.collect_substitutions_for_member(
                     measure.clone(),
                     &None,
-                    context_factory.render_references_mut(),
+                    &mut substitutions,
                 )?;
+            }
+        }
+
+        let over_full_aggregated_source = self.is_over_full_aggregated_source(logical_plan);
+        if over_full_aggregated_source {
+            references_builder.collect_substitutions_for_filter(&having, &mut substitutions)?;
+        }
+
+        // A select over a pre-aggregation reads its members from the rollup
+        // columns, which the pre-aggregation node already resolved; only the
+        // values pinned by the query are substituted here.
+        let substitutions = if is_pre_aggregation {
+            calc_group_literals
+        } else {
+            substitutions
+        };
+
+        let schema = logical_transforms::substitute_symbols_in_schema(&schema, &substitutions)?;
+        let filter = logical_transforms::substitute_symbols_in_filter(filter, &substitutions)?;
+        let having = logical_transforms::substitute_symbols_in_filter(having, &substitutions)?;
+
+        let mut select_builder = SelectBuilder::new(from);
+
+        for dimension in schema.all_dimensions() {
+            self.builder
+                .project_query_dimension(dimension, &mut select_builder, &context)?;
+        }
+
+        for (measure, exists) in measures_for_query.iter() {
+            if *exists {
+                let measure = transforms::substitute_by_name(measure, &substitutions)?;
                 select_builder.add_projection_member(&measure, None);
             } else {
                 select_builder.add_null_projection(&measure, None);
             }
         }
 
-        if self.is_over_full_aggregated_source(logical_plan) {
-            references_builder
-                .resolve_references_for_filter(&having, context_factory.render_references_mut())?;
+        if over_full_aggregated_source {
             select_builder.set_filter(having);
         } else {
             if !logical_plan.modifers().ungrouped {
@@ -238,15 +275,6 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         select_builder.set_limit(logical_plan.modifers().limit);
         select_builder.set_offset(logical_plan.modifers().offset);
 
-        if is_pre_aggregation {
-            context_factory.clear_render_references();
-            // Calc-group values are rendered as literals, not resolved from
-            // the rollup, so they must survive the render-reference reset.
-            for (name, value) in calc_group_value_references.into_iter() {
-                context_factory.add_render_reference(name, value);
-            }
-        }
-
         // When reading from a pre-aggregation, drop ORDER BY keys on measures that
         // are not part of the selection. CubeStore cannot ORDER BY an aggregate of a
         // rollup column that isn't projected.
@@ -264,25 +292,25 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         } else {
             logical_plan.modifers().order_by.clone()
         };
-        // Items present in the schema are sorted by their stamped schema
-        // symbol; only a measure absent from the projection carries its
-        // own symbol into the ORDER BY and needs the form here.
-        let order_by = if let Some(modifier) = &measure_modifier {
-            order_by
-                .iter()
-                .map(|o| -> Result<_, CubeError> {
-                    if !schema.find_member_positions(&o.name()).is_empty() {
-                        return Ok(o.clone());
+        // Items present in the schema are sorted by their stamped and
+        // substituted schema symbol; only a measure absent from the projection
+        // carries its own symbol into the ORDER BY and needs both here.
+        let order_by = order_by
+            .iter()
+            .map(|o| -> Result<_, CubeError> {
+                if !schema.find_member_positions(&o.name()).is_empty() {
+                    return Ok(o.clone());
+                }
+                let symbol = match &measure_modifier {
+                    Some(modifier) => {
+                        transforms::measures_render_modifier(&o.member_symbol(), modifier)?
                     }
-                    Ok(OrderByItem::new(
-                        transforms::measures_render_modifier(&o.member_symbol(), modifier)?,
-                        o.desc(),
-                    ))
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        } else {
-            order_by
-        };
+                    None => o.member_symbol(),
+                };
+                let symbol = transforms::substitute_by_name(&symbol, &substitutions)?;
+                Ok(OrderByItem::new(symbol, o.desc()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         select_builder.set_order_by(self.builder.make_order_by(&schema, &order_by)?);
 
         let res = Rc::new(select_builder.build(query_tools.clone(), context_factory));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -133,7 +133,7 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
 
         let mut schema = logical_plan.schema().clone();
         let references_builder = ReferencesBuilder::new(from.clone());
-        let mut substitutions = calc_group_literals.clone();
+        let mut substitutions = calc_group_literals;
 
         match logical_plan.source() {
             QuerySource::LogicalJoin(join) => {
@@ -202,39 +202,37 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
             );
         }
 
-        for dimension in schema.all_dimensions() {
-            self.builder.collect_query_dimension_substitution(
-                dimension,
-                &references_builder,
-                &from,
-                &mut substitutions,
-            )?;
-        }
-
         let measures_for_query = self.builder.measures_for_query(&schema.measures, &context);
-        for (measure, exists) in measures_for_query.iter() {
-            if *exists {
-                references_builder.collect_substitutions_for_member(
-                    measure.clone(),
-                    &None,
+        let over_full_aggregated_source = self.is_over_full_aggregated_source(logical_plan);
+
+        // A select over a pre-aggregation reads its members from the rollup
+        // columns, which the pre-aggregation node already resolved, so nothing
+        // is collected for it: the values pinned by the query, already in
+        // `substitutions`, are all it substitutes.
+        if !is_pre_aggregation {
+            for dimension in schema.all_dimensions() {
+                self.builder.collect_query_dimension_substitution(
+                    dimension,
+                    &references_builder,
+                    &from,
                     &mut substitutions,
                 )?;
             }
-        }
 
-        let over_full_aggregated_source = self.is_over_full_aggregated_source(logical_plan);
-        if over_full_aggregated_source {
-            references_builder.collect_substitutions_for_filter(&having, &mut substitutions)?;
-        }
+            for (measure, exists) in measures_for_query.iter() {
+                if *exists {
+                    references_builder.collect_substitutions_for_member(
+                        measure.clone(),
+                        &None,
+                        &mut substitutions,
+                    )?;
+                }
+            }
 
-        // A select over a pre-aggregation reads its members from the rollup
-        // columns, which the pre-aggregation node already resolved; only the
-        // values pinned by the query are substituted here.
-        let substitutions = if is_pre_aggregation {
-            calc_group_literals
-        } else {
-            substitutions
-        };
+            if over_full_aggregated_source {
+                references_builder.collect_substitutions_for_filter(&having, &mut substitutions)?;
+            }
+        }
 
         let schema = logical_transforms::substitute_symbols_in_schema(&schema, &substitutions)?;
         let filter = logical_transforms::substitute_symbols_in_filter(filter, &substitutions)?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/calc_group_dims_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/calc_group_dims_collector.rs
@@ -39,6 +39,9 @@ impl TraversalVisitor for CalcGroupDimsCollector {
             MemberSymbol::TimeDimension(e) => return self.on_node_traverse(e.base_symbol(), &()),
             MemberSymbol::Measure(_) => {}
             MemberSymbol::MemberExpression(_) => {}
+            // A reference is read from a source that already resolved the
+            // calc groups behind it.
+            MemberSymbol::ColumnRef(_) => {}
         };
         Ok(Some(()))
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/cube_names_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/cube_names_collector.rs
@@ -56,6 +56,9 @@ impl TraversalVisitor for CubeNamesCollector {
                 }
             }
             MemberSymbol::MemberExpression(_) => {}
+            // A reference is read from a source the query already has, so it
+            // brings no cube of its own into the join.
+            MemberSymbol::ColumnRef(_) => {}
         };
         Ok(Some(()))
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/join_hints_collector.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/collectors/join_hints_collector.rs
@@ -78,6 +78,9 @@ impl TraversalVisitor for JoinHintsCollector {
                 }
             }
             MemberSymbol::MemberExpression(_) => {}
+            // A reference is read from a source the query already has, so it
+            // hints at no join of its own.
+            MemberSymbol::ColumnRef(_) => {}
         };
         Ok(Some(()))
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
@@ -226,6 +226,20 @@ impl SqlCall {
         }
     }
 
+    /// A call whose whole body is one member symbol, so it renders as
+    /// exactly that symbol's SQL. Used to give a member an input it
+    /// does not declare itself — a symbol standing for a value the
+    /// enclosing select already has.
+    pub fn new_direct_reference(symbol: Rc<MemberSymbol>) -> Rc<Self> {
+        Rc::new(Self::new(
+            SqlTemplate::String(SqlCallArg::dependency(0)),
+            vec![SqlDependency::Symbol(symbol)],
+            vec![],
+            vec![],
+            SecutityContextProps { values: vec![] },
+        ))
+    }
+
     /// Renders the template into a single SQL string. Errors when
     /// the template is a `StringVec` — use `eval_vec` for that case.
     pub fn eval(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/column_ref_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/column_ref_symbol.rs
@@ -1,0 +1,92 @@
+use super::common::CompiledMemberPath;
+use super::deps::symbol_deps;
+use super::MemberSymbol;
+use crate::utils::debug::DebugSql;
+use std::rc::Rc;
+
+/// What a reference stands for in the SQL it renders into: a column of
+/// one of the enclosing select's sources, or a value the query pinned
+/// for the member.
+#[derive(Clone, Debug)]
+pub enum ReferenceValue {
+    Column {
+        source: Option<String>,
+        name: String,
+    },
+    Literal(String),
+}
+
+/// `MemberSymbol::ColumnRef` body: a member that is *read* instead of
+/// computed, because the select it belongs to takes it from a source
+/// that already produced it.
+///
+/// A reference is a leaf: it renders as the column or literal it names
+/// and nothing else. Anything that would still apply to the member —
+/// an aggregation, a granularity truncation, a mask — is expressed by
+/// a symbol standing above this one in the dependency tree, never by
+/// the reference itself.
+///
+/// `origin` is the member the reference stands for. It carries the
+/// symbol's identity — `full_name`, `alias`, `cube_name` all come from
+/// it, so column resolution, member-position lookup and filter
+/// matching keep working on a substituted symbol. It is deliberately
+/// not a dependency: the origin's SQL is precisely what this symbol
+/// replaces.
+#[derive(Clone)]
+pub struct ColumnRefSymbol {
+    pub(super) value: ReferenceValue,
+    pub(super) origin: Rc<MemberSymbol>,
+}
+
+symbol_deps! {
+    ColumnRefSymbol {
+        value: skip,
+        origin: skip,
+    }
+}
+
+impl ColumnRefSymbol {
+    pub fn new(origin: Rc<MemberSymbol>, value: ReferenceValue) -> Rc<Self> {
+        Rc::new(Self { value, origin })
+    }
+
+    pub fn value(&self) -> &ReferenceValue {
+        &self.value
+    }
+
+    pub fn origin(&self) -> &Rc<MemberSymbol> {
+        &self.origin
+    }
+
+    pub fn compiled_path(&self) -> &CompiledMemberPath {
+        self.origin.compiled_path()
+    }
+
+    pub fn full_name(&self) -> String {
+        self.compiled_path().full_name().clone()
+    }
+
+    pub fn alias(&self) -> String {
+        self.compiled_path().alias().clone()
+    }
+
+    pub fn name(&self) -> String {
+        self.compiled_path().name().clone()
+    }
+
+    pub fn cube_name(&self) -> String {
+        self.compiled_path().cube_name().clone()
+    }
+}
+
+impl DebugSql for ColumnRefSymbol {
+    fn debug_sql(&self, _expand_deps: bool) -> String {
+        match &self.value {
+            ReferenceValue::Column { source, name } => match source {
+                Some(source) => format!("{{REF:{}.{}}}", source, name),
+                None => format!("{{REF:{}}}", name),
+            },
+            ReferenceValue::Literal(value) => format!("{{REF:'{}'}}", value),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/deps.rs
@@ -113,6 +113,8 @@ macro_rules! symbol_deps {
                 &self,
                 visitor: &mut dyn $crate::planner::symbols::deps::DepVisitor,
             ) -> ::std::ops::ControlFlow<()> {
+                // A node whose every slot is `skip` never touches the visitor.
+                let _ = &visitor;
                 let Self { $($field),+ } = self;
                 $($crate::planner::symbols::deps::symbol_deps!(@visit $mode, $field, visitor);)+
                 ::std::ops::ControlFlow::Continue(())
@@ -122,6 +124,7 @@ macro_rules! symbol_deps {
                 &mut self,
                 visitor: &mut dyn $crate::planner::symbols::deps::DepVisitorMut,
             ) -> Result<(), ::cubenativeutils::CubeError> {
+                let _ = &visitor;
                 let Self { $($field),+ } = self;
                 $($crate::planner::symbols::deps::symbol_deps!(@visit_mut $mode, $field, visitor);)+
                 Ok(())

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -276,6 +276,28 @@ impl MeasureKind {
         }
     }
 
+    /// The same kind with `input` as the value it aggregates, replacing
+    /// whatever SQL the kind declared. The aggregation itself is kept,
+    /// so the measure still wraps its input the way its type demands.
+    ///
+    /// `Rank` is returned unchanged: it is produced by a window function
+    /// over a partition rather than computed from a value, so there is
+    /// no input for a reference to stand in for.
+    pub fn over_input_sql(&self, input: Rc<SqlCall>) -> Self {
+        match self {
+            Self::Count(_) => Self::Count(CountMeasure::new(CountSql::Explicit(input))),
+            Self::MultipliedCount(_) => {
+                Self::MultipliedCount(CountMeasure::new(CountSql::Explicit(input)))
+            }
+            Self::Aggregated(a) => Self::Aggregated(AggregatedMeasure::new(a.agg_type(), input)),
+            Self::AggregatedState(a) => {
+                Self::AggregatedState(AggregatedMeasure::new(a.agg_type(), input))
+            }
+            Self::Calculated(c) => Self::Calculated(CalculatedMeasure::new(c.calc_type(), input)),
+            Self::Rank => Self::Rank,
+        }
+    }
+
     /// `Some(render form)` when the kind's aggregation can render as a
     /// mergeable intermediate state for an outer aggregation to merge:
     /// only `count_distinct_approx` has such a form (an HLL state).

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
@@ -5,7 +5,9 @@ use crate::planner::{Case, CubeRef, SqlCall};
 
 use super::common::CompiledMemberPath;
 use super::deps::{self, DepVisitor, DepVisitorMut, SymbolDeps};
-use super::{DimensionSymbol, MeasureSymbol, MemberExpressionSymbol, TimeDimensionSymbol};
+use super::{
+    ColumnRefSymbol, DimensionSymbol, MeasureSymbol, MemberExpressionSymbol, TimeDimensionSymbol,
+};
 use std::fmt::Debug;
 use std::ops::ControlFlow;
 use std::rc::Rc;
@@ -25,12 +27,18 @@ use std::rc::Rc;
 /// Indivisible: renders as a single SQL expression. A symbol may depend
 /// on other symbols (`get_dependencies`); whether those deps are
 /// inlined or pushed into a CTE / subquery is a physical-plan decision.
+///
+/// `ColumnRef` is the one variant that describes no calculation at all:
+/// the member is read from a source of the select it appears in. It
+/// keeps the identity of the member it stands for, so it can hold any
+/// position the original held.
 #[derive(Clone)]
 pub enum MemberSymbol {
     Dimension(Rc<DimensionSymbol>),
     TimeDimension(Rc<TimeDimensionSymbol>),
     Measure(Rc<MeasureSymbol>),
     MemberExpression(Rc<MemberExpressionSymbol>),
+    ColumnRef(Rc<ColumnRefSymbol>),
 }
 
 impl Debug for MemberSymbol {
@@ -46,6 +54,7 @@ impl Debug for MemberSymbol {
                 .debug_tuple("MemberExpression")
                 .field(&self.full_name())
                 .finish(),
+            Self::ColumnRef(_) => f.debug_tuple("ColumnRef").field(&self.full_name()).finish(),
         }
     }
 }
@@ -80,12 +89,17 @@ impl MemberSymbol {
         Rc::new(Self::TimeDimension(symbol))
     }
 
+    pub fn new_column_ref(symbol: Rc<ColumnRefSymbol>) -> Rc<Self> {
+        Rc::new(Self::ColumnRef(symbol))
+    }
+
     pub fn compiled_path(&self) -> &CompiledMemberPath {
         match self {
             Self::Dimension(d) => d.compiled_path(),
             Self::TimeDimension(d) => d.compiled_path(),
             Self::Measure(m) => m.compiled_path(),
             Self::MemberExpression(e) => e.compiled_path(),
+            Self::ColumnRef(r) => r.compiled_path(),
         }
     }
 
@@ -182,6 +196,7 @@ impl MemberSymbol {
             Self::TimeDimension(d) => d.is_reference(),
             Self::Measure(m) => m.is_reference(),
             Self::MemberExpression(e) => e.is_reference(),
+            Self::ColumnRef(_) => true,
         }
     }
 
@@ -192,6 +207,10 @@ impl MemberSymbol {
             Self::TimeDimension(d) => d.reference_member(),
             Self::Measure(m) => m.reference_member(),
             Self::MemberExpression(e) => e.reference_member(),
+            // The origin is an identity annotation rather than a
+            // dependency, so it is named here explicitly instead of
+            // being picked up as the first dependency.
+            Self::ColumnRef(r) => Some(r.origin().clone()),
         }
     }
 
@@ -239,14 +258,30 @@ impl MemberSymbol {
         false
     }
 
-    /// `MemberExpression` symbols are never owned by a cube; for the other
-    /// variants, the answer comes from the underlying member definition.
+    /// `MemberExpression` and `ColumnRef` symbols are never owned by a cube —
+    /// the first has no member definition behind it, the second is read from a
+    /// source the select already has. For the other variants the answer comes
+    /// from the underlying member definition.
     pub fn owned_by_cube(&self) -> bool {
         match self {
             Self::Dimension(d) => d.owned_by_cube(),
             Self::TimeDimension(d) => d.owned_by_cube(),
             Self::Measure(m) => m.owned_by_cube(),
             Self::MemberExpression(_) => false,
+            Self::ColumnRef(_) => false,
+        }
+    }
+
+    /// The time dimension this symbol stands for: itself, or the one
+    /// behind a reference that reads it from a source. Answers a
+    /// question about member identity, so it looks through references;
+    /// `as_time_dimension` answers what the symbol renders as and does
+    /// not.
+    pub fn time_dimension_behind_references(&self) -> Option<Rc<TimeDimensionSymbol>> {
+        match self {
+            Self::TimeDimension(d) => Some(d.clone()),
+            Self::ColumnRef(r) => r.origin().time_dimension_behind_references(),
+            _ => None,
         }
     }
 
@@ -370,6 +405,7 @@ impl SymbolDeps for MemberSymbol {
             Self::TimeDimension(d) => d.as_ref().visit_deps(visitor),
             Self::Measure(m) => m.as_ref().visit_deps(visitor),
             Self::MemberExpression(e) => e.as_ref().visit_deps(visitor),
+            Self::ColumnRef(r) => r.as_ref().visit_deps(visitor),
         }
     }
 
@@ -395,6 +431,11 @@ impl SymbolDeps for MemberSymbol {
                 body.visit_deps_mut(visitor)?;
                 *e = Rc::new(body);
             }
+            Self::ColumnRef(r) => {
+                let mut body = (**r).clone();
+                body.visit_deps_mut(visitor)?;
+                *r = Rc::new(body);
+            }
         }
         Ok(())
     }
@@ -407,6 +448,7 @@ impl crate::utils::debug::DebugSql for MemberSymbol {
             MemberSymbol::Measure(m) => m.debug_sql(expand_deps),
             MemberSymbol::TimeDimension(t) => t.debug_sql(expand_deps),
             MemberSymbol::MemberExpression(e) => e.debug_sql(expand_deps),
+            MemberSymbol::ColumnRef(r) => r.debug_sql(expand_deps),
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
@@ -1,3 +1,4 @@
+mod column_ref_symbol;
 mod common;
 mod cube_symbol;
 pub mod deps;
@@ -11,6 +12,7 @@ mod symbol_factory;
 mod time_dimension_symbol;
 pub mod transforms;
 
+pub use column_ref_symbol::{ColumnRefSymbol, ReferenceValue};
 pub use common::*;
 pub use cube_symbol::{
     CubeNameSymbol, CubeNameSymbolFactory, CubeTableSymbol, CubeTableSymbolFactory,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/measure_over_reference.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/measure_over_reference.rs
@@ -2,20 +2,12 @@ use super::super::{MeasureSymbol, MemberSymbol};
 use crate::planner::SqlCall;
 use std::rc::Rc;
 
-/// Returns a copy of the measure that aggregates `reference` instead of
-/// the value it declares — the form a measure takes in a select that
-/// reads its row-level input from a source below.
+/// Returns a copy of the measure that aggregates `reference` instead of the
+/// value it declares.
 ///
-/// The measure keeps everything that describes how the aggregated
-/// result is emitted: its aggregation, its mask, the `order_by` a rank
-/// window uses, its multi-stage and rolling context, and any render
-/// modifier stamped on it.
-///
-/// It keeps nothing that describes how the input is computed: the
-/// `case` body and the measure-level filters produced the rows that the
-/// source below already aggregated, and re-applying them here would
-/// both double the condition and read members this select has no access
-/// to.
+/// The `case` body and the measure filters are dropped: they shaped the rows
+/// the source below already aggregated, so re-applying them here would double
+/// the condition and read members this select cannot reach.
 pub fn measure_over_reference(
     measure: &MeasureSymbol,
     reference: Rc<MemberSymbol>,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/measure_over_reference.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/measure_over_reference.rs
@@ -1,0 +1,40 @@
+use super::super::{MeasureSymbol, MemberSymbol};
+use crate::planner::SqlCall;
+use std::rc::Rc;
+
+/// Returns a copy of the measure that aggregates `reference` instead of
+/// the value it declares — the form a measure takes in a select that
+/// reads its row-level input from a source below.
+///
+/// The measure keeps everything that describes how the aggregated
+/// result is emitted: its aggregation, its mask, the `order_by` a rank
+/// window uses, its multi-stage and rolling context, and any render
+/// modifier stamped on it.
+///
+/// It keeps nothing that describes how the input is computed: the
+/// `case` body and the measure-level filters produced the rows that the
+/// source below already aggregated, and re-applying them here would
+/// both double the condition and read members this select has no access
+/// to.
+pub fn measure_over_reference(
+    measure: &MeasureSymbol,
+    reference: Rc<MemberSymbol>,
+) -> Rc<MeasureSymbol> {
+    let kind = measure
+        .kind()
+        .over_input_sql(SqlCall::new_direct_reference(reference));
+    Rc::new(MeasureSymbol {
+        compiled_path: measure.compiled_path.clone(),
+        kind,
+        rolling_window: measure.rolling_window.clone(),
+        multi_stage: measure.multi_stage.clone(),
+        is_reference: measure.is_reference,
+        is_view: measure.is_view,
+        case: None,
+        measure_filters: vec![],
+        measure_drill_filters: vec![],
+        measure_order_by: measure.measure_order_by.clone(),
+        mask_sql: measure.mask_sql.clone(),
+        render_modifier: measure.render_modifier.clone(),
+    })
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/mod.rs
@@ -12,6 +12,7 @@
 //! uses clone-and-mutate, so new fields flow through untouched.
 
 mod filter_symbols;
+mod measure_over_reference;
 mod measures_as_state;
 mod multiplied;
 mod patch_measure;
@@ -23,6 +24,7 @@ mod tz_converted_at_source;
 mod unroll_rolling;
 
 pub use filter_symbols::*;
+pub use measure_over_reference::*;
 pub use measures_as_state::*;
 pub use multiplied::*;
 pub use patch_measure::*;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/strip_join_prefix.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/strip_join_prefix.rs
@@ -26,5 +26,12 @@ pub fn strip_join_prefix(symbol: &Rc<MemberSymbol>) -> Rc<MemberSymbol> {
             new.compiled_path = new.compiled_path.strip_join_prefix();
             Rc::new(MemberSymbol::MemberExpression(Rc::new(new)))
         }
+        // A reference has no path of its own — it takes identity from the
+        // member it stands for, so that member is stripped instead.
+        MemberSymbol::ColumnRef(r) => {
+            let mut new = (**r).clone();
+            new.origin = strip_join_prefix(&new.origin);
+            Rc::new(MemberSymbol::ColumnRef(Rc::new(new)))
+        }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/substitute.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/transforms/substitute.rs
@@ -1,7 +1,29 @@
+use super::super::deps;
 use super::super::MemberSymbol;
 use cubenativeutils::CubeError;
 use std::collections::HashMap;
 use std::rc::Rc;
+
+/// The per-node replacement: a member named in `replacements` becomes
+/// the symbol mapped to it.
+///
+/// A `ColumnRef` node is left alone. It already names what it reads, and
+/// it carries the name of the member it stands for — so a substitute
+/// that reads its member from a reference stays put instead of being
+/// rebuilt around that reference over and over.
+fn replacement<'a>(
+    replacements: &'a HashMap<String, Rc<MemberSymbol>>,
+) -> impl Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError> + 'a {
+    move |node: &Rc<MemberSymbol>| {
+        if matches!(node.as_ref(), MemberSymbol::ColumnRef(_)) {
+            return Ok(node.clone());
+        }
+        Ok(replacements
+            .get(&node.full_name())
+            .cloned()
+            .unwrap_or_else(|| node.clone()))
+    }
+}
 
 /// Rebuilds the symbol tree with every node whose `full_name` appears
 /// in `replacements` substituted by the mapped symbol; the walk then
@@ -10,10 +32,22 @@ pub fn substitute_by_name(
     symbol: &Rc<MemberSymbol>,
     replacements: &HashMap<String, Rc<MemberSymbol>>,
 ) -> Result<Rc<MemberSymbol>, CubeError> {
-    symbol.apply_recursive(&|node| {
-        Ok(replacements
-            .get(&node.full_name())
-            .cloned()
-            .unwrap_or_else(|| node.clone()))
-    })
+    symbol.apply_recursive(&replacement(replacements))
+}
+
+/// Substitution for the member a filter names.
+///
+/// A filter renders the dimension behind a time-dimension wrapper
+/// rather than the wrapper itself (see `BaseFilter::member_evaluator`),
+/// so a granularity wrapper is never the symbol read from a source —
+/// the substitution applies inside it. Anything else is substituted as
+/// usual.
+pub fn substitute_filter_member_by_name(
+    symbol: &Rc<MemberSymbol>,
+    replacements: &HashMap<String, Rc<MemberSymbol>>,
+) -> Result<Rc<MemberSymbol>, CubeError> {
+    if matches!(symbol.as_ref(), MemberSymbol::TimeDimension(_)) {
+        return deps::apply_to_deps(symbol, &replacement(replacements));
+    }
+    substitute_by_name(symbol, replacements)
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_bucketing.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_bucketing.yaml
@@ -16,6 +16,15 @@ cubes:
             sql: created_at
             type: time
 
+          # Calc group: an abstract enumeration with no backing column. Used
+          # together with a multi-stage dimension, whose CTE is joined back by
+          # the plain dimensions of the query — this one among them.
+          - name: report_mode
+            type: switch
+            values:
+                - detailed
+                - summary
+
           - name: change_type
             sql: "CONCAT('Revenue is ', {revenue_change_type})"
             multi_stage: true

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_subquery_in_join.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_subquery_in_join.yaml
@@ -35,6 +35,12 @@ cubes:
       measures:
           - name: count
             type: count
+          # A measure that survives as a sum rather than collapsing into a
+          # COUNT(DISTINCT), so a query multiplying it builds the keys
+          # subquery and joins the source cube for it.
+          - name: sum_foo_id
+            type: sum
+            sql: foo_id
 
     - name: C
       sql: "SELECT * FROM c"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
@@ -6,7 +6,7 @@ use crate::logical_plan::PreAggregationUsage;
 use crate::logical_plan::{PreAggregation, PreAggregationSource, PreAggregationTable};
 use crate::physical_plan::filter::ToSql;
 use crate::physical_plan::sql_nodes::SqlNodesFactory;
-use crate::physical_plan::{SqlEvaluatorVisitor, VisitorContext};
+use crate::physical_plan::{QualifiedColumnName, SqlEvaluatorVisitor, VisitorContext};
 use crate::planner::filter::base_segment::BaseSegment;
 use crate::planner::filter::Filter;
 use crate::planner::sql_templates::PlanSqlTemplates;
@@ -382,6 +382,33 @@ impl TestContext {
     ) -> Result<String, CubeError> {
         let mut nodes_factory = SqlNodesFactory::default();
         nodes_factory.set_group_by_members(group_by_members.into_iter().collect());
+        let cube_ref_evaluator = Rc::new(nodes_factory.cube_ref_evaluator());
+        let visitor = SqlEvaluatorVisitor::new(
+            self.query_tools.query_tools().clone(),
+            cube_ref_evaluator,
+            None,
+        );
+        let base_tools = self.query_tools.base_tools();
+        let driver_tools = base_tools.driver_tools(false)?;
+        let templates = PlanSqlTemplates::try_new(driver_tools, false)?;
+        let node_processor = nodes_factory.default_node_processor(self.query_tools.query_tools());
+
+        visitor.apply(symbol, node_processor, &templates)
+    }
+
+    /// Like `evaluate_symbol`, but with render references configured on the
+    /// node factory — the map through which a join condition resolves the
+    /// members it names, since it is rendered outside any select's symbol
+    /// environment.
+    pub fn evaluate_symbol_with_render_references(
+        &self,
+        symbol: &Rc<MemberSymbol>,
+        references: Vec<(String, QualifiedColumnName)>,
+    ) -> Result<String, CubeError> {
+        let mut nodes_factory = SqlNodesFactory::default();
+        for (name, column) in references {
+            nodes_factory.add_render_reference(name, column);
+        }
         let cube_ref_evaluator = Rc::new(nodes_factory.cube_ref_evaluator());
         let visitor = SqlEvaluatorVisitor::new(
             self.query_tools.query_tools().clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs
@@ -312,6 +312,47 @@ async fn test_multi_fact_measure_filter_on_second_fact() {
     }
 }
 
+/// ORDER BY a measure that the query filters on but does not select. Such an
+/// item is absent from the select's schema, so it carries its own symbol into
+/// the ORDER BY and has to be read from the aggregate the same way the HAVING
+/// reads it — dropping the sort key silently would leave the rows unordered.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_order_by_filtered_measure_outside_selection() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - orders.count
+        dimensions:
+          - customers.name
+        filters:
+          - member: returns.count
+            operator: gt
+            values:
+              - \"1\"
+        order:
+          - id: returns.count
+            desc: true
+          - id: customers.name
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    let order_by = sql
+        .rsplit_once("ORDER BY")
+        .map(|(_, tail)| tail.to_string())
+        .unwrap_or_default();
+    assert!(
+        order_by.contains("returns__count"),
+        "Expected the filtered measure to survive as a sort key:\n{}",
+        sql
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multiplied_with_time_granularity() {
     let ctx = create_context();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/bucketing.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/bucketing.rs
@@ -233,3 +233,39 @@ async fn test_bucketing_with_two_dims_concated() {
         insta::assert_snapshot!(result);
     }
 }
+
+/// A multi-stage dimension is joined back to the query by the plain dimensions
+/// of that query, and a calc group among them is one of those plain dimensions.
+/// Pinned to a single value it is not read from anywhere — no values table is
+/// cross-joined — so the join condition has to render the value itself.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_calc_group_pinned_value_in_multistage_dimension_join() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.count
+        dimensions:
+          - orders.change_type
+          - orders.report_mode
+        filters:
+          - member: orders.report_mode
+            operator: equals
+            values:
+              - summary
+        order:
+          - id: orders.change_type
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    assert!(
+        sql.contains("\"orders__report_mode\" = 'summary'"),
+        "Expected the join condition to compare the CTE column with the pinned value:\n{}",
+        sql
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__bucketing__calc_group_pinned_value_in_multistage_dimension_join.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__bucketing__calc_group_pinned_value_in_multistage_dimension_join.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/bucketing.rs
+expression: result
+---
+orders__change_type | orders__report_mode | orders__count
+--------------------+---------------------+--------------
+Revenue is Down     | summary             | 36

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__multi_fact__order_by_filtered_measure_outside_selection.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__multi_fact__order_by_filtered_measure_outside_selection.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs
+expression: result
+---
+customers__name | orders__count
+----------------+--------------
+Bob             | 3            
+Charlie         | 0

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__subquery_in_join__sub_query_dim_join_key_for_multiplied_measure.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__subquery_in_join__sub_query_dim_join_key_for_multiplied_measure.snap
@@ -1,0 +1,11 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/subquery_in_join.rs
+expression: result
+---
+b__id | c__bar_id | b__sum_foo_id
+------+-----------+--------------
+100   | NULL      | 1            
+101   | NULL      | 2            
+102   | NULL      | 3            
+103   | 452       | 4            
+104   | 478       | 5

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/subquery_in_join.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/subquery_in_join.rs
@@ -40,3 +40,47 @@ async fn test_sub_query_dim_in_join_condition() {
         insta::assert_snapshot!(result);
     }
 }
+
+// A multiplied measure reads its rows from the source cube joined beside the
+// keys subquery, and a sub-query dimension the join condition names is joined
+// there too. That dimension's join matches on the primary key, so the key has
+// to resolve against the cube joined for the measure — resolving it anywhere
+// that is not in scope at that point makes the whole select unrunnable.
+//
+// `B.sum_foo_id` multiplies over the one-to-many join to C, and the B → C
+// condition names the sub_query dim `B.foo_id`, which is what puts the
+// dimension sub-query into that same join.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sub_query_dim_join_key_for_multiplied_measure() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - B.sum_foo_id
+        dimensions:
+          - B.id
+          - C.bar_id
+        order:
+          - id: B.id
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    let subquery_join = sql
+        .split("AS \"B_foo_id_subquery\" ON")
+        .nth(2)
+        .unwrap_or_default()
+        .split('\n')
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        subquery_join.contains("\"b_key_b\".id"),
+        "Expected the sub-query join to match on the key of the cube joined for the measure:\n{}",
+        sql
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/symbol_transforms.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/symbol_transforms.rs
@@ -4,12 +4,14 @@ use crate::logical_plan::transforms::{
     mark_tz_converted_at_source_in_schema, measures_render_modifier_in_schema,
 };
 use crate::logical_plan::LogicalSchema;
+use crate::physical_plan::symbols::column_ref_symbol::column_reference;
+use crate::physical_plan::QualifiedColumnName;
 use crate::planner::symbols::transforms;
 use crate::planner::{MeasureRenderModifier, MemberSymbol};
 use crate::test_fixtures::cube_bridge::MockSchema;
 use crate::test_fixtures::test_utils::TestContext;
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 fn ctx() -> TestContext {
@@ -140,5 +142,82 @@ fn tz_mark_reaches_time_dimensions_embedded_in_other_members() {
         tz_mark_of(&marked.dimensions[0], "events.created_at_day"),
         Some(true),
         "the embedded occurrence must carry the mark too"
+    );
+}
+
+/// A reference is terminal. It carries the name of the member it stands for, so
+/// a substitute that reads that member *through* a reference — an aggregation
+/// over a column of a source below — would match its own map entry again and be
+/// rebuilt around itself without end.
+#[test]
+fn substitution_does_not_reenter_a_reference() {
+    let ctx = ctx();
+    let measure = ctx.create_measure("events.count").unwrap();
+    let column = QualifiedColumnName::new(Some("src".to_string()), "cnt".to_string());
+    let over_reference = MemberSymbol::new_measure(transforms::measure_over_reference(
+        &measure.as_measure().unwrap(),
+        column_reference(&measure, column),
+    ));
+
+    let replacements = HashMap::from([(measure.full_name(), over_reference)]);
+    let substituted = transforms::substitute_by_name(&measure, &replacements).unwrap();
+
+    assert_eq!(
+        ctx.evaluate_symbol(&substituted).unwrap(),
+        "count(\"src\".\"cnt\")",
+        "the measure must read the column once, wrapped by its own aggregation"
+    );
+}
+
+/// The same holds for a reference embedded in another member's expression: the
+/// walk replaces the measure inside the `CASE` body and stops at the reference
+/// it now reads.
+#[test]
+fn substitution_does_not_reenter_a_nested_reference() {
+    let ctx = ctx();
+    let dimension = ctx.create_dimension("events.count_label").unwrap();
+    let measure = ctx.create_measure("events.count").unwrap();
+    let column = QualifiedColumnName::new(Some("src".to_string()), "cnt".to_string());
+    let over_reference = MemberSymbol::new_measure(transforms::measure_over_reference(
+        &measure.as_measure().unwrap(),
+        column_reference(&measure, column),
+    ));
+
+    let replacements = HashMap::from([(measure.full_name(), over_reference)]);
+    let substituted = transforms::substitute_by_name(&dimension, &replacements).unwrap();
+
+    let sql = ctx.evaluate_symbol(&substituted).unwrap();
+    assert!(
+        sql.contains("count(\"src\".\"cnt\")"),
+        "the nested measure must read the column: {sql}"
+    );
+}
+
+/// Nothing wraps a reference, and that includes the render-reference map a join
+/// condition resolves its members through: a reference carries the name of the
+/// member it stands for, so looking that name up would render it from the map
+/// instead of from itself.
+#[test]
+fn render_references_do_not_intercept_a_reference() {
+    let ctx = ctx();
+    let dimension = ctx.create_dimension("events.id").unwrap();
+    let reference = column_reference(
+        &dimension,
+        QualifiedColumnName::new(Some("src".to_string()), "id".to_string()),
+    );
+
+    let sql = ctx
+        .evaluate_symbol_with_render_references(
+            &reference,
+            vec![(
+                dimension.full_name(),
+                QualifiedColumnName::new(Some("other".to_string()), "other_id".to_string()),
+            )],
+        )
+        .unwrap();
+
+    assert_eq!(
+        sql, "\"src\".\"id\"",
+        "the reference must render the column it names"
     );
 }


### PR DESCRIPTION
## Summary

A member that a select reads from one of its sources was resolved while rendering, by looking its name up in a per-query map. The map was built bottom-up from the select's projections and applied to everything rendered beneath it, so a member it failed to record silently rendered its own expression against a source that may not carry the columns for it.

This replaces that map with a symbol. `MemberSymbol::ColumnRef` is a leaf that renders as the column or literal it names, carrying the member it stands for as an identity annotation rather than a dependency, so it keeps the member's name and alias and can hold any position the original held — column resolution, member-position lookup and filter matching keep working on it.

## Changes

- Introduce `MemberSymbol::ColumnRef`. `RootSqlNode` dispatches it to a bare evaluate node of its own, so masking, granularity truncation and time shifts never see one: a reference describes no calculation, and nothing may wrap it.
- Express whatever still applies to the member as a symbol standing above the reference instead. A measure reading its row-level input from a source below becomes a measure whose kind aggregates a direct-reference `SqlCall` over the reference (`measure_over_reference`), which removes `ungrouped_measure_references` entirely.
- Apply substitution per select to its whole symbol environment — schema, filters, group by, order by, window partitions — as the last transform, after render modifiers are stamped.
- Substitute *inside* a granularity wrapper rather than replacing it: a filter renders the dimension behind the wrapper, so replacing it would compare a date range against a truncated column.
- Treat a reference as terminal during substitution, in both the collector and the render-reference map. Substituting one again would rebuild a wrapper around its own reference without end.
- Keep `render_references` for one case only: the SQL of a join condition is built while the FROM is still being assembled, before there is a select symbol environment to rewrite. Its call sites go from six to three, all of them join conditions.
- `make_order_by` takes the select's substitutions, so an ORDER BY item absent from the schema — a measure the query filters on but does not select — is rewritten for all three callers rather than only the top-level query.
- Two measure lists skip members that are not measures instead of erroring on them: a member expression built by the SQL API sits in the same list and renders its own SQL.

Resolution itself stays bottom-up. Moving it into the logical plan is separate work.

## Testing

`cargo test -p cubesqlplanner --features integration-postgres` — 1381 tests pass, including the integration tests that execute their generated SQL against a real Postgres and snapshot the resulting rows.

New coverage for each mechanism the refactor rests on: substitution stopping at a reference (bare and nested), the render-reference map declining to intercept one, `find_member_positions` reaching a time dimension behind a reference, an ORDER BY on a filtered measure outside the selection, a pinned calc-group value in a multi-stage dimension join, and the sub-query dimension join of a multiplied measure.

Not in scope: a calc group **pinned to a single value** renders that value into the join condition and is covered here. A calc group with **several** values cross-joins its values table after the join that references it, so that reference is out of scope whichever way it renders; this does not run on master either and needs the FROM ordering fixed separately.

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required (no user-facing change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
