### PR TITLE
fix(tesseract): keep query-level join hints while matching pre-aggregations

### DIFF
--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1155,6 +1155,120 @@ describe('pre-aggregations', () => {
       expect(query.buildSqlAndParams()[0]).toMatch(/orders/);
     });
   });
+  // A cross-cube rollup makes matching re-derive the query's join groups. The query
+  // carries its own joinHints because `users` and `line_items` have no join between
+  // them — only `base_orders` joins both — so dropping those hints turns a fully
+  // specified query into "Can't find join path to join 'users', 'line_items'".
+  describe('a rollup that cannot serve the query does not change how it is planned', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(`
+cubes:
+  - name: base_orders
+    sql: SELECT * FROM orders
+    joins:
+      - name: line_items
+        sql: "{CUBE.id} = {line_items.order_id}"
+        relationship: one_to_many
+      - name: users
+        sql: "{CUBE.user_id} = {users.id}"
+        relationship: many_to_one
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: user_id
+        sql: user_id
+        type: number
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: orders_and_line_items_of_users
+        measures:
+          - count
+          - base_orders.line_items.count
+          - base_orders.line_items.sum_price
+        dimensions:
+          - base_orders.users.gender
+          - base_orders.users.state
+
+  - name: line_items
+    sql: SELECT * FROM line_items
+    joins:
+      - name: products
+        sql: "{CUBE.product_id} = {products.id}"
+        relationship: many_to_one
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: order_id
+        sql: order_id
+        type: number
+      - name: product_id
+        sql: product_id
+        type: number
+    measures:
+      - name: count
+        type: count
+      - name: sum_price
+        sql: price
+        type: sum
+
+  - name: users
+    sql: SELECT * FROM users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: gender
+        sql: gender
+        type: string
+      - name: state
+        sql: state
+        type: string
+
+  - name: products
+    sql: SELECT * FROM products
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: name
+        sql: name
+        type: string
+`);
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    describe.each([
+      ['legacy planner', false],
+      ['native planner', true],
+    ])('%s', (_name, useNativeSqlPlanner) => {
+      it('plans a multi-cube query along its own join hints', async () => {
+        const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+          measures: ['base_orders.count', 'line_items.count'],
+          dimensions: ['users.state'],
+          joinHints: [
+            ['base_orders', 'users'],
+            ['base_orders', 'line_items'],
+          ],
+          timezone: 'UTC',
+          preAggregationsSchema: '',
+          useNativeSqlPlanner,
+        });
+
+        expect(() => query.buildSqlAndParams()).not.toThrow();
+        expect(query.buildSqlAndParams()[0]).toMatch(/line_items/);
+      });
+    });
+  });
+
   // A rollupJoin resolves hop by hop, and each hop needs a leg rollup carrying that hop's key
   // on each side. That is a requirement on every leg rollup, not a limit on how many cubes the
   // chain spans — an interior rollup needs the upstream hop's key too, which no query selects.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -50,6 +50,10 @@ enum RowGrain {
 
 pub struct PreAggregationOptimizer {
     query_tools: Rc<State>,
+    // The join hints the query was planned with. A query whose members alone don't
+    // determine a join root resolves only with these, so the query-side hint sets
+    // rebuilt here have to start from them.
+    query_join_hints: Rc<JoinHints>,
     allow_multi_stage: bool,
     usages: Vec<PreAggregationUsage>,
     usage_counter: usize,
@@ -59,9 +63,14 @@ pub struct PreAggregationOptimizer {
 }
 
 impl PreAggregationOptimizer {
-    pub fn new(query_tools: Rc<State>, allow_multi_stage: bool) -> Self {
+    pub fn new(
+        query_tools: Rc<State>,
+        query_join_hints: Rc<JoinHints>,
+        allow_multi_stage: bool,
+    ) -> Self {
         Self {
             query_tools,
+            query_join_hints,
             allow_multi_stage,
             usages: Vec::new(),
             usage_counter: 0,
@@ -701,7 +710,7 @@ impl PreAggregationOptimizer {
                 let query_has_multiplied = if has_filters {
                     MultiFactJoinGroups::try_new(
                         self.query_tools.clone(),
-                        MeasuresJoinHints::builder(&JoinHints::new())
+                        MeasuresJoinHints::builder(&self.query_join_hints)
                             .add_dimensions(&schema.dimensions)
                             .add_dimensions(&schema.time_dimensions)
                             .add_filters(&filters.dimensions_filters)
@@ -850,7 +859,7 @@ impl PreAggregationOptimizer {
         schema: &Rc<LogicalSchema>,
         measures: &[Rc<MemberSymbol>],
     ) -> Result<MultiFactJoinGroups, CubeError> {
-        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+        let hints = MeasuresJoinHints::builder(&self.query_join_hints)
             .add_dimensions(&schema.dimensions)
             .add_dimensions(&schema.time_dimensions)
             .build(measures)?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/top_level_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/top_level_planner.rs
@@ -94,6 +94,7 @@ impl TopLevelPlanner {
         let result = if !self.request.is_pre_aggregation_query() {
             let mut pre_aggregation_optimizer = PreAggregationOptimizer::new(
                 self.query_tools.clone(),
+                self.request.query_join_hints().clone(),
                 self.cubestore_support_multistage,
             );
             let disable_external_pre_aggregations =

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_agg_query_join_hints.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/pre_agg_query_join_hints.yaml
@@ -1,0 +1,105 @@
+# base_orders is the only cube that joins both line_items and users; line_items
+# joins products only and users joins nothing, so a query touching base_orders
+# and line_items cannot derive a join root from its members alone and the SQL API
+# sends explicit query-level joinHints instead.
+cubes:
+  - name: base_orders
+    sql: "SELECT * FROM base_orders"
+    joins:
+      - name: line_items
+        relationship: one_to_many
+        sql: "{CUBE.id} = {line_items.order_id}"
+      - name: users
+        relationship: many_to_one
+        sql: "{CUBE.user_id} = {users.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: user_id
+        type: number
+        sql: user_id
+      - name: status
+        type: string
+        sql: status
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: orders_and_line_items_of_users
+        type: rollup
+        measures:
+          - count
+          - base_orders.line_items.count
+          - base_orders.line_items.sum_price
+        dimensions:
+          - base_orders.users.gender
+          - base_orders.users.state
+
+  - name: line_items
+    sql: "SELECT * FROM line_items"
+    joins:
+      - name: products
+        relationship: many_to_one
+        sql: "{CUBE.product_id} = {products.id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: order_id
+        type: number
+        sql: order_id
+      - name: product_id
+        type: number
+        sql: product_id
+    measures:
+      - name: count
+        type: count
+      - name: sum_price
+        type: sum
+        sql: price
+
+  - name: users
+    sql: "SELECT * FROM users"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: gender
+        type: string
+        sql: gender
+      - name: state
+        type: string
+        sql: state
+
+  - name: products
+    sql: "SELECT * FROM products"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: name
+        type: string
+        sql: name
+
+views:
+  - name: orders_view
+    cubes:
+      - join_path: base_orders
+        includes:
+          - count
+          - status
+      - join_path: base_orders.line_items
+        prefix: true
+        includes:
+          - count
+          - sum_price
+      - join_path: base_orders.users
+        prefix: true
+        includes:
+          - gender
+          - state

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/mod.rs
@@ -1,5 +1,6 @@
 mod multi_fact;
 mod multi_stage;
+mod query_join_hints;
 mod rollup_join_keys;
 mod sql_generation;
 mod ungrouped_gate;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/query_join_hints.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/query_join_hints.rs
@@ -1,0 +1,125 @@
+//! A rollup that cannot serve a query must not change how that query is planned.
+//!
+//! The SQL API sends explicit query-level join hints whenever the queried members alone
+//! do not determine a join root. Pre-aggregation matching re-derives the query's join
+//! groups to compare them against a candidate's, and that re-derivation has to keep the
+//! hints the query came with.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use cubenativeutils::CubeError;
+use indoc::indoc;
+
+const SCHEMA: &str = "common/pre_agg_query_join_hints.yaml";
+const ROLLUP: &str = "orders_and_line_items_of_users";
+
+// Members from `users` and `line_items`, which have no join between them: only the
+// query-level hints name `base_orders` as the root.
+const COVERED_QUERY: &str = indoc! {"
+    measures:
+      - line_items.count
+    dimensions:
+      - users.gender
+    joinHints:
+      - [base_orders, users]
+      - [base_orders, line_items]
+"};
+
+// Same shape, but `base_orders.count` is multiplied over the `line_items` fan-out,
+// so the rollup cannot serve it.
+const UNCOVERED_QUERY: &str = indoc! {"
+    measures:
+      - base_orders.count
+      - line_items.count
+    dimensions:
+      - users.state
+    joinHints:
+      - [base_orders, users]
+      - [base_orders, line_items]
+"};
+
+fn context_with_rollup() -> Result<TestContext, CubeError> {
+    TestContext::new(MockSchema::from_yaml_file(SCHEMA).only_pre_aggregations(&[ROLLUP]))
+}
+
+fn context_without_pre_aggregations() -> Result<TestContext, CubeError> {
+    TestContext::new(MockSchema::from_yaml_file(SCHEMA).only_pre_aggregations(&[]))
+}
+
+#[test]
+fn test_query_join_hints_are_kept_while_matching() -> Result<(), CubeError> {
+    let (_sql, pre_aggrs) =
+        context_with_rollup()?.build_sql_with_used_pre_aggregations(COVERED_QUERY)?;
+
+    assert_eq!(
+        pre_aggrs
+            .iter()
+            .map(|p| p.name().clone())
+            .collect::<Vec<_>>(),
+        vec![ROLLUP.to_string()]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unusable_rollup_does_not_change_the_plan() -> Result<(), CubeError> {
+    let (sql, pre_aggrs) =
+        context_with_rollup()?.build_sql_with_used_pre_aggregations(UNCOVERED_QUERY)?;
+
+    assert!(
+        pre_aggrs.is_empty(),
+        "Rollup cannot serve a measure multiplied by the line_items fan-out, got: {:?}",
+        pre_aggrs.iter().map(|p| p.name()).collect::<Vec<_>>()
+    );
+
+    let (baseline, _) = context_without_pre_aggregations()?
+        .build_sql_with_used_pre_aggregations(UNCOVERED_QUERY)?;
+    assert_eq!(sql, baseline);
+
+    Ok(())
+}
+
+#[test]
+fn test_query_join_hints_plan_without_pre_aggregations() -> Result<(), CubeError> {
+    let ctx = context_without_pre_aggregations()?;
+
+    for query in [COVERED_QUERY, UNCOVERED_QUERY] {
+        let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query)?;
+        assert!(pre_aggrs.is_empty());
+        assert!(
+            sql.contains("line_items") && sql.contains("users"),
+            "Query must be planned along its own join hints, got: {sql}"
+        );
+    }
+
+    Ok(())
+}
+
+// A view resolves the same ambiguity through its own `join_path`, so its queries carry
+// no query-level hints and matching must keep working exactly as before.
+#[test]
+fn test_view_query_still_matches_without_query_join_hints() -> Result<(), CubeError> {
+    let query = indoc! {"
+        measures:
+          - orders_view.line_items_count
+        dimensions:
+          - orders_view.users_gender
+    "};
+
+    let (sql, pre_aggrs) = context_with_rollup()?.build_sql_with_used_pre_aggregations(query)?;
+
+    assert_eq!(
+        pre_aggrs
+            .iter()
+            .map(|p| p.name().clone())
+            .collect::<Vec<_>>(),
+        vec![ROLLUP.to_string()]
+    );
+    assert!(
+        sql.contains(ROLLUP),
+        "Query must read the rollup, got: {sql}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

A raw multi-cube query that carries explicit `joinHints` — the shape the SQL API sends whenever
the queried members alone don't determine a join root — fails as soon as any cube declares a
cross-cube pre-aggregation:

```
Can't find join path to join 'users', 'line_items'
```

The query is fully specified: its hints name `base_orders` as the root, and `base_orders` is the
only cube that joins both `users` and `line_items`. Removing the pre-aggregation makes the same
query plan fine, so the failure comes from a rollup that cannot even serve the query.

The legacy planner does not reproduce this — matching simply finds no rollup and moves on.

## Cause

`PreAggregationOptimizer` re-derives the query's join groups so it can compare join paths against
a candidate rollup (`query_join_groups`, and the multiplied-measure check next to it). Both seeded
`MeasuresJoinHints::builder` with an empty `JoinHints`, so the hints the query was planned with
were dropped and the hint set was rebuilt from members only. For a query whose members don't
determine a root, that set has no resolvable root and `JoinGraph.buildJoin` throws instead of the
candidate simply being rejected.

## What was done

- `PreAggregationOptimizer` now takes the request's join hints and seeds both query-side hint
  builders with them, so matching derives the query's join groups exactly the way the query
  planner does.
- The hints of a pre-aggregation itself are unchanged: they still come from its own members.

The change is a no-op for queries that carry no `joinHints` — the seed is empty and every hint set
comes out byte-identical, so view queries (which resolve the same ambiguity through their own
`join_path`) are unaffected.

## How it was verified

- New Rust fixture + tests in `tests/integration/pre_aggregations/query_join_hints.rs`: the rollup
  serves the query; the rollup cannot serve the query and the plan stays identical to the one built
  with no pre-aggregation at all; no pre-aggregation declared; a view query still matches.
  Reverting the fix fails the first two with the reported error and leaves the controls green.
- `packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts` runs the same shape on both
  planners. Before the fix: legacy passes, native throws `Can't find join path to join 'users',
  'line_items'`. After: both pass.
- `cargo test -p cubesqlplanner --lib` — 1378 passed, 0 failed.
- `jest dist/test/unit` in `cubejs-schema-compiler` — 954 passed; the 2 failures are
  `error-reporter` ANSI-colour snapshots that also fail on a clean tree without a TTY.

## Risks

Matching now compares against the join tree the query actually uses rather than one re-derived from
members alone. For a query with explicit `joinHints` whose hint-derived tree differed from the
member-derived one, a rollup that used to be accepted may now be rejected (or the reverse) — that is
the intended correction, but it is a behaviour change for such queries. Queries without `joinHints`
are untouched.

Not covered here: a rollup whose members are written **without** a join path still throws during its
own compilation, from a hint set seeded only by its dimensions. That is a separate defect on the
pre-aggregation side and is out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
