### PR TITLE
docs(embedding, integrations): Creator Mode SQL visibility, and add-in chat pane

### DIFF
--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -256,8 +256,9 @@ The chat pane is currently in preview, and the tools it can call may still chang
 
 With chat enabled, the add-on's sidebar gains a pane that can act on the
 spreadsheet, not just answer questions about it. Ask it to run a query and
-place the results, refresh or clear a placed exploration, or — depending on
-your add-on version — create, rename, or delete a sheet.
+place the results, or refresh or clear a placed exploration. It can also
+create, rename, or delete a sheet — older installs that don't support this
+yet simply won't offer it, rather than failing.
 
 Before any destructive or ambiguous action — writing over an occupied area,
 clearing a placement, renaming or deleting a sheet — the pane asks you to

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -257,8 +257,7 @@ The chat pane is currently in preview, and the tools it can call may still chang
 With chat enabled, the add-on's sidebar gains a pane that can act on the
 spreadsheet, not just answer questions about it. Ask it to run a query and
 place the results, or refresh or clear a placed exploration. It can also
-create, rename, or delete a sheet — older installs that don't support this
-yet simply won't offer it, rather than failing.
+create, rename, or delete a sheet.
 
 Before any destructive or ambiguous action — writing over an occupied area,
 clearing a placement, renaming or deleting a sheet — the pane asks you to

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -265,8 +265,9 @@ confirm first. A query the agent places lands as an **unsaved** exploration;
 save it yourself if you want to keep it.
 
 Answers are tables, not charts — the chat pane doesn't render
-visualizations. Chat history is kept in this browser only, per spreadsheet;
-it isn't available if you open the file on another device.
+visualizations. Chat history is stored locally per spreadsheet, on the
+device where you had the conversation — it isn't available if you open the
+file elsewhere.
 
 {/* TODO: screenshot — the chat pane open in the add-on sidebar */}
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -246,6 +246,30 @@ their header, both when the exploration is inserted and after **Refresh**.
 Saved explorations also appear in the Cube workspace. See
 [Saving explorations][ref-explorations] for details.
 
+## Chat
+
+<Warning>
+
+The chat pane is currently in preview, and the tools it can call may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate this feature for your account.
+
+</Warning>
+
+With chat enabled, the add-on's sidebar gains a pane that can act on the
+spreadsheet, not just answer questions about it. Ask it to run a query and
+place the results, refresh or clear a placed exploration, or — depending on
+your add-on version — create, rename, or delete a sheet.
+
+Before any destructive or ambiguous action — writing over an occupied area,
+clearing a placement, renaming or deleting a sheet — the pane asks you to
+confirm first. A query the agent places lands as an **unsaved** exploration;
+save it yourself if you want to keep it.
+
+Answers are tables, not charts — the chat pane doesn't render
+visualizations. Chat history is kept in this browser only, per spreadsheet;
+it isn't available if you open the file on another device.
+
+{/* TODO: screenshot — the chat pane open in the add-on sidebar */}
+
 
 [link-google-sheets]: https://workspace.google.com/products/sheets/
 [link-marketplace-listing]: https://workspace.google.com/u/0/marketplace/app/cube_cloud_for_sheets/641460343379

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -254,8 +254,9 @@ confirm first. A query the agent places lands as an **unsaved** exploration;
 save it yourself if you want to keep it.
 
 Answers are tables, not charts — the chat pane doesn't render
-visualizations. Chat history is kept in this browser only, per workbook; it
-isn't available if you open the file on another device.
+visualizations. Chat history is stored locally per workbook, on the device
+where you had the conversation — it isn't available if you open the file
+elsewhere.
 
 {/* TODO: screenshot — the chat pane open in the add-in sidebar */}
 

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -245,8 +245,9 @@ The chat pane is currently in preview, and the tools it can call may still chang
 
 With chat enabled, the add-in's sidebar gains a pane that can act on the
 workbook, not just answer questions about it. Ask it to run a query and
-place the results, refresh or clear a placed exploration, or — depending on
-your add-in version — create, rename, or delete a sheet.
+place the results, or refresh or clear a placed exploration. It can also
+create, rename, or delete a sheet — older installs that don't support this
+yet simply won't offer it, rather than failing.
 
 Before any destructive or ambiguous action — writing over an occupied area,
 clearing a placement, renaming or deleting a sheet — the pane asks you to

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -246,8 +246,7 @@ The chat pane is currently in preview, and the tools it can call may still chang
 With chat enabled, the add-in's sidebar gains a pane that can act on the
 workbook, not just answer questions about it. Ask it to run a query and
 place the results, or refresh or clear a placed exploration. It can also
-create, rename, or delete a sheet — older installs that don't support this
-yet simply won't offer it, rather than failing.
+create, rename, or delete a sheet.
 
 Before any destructive or ambiguous action — writing over an occupied area,
 clearing a placement, renaming or deleting a sheet — the pane asks you to

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -235,6 +235,30 @@ their header, both when the exploration is inserted and after **Refresh**.
 Saved explorations also appear in the Cube workspace. See
 [Saving explorations][ref-explorations] for details.
 
+## Chat
+
+<Warning>
+
+The chat pane is currently in preview, and the tools it can call may still change. Reach out to the [Cube support team](/admin/account-billing/support) to activate this feature for your account.
+
+</Warning>
+
+With chat enabled, the add-in's sidebar gains a pane that can act on the
+workbook, not just answer questions about it. Ask it to run a query and
+place the results, refresh or clear a placed exploration, or — depending on
+your add-in version — create, rename, or delete a sheet.
+
+Before any destructive or ambiguous action — writing over an occupied area,
+clearing a placement, renaming or deleting a sheet — the pane asks you to
+confirm first. A query the agent places lands as an **unsaved** exploration;
+save it yourself if you want to keep it.
+
+Answers are tables, not charts — the chat pane doesn't render
+visualizations. Chat history is kept in this browser only, per workbook; it
+isn't available if you open the file on another device.
+
+{/* TODO: screenshot — the chat pane open in the add-in sidebar */}
+
 
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -52,7 +52,7 @@ See [Session settings][ref-session-settings] for the full list of AI-related key
 Four account-wide switches under **Embed → Settings**, in the **Creator Mode** section, control the embedded workspace's chrome and how much of the underlying query embed users can see. Each auto-saves.
 
 - **Show workspace title** (`showWorkspaceTitle`, boolean, default `true`) — whether the header row at the embedded workspace root renders at all.
-- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 entries — each a full locale code like `es-ES`, not a short code like `es`).
+- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 entries), picked from Cube's list of supported languages — the same list used to set the [account-wide UI language][ref-localization-account-default].
 - **Show Semantic SQL** (`showSemanticSql`, boolean, default `true`) — lets embed users view the semantic (Cube) query behind reports and chat results.
 - **Show Generated SQL** (`showGeneratedSql`, boolean, default `false`) — lets embed users view the generated SQL, the physical data-source query. It defaults to hidden, the opposite polarity of the switch above, because generated SQL reveals table and schema names from your data source.
 
@@ -148,3 +148,4 @@ For a complete working example, see the [cube-embedding-demo](https://github.com
 [ref-bootstrap]: /reference/embed-apis/generate-session#creator-mode-bootstrapping-groups-and-user-attributes
 [ref-session-settings]: /reference/embed-apis/generate-session#session-settings
 [ref-localization]: /embedding/iframe/localization
+[ref-localization-account-default]: /embedding/iframe/localization#account-wide-default

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -52,7 +52,7 @@ See [Session settings][ref-session-settings] for the full list of AI-related key
 Four account-wide switches under **Embed → Settings**, in the **Creator Mode** section, control the embedded workspace's chrome and how much of the underlying query embed users can see. Each auto-saves.
 
 - **Show workspace title** (`showWorkspaceTitle`, boolean, default `true`) — whether the header row at the embedded workspace root renders at all.
-- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 entries), picked from Cube's list of supported languages — the same list used to set the [account-wide UI language][ref-localization-account-default].
+- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 entries), picked from [Cube's list of supported languages][ref-localization-supported-languages] — the same list the account-wide UI language is set from.
 - **Show Semantic SQL** (`showSemanticSql`, boolean, default `true`) — lets embed users view the semantic (Cube) query behind reports and chat results.
 - **Show Generated SQL** (`showGeneratedSql`, boolean, default `false`) — lets embed users view the generated SQL, the physical data-source query. It defaults to hidden, the opposite polarity of the switch above, because generated SQL reveals table and schema names from your data source.
 
@@ -148,4 +148,4 @@ For a complete working example, see the [cube-embedding-demo](https://github.com
 [ref-bootstrap]: /reference/embed-apis/generate-session#creator-mode-bootstrapping-groups-and-user-attributes
 [ref-session-settings]: /reference/embed-apis/generate-session#session-settings
 [ref-localization]: /embedding/iframe/localization
-[ref-localization-account-default]: /embedding/iframe/localization#account-wide-default
+[ref-localization-supported-languages]: /embedding/iframe/localization#supported-languages

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -47,6 +47,17 @@ Three account-wide switches under **Embed → Settings** control this, each over
 
 See [Session settings][ref-session-settings] for the full list of AI-related keys, including `allowChatWorkspaceAuthoring` for headless chat integrations that shouldn't let the agent create or modify workbooks, explorations, or dashboards.
 
+## Workspace appearance and SQL visibility
+
+Four account-wide switches under **Embed → Settings**, in the **Creator Mode** section, control the embedded workspace's chrome and how much of the underlying query embed users can see. Each auto-saves.
+
+- **Show workspace title** (`showWorkspaceTitle`, boolean, default `true`) — whether the header row at the embedded workspace root renders at all.
+- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 full BCP-47 locale codes). An embed resolves the title by the visitor's language: an exact locale override, then any stored same-language variant, then this default. A blank or all-whitespace title falls back to `Workspace` rather than rendering an empty header — use **Show workspace title** to hide the header instead.
+- **Show Semantic SQL** (`showSemanticSql`, boolean, default `true`) — lets embed users view the semantic (Cube) query behind reports and chat results.
+- **Show Generated SQL** (`showGeneratedSql`, boolean, default `false`) — lets embed users view the generated SQL, the physical data-source query. It defaults to hidden, the opposite polarity of the switch above, because generated SQL reveals table and schema names from your data source.
+
+These are account-wide only — there's no per-session `settings` key or URL parameter for any of them. Turning on **Show Generated SQL** doesn't expose source tables: the workbook launchpad's Source tables tab and the data pane's source-schema explorer stay hidden in every embed regardless of this switch, since an embed's deployment token carries no `sql-runner` scope.
+
 ## Embed tenant scoping
 
 In Creator Mode, content (workbooks, dashboards) and the groups/user attributes referenced by the session are scoped to an **embed tenant**. Pass `embedTenantName` to isolate content per customer; omit it to use the current tenant.

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -52,9 +52,11 @@ See [Session settings][ref-session-settings] for the full list of AI-related key
 Four account-wide switches under **Embed → Settings**, in the **Creator Mode** section, control the embedded workspace's chrome and how much of the underlying query embed users can see. Each auto-saves.
 
 - **Show workspace title** (`showWorkspaceTitle`, boolean, default `true`) — whether the header row at the embedded workspace root renders at all.
-- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 full BCP-47 locale codes). An embed resolves the title by the visitor's language: an exact locale override, then any stored same-language variant, then this default. A blank or all-whitespace title falls back to `Workspace` rather than rendering an empty header — use **Show workspace title** to hide the header instead.
+- **Workspace title** (`workspaceTitle`, string, default `Workspace`) — the header's text; breadcrumbs reuse it as the root label. **Edit titles** opens per-language overrides (`localizedTitles`, up to 50 entries — each a full locale code like `es-ES`, not a short code like `es`).
 - **Show Semantic SQL** (`showSemanticSql`, boolean, default `true`) — lets embed users view the semantic (Cube) query behind reports and chat results.
 - **Show Generated SQL** (`showGeneratedSql`, boolean, default `false`) — lets embed users view the generated SQL, the physical data-source query. It defaults to hidden, the opposite polarity of the switch above, because generated SQL reveals table and schema names from your data source.
+
+The workspace title resolves against the same UI language the embed has already resolved (see [Localization][ref-localization]): an exact locale override, then a same-language override, then this default. A blank or all-whitespace title falls back to `Workspace` rather than rendering an empty header — use **Show workspace title** to hide the header instead.
 
 These are account-wide only — there's no per-session `settings` key or URL parameter for any of them. Turning on **Show Generated SQL** doesn't expose source tables: the workbook launchpad's Source tables tab and the data pane's source-schema explorer stay hidden in every embed regardless of this switch, since an embed's deployment token carries no `sql-runner` scope.
 
@@ -145,3 +147,4 @@ For a complete working example, see the [cube-embedding-demo](https://github.com
 [ref-generate-session]: /reference/embed-apis/generate-session
 [ref-bootstrap]: /reference/embed-apis/generate-session#creator-mode-bootstrapping-groups-and-user-attributes
 [ref-session-settings]: /reference/embed-apis/generate-session#session-settings
+[ref-localization]: /embedding/iframe/localization

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -58,7 +58,7 @@ Four account-wide switches under **Embed → Settings**, in the **Creator Mode**
 
 The workspace title resolves against the same UI language the embed has already resolved (see [Localization][ref-localization]): an exact locale override, then a same-language override, then this default. A blank or all-whitespace title falls back to `Workspace` rather than rendering an empty header — use **Show workspace title** to hide the header instead.
 
-These are account-wide only — there's no per-session `settings` key or URL parameter for any of them. Turning on **Show Generated SQL** doesn't expose source tables: the workbook launchpad's Source tables tab and the data pane's source-schema explorer stay hidden in every embed regardless of this switch, since an embed's deployment token carries no `sql-runner` scope.
+These are account-wide only — there's no per-session `settings` key or URL parameter for any of them. Turning on **Show Generated SQL** doesn't expose source tables: the workbook launchpad's Source tables tab and the data pane's source-schema explorer stay hidden in every embed regardless of this switch.
 
 ## Embed tenant scoping
 

--- a/docs-mintlify/embedding/iframe/localization.mdx
+++ b/docs-mintlify/embedding/iframe/localization.mdx
@@ -75,6 +75,13 @@ something higher in the ladder above overrides it: a session's own `settings.loc
 Clearing the setting removes the stored default, and embeds fall back to `en-US` — unless
 a session or a per-embed override names a language.
 
+<Note>
+  The Creator Mode workspace title has its own, separate per-language overrides — set
+  under **Embed → Settings**, in the same **Creator Mode** section — resolved by the
+  visitor's language independently of the UI language above. See [Workspace appearance
+  and SQL visibility](/embedding/iframe/creator-mode#workspace-appearance-and-sql-visibility).
+</Note>
+
 ## Per embed via URL
 
 Override the account default for an individual embed by adding the `?locale=` query

--- a/docs-mintlify/embedding/iframe/localization.mdx
+++ b/docs-mintlify/embedding/iframe/localization.mdx
@@ -77,9 +77,10 @@ a session or a per-embed override names a language.
 
 <Note>
   The Creator Mode workspace title has its own, separate per-language overrides — set
-  under **Embed → Settings**, in the same **Creator Mode** section — resolved by the
-  visitor's language independently of the UI language above. See [Workspace appearance
-  and SQL visibility](/embedding/iframe/creator-mode#workspace-appearance-and-sql-visibility).
+  under **Embed → Settings**, in the same **Creator Mode** section. It resolves against
+  the *same* UI language resolved above (session setting, `?locale=`, runtime override,
+  or account default) — not an independent value. See [Workspace appearance and SQL
+  visibility](/embedding/iframe/creator-mode#workspace-appearance-and-sql-visibility).
 </Note>
 
 ## Per embed via URL


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

## Description of Changes Made

Two independent documentation additions:

1. **Embedding — Creator Mode workspace appearance and SQL visibility.** The **Creator Mode** section of **Embed → Settings** has four account-wide controls (workspace title + per-language overrides, whether the title header shows at all, and whether embed users can see semantic vs. generated SQL) that were never documented. Adds a new section to `embedding/iframe/creator-mode.mdx` covering the exact settings, types, and defaults, and cross-links the per-language title override from `embedding/iframe/localization.mdx`.

2. **Google Sheets / Excel add-ins — chat pane.** Both add-ins can now open a chat pane that acts on the spreadsheet directly — running and placing queries, refreshing or clearing placed results, and (depending on add-in version) creating, renaming, or deleting sheet tabs — instead of only answering questions about it. This is a preview feature, so the new "Chat" section on each page opens with the standard preview callout, and documents the confirm-before-destructive-action behavior and current limits (table-only answers, per-device chat history).

No new pages, no navigation changes — both additions are new sections on existing pages.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejmxjcp41Nn2TyndivFD97

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ejmxjcp41Nn2TyndivFD97)_