### PR TITLE
docs(explore-analyze): document chat Artifacts tab

### DIFF
--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -52,6 +52,17 @@ This allows you to:
 - **Provide additional context** to give the agent more information that it
   can incorporate into its next response
 
+## Artifacts
+
+The chat sidebar's **Artifacts** tab collects the explorations, workbooks, and
+dashboards this conversation has touched. An object lands there automatically
+when the agent saves it for you, and you can also ask the agent to link an
+existing saved object so it's handy for reference — for example, "keep the Q3
+revenue exploration handy" or "link the Executive Overview dashboard here."
+
+Click an artifact to preview it in a dialog, or open its full page from
+there.
+
 ## Sharing
 
 Click **Share** in the chat header to grant view access to other members


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

The chat sidebar's **Artifacts** tab (in Analytics Chat, the Data Model Agent, and embedded chat) was renamed from a semantic-model-only "Changes" tab and now also collects explorations, workbooks, and dashboards saved during or explicitly linked to a conversation — with no public documentation. This adds a short "Artifacts" section to `docs/explore-analyze/analytics-chat.mdx` covering:

- What lands in the tab (auto-saved objects, plus objects you ask the agent to link)
- How to preview an artifact (dialog) or open its full page

Source: cubedevinc/cubejs-enterprise#14940 ("feat(chat): link saved artifacts to conversations").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNhy9SUJQU13Ur2ww2WM8h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNhy9SUJQU13Ur2ww2WM8h)_